### PR TITLE
[codex] Cache streamed HF-to-Prime conversion

### DIFF
--- a/src/prime_rl/trainer/hf_to_prime.py
+++ b/src/prime_rl/trainer/hf_to_prime.py
@@ -1,0 +1,177 @@
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import cast
+
+import torch
+from torch import Tensor
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.distributed.checkpoint.hf_storage import HuggingFaceStorageReader
+from torch.distributed.checkpoint.metadata import (
+    ChunkStorageMetadata,
+    Metadata,
+    MetadataIndex,
+    StorageMeta,
+    TensorProperties,
+    TensorStorageMetadata,
+)
+from torch.distributed.checkpoint.planner import LoadPlan, LoadPlanner, ReadItem
+from torch.futures import Future
+
+_LAYER_KEY_RE = re.compile(r"^(?:model(?:\.language_model)?|backbone)\.layers\.(?P<layer>\d+)\.")
+
+
+@dataclass(frozen=True)
+class _ConvertedStorageInfo:
+    group_idx: int
+
+
+@dataclass(frozen=True)
+class _SourceChunk:
+    key: str
+    chunk: ChunkStorageMetadata
+    tensor_metadata: TensorStorageMetadata
+
+
+class HFToPrimeStorageReader(HuggingFaceStorageReader):
+    """Stream HF safetensors through a model's layer conversion code without writing a converted snapshot."""
+
+    def __init__(
+        self,
+        path: str,
+        convert_layer_to_prime: Callable[[dict[str, Tensor], int], dict[str, Tensor]],
+        thread_count: int = 1,
+    ) -> None:
+        super().__init__(path=path, thread_count=thread_count)
+        self.convert_layer_to_prime = convert_layer_to_prime
+        self.source_metadata: Metadata | None = None
+        self.source_storage_data: dict[MetadataIndex, object] = {}
+        self.source_groups: dict[int, list[str]] = {}
+        self.target_groups: dict[str, int] = {}
+
+    def read_metadata(self) -> Metadata:
+        source_metadata = super().read_metadata()
+        self.source_metadata = source_metadata
+        self.source_storage_data = source_metadata.storage_data
+        self.source_groups = self._group_source_keys(source_metadata)
+
+        state_dict_metadata: dict[str, TensorStorageMetadata] = {}
+        storage_data: dict[MetadataIndex, _ConvertedStorageInfo] = {}
+
+        for group_idx, source_keys in self.source_groups.items():
+            with FakeTensorMode():
+                fake_state_dict = self._make_fake_state_dict(source_keys, source_metadata)
+                fake_state_dict = self.convert_layer_to_prime(fake_state_dict, group_idx)
+
+            for key, tensor in fake_state_dict.items():
+                if not isinstance(tensor, Tensor):
+                    continue
+                offsets = torch.Size([0] * tensor.ndim)
+                state_dict_metadata[key] = TensorStorageMetadata(
+                    properties=TensorProperties.create_from_tensor(tensor),
+                    size=tensor.size(),
+                    chunks=[ChunkStorageMetadata(offsets=offsets, sizes=tensor.size())],
+                )
+                storage_data[MetadataIndex(key, offsets)] = _ConvertedStorageInfo(group_idx)
+                self.target_groups[key] = group_idx
+
+        return Metadata(
+            state_dict_metadata=state_dict_metadata,
+            storage_data=storage_data,
+            storage_meta=StorageMeta(load_id=self.load_id),
+        )
+
+    def read_data(self, plan: LoadPlan, planner: LoadPlanner) -> Future[None]:
+        read_items_by_group: dict[int, list[ReadItem]] = {}
+        for read_item in plan.items:
+            group_idx = self.target_groups[read_item.storage_index.fqn]
+            read_items_by_group.setdefault(group_idx, []).append(read_item)
+
+        for group_idx, read_items in read_items_by_group.items():
+            state_dict = self._load_source_group(group_idx)
+            state_dict = self.convert_layer_to_prime(state_dict, group_idx)
+            for read_item in read_items:
+                self._copy_read_item(state_dict, read_item, planner)
+
+        fut: Future[None] = Future()
+        fut.set_result(None)
+        return fut
+
+    def _group_source_keys(self, metadata: Metadata) -> dict[int, list[str]]:
+        groups: dict[int, list[str]] = {}
+        for key, tensor_metadata in metadata.state_dict_metadata.items():
+            if not isinstance(tensor_metadata, TensorStorageMetadata):
+                continue
+            group_idx = self._group_idx(key)
+            groups.setdefault(group_idx, []).append(key)
+        return groups
+
+    def _make_fake_state_dict(self, source_keys: list[str], metadata: Metadata) -> dict[str, Tensor]:
+        state_dict = {}
+        for key in source_keys:
+            tensor_metadata = cast(TensorStorageMetadata, metadata.state_dict_metadata[key])
+            state_dict[key] = torch.empty(tensor_metadata.size, dtype=tensor_metadata.properties.dtype)
+        return state_dict
+
+    def _load_source_group(self, group_idx: int) -> dict[str, Tensor]:
+        from safetensors import safe_open
+
+        if self.source_metadata is None:
+            raise AssertionError("source metadata must be initialized before reading data")
+
+        chunks_by_file: dict[str, list[_SourceChunk]] = {}
+        for key in self.source_groups[group_idx]:
+            tensor_metadata = self.source_metadata.state_dict_metadata[key]
+            if not isinstance(tensor_metadata, TensorStorageMetadata):
+                continue
+            for chunk in tensor_metadata.chunks:
+                storage_info = self.source_storage_data[MetadataIndex(key, chunk.offsets)]
+                chunks_by_file.setdefault(storage_info.relative_path, []).append(
+                    _SourceChunk(key=key, chunk=chunk, tensor_metadata=tensor_metadata)
+                )
+
+        state_dict: dict[str, Tensor] = {}
+        for file_name, source_chunks in chunks_by_file.items():
+            with safe_open(filename=file_name, framework="pt", device="cpu") as f:
+                for source_chunk in source_chunks:
+                    self._set_source_chunk(state_dict, source_chunk, f.get_tensor(source_chunk.key))
+        return state_dict
+
+    @staticmethod
+    def _set_source_chunk(state_dict: dict[str, Tensor], source_chunk: _SourceChunk, tensor: Tensor) -> None:
+        key = source_chunk.key
+        chunk = source_chunk.chunk
+        tensor_metadata = source_chunk.tensor_metadata
+        if chunk.offsets == torch.Size([0] * len(chunk.offsets)) and chunk.sizes == tensor_metadata.size:
+            state_dict[key] = tensor
+            return
+        if key not in state_dict:
+            state_dict[key] = torch.empty(tensor_metadata.size, dtype=tensor_metadata.properties.dtype)
+        slices = tuple(slice(offset, offset + length) for offset, length in zip(chunk.offsets, chunk.sizes))
+        state_dict[key][slices].copy_(tensor)
+
+    def _copy_read_item(self, state_dict: dict[str, Tensor], read_item: ReadItem, planner: LoadPlanner) -> None:
+        tensor = state_dict[read_item.storage_index.fqn]
+        slices = tuple(
+            slice(offset, offset + length) for offset, length in zip(read_item.storage_offsets, read_item.lengths)
+        )
+        tensor = tensor[slices]
+        target_tensor = planner.resolve_tensor(read_item).detach()
+
+        if target_tensor.size() != tensor.size():
+            raise AssertionError(
+                f"req {read_item.storage_index} mismatch sizes {target_tensor.size()} vs {tensor.size()}"
+            )
+
+        target_tensor.copy_(tensor)
+        planner.commit_tensor(read_item, target_tensor)
+
+    @staticmethod
+    def _group_idx(key: str) -> int:
+        match = _LAYER_KEY_RE.match(key)
+        if match is None:
+            return -1
+        return int(match.group("layer"))
+
+
+__all__ = ["HFToPrimeStorageReader"]

