### PR TITLE
[codex] fix orchestrator dispatch gate lead

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -522,7 +522,7 @@ class Orchestrator:
         await asyncio.to_thread(save_rollouts, rollout_dicts, step_path / "train_rollouts.jsonl")
 
         await self.sender.send(TrainingBatch(examples=batch.samples, step=step))
-        self.update_dispatch_gate()
+        self.update_dispatch_gate(next_step=step + 1)
         trim_process_memory()
 
         # Rollout metrics over the {agg,<env>} × {all,effective} matrix. ``batch.rollouts`` is the
@@ -785,12 +785,12 @@ class Orchestrator:
         await asyncio.to_thread(self.ckpt_manager.save, self.progress, step)
         return time.perf_counter() - t
 
-    def update_dispatch_gate(self) -> None:
+    def update_dispatch_gate(self, *, next_step: int | None = None) -> None:
         """Pause/resume the dispatcher based on how far the orchestrator's
         next batch would run ahead of ``policy.version``. Called from two
         sites: after shipping a batch (step advances) and from
         ``on_new_version`` (policy advances)."""
-        lead = (self.progress.step + 1) - self.policy.version
+        lead = (self.progress.step if next_step is None else next_step) - self.policy.version
         gate = self.dispatcher.dispatch_allowed
         was_set = gate.is_set()
         if lead > TARGET_LAG:


### PR DESCRIPTION
Fixes a dispatch-gate off-by-one in the async orchestrator.

After shipping a train batch, `progress.step` has not advanced yet, so the gate must evaluate `step + 1`. But when the watcher installs a new policy, `progress.step` already is the next batch being collected. Using `(progress.step + 1) - policy.version` for both paths made the watcher path wait for one extra policy version and could leave the dispatcher paused with too few in-flight rollouts to finish another batch.

The old formula was correct at ship time but wrong at policy-update time. At ship time, after shipping batch `S`, progress.step is still `S`, so the next batch really is `S + 1`. At watcher time, progress.step already means the next/current batch being collected, so adding +1 invents an extra future batch and makes the gate one version too strict.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async pipeline backpressure between orchestrator and trainer; incorrect gating affects rollout throughput but not data correctness directly.
> 
> **Overview**
> Fixes an off-by-one in **`update_dispatch_gate`** so orchestrator–trainer lag (`TARGET_LAG`) is computed correctly on both code paths.
> 
> After a train batch is shipped, the gate now runs with **`next_step=step + 1`** because **`progress.step`** is still the shipped step until later in **`finalize_train_batch`**. When the weight watcher advances **`policy.version`**, the gate is re-evaluated with **`progress.step`** only (no `+1`), since that value already reflects the batch being collected.
> 
> Previously both paths used **`(progress.step + 1) - policy.version`**, which overstated lead on the watcher path and could keep the dispatcher paused one policy version too long, starving in-flight rollouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e7be2a278ccd1858a3427c1bf77b5379f4fdb86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->