### PR TITLE
chore(deps): add longpdf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ envs = [
     "logic-env",
     "longcot-mini-v1",
     "longcot-v1",
+    "longpdfs-v1",
     "math-env",
     "math-env-v1",
     "math-python",
@@ -265,6 +266,7 @@ livecodebench-v1 = { path = "deps/research-environments/environments/livecodeben
 logic-env = { path = "deps/research-environments/environments/logic_env", editable = true }
 longcot-mini-v1 = { path = "deps/research-environments/environments/longcot_mini_v1", editable = true }
 longcot-v1 = { path = "deps/research-environments/environments/longcot_v1", editable = true }
+longpdfs-v1 = { path = "deps/research-environments/environments/longpdfs_v1", editable = true }
 math-env = { path = "deps/research-environments/environments/math_env", editable = true }
 math-env-v1 = { path = "deps/research-environments/environments/math_env_v1", editable = true }
 math-python = { path = "deps/verifiers/environments/math_python", editable = true }

--- a/uv.lock
+++ b/uv.lock
@@ -2480,6 +2480,21 @@ requires-dist = [
 ]
 
 [[package]]
+name = "longpdfs-v1"
+version = "0.0.1"
+source = { editable = "deps/research-environments/environments/longpdfs_v1" }
+dependencies = [
+    { name = "datasets" },
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "datasets", specifier = ">=3.0" },
+    { name = "verifiers", specifier = ">=0.1.15.dev381" },
+]
+
+[[package]]
 name = "mamba-ssm"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3993,6 +4008,7 @@ envs = [
     { name = "logic-env" },
     { name = "longcot-mini-v1" },
     { name = "longcot-v1" },
+    { name = "longpdfs-v1" },
     { name = "math-env" },
     { name = "math-env-v1" },
     { name = "math-python" },
@@ -4105,6 +4121,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "longcot-mini-v1", marker = "extra == 'envs'", editable = "deps/research-environments/environments/longcot_mini_v1" },
     { name = "longcot-v1", marker = "extra == 'envs'", editable = "deps/research-environments/environments/longcot_v1" },
+    { name = "longpdfs-v1", marker = "extra == 'envs'", editable = "deps/research-environments/environments/longpdfs_v1" },
     { name = "math-env", marker = "extra == 'envs'", editable = "deps/research-environments/environments/math_env" },
     { name = "math-env-v1", marker = "extra == 'envs'", editable = "deps/research-environments/environments/math_env_v1" },
     { name = "math-python", marker = "extra == 'envs'", editable = "deps/verifiers/environments/math_python" },


### PR DESCRIPTION
- research-environments: includes longpdfs
- verifiers: latest v1 main


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and lockfile registration only; no application or training logic changes in this diff.
> 
> **Overview**
> Registers the **`longpdfs-v1`** research environment so it can be installed with the **`envs`** optional extra, alongside the existing long-context / long-document style `-v1` envs.
> 
> **`pyproject.toml`** adds `longpdfs-v1` to the `envs` list and maps it to the editable path `deps/research-environments/environments/longpdfs_v1`. **`uv.lock`** picks up the new package (depends on `datasets` and `verifiers`) and links it into the root project’s `envs` dependency set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56bf10daea32755b1a015356845d5c608dbeee86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->