### PR TITLE
refactor: flash-attn import guard + build_scope_metrics dedup (stacked on #2922)

### DIFF
--- a/src/prime_rl/orchestrator/inference_metrics.py
+++ b/src/prime_rl/orchestrator/inference_metrics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 import wandb
@@ -256,6 +257,22 @@ def mean(values: list[float]) -> float | None:
     return sum(values) / len(values)
 
 
+def _scope_value(
+    scope: str,
+    prefill_value: float | None,
+    decode_value: float | None,
+    aggregate: Callable[[list[float]], float],
+) -> float | None:
+    """Pick a scope's metric value: prefill/decode use their own value; the
+    aggregate scope combines both non-None values via ``aggregate`` (None if neither)."""
+    if scope == "prefill":
+        return prefill_value
+    if scope == "decode":
+        return decode_value
+    values = [v for v in (prefill_value, decode_value) if v is not None]
+    return aggregate(values) if values else None
+
+
 def build_scope_metrics(
     scope: str,
     samples: list[EndpointSample],
@@ -304,16 +321,9 @@ def build_scope_metrics(
 
     prompt_token_rate = counter_rate(samples, previous, "prompt_tokens_total")
     generation_token_rate = counter_rate(samples, previous, "generation_tokens_total")
-    if scope == "prefill":
-        if prompt_token_rate is not None:
-            metrics[f"{prefix}/throughput"] = prompt_token_rate
-    elif scope == "decode":
-        if generation_token_rate is not None:
-            metrics[f"{prefix}/throughput"] = generation_token_rate
-    else:
-        token_rates = [rate for rate in (prompt_token_rate, generation_token_rate) if rate is not None]
-        if token_rates:
-            metrics[f"{prefix}/throughput"] = sum(token_rates)
+    throughput = _scope_value(scope, prompt_token_rate, generation_token_rate, sum)
+    if throughput is not None:
+        metrics[f"{prefix}/throughput"] = throughput
 
     counter_metrics = {
         "completed_requests": "request_success_total",
@@ -368,16 +378,9 @@ def build_scope_metrics(
         "request_decode_time_seconds_sum",
         "request_decode_time_seconds_count",
     )
-    if scope == "prefill":
-        if prefill_time is not None:
-            metrics[f"{prefix}/avg_time_seconds"] = prefill_time
-    elif scope == "decode":
-        if decode_time is not None:
-            metrics[f"{prefix}/avg_time_seconds"] = decode_time
-    else:
-        time_values = [value for value in (prefill_time, decode_time) if value is not None]
-        if time_values:
-            metrics[f"{prefix}/avg_time_seconds"] = sum(time_values) / len(time_values)
+    avg_time = _scope_value(scope, prefill_time, decode_time, lambda values: sum(values) / len(values))
+    if avg_time is not None:
+        metrics[f"{prefix}/avg_time_seconds"] = avg_time
 
     return metrics
 

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -19,6 +19,11 @@ from transformers.processing_utils import Unpack
 from transformers.utils import TransformersKwargs
 
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.layers.attn import (
+    flash_attn_3_varlen_func,
+    flash_attn_4_varlen_func,
+    flash_attn_varlen_func,
+)
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
@@ -29,21 +34,6 @@ from prime_rl.trainer.models.layers.rotary_emb import (
     apply_rotary_pos_emb,
 )
 from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
-
-try:
-    from flash_attn import flash_attn_varlen_func
-except ImportError:
-    flash_attn_varlen_func = None  # type: ignore
-
-try:
-    from flash_attn_interface import flash_attn_varlen_func as flash_attn_3_varlen_func
-except ImportError:
-    flash_attn_3_varlen_func = None  # type: ignore
-
-try:
-    from flash_attn.cute import flash_attn_varlen_func as flash_attn_4_varlen_func
-except ImportError:
-    flash_attn_4_varlen_func = None  # type: ignore
 
 from .configuration_afmoe import AfmoeConfig
 from .converting_afmoe import (

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -16,6 +16,11 @@ from transformers.processing_utils import Unpack
 from transformers.utils import TransformersKwargs, logging
 
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.layers.attn import (
+    flash_attn_3_varlen_func,
+    flash_attn_4_varlen_func,
+    flash_attn_varlen_func,
+)
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.moe import FeedForward, MoE, MoEArgs
 from prime_rl.trainer.models.layers.rotary_emb import apply_rotary_pos_emb
@@ -29,22 +34,6 @@ from .converting_qwen3_5_moe import (
     convert_tt_to_hf_moe,
 )
 from .mrope import build_qwen3_5_mrope_position_ids
-
-# Flash attention imports
-try:
-    from flash_attn import flash_attn_varlen_func
-except ImportError:
-    flash_attn_varlen_func = None  # type: ignore
-
-try:
-    from flash_attn_interface import flash_attn_varlen_func as flash_attn_3_varlen_func
-except ImportError:
-    flash_attn_3_varlen_func = None  # type: ignore
-
-try:
-    from flash_attn.cute import flash_attn_varlen_func as flash_attn_4_varlen_func
-except ImportError:
-    flash_attn_4_varlen_func = None  # type: ignore
 
 # Flash linear attention imports (for GatedDeltaNet fast path)
 try:


### PR DESCRIPTION
> **Stacked on #2922** (`fix/weight-sync-hardening`). Base branch is that PR, not `main`. **Merge #2922 first**, then this retargets to `main` and can merge.

## Summary

Follow-up refactors from the same audit as #2922. Scoped to changes that are **safe to verify by inspection**, since the test suite can't run in this environment (`uv sync` is blocked by the unchecked-out `deps/renderers` submodule). Two commits:

### `refactor:` centralize flash-attn varlen import guard
`afmoe` and `qwen3_5_moe` each re-declared the identical three-way `try/except` import guard for `flash_attn_varlen_func` / `_3_` / `_4_` that already lives in `trainer/models/layers/attn.py`. They now import the (None-able) module-level names from there; each model's `_funcs` dispatch table is unchanged.

> Note: the audit suggested these two could *subclass* the shared `FlashAttention`. On inspection they **can't** — both have genuinely model-specific attention (gated output via `gate_proj`, local/global split, MRoPE, GatedDeltaNet). Only the optional-dependency import guard was actually duplicated, so that's all this touches. The numerically-sensitive `_compute_attention`/`forward` are left alone.

### `refactor:` extract `_scope_value` helper in `build_scope_metrics`
The prefill/decode/aggregate branching was duplicated verbatim for the `throughput` and `avg_time_seconds` metrics (differing only in the aggregate — `sum` vs mean). Extracted `_scope_value(scope, prefill, decode, aggregate)`; both call sites collapse to three lines. Behavior-identical (verified case-by-case, including the empty-values guard).

## Verification
`ruff check` passes and all edited files compile. As above, the unit tests were **not** run here — a reviewer should run them (CI should be green on these files).

## Deliberately deferred (need a test run — not done here)
The remaining audit items turned out to be riskier or less applicable than first framed; I did **not** attempt them untested:

- **`PrimeMonitor` → `BackgroundAsync`**: not a clean mechanical swap — PrimeMonitor interleaves monitor-specific state (`enabled` gating, `_pending_sample_steps.clear()` on fork, direct `self._client` use in the sample-upload paths) with the generic async machinery. Doable, but wants test coverage.
- **`converting_*` MoE weight-conversion core dedup**: the per-family expert stack/unstack genuinely differs (e.g. afmoe uses per-expert regex keys; others use the fused gate_up format). This is correctness-critical weight math — unsafe to unify without a conversion round-trip test.
- **SFT/RL grad-rescale unify**: `sft/train.py` and `rl/train.py` compute *different* scalings on purpose; not a safe mechanical dedup.

Happy to pick up `PrimeMonitor` and the `converting_*` dedup as further commits here once there's a way to run the suite.