--- a/src/prime_rl/trainer/hf_to_prime.py
+++ b/src/prime_rl/trainer/hf_to_prime.py
@@ -1,6 +1,10 @@
+import json
 import re
-from collections.abc import Callable
+import shutil
+import tempfile
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
+from pathlib import Path
 from typing import cast
 
 import torch
@@ -97,6 +101,14 @@ class HFToPrimeStorageReader(HuggingFaceStorageReader):
         fut.set_result(None)
         return fut
 
+    def converted_state_dicts(self) -> Iterator[tuple[int, dict[str, Tensor]]]:
+        if self.source_metadata is None:
+            self.read_metadata()
+
+        for group_idx in sorted(self.source_groups):
+            state_dict = self._load_source_group(group_idx)
+            yield group_idx, self.convert_layer_to_prime(state_dict, group_idx)
+
     def _group_source_keys(self, metadata: Metadata) -> dict[int, list[str]]:
         groups: dict[int, list[str]] = {}
         for key, tensor_metadata in metadata.state_dict_metadata.items():
@@ -174,4 +186,53 @@ class HFToPrimeStorageReader(HuggingFaceStorageReader):
         return int(match.group("layer"))
 
 
-__all__ = ["HFToPrimeStorageReader"]
+def materialize_hf_to_prime(
+    path: Path,
+    output_path: Path,
+    convert_layer_to_prime: Callable[[dict[str, Tensor], int], dict[str, Tensor]],
+) -> None:
+    from safetensors.torch import save_file
+
+    if output_path.exists():
+        return
+
+    reader = HFToPrimeStorageReader(path=path.as_posix(), convert_layer_to_prime=convert_layer_to_prime)
+    reader.read_metadata()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = Path(tempfile.mkdtemp(prefix=f".{output_path.name}.tmp-", dir=output_path.parent))
+
+    try:
+        group_indices = sorted(reader.source_groups)
+        num_shards = len(group_indices)
+        total_size = 0
+        weight_map: dict[str, str] = {}
+        for shard_idx, (_group_idx, state_dict) in enumerate(reader.converted_state_dicts(), start=1):
+            tensors = {
+                key: tensor.detach().cpu().contiguous()
+                for key, tensor in state_dict.items()
+                if isinstance(tensor, Tensor)
+            }
+            if not tensors:
+                continue
+            shard_name = f"model-{shard_idx:05d}-of-{num_shards:05d}.safetensors"
+            save_file(tensors, tmp_path / shard_name, metadata={"format": "pt"})
+            for key, tensor in tensors.items():
+                weight_map[key] = shard_name
+                total_size += tensor.numel() * tensor.element_size()
+            del tensors
+            del state_dict
+        index = {"metadata": {"total_size": total_size}, "weight_map": weight_map}
+        with open(tmp_path / "model.safetensors.index.json", "w", encoding="utf-8") as f:
+            f.write(json.dumps(index, indent=2, sort_keys=True) + "\n")
+        tmp_path.rename(output_path)
+    except FileExistsError:
+        shutil.rmtree(tmp_path)
+        if not output_path.exists():
+            raise
+    except Exception:
+        shutil.rmtree(tmp_path)
+        raise
+
+
+__all__ = ["HFToPrimeStorageReader", "materialize_hf_to_prime"]

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -28,7 +28,7 @@ from transformers.utils.import_utils import is_flash_attn_3_available
 
 from prime_rl.configs.trainer import ActivationCheckpointConfig, CompileConfig, ModelConfig, TokenizerConfig
 from prime_rl.trainer.distributed import DeepEPExpertParallel
