### PR TITLE
chore: dead-code sweep across trainer, orchestrator, utils, and configs

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/utils/config.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/config.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel
 from pydantic_config import BaseConfig as BaseConfig  # noqa: F401
 from pydantic_config import cli  # noqa: F401
 
@@ -38,19 +37,3 @@ def rsetattr(obj: Any, attr_path: str, value: Any) -> None:
         return setattr(obj, attr_path, value)
     parent_path, attr = attr_path.rsplit(".", 1)
     setattr(rgetattr(obj, parent_path), attr, value)
-
-
-def get_all_fields(model: BaseModel | type) -> list[str]:
-    if isinstance(model, BaseModel):
-        model_cls = model.__class__
-    else:
-        model_cls = model
-
-    fields = []
-    for name, field in model_cls.model_fields.items():
-        field_type = field.annotation
-        fields.append(name)
-        if field_type is not None and hasattr(field_type, "model_fields"):
-            sub_fields = get_all_fields(field_type)
-            fields.extend(f"{name}.{sub}" for sub in sub_fields)
-    return fields

--- a/src/prime_rl/inference/server.py
+++ b/src/prime_rl/inference/server.py
@@ -2,7 +2,6 @@ import logging.config
 import os
 
 from prime_rl.configs.inference import InferenceConfig
-from prime_rl.utils.config import cli
 
 
 def setup_vllm_env(config: InferenceConfig):
@@ -41,17 +40,3 @@ def setup_vllm_env(config: InferenceConfig):
         os.environ["VLLM_CONFIGURE_LOGGING"] = "1"
         os.environ["VLLM_LOGGING_CONFIG_PATH"] = str(config_path)
         logging.config.dictConfig(build_dict_config(config.log.level))
