### PR TITLE
feat: optional per-node uv sync for multi-node RL

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -58,8 +58,8 @@ class SlurmConfig(BaseConfig):
     cleanup_grace_period: int = Field(3600, ge=0)
     """Seconds to wait before tearing down a multi-node RL job that hit a non-zero exit, letting in-flight checkpoints flush. Set to 0 to tear down immediately."""
 
-    per_node_venv_sync: bool = False
-    """Run ``uv sync`` on every node via srun (one task per node) instead of only the batch node. Enable when the venv is node-local (e.g. ``UV_PROJECT_ENVIRONMENT`` on ``/tmp``); leave off for a shared (NFS) venv where a single sync suffices."""
+    shared_fs: bool = True
+    """Whether the project filesystem (including the venv) is shared across nodes (e.g. NFS). When True, a single ``uv sync`` on the batch node suffices. Set to False when the venv is node-local (e.g. ``UV_PROJECT_ENVIRONMENT`` on ``/tmp``) so ``uv sync`` runs on every node via srun."""
 
     @property
     def template_vars(self) -> dict:
@@ -74,7 +74,7 @@ class SlurmConfig(BaseConfig):
             "time": self.time,
             "pre_run_command": self.pre_run_command,
             "cleanup_grace_period": self.cleanup_grace_period,
-            "per_node_venv_sync": self.per_node_venv_sync,
+            "shared_fs": self.shared_fs,
         }
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -58,6 +58,9 @@ class SlurmConfig(BaseConfig):
     cleanup_grace_period: int = Field(3600, ge=0)
     """Seconds to wait before tearing down a multi-node RL job that hit a non-zero exit, letting in-flight checkpoints flush. Set to 0 to tear down immediately."""
 
+    per_node_venv_sync: bool = False
+    """Run ``uv sync`` on every node via srun (one task per node) instead of only the batch node. Enable when the venv is node-local (e.g. ``UV_PROJECT_ENVIRONMENT`` on ``/tmp``); leave off for a shared (NFS) venv where a single sync suffices."""
+
     @property
     def template_vars(self) -> dict:
         """Common template variables for all SLURM templates."""
@@ -71,6 +74,7 @@ class SlurmConfig(BaseConfig):
             "time": self.time,
             "pre_run_command": self.pre_run_command,
             "cleanup_grace_period": self.cleanup_grace_period,
+            "per_node_venv_sync": self.per_node_venv_sync,
         }
 
     @model_validator(mode="after")

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -61,7 +61,17 @@ ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log
 cd $PROJECT_DIR
 [ -f .env ] && source .env
 source .venv/bin/activate
+{% if not shared_fs %}
+# Node-local venv (e.g. UV_PROJECT_ENVIRONMENT on /tmp): a bare `uv sync` would only
+# build the batch node, so srun runs it on every node (one task each) and blocks until
+# all finish. `set -e` above aborts the job if any node's sync fails. Re-source .env
+# inside the task because unexported vars in .env don't cross srun even with normal
+# SLURM env propagation; otherwise uv would silently fall back to the shared .venv.
+srun --ntasks-per-node=1 bash -c 'cd $PROJECT_DIR && { [ -f .env ] && source .env || true; } && uv sync --all-extras'
+{% else %}
+# Shared (NFS) venv: one sync on the batch node populates it for all nodes.
 uv sync --all-extras
+{% endif %}
 
 # Print inference URLs
 export HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -144,7 +144,17 @@ echo "MASTER_PORT=${MASTER_PORT}"
 cd $PROJECT_DIR
 [ -f .env ] && source .env
 source .venv/bin/activate
+{% if per_node_venv_sync %}
+# Node-local venv (e.g. UV_PROJECT_ENVIRONMENT on /tmp): a bare `uv sync` would only
+# build the batch node, so srun runs it on every node (one task each) and blocks until
+# all finish. `set -e` above aborts the job if any node's sync fails. Re-source .env
+# inside the task so uv reads the /tmp paths even if SLURM env propagation is disabled;
+# otherwise uv would silently fall back to the shared .venv.
+srun --ntasks-per-node=1 bash -c 'cd $PROJECT_DIR && { [ -f .env ] && source .env; } && uv sync --all-extras'
+{% else %}
+# Shared (NFS) venv: one sync on the batch node populates it for all nodes.
 uv sync --all-extras
