### PR TITLE
fix: correct env log glob to logs/envs/<split>/<env>.log

### DIFF
--- a/examples/Intellect-3.1/README.md
+++ b/examples/Intellect-3.1/README.md
@@ -70,9 +70,9 @@ Logs:
   Trainer:          tail -F /shared/outputs/intellect-3.1/logs/trainer.log
   Orchestrator:     tail -F /shared/outputs/intellect-3.1/logs/orchestrator.log
   Inference:        tail -F /shared/outputs/intellect-3.1/logs/inference.log
-  Envs:             tail -F /shared/outputs/intellect-3.1/logs/envs/*/*/*.log
-   Train:           tail -F /shared/outputs/intellect-3.1/logs/envs/train/*/*.log
-    swe:           tail -F /shared/outputs/intellect-3.1/logs/envs/train/swe/*.log 
+  Envs:             tail -F /shared/outputs/intellect-3.1/logs/envs/*/*.log
+   Train:           tail -F /shared/outputs/intellect-3.1/logs/envs/train/*.log
+    swe:           tail -F /shared/outputs/intellect-3.1/logs/envs/train/swe.log 
 ```
 
 

--- a/examples/Intellect-3.1/README.md
+++ b/examples/Intellect-3.1/README.md
@@ -58,21 +58,3 @@ PS: If using the tmux helper, you can run the command in the `Terminal` (window 
 ```bash
 uv run rl @ examples/Intellect-3.1/rl.toml --output-dir /shared/outputs/intellect-3.1
 ```
-
-Output of the command:
-```
-XXX:XX:XX    INFO Wrote subconfigs to /shared/outputs/intellect-3.1/configs [rl.py::515]
-XXX:XX:XX    INFO Wrote SLURM script to /shared/outputs/intellect-3.1/rl.sbatch [rl.py::534]
-XXX:XX:XX    INFO Submitting: sbatch /shared/outputs/intellect-3.1/rl.sbatch [rl.py::540]
-XXX:XX:XX SUCCESS Submitted batch job YYYY
-
-Logs:
-  Trainer:          tail -F /shared/outputs/intellect-3.1/logs/trainer.log
-  Orchestrator:     tail -F /shared/outputs/intellect-3.1/logs/orchestrator.log
-  Inference:        tail -F /shared/outputs/intellect-3.1/logs/inference.log
-  Envs:             tail -F /shared/outputs/intellect-3.1/logs/envs/*/*.log
-   Train:           tail -F /shared/outputs/intellect-3.1/logs/envs/train/*.log
-    swe:           tail -F /shared/outputs/intellect-3.1/logs/envs/train/swe.log 
-```
-
-

--- a/examples/glm5_llmd/README.md
+++ b/examples/glm5_llmd/README.md
@@ -83,5 +83,5 @@ Logs:
   Trainer:          tail -F /shared/outputs/glm5-llmd/logs/trainer.log
   Orchestrator:     tail -F /shared/outputs/glm5-llmd/logs/orchestrator.log
   Inference:        tail -F /shared/outputs/glm5-llmd/logs/inference.log
-  Envs:             tail -F /shared/outputs/glm5-llmd/logs/envs/*/*/*.log
+  Envs:             tail -F /shared/outputs/glm5-llmd/logs/envs/*/*.log
 ```

--- a/examples/glm5_llmd/README.md
+++ b/examples/glm5_llmd/README.md
@@ -71,17 +71,3 @@ PS: If using the tmux helper, you can run the command in the `Terminal` (window 
 ```bash
 uv run rl @ examples/glm5_llmd/rl.toml --output-dir /shared/outputs/glm5-llmd
 ```
-
-Output of the command:
-```
-XXX:XX:XX    INFO Wrote subconfigs to /shared/outputs/glm5-llmd/configs [rl.py::515]
-XXX:XX:XX    INFO Wrote SLURM script to /shared/outputs/glm5-llmd/rl.sbatch [rl.py::534]
-XXX:XX:XX    INFO Submitting: sbatch /shared/outputs/glm5-llmd/rl.sbatch [rl.py::540]
-XXX:XX:XX SUCCESS Submitted batch job YYYY
-
-Logs:
-  Trainer:          tail -F /shared/outputs/glm5-llmd/logs/trainer.log
-  Orchestrator:     tail -F /shared/outputs/glm5-llmd/logs/orchestrator.log
-  Inference:        tail -F /shared/outputs/glm5-llmd/logs/inference.log
-  Envs:             tail -F /shared/outputs/glm5-llmd/logs/envs/*/*.log
-```

--- a/examples/glm5_pd_disag/README.md
+++ b/examples/glm5_pd_disag/README.md
@@ -66,9 +66,9 @@ Logs:
   Trainer:          tail -F /shared/outputs/glm5-pd-disag/logs/trainer.log
   Orchestrator:     tail -F /shared/outputs/glm5-pd-disag/logs/orchestrator.log
   Inference:        tail -F /shared/outputs/glm5-pd-disag/logs/inference.log
-  Envs:             tail -F /shared/outputs/glm5-pd-disag/logs/envs/*/*/*.log
-   Train:           tail -F /shared/outputs/glm5-pd-disag/logs/envs/train/*/*.log
-    swe:           tail -F /shared/outputs/glm5-pd-disag/logs/envs/train/swe/*.log 
+  Envs:             tail -F /shared/outputs/glm5-pd-disag/logs/envs/*/*.log
+   Train:           tail -F /shared/outputs/glm5-pd-disag/logs/envs/train/*.log
+    swe:           tail -F /shared/outputs/glm5-pd-disag/logs/envs/train/swe.log 
 ```
 
 

--- a/examples/glm5_pd_disag/README.md
+++ b/examples/glm5_pd_disag/README.md
@@ -54,21 +54,3 @@ PS: If using the tmux helper, you can run the command in the `Terminal` (window 
 ```bash
 uv run rl @ examples/glm5_pd_disag/rl.toml --output-dir /shared/outputs/glm5-pd-disag
 ```
-
-Output of the command:
-```
-XXX:XX:XX    INFO Wrote subconfigs to /shared/outputs/glm5-pd-disag/configs [rl.py::515]
-XXX:XX:XX    INFO Wrote SLURM script to /shared/outputs/glm5-pd-disag/rl.sbatch [rl.py::534]
-XXX:XX:XX    INFO Submitting: sbatch /shared/outputs/glm5-pd-disag/rl.sbatch [rl.py::540]
-XXX:XX:XX SUCCESS Submitted batch job YYYY
-
-Logs:
-  Trainer:          tail -F /shared/outputs/glm5-pd-disag/logs/trainer.log
-  Orchestrator:     tail -F /shared/outputs/glm5-pd-disag/logs/orchestrator.log
-  Inference:        tail -F /shared/outputs/glm5-pd-disag/logs/inference.log
-  Envs:             tail -F /shared/outputs/glm5-pd-disag/logs/envs/*/*.log
-   Train:           tail -F /shared/outputs/glm5-pd-disag/logs/envs/train/*.log
-    swe:           tail -F /shared/outputs/glm5-pd-disag/logs/envs/train/swe.log 
-```
-
-

--- a/examples/minimax_m2.5_swe/README.md
+++ b/examples/minimax_m2.5_swe/README.md
@@ -66,9 +66,9 @@ Logs:
   Trainer:          tail -F /shared/outputs/minimax-swe/logs/trainer.log
   Orchestrator:     tail -F /shared/outputs/minimax-swe/logs/orchestrator.log
   Inference:        tail -F /shared/outputs/minimax-swe/logs/inference.log
-  Envs:             tail -F /shared/outputs/minimax-swe/logs/envs/*/*/*.log
-   Train:           tail -F /shared/outputs/minimax-swe/logs/envs/train/*/*.log
-    swe:           tail -F /shared/outputs/minimax-swe/logs/envs/train/swe/*.log 
+  Envs:             tail -F /shared/outputs/minimax-swe/logs/envs/*/*.log
+   Train:           tail -F /shared/outputs/minimax-swe/logs/envs/train/*.log
+    swe:           tail -F /shared/outputs/minimax-swe/logs/envs/train/swe.log 
 ```
 
 

--- a/examples/minimax_m2.5_swe/README.md
+++ b/examples/minimax_m2.5_swe/README.md
@@ -54,21 +54,3 @@ PS: If using the tmux helper, you can run the command in the `Terminal` (window 
 ```bash
 uv run rl @ examples/minimax_m2.5_swe/rl.toml --output-dir /shared/outputs/minimax-swe
 ```
-
-Output of the command:
-```
-XXX:XX:XX    INFO Wrote subconfigs to /shared/outputs/minimax-swe/configs [rl.py::515]
-XXX:XX:XX    INFO Wrote SLURM script to /shared/outputs/minimax-swe/rl.sbatch [rl.py::534]
-XXX:XX:XX    INFO Submitting: sbatch /shared/outputs/minimax-swe/rl.sbatch [rl.py::540]
-XXX:XX:XX SUCCESS Submitted batch job YYYY
-
-Logs:
-  Trainer:          tail -F /shared/outputs/minimax-swe/logs/trainer.log
-  Orchestrator:     tail -F /shared/outputs/minimax-swe/logs/orchestrator.log
-  Inference:        tail -F /shared/outputs/minimax-swe/logs/inference.log
-  Envs:             tail -F /shared/outputs/minimax-swe/logs/envs/*/*.log
-   Train:           tail -F /shared/outputs/minimax-swe/logs/envs/train/*.log
-    swe:           tail -F /shared/outputs/minimax-swe/logs/envs/train/swe.log 
-```
-
-

--- a/examples/qwen30b_math/README.md
+++ b/examples/qwen30b_math/README.md
@@ -46,21 +46,3 @@ PS: If using the tmux helper, you can run the command in the `Terminal` (window 
 ```bash
 uv run rl @ examples/qwen30b_math/rl.toml --output-dir /shared/outputs/qwen30b-math
 ```
-
-Output of the command:
-```
-XXX:XX:XX    INFO Wrote subconfigs to /shared/outputs/qwen30b-math/configs [rl.py::515]
-XXX:XX:XX    INFO Wrote SLURM script to /shared/outputs/qwen30b-math/rl.sbatch [rl.py::534]
-XXX:XX:XX    INFO Submitting: sbatch /shared/outputs/qwen30b-math/rl.sbatch [rl.py::540]
-XXX:XX:XX SUCCESS Submitted batch job YYYY
-
-Logs:
-  Trainer:          tail -F /shared/outputs/qwen30b-math/logs/trainer.log
-  Orchestrator:     tail -F /shared/outputs/qwen30b-math/logs/orchestrator.log
-  Inference:        tail -F /shared/outputs/qwen30b-math/logs/inference.log
-  Envs:             tail -F /shared/outputs/qwen30b-math/logs/envs/*/*.log
-   Train:           tail -F /shared/outputs/qwen30b-math/logs/envs/train/*.log
-    math:           tail -F /shared/outputs/qwen30b-math/logs/envs/train/math.log 
-```
-
-

--- a/examples/qwen30b_math/README.md
+++ b/examples/qwen30b_math/README.md
@@ -58,9 +58,9 @@ Logs:
   Trainer:          tail -F /shared/outputs/qwen30b-math/logs/trainer.log
   Orchestrator:     tail -F /shared/outputs/qwen30b-math/logs/orchestrator.log
   Inference:        tail -F /shared/outputs/qwen30b-math/logs/inference.log
-  Envs:             tail -F /shared/outputs/qwen30b-math/logs/envs/*/*/*.log
-   Train:           tail -F /shared/outputs/qwen30b-math/logs/envs/train/*/*.log
-    math:           tail -F /shared/outputs/qwen30b-math/logs/envs/train/math/*.log 
+  Envs:             tail -F /shared/outputs/qwen30b-math/logs/envs/*/*.log
+   Train:           tail -F /shared/outputs/qwen30b-math/logs/envs/train/*.log
+    math:           tail -F /shared/outputs/qwen30b-math/logs/envs/train/math.log 
 ```
 
 

--- a/examples/qwen30b_swe/README.md
+++ b/examples/qwen30b_swe/README.md
@@ -54,21 +54,3 @@ PS: If using the tmux helper, you can run the command in the `Terminal` (window 
 ```bash
 uv run rl @ examples/qwen30b_swe/rl.toml --output-dir /shared/outputs/qwen30b-swe
 ```
-
-Output of the command:
-```
-XXX:XX:XX    INFO Wrote subconfigs to /shared/outputs/qwen30b-swe/configs [rl.py::515]
-XXX:XX:XX    INFO Wrote SLURM script to /shared/outputs/qwen30b-swe/rl.sbatch [rl.py::534]
-XXX:XX:XX    INFO Submitting: sbatch /shared/outputs/qwen30b-swe/rl.sbatch [rl.py::540]
-XXX:XX:XX SUCCESS Submitted batch job YYYY
-
-Logs:
-  Trainer:          tail -F /shared/outputs/qwen30b-swe/logs/trainer.log
-  Orchestrator:     tail -F /shared/outputs/qwen30b-swe/logs/orchestrator.log
-  Inference:        tail -F /shared/outputs/qwen30b-swe/logs/inference.log
-  Envs:             tail -F /shared/outputs/qwen30b-swe/logs/envs/*/*.log
-   Train:           tail -F /shared/outputs/qwen30b-swe/logs/envs/train/*.log
-    swe:           tail -F /shared/outputs/qwen30b-swe/logs/envs/train/swe.log 
-```
-
-

--- a/examples/qwen30b_swe/README.md
+++ b/examples/qwen30b_swe/README.md
@@ -66,9 +66,9 @@ Logs:
   Trainer:          tail -F /shared/outputs/qwen30b-swe/logs/trainer.log
   Orchestrator:     tail -F /shared/outputs/qwen30b-swe/logs/orchestrator.log
   Inference:        tail -F /shared/outputs/qwen30b-swe/logs/inference.log
-  Envs:             tail -F /shared/outputs/qwen30b-swe/logs/envs/*/*/*.log
-   Train:           tail -F /shared/outputs/qwen30b-swe/logs/envs/train/*/*.log
-    swe:           tail -F /shared/outputs/qwen30b-swe/logs/envs/train/swe/*.log 
+  Envs:             tail -F /shared/outputs/qwen30b-swe/logs/envs/*/*.log
+   Train:           tail -F /shared/outputs/qwen30b-swe/logs/envs/train/*.log
+    swe:           tail -F /shared/outputs/qwen30b-swe/logs/envs/train/swe.log 
 ```
 
 

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -44,16 +44,16 @@ def format_log_message(
             log_lines.append(f"{i2}{'All nodes:':<{col - 1}}tail -F {log_dir}/inference/node_*.log")
     if train_env_names:
         env_log_dir = log_dir / "envs"
-        log_lines.append(f"{i1}{'Envs:':<{col}}tail -F {env_log_dir}/*/*/*.log")
-        log_lines.append(f"{i2}{'Train:':<{col - 1}}tail -F {env_log_dir}/train/*/*.log")
+        log_lines.append(f"{i1}{'Envs:':<{col}}tail -F {env_log_dir}/*/*.log")
+        log_lines.append(f"{i2}{'Train:':<{col - 1}}tail -F {env_log_dir}/train/*.log")
         for name in train_env_names:
             short = name if len(name) <= max_name else name[: max_name - 3] + "..."
