### PR TITLE
feat(metrics): add effective_reward metric

### DIFF
--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -135,7 +135,11 @@ class MetricsBuilder:
 
         eff = effective_reward_stats(results_df)
         if eff is not None:
-            to_log["effective_reward/all/mean"], to_log["effective_reward/all/max"], to_log["effective_reward/all/min"] = eff
+            (
+                to_log["effective_reward/all/mean"],
+                to_log["effective_reward/all/max"],
+                to_log["effective_reward/all/min"],
+            ) = eff
 
         # Per-env metrics
         per_env_columns = [
@@ -164,7 +168,11 @@ class MetricsBuilder:
             to_log[f"reward/{env}/min"] = env_by_example.reward.mean().min()
             env_eff = effective_reward_stats(env_df)
             if env_eff is not None:
-                to_log[f"effective_reward/{env}/mean"], to_log[f"effective_reward/{env}/max"], to_log[f"effective_reward/{env}/min"] = env_eff
+                (
+                    to_log[f"effective_reward/{env}/mean"],
+                    to_log[f"effective_reward/{env}/max"],
+                    to_log[f"effective_reward/{env}/min"],
+                ) = env_eff
             sn, sa, eb = compute_solve_rates(env_df)
             to_log[f"solve_none/{env}"] = sn
             to_log[f"solve_all/{env}"] = sa

--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -39,8 +39,6 @@ class MetricsBuilder:
                 "task_idx": [r.task.idx for r in rollouts],
                 "env_name": [r.env_name for r in rollouts],
                 "reward": [r.reward for r in rollouts],
-                # True when the rollout has a non-zero advantage stream, i.e. the sample the
-                # zero-advantage filter would keep (see effective_reward below).
                 "nonzero_advantage": [
                     r.advantages is not None and any(a != 0.0 for a in r.advantages) for r in rollouts
                 ],
@@ -71,10 +69,6 @@ class MetricsBuilder:
             return solve_none, solve_all, 1 - solve_none - solve_all
 
         def effective_reward_stats(df):
-            """Mean/max/min reward over only the non-zero-advantage rollouts — the reward as it
-            would look if the zero-advantage filter were applied before the batch. Per-example
-            mean first (matching the plain reward metric), then aggregated across examples.
-            Returns None when no rollout has a non-zero advantage."""
             nonzero = df[df.nonzero_advantage]
             if nonzero.empty:
                 return None

--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -39,6 +39,11 @@ class MetricsBuilder:
                 "task_idx": [r.task.idx for r in rollouts],
                 "env_name": [r.env_name for r in rollouts],
                 "reward": [r.reward for r in rollouts],
+                # True when the rollout has a non-zero advantage stream, i.e. the sample the
+                # zero-advantage filter would keep (see effective_reward below).
+                "nonzero_advantage": [
+                    r.advantages is not None and any(a != 0.0 for a in r.advantages) for r in rollouts
+                ],
                 "is_truncated": [r.is_truncated for r in rollouts],
                 "is_filtered": [r.is_filtered for r in rollouts],
                 "stop_condition": [r.stop_condition for r in rollouts],
@@ -64,6 +69,17 @@ class MetricsBuilder:
             expected = grouped.env_name.first().map(env_group_size)
             solve_all = (reward_per_problem == expected).mean()
             return solve_none, solve_all, 1 - solve_none - solve_all
+
+        def effective_reward_stats(df):
+            """Mean/max/min reward over only the non-zero-advantage rollouts — the reward as it
+            would look if the zero-advantage filter were applied before the batch. Per-example
+            mean first (matching the plain reward metric), then aggregated across examples.
+            Returns None when no rollout has a non-zero advantage."""
+            nonzero = df[df.nonzero_advantage]
+            if nonzero.empty:
+                return None
+            per_example = nonzero.groupby("group_id").reward.mean()
+            return per_example.mean(), per_example.max(), per_example.min()
 
         by_example = results_df.groupby("group_id")
         solve_none, solve_all, effective_batch_size = compute_solve_rates(results_df)
@@ -123,6 +139,10 @@ class MetricsBuilder:
             "step": step,
         }
 
+        eff = effective_reward_stats(results_df)
+        if eff is not None:
+            to_log["effective_reward/all/mean"], to_log["effective_reward/all/max"], to_log["effective_reward/all/min"] = eff
+
         # Per-env metrics
         per_env_columns = [
             "seq_len",
@@ -148,6 +168,9 @@ class MetricsBuilder:
             to_log[f"reward/{env}/mean"] = env_by_example.reward.mean().mean()
             to_log[f"reward/{env}/max"] = env_by_example.reward.mean().max()
             to_log[f"reward/{env}/min"] = env_by_example.reward.mean().min()
+            env_eff = effective_reward_stats(env_df)
+            if env_eff is not None:
+                to_log[f"effective_reward/{env}/mean"], to_log[f"effective_reward/{env}/max"], to_log[f"effective_reward/{env}/min"] = env_eff
             sn, sa, eb = compute_solve_rates(env_df)
             to_log[f"solve_none/{env}"] = sn
             to_log[f"solve_all/{env}"] = sa


### PR DESCRIPTION
## What

Adds an **`effective_reward`** metric to the orchestrator's per-step W&B dict, logged as `effective_reward/{all,<env>}/{mean,max,min}`.

It is the same as the existing `reward` metric, but computed over **only the non-zero-advantage rollouts** — i.e. the reward as it would look if the zero-advantage filter were applied *before* the batch. A rollout counts when its advantage stream is non-zero (`r.advantages is not None and any(a != 0.0 ...)`), mirroring `ZeroAdvantageFilter`'s predicate. Per-example mean first (matching the plain `reward` metric), then aggregated across examples.

## Why

`reward/all/mean` includes whole groups that contribute no gradient (all rollouts earned the same reward → centered advantage collapses to zero). `effective_reward` shows the mean reward among the samples that actually drive learning, which tracks training signal more faithfully — useful for spotting when a run's reward is rising only on already-solved/already-failed groups.

## Notes

- Computed directly from the advantage stream, independent of filter config — so it reflects the would-be effective reward even when the zero-advantage filter is set to *monitoring* (not enforcing).
- Returns nothing (metric omitted) for a step where no rollout has a non-zero advantage.
- Self-contained: one file, `src/prime_rl/orchestrator/metrics.py` (+23 lines). Stable metric names, no change to existing keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in metrics assembly; no training, filtering, or API behavior changes.
> 
> **Overview**
> Adds **`effective_reward`** to per-step W&B logging (`effective_reward/{all,<env>}/{mean,max,min}`), parallel to the existing `reward` stats but restricted to rollouts with a **non-zero advantage stream** (inverse of `ZeroAdvantageFilter`’s all-zero check).
> 
> Rollouts are tagged via a new `nonzero_advantage` column on the step results frame; `effective_reward_stats` averages reward per `group_id` over those rows, then aggregates mean/max/min across examples. Keys are **omitted** when every rollout has zero advantage. Existing metric names are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec83a51ec762f51087a1b74b7e31cb1e718883fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->