-
-
-def main():
-    config = cli(InferenceConfig)
-    setup_vllm_env(config)
-
-    # We import here to be able to set environment variables before importing vLLM
-    from prime_rl.inference.vllm.server import server  # pyright: ignore
-
-    server(config, vllm_extra=config.vllm_extra)
-
-
-if __name__ == "__main__":
-    main()

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -75,12 +75,12 @@ def trace_to_samples(
     Each `trace.branches` entry is already a flat token sequence (`branch.token_ids` /
     `branch.sampled_mask` / `branch.logprobs`), so a sample carries it directly: `mask` marks
     the trainable (model-sampled) tokens, the context tokens between completions stay masked
-    out. On a rollout error the whole completion is masked out. A branch carrying images also
-    gets `mm_kwargs` (the concatenated pixel tensors) and `mm_token_type_ids` (the renderer's
-    `mm_token_type_id_map` applied to the branch tokens). Branches with no sampled tokens
-    (e.g. an openai client carrying none) yield nothing.
+    out. Errored rollouts are dropped upstream (`TrainSink.process_rollout`), so no error
+    handling happens here. A branch carrying images also gets `mm_kwargs` (the concatenated
+    pixel tensors) and `mm_token_type_ids` (the renderer's `mm_token_type_id_map` applied to
+    the branch tokens). Branches with no sampled tokens (e.g. an openai client carrying none)
+    yield nothing.
     """
-    has_error = trace.has_error
     samples: list[TrainingSample] = []
     for branch in trace.branches:
         mask = branch.sampled_mask
@@ -97,7 +97,7 @@ def trace_to_samples(
         samples.append(
             TrainingSample(
                 token_ids=token_ids,
-                mask=[m and not has_error for m in mask],
+                mask=mask,
                 logprobs=branch.logprobs,
                 temperatures=[],  # filled by TrainSink.process_group
                 env_name=env_name,
@@ -108,6 +108,6 @@ def trace_to_samples(
         )
     if not samples:
         get_logger().warning(
-            f"No trainable samples (error={has_error}, stop={trace.stop_condition}, num_turns={trace.num_turns})."
+            f"No trainable samples (error={trace.has_error}, stop={trace.stop_condition}, num_turns={trace.num_turns})."
         )
     return samples

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -8,7 +8,6 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import orjson
-import verifiers.v1 as vf
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.utils.client import setup_inference_pool
@@ -51,14 +50,13 @@ async def setup_policy_inference_pool(*, config: OrchestratorConfig, tokenizer):
     return renderer, inference_pool
 
 
-def save_rollouts(rollouts: list[dict], path: Path, exclude_keys: set[str] | None = None) -> None:
+def save_rollouts(rollouts: list[dict], path: Path) -> None:
     """Save rollouts (Trace dicts, already JSON-serializable) to a JSONL file."""
     path.parent.mkdir(parents=True, exist_ok=True)
     opts = orjson.OPT_APPEND_NEWLINE | orjson.OPT_SERIALIZE_NUMPY
     with open(path, "wb") as f:
         for rollout in rollouts:
-            row = {k: v for k, v in rollout.items() if k not in exclude_keys} if exclude_keys else rollout
-            f.write(orjson.dumps(row, default=str, option=opts))
+            f.write(orjson.dumps(rollout, default=str, option=opts))
 
 
 def intercept_vf_logging(logger: str = "verifiers", level: str = "DEBUG", prefix: str | None = None):
@@ -92,16 +90,6 @@ def trim_process_memory() -> None:
         ctypes.CDLL("libc.so.6").malloc_trim(0)
     except Exception as exc:
         get_logger().debug(f"malloc_trim(0) failed: {exc!r}")
-
-
-def get_tool_response_len(trace: vf.Trace) -> int:
-    """Total tool-response tokens consumed across the whole rollout, read from a
-    harness-emitted metric (e.g. RLM's `rlm_total_tool_response_tokens`, deduped
-    across turns/branches/sub-RLMs). Returns 0 when no such metric is present."""
-    for key, value in (trace.metrics or {}).items():
-        if key.endswith("total_tool_response_tokens") and isinstance(value, (int, float)):
-            return int(value)
-    return 0
 
 
 def get_weight_dir(output_dir: Path, step: int, check_exists: bool = True, wait_timeout: int | None = None) -> Path:

--- a/src/prime_rl/trainer/models/layers/rotary_emb.py
+++ b/src/prime_rl/trainer/models/layers/rotary_emb.py
@@ -115,34 +115,3 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     q_embed = torch.cat([q_embed, q_pass], dim=-1)
     k_embed = torch.cat([k_embed, k_pass], dim=-1)
     return q_embed, k_embed
-
-
-def apply_rotary_pos_emb_interleave(q, k, cos, sin, unsqueeze_dim=1):
-    """Interleaved RoPE: converts from [r0, i0, r1, i1, ...] layout before applying rotation.
-
-    Args:
-        q (`torch.Tensor`): The query tensor.
-        k (`torch.Tensor`): The key tensor.
-        cos (`torch.Tensor`): The cosine part of the rotary embedding.
-        sin (`torch.Tensor`): The sine part of the rotary embedding.
-        unsqueeze_dim (`int`, *optional*, defaults to 1):
-            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
-            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
-            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
-            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
-            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
-            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
-    Returns:
-        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
-    """
-    cos = cos.unsqueeze(unsqueeze_dim)
-    sin = sin.unsqueeze(unsqueeze_dim)
-
-    b, h, s, d = q.shape
-    q = q.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
-    b, h, s, d = k.shape
-    k = k.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
-
-    q_embed = (q * cos) + (rotate_half(q) * sin)
-    k_embed = (k * cos) + (rotate_half(k) * sin)
-    return q_embed, k_embed

--- a/src/prime_rl/trainer/perf.py
+++ b/src/prime_rl/trainer/perf.py
@@ -37,9 +37,6 @@ class PerfCounter:
             self.gpu_peak_flops = self._get_peak_flops(torch.cuda.get_device_name(torch.device("cuda")))
         else:
             self.gpu_peak_flops = 0
-        # If not tie_word_embeddings, we exclude the embedding parameters from the total number of parameters
-        # If tie_word_embeddings, the embedding parameters are already excluded (shared with the LM head)
-        self.num_params = self._get_num_params(model, exclude_embedding=not model.config.tie_word_embeddings)
         self.num_flop_per_token = self._get_num_flop_per_token(model.config, seq_len=seq_len)
 
     def count_tokens(self, tokens: int) -> None:
@@ -208,15 +205,6 @@ class PerfCounter:
             flop_per_token = 6 * self.get_active_mm_params(model_config) + attention_flops
 
         return flop_per_token
-
-    def _get_num_params(self, model: nn.Module, exclude_embedding: bool = False) -> int:
-        num_params = sum(p.numel() for p in model.parameters())
-        if exclude_embedding:
-            if hasattr(model.lm_head, "weight"):
-                num_params -= model.lm_head.weight.numel()
-            elif hasattr(model.lm_head, "base_layer"):  # MultiLoRAModule
-                num_params -= model.lm_head.base_layer.weight.numel()
-        return num_params
 
     def _count_lora_adapter_params(self) -> int:
         """Count LoRA adapter parameters (sum of lora_A and lora_B across all MultiLoRAModules)."""

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -5,7 +5,6 @@ from typing import TypedDict
 import torch
 from jaxtyping import Bool, Float, Int
 from torch import Tensor
-from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.configs.trainer import FakeDataLoaderConfig
 from prime_rl.trainer.rl.packer import BasePacker, setup_packer
@@ -183,7 +182,6 @@ class DataLoader:
         dp_world_size: int,
         seq_len: int,
         pad_to_multiple_of: int,
-        tokenizer: PreTrainedTokenizer,
         bin_cost: Callable[[Sequence[int]], int],
         config: TransportConfig,
     ):
@@ -193,7 +191,6 @@ class DataLoader:
             self.packer: BasePacker = setup_packer(
                 dp_world_size=dp_world_size,
                 seq_len=seq_len,
-                tokenizer=tokenizer,
                 transport_config=config,
                 pad_to_multiple_of=pad_to_multiple_of,
                 bin_cost=bin_cost,

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -6,8 +6,6 @@ from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Callable, Sequence
 
-from transformers.tokenization_utils import PreTrainedTokenizer
-
 from prime_rl.trainer.batch import prepare_batch
 from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.transport import (
@@ -31,7 +29,6 @@ class BasePacker(ABC):
         dp_world_size: int,
         seq_len: int,
         pad_to_multiple_of: int,
-        tokenizer: PreTrainedTokenizer,
         config: TransportConfig,
         bin_cost: Callable[[Sequence[int]], int],
         start_step: int = 0,
@@ -41,7 +38,6 @@ class BasePacker(ABC):
         self.dp_world_size = dp_world_size
         self.seq_len = seq_len
         self.pad_to_multiple_of = pad_to_multiple_of
-        self.tokenizer = tokenizer
         self.bin_cost = bin_cost
         self.receiver = setup_training_batch_receiver(config)
         shutil.rmtree(get_rollout_dir(self.multi_run_manager.output_dir), ignore_errors=True)
@@ -85,12 +81,11 @@ class SinglePacker(BasePacker):
         dp_world_size: int,
         seq_len: int,
         pad_to_multiple_of: int,
-        tokenizer: PreTrainedTokenizer,
         config: TransportConfig,
         bin_cost: Callable[[Sequence[int]], int],
         start_step: int = 0,
     ):
-        super().__init__(dp_world_size, seq_len, pad_to_multiple_of, tokenizer, config, bin_cost, start_step)
+        super().__init__(dp_world_size, seq_len, pad_to_multiple_of, config, bin_cost, start_step)
         assert self.multi_run_manager.max_runs == 1, "SinglePacker only supports one run"
 
     def pack(self):
@@ -132,12 +127,11 @@ class MultiPacker(BasePacker):
         dp_world_size: int,
         seq_len: int,
         pad_to_multiple_of: int,
-        tokenizer: PreTrainedTokenizer,
         config: TransportConfig,
         bin_cost: Callable[[Sequence[int]], int],
         start_step: int = 0,
     ):
-        super().__init__(dp_world_size, seq_len, pad_to_multiple_of, tokenizer, config, bin_cost, start_step)
+        super().__init__(dp_world_size, seq_len, pad_to_multiple_of, config, bin_cost, start_step)
         # Per-run buffer: stores (TrainingSample, step) tuples
         self.buffers: list[deque[tuple[TrainingSample, int]]] = [
             deque() for _ in range(self.multi_run_manager.max_runs)
@@ -351,17 +345,12 @@ def setup_packer(
     dp_world_size: int,
     seq_len: int,
     pad_to_multiple_of: int,
-    tokenizer: PreTrainedTokenizer,
     transport_config: TransportConfig,
     bin_cost: Callable[[Sequence[int]], int],
     start_step: int = 0,
 ) -> BasePacker:
     multi_run_manager = get_multi_run_manager()
     if multi_run_manager.max_runs == 1:
-        return SinglePacker(
-            dp_world_size, seq_len, pad_to_multiple_of, tokenizer, transport_config, bin_cost, start_step
-        )
+        return SinglePacker(dp_world_size, seq_len, pad_to_multiple_of, transport_config, bin_cost, start_step)
     else:
-        return MultiPacker(
-            dp_world_size, seq_len, pad_to_multiple_of, tokenizer, transport_config, bin_cost, start_step
-        )
+        return MultiPacker(dp_world_size, seq_len, pad_to_multiple_of, transport_config, bin_cost, start_step)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -239,7 +239,6 @@ def train(config: TrainerConfig):
             parallel_dims.get_mesh("dp").size(),
             config.model.seq_len,
             config.model.cp,
-            tokenizer,
             build_bin_cost(model.config),
             config.rollout_transport,
         )

--- a/src/prime_rl/utils/chat_template.py
+++ b/src/prime_rl/utils/chat_template.py
@@ -10,14 +10,6 @@ class IncrementalTokenizationError(ValueError):
     pass
 
 
-def common_prefix_len(a: list[int], b: list[int]) -> int:
-    max_len = min(len(a), len(b))
-    for idx in range(max_len):
-        if a[idx] != b[idx]:
-            return idx
-    return max_len
-
-
 def normalize_messages(messages: Any, default_role: str) -> list[dict[str, Any]]:
     if messages is None:
         return []

--- a/src/prime_rl/utils/cp.py
+++ b/src/prime_rl/utils/cp.py
@@ -155,34 +155,6 @@ def gather_for_cp_wo_grad(t: torch.Tensor, cp_world_size: int, cp_group: dist.Pr
     return torch.cat(empty_like_t, dim=1)
 
 
-def get_padding_logit_from_prev_cp_rank(
-    logits: torch.Tensor, cp_rank: int, cp_world_size: int, cp_group: dist.ProcessGroup
-) -> torch.Tensor | None:
-    """
-    Get the padding logit from the previous context parallel rank.
-    Args:
-        logits: The logits tensor.
-        cp_rank: The rank of the current process.
-        cp_world_size: The number of processes in the context parallel group.
-        cp_group: The context parallel group.
-    Returns:
-        The padding logit from the previous context parallel rank.
-    """
-    last_logit = logits[:, -1, :].unsqueeze(1)
-
-    all_rank_last_logits = [
-        torch.zeros(1, 1, logits.shape[2], dtype=logits.dtype, device=logits.device) for _ in range(cp_world_size)
-    ]
-
-    dist.all_gather(all_rank_last_logits, last_logit, group=cp_group)
-
-    prev_cp_rank = cp_rank - 1
-    if prev_cp_rank >= 0:
-        return all_rank_last_logits[prev_cp_rank]
-    else:
-        return None
-
-
 def setup_cp_params(
     input_ids: torch.Tensor,
     position_ids: torch.Tensor,

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -163,15 +163,6 @@ def get_free_port() -> int:
     return port
 
 
-def get_cuda_visible_devices() -> list[int]:
-    """Returns the list of availble CUDA devices, taking into account the CUDA_VISIBLE_DEVICES environment variable."""
-    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
-    if cuda_visible is None:
-        # Default to all devices if the environment variable is not set
-        return list(range(torch.cuda.device_count()))
-    return list(sorted([int(device) for device in cuda_visible.split(",")]))
-
-
 def get_latest_ckpt_step(weights_dir: Path) -> int | None:
     step_dirs = list(weights_dir.glob("step_*"))
     if len(step_dirs) == 0:
@@ -181,11 +172,6 @@ def get_latest_ckpt_step(weights_dir: Path) -> int | None:
         if Path(weights_dir / f"step_{latest_step}" / "STABLE").exists():
             return latest_step
     return None
-
-
-def mean(values: list[float] | list[int]) -> float:
-    """Compute the mean of a list of values."""
-    return sum(values) / len(values) if values else 0.0
 
 
 @contextmanager

--- a/tests/unit/train/rl/test_packer.py
+++ b/tests/unit/train/rl/test_packer.py
@@ -92,7 +92,6 @@ def test_packer_progress_updates_once_per_run(tmp_path: Path, monkeypatch: pytes
         dp_world_size=1,
         seq_len=4,
         pad_to_multiple_of=1,
-        tokenizer=None,
         config=FileSystemTransportConfig(),
         bin_cost=build_bin_cost(None),
         start_step=0,


### PR DESCRIPTION
## Summary

Removes a batch of independently-verified dead code (repo-wide grep over src/, packages/, tests/, configs/, docs/, skills/ for each symbol):

- **packer tokenizer param**: `BasePacker.__init__` stored `self.tokenizer` but nothing ever read it; the param was threaded through five signatures (`BasePacker`/`SinglePacker`/`MultiPacker`/`setup_packer`/`DataLoader`) and the `DataLoader` call in `rl/train.py`. Dropped everywhere, incl. the `tokenizer=None` kwarg in `test_packer.py`.
- **`apply_rotary_pos_emb_interleave`** (`layers/rotary_emb.py`): zero references. The only interleaved-RoPE consumer (glm_moe_dsa) uses its own single-tensor variant and can't be retargeted to this q/k-pair form.
- **`PerfCounter.num_params` / `_get_num_params`**: computed in `__init__`, never read — MFU uses `num_flop_per_token` exclusively.
- **`inference/server.py` `main()`**: the console script is `entrypoints.inference:main`; this duplicate skipped the launcher env-var defaults if ever run. Only `setup_vllm_env` remains.
- **`get_all_fields()`** (prime-rl-configs `utils/config.py`): only reference was its own recursive call.
- **Dead utils helpers**: `get_cuda_visible_devices`, `mean` (`utils/utils.py`), `common_prefix_len` (`chat_template.py` — deps/renderers has its own private copy), `get_padding_logit_from_prev_cp_rank` (`cp.py`).
- **`orchestrator/utils.py`**: `get_tool_response_len` had no callers; `save_rollouts`' `exclude_keys` param was never passed by either call site.
- **`trajectories.py` `has_error` mask-zeroing**: dead path — the only production caller (`TrainSink.process_rollout`) early-returns on errored rollouts, so `has_error` was always False here. Error dropping stays solely in the sink; docstring updated.

## Test plan

- `uv run pytest tests/unit/train/rl/test_packer.py tests/unit/train/test_perf.py tests/unit/orchestrator/test_advantage.py tests/unit/orchestrator/test_algorithms.py tests/unit/test_configs.py tests/unit/utils` — 214 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removals are unused symbols verified by grep; the trajectories mask change only drops redundant error handling already enforced in TrainSink.
> 
> **Overview**
> This PR is a **dead-code sweep** with no intended behavior change for live training paths, aside from clarifying where errored rollouts are handled.
> 
> **Trainer / RL data path:** Removes the unused `tokenizer` argument from `BasePacker`, `DataLoader`, and `setup_packer` (it was stored but never read). Drops `PerfCounter._get_num_params` / `num_params` (MFU already uses `num_flop_per_token` only). Removes unused `apply_rotary_pos_emb_interleave` from `rotary_emb.py`.
> 
> **Orchestrator:** `trace_to_samples` no longer zeroes masks on `has_error`—`TrainSink.process_rollout` already returns early for errored rollouts. Removes `get_tool_response_len` and the unused `exclude_keys` parameter on `save_rollouts`.
> 
> **Inference / configs / utils:** Deletes duplicate `inference/server.py` `main()` (real entrypoint is elsewhere); removes `get_all_fields` from prime-rl-configs; trims unused helpers (`get_cuda_visible_devices`, `mean`, `common_prefix_len`, `get_padding_logit_from_prev_cp_rank`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72e7e4902c55b5971e490117243d050f9aa8b406. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->