-            log_lines.append(f"{i3}{f'{short}:':<{col - 2}}tail -F {env_log_dir}/train/{name}/*.log")
+            log_lines.append(f"{i3}{f'{short}:':<{col - 2}}tail -F {env_log_dir}/train/{name}.log")
         if eval_env_names:
-            log_lines.append(f"{i2}{'Eval:':<{col - 1}}tail -F {env_log_dir}/eval/*/*.log")
+            log_lines.append(f"{i2}{'Eval:':<{col - 1}}tail -F {env_log_dir}/eval/*.log")
             for name in eval_env_names:
                 short = name if len(name) <= max_name else name[: max_name - 3] + "..."
-                log_lines.append(f"{i3}{f'{short}:':<{col - 2}}tail -F {env_log_dir}/eval/{name}/*.log")
+                log_lines.append(f"{i3}{f'{short}:':<{col - 2}}tail -F {env_log_dir}/eval/{name}.log")
     return "Logs:\n" + "\n".join(log_lines)
 
 


### PR DESCRIPTION
## Summary

- Since the nano-as-v1 migration, each env writes a single log file at `logs/envs/{train,eval}/<env>.log` (two levels: split, then env). The launch banner generated by `format_log_message` still printed three-level globs (`logs/envs/*/*/*.log`, `logs/envs/train/<env>/*.log`), which match nothing — so copy-pasting them tails empty.
- Fix the banner generator in `src/prime_rl/utils/pathing.py` to emit the correct paths:
  - `Envs:` → `logs/envs/*/*.log`
  - `Train:`/`Eval:` → `logs/envs/{train,eval}/*.log`
  - per-env → `logs/envs/{train,eval}/<env>.log` (a single file, no glob)