+{% endif %}
 
 {% if pre_run_command %}
 # Pre-run command

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -144,13 +144,13 @@ echo "MASTER_PORT=${MASTER_PORT}"
 cd $PROJECT_DIR
 [ -f .env ] && source .env
 source .venv/bin/activate
-{% if per_node_venv_sync %}
+{% if not shared_fs %}
 # Node-local venv (e.g. UV_PROJECT_ENVIRONMENT on /tmp): a bare `uv sync` would only
 # build the batch node, so srun runs it on every node (one task each) and blocks until
 # all finish. `set -e` above aborts the job if any node's sync fails. Re-source .env
-# inside the task so uv reads the /tmp paths even if SLURM env propagation is disabled;
-# otherwise uv would silently fall back to the shared .venv.
-srun --ntasks-per-node=1 bash -c 'cd $PROJECT_DIR && { [ -f .env ] && source .env; } && uv sync --all-extras'
+# inside the task because unexported vars in .env don't cross srun even with normal
+# SLURM env propagation; otherwise uv would silently fall back to the shared .venv.
+srun --ntasks-per-node=1 bash -c 'cd $PROJECT_DIR && { [ -f .env ] && source .env || true; } && uv sync --all-extras'
 {% else %}
 # Shared (NFS) venv: one sync on the batch node populates it for all nodes.
 uv sync --all-extras

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -48,9 +48,17 @@ echo "MASTER_PORT=${MASTER_PORT}"
 # Install environment
 [ -f $PROJECT_DIR/.env ] && source $PROJECT_DIR/.env
 source $PROJECT_DIR/.venv/bin/activate
-
-# Install environment as local package
+{% if not shared_fs %}
+# Node-local venv (e.g. UV_PROJECT_ENVIRONMENT on /tmp): a bare `uv sync` would only
+# build the batch node, so srun runs it on every node (one task each) and blocks until
+# all finish. `set -e` above aborts the job if any node's sync fails. Re-source .env
+# inside the task because unexported vars in .env don't cross srun even with normal
+# SLURM env propagation; otherwise uv would silently fall back to the shared .venv.
+srun --ntasks-per-node=1 bash -c 'cd $PROJECT_DIR && { [ -f .env ] && source .env || true; } && uv sync --all-extras'
+{% else %}
+# Shared (NFS) venv: one sync on the batch node populates it for all nodes.
 cd $PROJECT_DIR && uv sync --all-extras
+{% endif %}
 
 
 {% if pre_run_command %}


### PR DESCRIPTION
Add a SlurmConfig.per_node_venv_sync flag (default False). When enabled, the multi-node RL sbatch runs uv sync on every node via srun (one task per node, blocking) instead of only the batch node.

This is needed when the venv is node-local (e.g. UV_PROJECT_ENVIRONMENT on /tmp): a single batch-node sync would leave the other nodes without a venv. The srun task re-sources .env so uv sees the node-local UV_PROJECT_ENVIRONMENT / UV_CACHE_DIR even if SLURM env propagation is disabled. With set -e, a failed sync on any node aborts the job. Default keeps the original head-only behavior for shared (NFS) venvs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Launcher-only SLURM bootstrap change with default preserving existing head-only sync; risk is mainly mis-setting shared_fs on clusters with local venvs.
> 
> **Overview**
> Multi-node SLURM jobs can now distinguish **shared** vs **node-local** Python environments via **`SlurmConfig.shared_fs`** (default **`True`**), exposed in **`template_vars`** for all bundled sbatch templates.
> 
> When **`shared_fs` is `False`**, **`inference`**, **`multi_node_rl`**, and **`multi_node_sft`** run **`srun --ntasks-per-node=1 … uv sync --all-extras`** so each node builds its own venv (e.g. **`UV_PROJECT_ENVIRONMENT`** on **`/tmp`**). The srun task **re-sources `.env`** so node-local uv settings are not lost across srun; with **`set -e`**, any failed sync aborts the job. When **`shared_fs` is `True`**, behavior is unchanged: a single **`uv sync`** on the batch node for NFS/shared venvs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 660de820c06e8a0f1c255d671ffdc92f9990aa54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->