### PR TITLE
feat: add rl-wide env vars

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ Every `prime-rl` entrypoint uses [`pydantic-config`](https://github.com/PrimeInt
   - [None](#none)
   - [Discriminated Unions](#discriminated-unions)
   - [Environments](#environments-orchestratortrainenv)
-  - [Environment Variables](#environment-variables-componentenv_vars)
+  - [Environment Variables](#environment-variables)
 - [Examples](#examples)
 
 ## Sources and Precedence
@@ -166,9 +166,17 @@ args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }
 
 The same `id` can appear multiple times across train and eval (or with different `args`) — useful for evaluating on a held-out split of the env you're training on, or comparing two configurations of the same env side by side. When `id` is reused, set a distinct `name` on each entry; `name` defaults to `id` and must be unique across all envs in the same group.
 
-### Environment Variables (`[component.env_vars]`)
+### Environment Variables
 
-OS environment variables exported into each launched component's process(es), set per component:
+OS environment variables exported into launched component process(es). In `rl` configs, top-level `[env_vars]` applies to trainer, inference, and orchestrator:
+
+```toml
+[env_vars]
+HF_HUB_OFFLINE = "1"
+TOKENIZERS_PARALLELISM = "false"
+```
+
+Component-specific tables layer on top:
 
 ```toml
 [trainer.env_vars]
@@ -185,10 +193,11 @@ PI_USAGE_BASE_URL = "https://..."
 The `rl` launcher applies these the same way in both single-node and multi-node (SLURM) runs. Precedence, low to high:
 
 1. The launcher's own defaults — **your `env_vars` override these**.
-2. Your `[component.env_vars]`.
-3. Orchestration-critical vars the launcher always sets last — `CUDA_VISIBLE_DEVICES` (GPU partitioning) and `WANDB_SHARED_*` (the single shared W&B run) — **these cannot be overridden** from `env_vars`.
+2. Your top-level `[env_vars]`.
+3. Your `[component.env_vars]`.
+4. Orchestration-critical vars the launcher always sets last — `CUDA_VISIBLE_DEVICES` (GPU partitioning) and `WANDB_SHARED_*` (the single shared W&B run) — **these cannot be overridden** from `env_vars`.
 
-For disaggregated P/D inference, the role-specific [`deployment.{prefill,decode}_env_vars`](inference.md) layer on top of `inference.env_vars`.
+For standalone `sft` and `inference` configs, `[env_vars]` applies to that entrypoint's process(es). For disaggregated P/D inference, the role-specific [`deployment.{prefill,decode}_env_vars`](inference.md) layer on top of any shared inference env vars.
 
 ## Examples
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -257,7 +257,7 @@ prefill_env_vars = {"VLLM_ENABLE_MOE_DP_CHUNK"="0", "VLLM_DEEP_GEMM_WARMUP"="ski
 decode_env_vars = {"VLLM_DEEP_GEMM_WARMUP"="skip"}
 ```
 
-These are role-specific and layer on top of [`[inference.env_vars]`](configuration.md#environment-variables-componentenv_vars), which applies to all inference processes regardless of role.
+These are role-specific and layer on top of [`env_vars`](configuration.md#environment-variables) shared by all inference processes regardless of role.
 
 ### Other vLLM features
 We support various other vLLM features. Some of those, such as `enable_dbo`, `enable_eplb` are exposed as a top-level config fields. For those that are not, you can configure them by setting `inference.vllm_extra` to the desired value.

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -16,6 +16,7 @@ from prime_rl.configs.orchestrator import (
     OrchestratorConfig,
 )
 from prime_rl.configs.shared import (
+    EnvVars,
     SlurmConfig,
     VLMConfig,
 )
@@ -187,6 +188,9 @@ class RLConfig(BaseConfig):
 
     inference: InferenceConfig | None = None
     """Inference server configuration. If None, the rl entrypoint will not start an inference server (useful for elastic inference pools or manually started servers)."""
+
+    env_vars: EnvVars = {}
+    """Extra environment variables for every launched RL component. Component-specific env_vars override these."""
 
     output_dir: Path = Path("outputs")
     """Output directory. Should be unique per experiment."""

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -173,6 +173,7 @@ def rl_local(config: RLConfig):
                         **os.environ,
                         **DEFAULT_COMMON_ENV_VARS,
                         **DEFAULT_INFERENCE_ENV_VARS,
+                        **config.env_vars,
                         **config.inference.env_vars,
                         "CUDA_VISIBLE_DEVICES": ",".join(map(str, infer_gpu_ids)),
                     },
@@ -229,6 +230,7 @@ def rl_local(config: RLConfig):
                     "LOGURU_FORCE_COLORS": "1",
                     "WANDB_PROGRAM": "uv run rl",
                     "WANDB_ARGS": json.dumps(start_command),
+                    **config.env_vars,
                     **config.orchestrator.env_vars,
                     **wandb_shared_env,
                     "WANDB_SHARED_LABEL": "orchestrator",
@@ -278,6 +280,7 @@ def rl_local(config: RLConfig):
                     "LOGURU_FORCE_COLORS": "1",
                     "WANDB_PROGRAM": "uv run rl",
                     "WANDB_ARGS": json.dumps(start_command),
+                    **config.env_vars,
                     **config.trainer.env_vars,
                     **wandb_shared_env,
                     "WANDB_SHARED_LABEL": "trainer",
@@ -375,12 +378,12 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
     trainer_env_vars = {
         **DEFAULT_COMMON_ENV_VARS,
         **DEFAULT_TRAINER_ENV_VARS,
-        "HF_HUB_OFFLINE": os.environ.get("HF_HUB_OFFLINE", "1"),
+        **config.env_vars,
         **config.trainer.env_vars,
     }
-    orchestrator_env_vars = {**DEFAULT_COMMON_ENV_VARS, **config.orchestrator.env_vars}
+    orchestrator_env_vars = {**DEFAULT_COMMON_ENV_VARS, **config.env_vars, **config.orchestrator.env_vars}
     inference_env_vars = (
-        {**DEFAULT_COMMON_ENV_VARS, **DEFAULT_INFERENCE_ENV_VARS, **config.inference.env_vars}
+        {**DEFAULT_COMMON_ENV_VARS, **DEFAULT_INFERENCE_ENV_VARS, **config.env_vars, **config.inference.env_vars}
         if config.inference
         else {}
     )

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -46,7 +46,6 @@ def write_slurm_script(config: SFTConfig, config_path: Path, script_path: Path) 
     trainer_env_vars = {
         **DEFAULT_COMMON_ENV_VARS,
         **DEFAULT_TRAINER_ENV_VARS,
-        "HF_HUB_OFFLINE": os.environ.get("HF_HUB_OFFLINE", "1"),
         **config.env_vars,
     }
 

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -211,7 +211,7 @@ srun --kill-on-bad-exit=1 bash -c '
 
 if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     INFER_NODE_RANK=$SLURM_PROCID
-    # Inference env vars: launcher defaults + [inference.env_vars]
+    # Inference env vars: launcher defaults + [env_vars] + [inference.env_vars]
 {%- for key, value in inference_env_vars.items() %}
     export {{ key }}="{{ value }}"
 {%- endfor %}
@@ -374,7 +374,7 @@ else
     TRAIN_NODE_RANK=$SLURM_PROCID
 {%- endif %}
 
-    # Trainer env vars: launcher defaults + [trainer.env_vars]
+    # Trainer env vars: launcher defaults + [env_vars] + [trainer.env_vars]
 {%- for key, value in trainer_env_vars.items() %}
     export {{ key }}="{{ value }}"
 {%- endfor %}
@@ -407,7 +407,7 @@ if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
     ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --student.client.base-url $INFER_URLS"
     ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --student.client.admin-base-url $ADMIN_URLS"
 {%- if orchestrator_env_vars %}
-    # Orchestrator env vars from [orchestrator.env_vars]
+    # Orchestrator env vars from [env_vars] + [orchestrator.env_vars]
 {%- for key, value in orchestrator_env_vars.items() %}
     export {{ key }}="{{ value }}"
 {%- endfor %}

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -102,7 +102,7 @@ srun --kill-on-bad-exit=1 bash -c '
 
     TRAIN_NODE_RANK=$SLURM_PROCID
 
-    # Trainer env vars: launcher defaults + [sft.env_vars]
+    # Trainer env vars: launcher defaults + [env_vars]
 {%- for key, value in trainer_env_vars.items() %}
     export {{ key }}="{{ value }}"
 {%- endfor %}


### PR DESCRIPTION
## Summary

Adds a top-level `[env_vars]` table to RL configs so one env var can apply to trainer, inference, and orchestrator.

Component-specific env var tables still layer on top, so `[trainer.env_vars]`, `[inference.env_vars]`, and `[orchestrator.env_vars]` can override the shared RL-wide values.

This also removes the implicit `HF_HUB_OFFLINE=1` injection from generated RL/SFT SLURM trainer envs. Users who want offline Hub behavior should now set it explicitly:

```toml
[env_vars]
HF_HUB_OFFLINE = "1"
```

## Validation

- `uv run --extra envs rl @ examples/qwen30b_math/rl.toml --dry-run --output-dir /tmp/prime-rl-env-vars-dry-run`
- schema/render probe for RL-wide env vars and protected-var rejection
- `git diff --check`
- confirmed generated `rl.sbatch` has no `HF_HUB_OFFLINE` unless configured

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process environment for every RL component on local and SLURM launches; removing implicit HF_HUB_OFFLINE on SLURM trainer jobs can change Hub/network behavior for existing configs that relied on the old default.
> 
> **Overview**
> Adds **`env_vars`** on **`RLConfig`** so a single `[env_vars]` table in TOML can set OS environment variables for **trainer**, **inference**, and **orchestrator**. The `rl` launcher merges it into local `Popen` envs and into SLURM-rendered `trainer_env_vars` / `inference_env_vars` / `orchestrator_env_vars`, with **`[trainer.env_vars]`**, **`[inference.env_vars]`**, and **`[orchestrator.env_vars]`** still overriding on top.
> 
> Documentation now describes this precedence (launcher defaults → top-level `[env_vars]` → per-component tables → protected `CUDA_VISIBLE_DEVICES` / `WANDB_SHARED_*`) and updates inference P/D docs to point at the shared env-var section.
> 
> **Breaking-ish behavior change:** generated RL (and SFT) multi-node trainer env no longer injects **`HF_HUB_OFFLINE=1`** from the host environment; set it explicitly under `[env_vars]` if you need offline Hub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 441b715884f50553b092d16dc803f70e7316e8c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->