### PR TITLE
fix(template): orchestrator URLs use canonical model.client path

### DIFF
--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -415,8 +415,8 @@ else
 {% if orchestrator_on_inference %}ORCH_PROCID=$((NUM_INFER_NODES - 1)){% else %}ORCH_PROCID=$NUM_INFER_NODES{% endif %}
 if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
     ORCHESTRATOR_ARGS="@ $CONFIG_DIR/orchestrator.toml"
-    ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --student.client.base-url $INFER_URLS"
-    ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --student.client.admin-base-url $ADMIN_URLS"
+    ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --model.client.base-url $INFER_URLS"
+    ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --model.client.admin-base-url $ADMIN_URLS"
     {% if use_nccl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $MASTER_ADDR"
     {% endif %}WANDB_SHARED_LABEL=orchestrator uv run orchestrator $ORCHESTRATOR_ARGS \
         2>&1 | tee $OUTPUT_DIR/logs/orchestrator.log &


### PR DESCRIPTION
## Problem

The multi-node RL sbatch template launches the orchestrator with `--student.client.base-url` / `--student.client.admin-base-url`, but `OrchestratorConfig` has no `student` field — the canonical path is `model.client` (`base_url` / `admin_base_url` on `ClientConfig`). The orchestrator-config rename left the template stale.

As a result **every multi-node RL launch** fails at orchestrator startup with a config-parse error:

```
╭─ Config file error ──────────────────╮
│ Unrecognized arguments:              │
│ http://<infer-host>:8201/v1          │
│ ...                                  │
╰──────────────────────────────────────╯
```

(the unrecognized `--student.*` flag drops its URL values to positional args).

## Fix

Point the template at the canonical CLI path:

```diff
- --student.client.base-url $INFER_URLS
- --student.client.admin-base-url $ADMIN_URLS
+ --model.client.base-url $INFER_URLS
+ --model.client.admin-base-url $ADMIN_URLS
```

This matches `orchestrator.model.client.{base_url,admin_base_url}` as read by `rl.py` and defined on `ClientConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only CLI flag rename with no logic changes; restores correct config parsing for multi-node orchestrator startup.
> 
> **Overview**
> Multi-node RL jobs were failing at orchestrator startup because the sbatch template passed **`--student.client.base-url`** and **`--student.client.admin-base-url`**, which are not valid on `OrchestratorConfig` after the config rename.
> 
> The template now passes **`--model.client.base-url`** and **`--model.client.admin-base-url`**, aligned with `orchestrator.model.client` and the same paths used in `rl.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f667e31942ed3a734fd8cef9811a1a94c487ce6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->