- Drop the captured "Output of the command" launch-banner blocks from the `examples/*/README.md` files. They duplicated the live banner and drift out of sync; the run command stays.

`scripts/tmux.sh` and the `monitor-run` skill already used the correct two-level globs, so they're unchanged.

## Verification

Banner rendered with the fix (`train_env_names=['swe','math']`, `eval_env_names=['aime']`):

```
  Envs:             tail -F /out/logs/envs/*/*.log
   Train:           tail -F /out/logs/envs/train/*.log
    swe:            tail -F /out/logs/envs/train/swe.log
    math:           tail -F /out/logs/envs/train/math.log
   Eval:            tail -F /out/logs/envs/eval/*.log
    aime:           tail -F /out/logs/envs/eval/aime.log
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and log-hint string changes only; no training, auth, or runtime behavior.
> 
> **Overview**
> After the nano-as-v1 layout change, env logs live at **`logs/envs/{train,eval}/<env>.log`** (two directory levels). **`format_log_message`** in `pathing.py` still printed three-level globs and per-env `.../<env>/*.log`, so the post-submit **Logs:** banner from `uv run rl` did not match real files.
> 
> The banner now uses **`logs/envs/*/*.log`**, split-level **`train/*.log` / `eval/*.log`**, and per-env **`train/<name>.log`** (single file, no extra glob). Six example READMEs drop the stale captured **Output of the command** blocks that showed the old paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ad99f16142ce7b0d82843c91c6a63922b34b6eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->