### PR TITLE
chore: bump dist_timeout_seconds default to 3600

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -226,7 +226,7 @@ class SFTConfig(BaseConfig):
     trace_path: Path | None = None
     """Path to write the PyTorch profiler trace to."""
 
-    dist_timeout_seconds: int = 600
+    dist_timeout_seconds: int = 3600
     """Timeout in seconds for torch distributed ops."""
 
     loss_impl: Literal["liger", "torch", "liger_fused", "quack_fused"] = "torch"

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -554,7 +554,7 @@ class TrainerConfig(BaseConfig):
     trace_path: Path | None = None
     """Path to write the PyTorch profiler trace to."""
 
-    dist_timeout_seconds: int = 600
+    dist_timeout_seconds: int = 3600
     """Timeout in seconds for torch distributed ops."""
 
     heartbeat: HeartbeatConfig | None = None


### PR DESCRIPTION
## Summary

- Bump the default `dist_timeout_seconds` (torch/NCCL distributed op timeout, passed straight into `init_process_group`) from **600s → 3600s** for both the RL trainer (`packages/prime-rl-configs/src/prime_rl/configs/trainer.py`) and SFT trainer (`packages/prime-rl-configs/src/prime_rl/configs/sft.py`).

## Motivation

The 600s default matched PyTorch's own NCCL default, but was too tight for large multi-node runs. Startup collectives (step-0 evals, the slow first SWE batch) were tripping the `_ALLGATHER_BASE` watchdog and SIGABRT-ing the trainer — see the workaround comment in `configs/debug/v1/scaleswe.toml`, which already sets `dist_timeout_seconds = 3600` explicitly. Several private/prod configs bump it even higher (`7200`, `12000`). Making 3600 the default covers the common case out of the box; configs that need a different value can still override it.

## Note

This changes a default value only — no config migration is required, so no CHANGELOG entry (that file tracks renamed/removed/moved fields). Configs that set `dist_timeout_seconds` explicitly are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes an unset-config default for distributed timeouts; no logic or migration, with explicit overrides still honored.
> 
> **Overview**
> Raises the default **`dist_timeout_seconds`** from **600** to **3600** on both **`SFTConfig`** and **`TrainerConfig`**, so torch distributed / NCCL collectives get a one-hour watchdog unless a config overrides it.
> 
> This is a default-only change: runs that already set `dist_timeout_seconds` are unchanged; configs that relied on the old implicit 600s now wait longer before failing on slow multi-node startup or long first-step work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 035497d39be26844d7cfaef500a813af76baf238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->