### PR TITLE
fix: advance progress.step before gating so dispatch lead is correct

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -522,6 +522,7 @@ class Orchestrator:
         await asyncio.to_thread(save_rollouts, rollout_dicts, step_path / "train_rollouts.jsonl")
 
         await self.sender.send(TrainingBatch(examples=batch.samples, step=step))
+        self.progress.step += 1
         self.update_dispatch_gate()
         trim_process_memory()
 
@@ -592,7 +593,6 @@ class Orchestrator:
         self.log_train_batch(batch, step=step, step_time=step_time)
 
         self.train_sink.reset_pre_filter_stats()
-        self.progress.step += 1
         self.maybe_trigger_eval(self.progress.step)
         trim_process_memory()
 
@@ -786,11 +786,11 @@ class Orchestrator:
         return time.perf_counter() - t
 
     def update_dispatch_gate(self) -> None:
-        """Pause/resume the dispatcher based on how far the orchestrator's
-        next batch would run ahead of ``policy.version``. Called from two
-        sites: after shipping a batch (step advances) and from
-        ``on_new_version`` (policy advances)."""
-        lead = (self.progress.step + 1) - self.policy.version
+        """Pause/resume the dispatcher based on how far the in-flight batch runs
+        ahead of ``policy.version``. ``progress.step`` is always the batch being
+        collected — advanced right after shipping — so both call sites (ship time
+        here, policy update in ``on_new_version``) share one lead formula."""
+        lead = self.progress.step - self.policy.version
         gate = self.dispatcher.dispatch_allowed
         was_set = gate.is_set()
         if lead > TARGET_LAG:


### PR DESCRIPTION
## Summary

- Fixes an off-by-one in `update_dispatch_gate` (async orchestrator backpressure) that could pause the dispatcher one policy version too long — and self-sustain into a stall.
- `update_dispatch_gate` computed `lead = (progress.step + 1) - policy.version` at **both** call sites, but `progress.step` means different things at each:
  - **Ship time** (`finalize_train_batch`): `progress.step` is still the just-shipped step `S` (it was incremented at the *end* of the method), so the batch being collected is `S + 1` — the `+1` was correct.
  - **Policy update** (`on_new_version`): a prior ship had already advanced `progress.step` to the batch being collected, so the `+1` double-counts and overstates the lead by one → gate too strict.
- The fix advances `progress.step` immediately after `send()`, so it always names the batch currently being collected. Both sites then share a single, correct formula: `lead = progress.step - policy.version`.

## Why it matters

At `TARGET_LAG = 1`, the overstated watcher-path lead can be self-sustaining: the gate won't reopen until `policy.version` reaches the collecting batch, but that version can only be produced once that batch ships — which can't happen while the dispatcher is paused. The corrected lead only ever requires the version from an already-shipped prior batch, so it can't falsely stall. The new formula is also never *too strict* (the only direction that stalls); at worst it's momentarily one too low during `send()`'s await, which self-corrects.

## Notes

- Alternative to #2936, which fixes the same bug by passing `next_step=step+1` at the ship site and keeping the `+1`-free formula only for the watcher path. This PR instead keeps `progress.step` in sync with the in-flight batch so a single formula is correct at both sites (no extra parameter).
- Behavior is otherwise unchanged: the shipped step, checkpoint step (saved before `send`), metrics (use the local `step`), and eval trigger (still fires on the advanced `progress.step`) are all preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core pipeline backpressure between orchestrator and trainer; incorrect gating can stall training, but the change is a focused semantic fix with preserved step semantics for I/O and metrics.
> 
> **Overview**
> Fixes an **off-by-one in async orchestrator backpressure** where `update_dispatch_gate` could keep the dispatcher paused one policy version too long—and at `TARGET_LAG = 1`, that mismatch could **self-sustain into a stall**.
> 
> **`progress.step` is incremented immediately after `sender.send()`** (instead of at the end of `finalize_train_batch`), so it always names the batch currently being collected. **`update_dispatch_gate` now uses `lead = progress.step - policy.version`** everywhere (ship path and `on_new_version`), replacing the old `(progress.step + 1) - policy.version` that double-counted on policy updates.
> 
> Shipped step, checkpoints, metrics, and eval triggers are unchanged in intent: finalize still uses the local `step` for the batch just shipped; eval still runs on the advanced `progress.step`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b88f92b2bc626c73ae3d56843b8f5f4ca8d44bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->