-from prime_rl.trainer.hf_to_prime import HFToPrimeStorageReader
+from prime_rl.trainer.hf_to_prime import materialize_hf_to_prime
 from prime_rl.trainer.lora import apply_lora_to_model, freeze_all_except_lora_and_specified, strip_lora_from_state_dict
 from prime_rl.trainer.models import (
     AutoModelForCausalLMPrimeRL,
@@ -793,9 +793,7 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
     # Dynamically convert between different weight formats if needed.
     # All ranks read just the key names (cheap) to determine the path independently.
     # HF -> PrimeRL conversion streams each layer through the model's existing
-    # layer conversion code, then serves the converted tensors through DCP without
-    # writing a converted snapshot to disk.
-    load_hf_as_prime = False
+    # layer conversion code and materializes the result once for fast subsequent loads.
     if isinstance(model, PreTrainedModelPrimeRL):
         snapshot_keys = dict.fromkeys(load_state_dict_keys(snapshot_path))
         model_keys = dict.fromkeys(model.state_dict().keys())
@@ -804,7 +802,16 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
             logger.warning(
                 "Found HF weight format in snapshot state dict and PrimeRL weight format in model state dict. Trying to auto-convert..."
             )
-            load_hf_as_prime = True
+            snapshot_path = snapshot_path / "prime"
+            if not snapshot_path.exists() and get_world().is_master:
+                logger.info(
+                    f"Converting snapshot state dict to PrimeRL format and saving to {snapshot_path} on master rank. This is a one-time operation."
+                )
+                materialize_hf_to_prime(
+                    path=snapshot_path.parent,
+                    output_path=snapshot_path,
+                    convert_layer_to_prime=model.convert_layer_to_prime,
+                )
 
         elif model.is_prime_state_dict(snapshot_keys) and model.is_hf_state_dict(model_keys):
             logger.warning(
@@ -820,7 +827,7 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
                 save_state_dict(snapshot_state_dict, snapshot_path)
                 del snapshot_state_dict
 
-    # All ranks wait for any master-written PrimeRL -> HF conversion.
+    # All ranks wait for any master-written format conversion.
     torch.distributed.barrier()
 
     logger.info(f"Preparing to load weights using HF DCP from {snapshot_path}")
@@ -830,12 +837,6 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
     if model.config.tie_word_embeddings:
         del state_dict["lm_head.weight"]
     storage_reader = HuggingFaceStorageReader(path=snapshot_path.as_posix())
-    if load_hf_as_prime:
-        logger.info("Streaming HF-format snapshot through PrimeRL layer conversion")
-        storage_reader = HFToPrimeStorageReader(
-            path=snapshot_path.as_posix(),
-            convert_layer_to_prime=model.convert_layer_to_prime,
-        )
     logger.info(f"Loading weights using DCP from {snapshot_path}")
     dcp_load(
         state_dict,

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -28,6 +28,7 @@ from transformers.utils.import_utils import is_flash_attn_3_available
 
 from prime_rl.configs.trainer import ActivationCheckpointConfig, CompileConfig, ModelConfig, TokenizerConfig
 from prime_rl.trainer.distributed import DeepEPExpertParallel
+from prime_rl.trainer.hf_to_prime import HFToPrimeStorageReader
 from prime_rl.trainer.lora import apply_lora_to_model, freeze_all_except_lora_and_specified, strip_lora_from_state_dict
 from prime_rl.trainer.models import (
     AutoModelForCausalLMPrimeRL,
@@ -791,7 +792,10 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
 
     # Dynamically convert between different weight formats if needed.
     # All ranks read just the key names (cheap) to determine the path independently.
-    # Only master loads the full state dict when conversion is actually needed.
+    # HF -> PrimeRL conversion streams each layer through the model's existing
+    # layer conversion code, then serves the converted tensors through DCP without
+    # writing a converted snapshot to disk.
+    load_hf_as_prime = False
     if isinstance(model, PreTrainedModelPrimeRL):
         snapshot_keys = dict.fromkeys(load_state_dict_keys(snapshot_path))
         model_keys = dict.fromkeys(model.state_dict().keys())
@@ -800,15 +804,7 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
             logger.warning(
                 "Found HF weight format in snapshot state dict and PrimeRL weight format in model state dict. Trying to auto-convert..."
             )
-            snapshot_path = snapshot_path / "prime"
-            if not snapshot_path.exists() and get_world().is_master:
-                logger.debug(
-                    f"Converting snapshot state dict to PrimeRL format and saving to {snapshot_path} on master rank. This is a one-time operation."
-                )
-                snapshot_state_dict = load_state_dict(snapshot_path.parent)
-                model.convert_to_prime(snapshot_state_dict)
-                save_state_dict(snapshot_state_dict, snapshot_path)
-                del snapshot_state_dict
+            load_hf_as_prime = True
 
         elif model.is_prime_state_dict(snapshot_keys) and model.is_hf_state_dict(model_keys):
             logger.warning(
@@ -824,18 +820,26 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
                 save_state_dict(snapshot_state_dict, snapshot_path)
                 del snapshot_state_dict
 
-    # All ranks wait for master rank to finish conversion
+    # All ranks wait for any master-written PrimeRL -> HF conversion.
     torch.distributed.barrier()
 
-    logger.info(f"Loading weights using HF DCP from {snapshot_path}")
+    logger.info(f"Preparing to load weights using HF DCP from {snapshot_path}")
     load_dcp_start_time = time.perf_counter()
     state_dict = model.state_dict()
     state_dict = strip_lora_from_state_dict(state_dict)
     if model.config.tie_word_embeddings:
         del state_dict["lm_head.weight"]
+    storage_reader = HuggingFaceStorageReader(path=snapshot_path.as_posix())
+    if load_hf_as_prime:
+        logger.info("Streaming HF-format snapshot through PrimeRL layer conversion")
+        storage_reader = HFToPrimeStorageReader(
+            path=snapshot_path.as_posix(),
+            convert_layer_to_prime=model.convert_layer_to_prime,
+        )
+    logger.info(f"Loading weights using DCP from {snapshot_path}")
     dcp_load(
         state_dict,
-        storage_reader=HuggingFaceStorageReader(path=snapshot_path.as_posix()),
+        storage_reader=storage_reader,
     )
     # Restore weight tying broken by to_empty() for HF models
     if not isinstance(model, PreTrainedModelPrimeRL) and model.config.tie_word_embeddings:

--- a/tests/unit/train/models/test_hf_to_prime_reader.py
+++ b/tests/unit/train/models/test_hf_to_prime_reader.py
@@ -1,0 +1,164 @@
+import torch
+from safetensors.torch import save_file
+from torch.distributed.checkpoint.state_dict_loader import load as dcp_load
+from transformers import Glm4MoeForCausalLM as HFGlm4MoeForCausalLM
+from transformers import Qwen3_5MoeForCausalLM as HFQwen3_5MoeForCausalLM
+from transformers import Qwen3MoeForCausalLM as HFQwen3MoeForCausalLM
+
+from prime_rl.trainer.hf_to_prime import HFToPrimeStorageReader
+from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig
+from prime_rl.trainer.models.glm4_moe import Glm4MoeForCausalLM as PrimeRLGlm4MoeForCausalLM
+from prime_rl.trainer.models.qwen3_5_moe import Qwen3_5MoeConfig
+from prime_rl.trainer.models.qwen3_5_moe import Qwen3_5MoeForCausalLM as PrimeRLQwen3_5MoeForCausalLM
+from prime_rl.trainer.models.qwen3_moe import Qwen3MoeConfig
+from prime_rl.trainer.models.qwen3_moe import Qwen3MoeForCausalLM as PrimeRLQwen3MoeForCausalLM
+
+
+def _glm4_moe_config():
+    return Glm4MoeConfig(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        max_position_embeddings=128,
+        moe_intermediate_size=16,
+        norm_topk_prob=True,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        n_routed_experts=4,
+        num_experts_per_tok=2,
+        n_shared_experts=1,
+        num_hidden_layers=3,
+        rope_theta=1000000.0,
+        first_k_dense_replace=1,
+        partial_rotary_factor=0.5,
+        use_grouped_mm=False,
+    )
+
+
+def _qwen3_moe_config():
+    return Qwen3MoeConfig(
+        vocab_size=128,
+        head_dim=8,
+        hidden_size=32,
+        intermediate_size=64,
+        max_position_embeddings=128,
+        max_window_layers=4,
+        moe_intermediate_size=16,
+        norm_topk_prob=True,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_experts=4,
+        num_experts_per_tok=2,
+        num_hidden_layers=3,
+        rope_theta=1000000.0,
+        use_qk_norm=True,
+        mlp_only_layers=[1],
+        use_grouped_mm=False,
+    )
+
+
+def _qwen3_5_moe_config():
+    return Qwen3_5MoeConfig(
+        vocab_size=128,
+        hidden_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        moe_intermediate_size=32,
+        shared_expert_intermediate_size=32,
+        num_experts=4,
+        num_experts_per_tok=2,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-6,
+        linear_conv_kernel_dim=4,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_num_key_heads=4,
+        linear_num_value_heads=4,
+        use_grouped_mm=False,
+    )
+
+
+def _check_hf_to_prime_reader_matches_state_dict_conversion(tmp_path, config, hf_cls, prime_cls):
+    config._attn_implementation = "sdpa"
+    with torch.device("cpu"):
+        hf_model = hf_cls._from_config(config)
+        prime_model = prime_cls._from_config(config)
+
+    hf_model.save_pretrained(tmp_path, safe_serialization=True)
+
+    expected = hf_model.state_dict()
+    prime_cls.convert_to_prime(expected)
+
+    loaded = prime_model.state_dict()
+    dcp_load(
+        loaded,
+        storage_reader=HFToPrimeStorageReader(tmp_path.as_posix(), prime_cls.convert_layer_to_prime),
+        no_dist=True,
+    )
+    assert not (tmp_path / "prime").exists()
+
+    assert expected.keys() <= loaded.keys()
+    for key, expected_tensor in expected.items():
+        assert torch.equal(expected_tensor.detach().cpu(), loaded[key].detach().cpu()), key
+
+
+def test_hf_to_prime_reader_glm4_moe(tmp_path):
+    _check_hf_to_prime_reader_matches_state_dict_conversion(
+        tmp_path,
+        _glm4_moe_config(),
+        HFGlm4MoeForCausalLM,
+        PrimeRLGlm4MoeForCausalLM,
+    )
+
+
+def test_hf_to_prime_reader_qwen3_moe(tmp_path):
+    _check_hf_to_prime_reader_matches_state_dict_conversion(
+        tmp_path,
+        _qwen3_moe_config(),
+        HFQwen3MoeForCausalLM,
+        PrimeRLQwen3MoeForCausalLM,
+    )
+
+
+def test_hf_to_prime_reader_qwen3_5_moe(tmp_path):
+    _check_hf_to_prime_reader_matches_state_dict_conversion(
+        tmp_path,
+        _qwen3_5_moe_config(),
+        HFQwen3_5MoeForCausalLM,
+        PrimeRLQwen3_5MoeForCausalLM,
+    )
+
+
+def test_hf_to_prime_reader_streams_layer_conversion_with_cat(tmp_path):
+    source = {
+        "model.layers.0.left.weight": torch.arange(6, dtype=torch.float32).reshape(2, 3),
+        "model.layers.0.right.weight": torch.arange(6, 12, dtype=torch.float32).reshape(2, 3),
+    }
+    target = {
+        "model.layers.0.cat.weight": torch.empty(4, 3),
+    }
+    save_file(source, tmp_path / "model.safetensors")
+
+    class CatConverter:
+        @staticmethod
+        def convert_layer_to_prime(state_dict: dict[str, torch.Tensor], layer_idx: int) -> dict[str, torch.Tensor]:
+            assert layer_idx == 0
+            state_dict["model.layers.0.cat.weight"] = torch.cat(
+                [
+                    state_dict.pop("model.layers.0.left.weight"),
+                    state_dict.pop("model.layers.0.right.weight"),
+                ],
+                dim=0,
+            )
+            return state_dict
+
+    dcp_load(
+        target,
+        storage_reader=HFToPrimeStorageReader(tmp_path.as_posix(), CatConverter.convert_layer_to_prime),
+        no_dist=True,
+    )
+
+    assert not (tmp_path / "prime").exists()
+    assert torch.equal(target["model.layers.0.cat.weight"], torch.cat(list(source.values()), dim=0))

--- a/tests/unit/train/models/test_hf_to_prime_reader.py
+++ b/tests/unit/train/models/test_hf_to_prime_reader.py
@@ -1,11 +1,12 @@
 import torch
 from safetensors.torch import save_file
+from torch.distributed.checkpoint.hf_storage import HuggingFaceStorageReader
 from torch.distributed.checkpoint.state_dict_loader import load as dcp_load
 from transformers import Glm4MoeForCausalLM as HFGlm4MoeForCausalLM
 from transformers import Qwen3_5MoeForCausalLM as HFQwen3_5MoeForCausalLM
 from transformers import Qwen3MoeForCausalLM as HFQwen3MoeForCausalLM
 
-from prime_rl.trainer.hf_to_prime import HFToPrimeStorageReader
+from prime_rl.trainer.hf_to_prime import HFToPrimeStorageReader, materialize_hf_to_prime
 from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig
 from prime_rl.trainer.models.glm4_moe import Glm4MoeForCausalLM as PrimeRLGlm4MoeForCausalLM
 from prime_rl.trainer.models.qwen3_5_moe import Qwen3_5MoeConfig
@@ -120,6 +121,37 @@ def test_hf_to_prime_reader_qwen3_moe(tmp_path):
         HFQwen3MoeForCausalLM,
         PrimeRLQwen3MoeForCausalLM,
     )
+
+
+def test_materialize_hf_to_prime_qwen3_moe(tmp_path):
+    config = _qwen3_moe_config()
+    config._attn_implementation = "sdpa"
+    with torch.device("cpu"):
+        hf_model = HFQwen3MoeForCausalLM._from_config(config)
+        prime_model = PrimeRLQwen3MoeForCausalLM._from_config(config)
+
+    hf_model.save_pretrained(tmp_path, safe_serialization=True)
+
+    expected = hf_model.state_dict()
+    PrimeRLQwen3MoeForCausalLM.convert_to_prime(expected)
+
+    materialize_hf_to_prime(
+        path=tmp_path,
+        output_path=tmp_path / "prime",
+        convert_layer_to_prime=PrimeRLQwen3MoeForCausalLM.convert_layer_to_prime,
+    )
+
+    loaded = prime_model.state_dict()
+    dcp_load(
+        loaded,
+        storage_reader=HuggingFaceStorageReader((tmp_path / "prime").as_posix()),
+        no_dist=True,
+    )
+
+    assert (tmp_path / "prime").exists()
+    assert expected.keys() <= loaded.keys()
+    for key, expected_tensor in expected.items():
+        assert torch.equal(expected_tensor.detach().cpu(), loaded[key].detach().cpu()), key
 
 
 def test_hf_to_prime_reader_qwen3_5_moe(tmp_path):


### PR DESCRIPTION
## Summary

Replaces the old HF-to-PrimeRL conversion path that loaded the full HF checkpoint into one CPU state dict, called `model.convert_to_prime(...)`, and then wrote `<snapshot>/prime`.

The new path reuses the streamed HF-to-Prime reader as the single conversion primitive:

- metadata planning runs each source layer/group through `convert_layer_to_prime` under `FakeTensorMode` to derive converted keys, shapes, and dtypes;
- materialization reads one source group of real CPU tensors from safetensors, runs the same layer conversion callable, and writes that converted group as a safetensors shard under `<snapshot>/prime`;
- subsequent model loading uses the normal `HuggingFaceStorageReader` from `<snapshot>/prime`, matching the fast cached path on `main`.

That keeps model-specific renames, splits, stacks, and cats in the existing conversion code instead of duplicating them in the loader, while avoiding whole-model converted state dict materialization.

## Impact

- Restores the `format once, load fast afterward` behavior for HF-to-PrimeRL loads.
- Creates `<snapshot>/prime` through bounded, layer/group-streamed conversion instead of the old full-checkpoint CPU conversion.
- Uses a temp directory plus atomic rename so other ranks do not see a half-written `prime/` directory.
- Reuses an existing `<snapshot>/prime` cache when present.
- Keeps PrimeRL-to-HF disk conversion behavior unchanged.
- Keeps the direct streaming reader covered and reusable for tests or future no-disk paths.
- Batches streamed source reads by safetensor file within each conversion group, reducing Qwen3-30B source file opens from 18,867 to 64 in the measured checkpoint.

## Load Microbenchmark

Measured with the same Qwen3-30B-A3B custom SFT LoRA fake-data smoke on 2 GPUs (`max_steps=1`, `seq_len=128`, `model.ep=1`). Timing is from the trainer log line that starts DCP weight loading to the `Initializing tokenizer` line.

| Case | Weight path | Load window | Time |
| --- | --- | ---: | ---: |
| `main` cache hit | existing `<snapshot>/prime` | `01:03:55` -> `01:04:14` | **19s** |
| Current PR cache hit | existing `<snapshot>/prime` | `02:56:32` -> `02:56:51` | **19s** |
| Earlier PR stream-only, batched reads | HF root, no `prime/` load | `00:59:17` -> `00:59:55` | **38s** |
| Earlier PR stream-only, unoptimized reads | HF root, no `prime/` load | `01:09:51` -> `01:10:41` | **50s** |

The current PR intentionally returns cache-hit loading to parity with `main`. The stream-only rows are included to show why the final path keeps the persistent `prime/` artifact while still using the streamed converter to create it.

## Validation

- `uv run ruff check src/prime_rl/trainer/hf_to_prime.py src/prime_rl/trainer/model.py tests/unit/train/models/test_hf_to_prime_reader.py`
- `uv run pytest tests/unit/train/models/test_hf_to_prime_reader.py -q`
- `uv run pytest tests/unit/train/models/test_glm4_moe.py tests/unit/train/models/test_qwen3_moe.py -q`
- Qwen3-30B-A3B custom SFT LoRA fake-data smoke completed 1 step using the existing `<snapshot>/prime` cached path; load window was `02:56:32` -> `02:56:51` (**19s**).
