### PR TITLE
chore(configs): remove empty *ExperimentalConfig placeholders

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -337,10 +337,6 @@ InferenceDeploymentConfig: TypeAlias = Annotated[
 ]
 
 
-class InferenceExperimentalConfig(BaseConfig):
-    pass
-
-
 class InferenceConfig(BaseConfig):
     server: ServerConfig = ServerConfig()
 
@@ -435,8 +431,6 @@ class InferenceConfig(BaseConfig):
 
     dry_run: bool = False
     """Only validate and dump resolved configs, then exit early."""
-
-    experimental: InferenceExperimentalConfig = InferenceExperimentalConfig()
 
     @model_validator(mode="after")
     def validate_multi_node_requires_slurm(self):

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -443,10 +443,6 @@ WeightBroadcastConfig: TypeAlias = Annotated[
 ]
 
 
-class OrchestratorExperimentalConfig(BaseConfig):
-    pass
-
-
 class OrchestratorConfig(BaseConfig):
     algo: AlgoConfig = GRPOAlgoConfig()
     """Training algorithm: sampling plus the per-token training signal (credit
@@ -562,8 +558,6 @@ class OrchestratorConfig(BaseConfig):
 
     heartbeat: HeartbeatConfig | None = None
     """BetterStack heartbeat configuration for monitoring training progress."""
-
-    experimental: OrchestratorExperimentalConfig = OrchestratorExperimentalConfig()
 
     @model_validator(mode="before")
     @classmethod

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -46,10 +46,6 @@ from prime_rl.utils.validation import (
 )
 
 
-class RLExperimentalConfig(BaseConfig):
-    pass
-
-
 class SharedLogConfig(BaseConfig):
     level: str | None = None
     """Log level for trainer, orchestrator, and inference. When unset, each sub-config's own log level applies (defaults to ``$PRIME_LOG_LEVEL`` if set, else ``info``)."""
@@ -233,8 +229,6 @@ class RLConfig(BaseConfig):
 
     dry_run: bool = False
     """Only validate and dump resolved configs, then exit early."""
-
-    experimental: RLExperimentalConfig = RLExperimentalConfig()
 
     ### Validate configs (e.g. raise for unsupported (combinations of) configs)
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -167,10 +167,6 @@ SFTDeploymentConfig: TypeAlias = Annotated[
 ]
 
 
-class SFTExperimentalConfig(BaseConfig):
-    pass
-
-
 class SFTConfig(BaseConfig):
     model: ModelConfig = ModelConfig()
 
@@ -242,8 +238,6 @@ class SFTConfig(BaseConfig):
 
     dry_run: bool = False
     """Only validate and dump resolved configs, then exit early."""
-
-    experimental: SFTExperimentalConfig = SFTExperimentalConfig()
 
     ### Pre-validation normalization
 


### PR DESCRIPTION
## Summary

Deletes the four empty `*ExperimentalConfig` models (`pass` bodies) and their `experimental` fields from the `inference`, `orchestrator`, `rl`, and `sft` configs — 24 dead lines.

Repo-wide grep finds no reader of any `.experimental` attribute and no TOML setting one. Since the models are empty and `BaseConfig` uses `extra="forbid"`, no key could ever be set under them; the only expressible usage was an empty `[experimental]` table. A future experimental namespace can be re-added together with its first real field.

## Test plan

- `uv run pytest tests/unit/test_configs.py` — 114 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only cleanup with no runtime logic changes; the only user impact is TOMLs that still include `[experimental]`, which will error on load.
> 
> **Overview**
> Removes four no-op `*ExperimentalConfig` Pydantic models and their `experimental` fields from **`InferenceConfig`**, **`OrchestratorConfig`**, **`RLConfig`**, and **`SFTConfig`**.
> 
> Those blocks were empty (`pass` only) and unused in code or TOML; with `extra="forbid"`, they could not hold future keys anyway. **Breaking for configs that still declare an `[experimental]` table** (including empty ones): validation will now reject that section, consistent with the earlier `TrainerExperimentalConfig` removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5513cd387b66efbdfd9eac205c20899282c0a387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->