### PR TITLE
feat: log time/wait_for_policy for dispatch gate stalls

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -165,6 +165,11 @@ class Orchestrator:
         # Trigger timestamps so eval success logs can report epoch duration
         self.eval_triggered_at = {}
         self.consecutive_empty_batches = 0
+        # Wall-clock the dispatcher spends paused at the dispatch gate waiting for
+        # the trainer to ship a new policy. Accumulated across pause/resume cycles,
+        # then logged as ``time/wait_for_policy`` and reset every shipped batch.
+        self.gate_closed_at = None
+        self.wait_for_policy_time = 0.0
         self.component_tasks = []
 
         # Optional attributes — ``setup()`` populates them when the relevant
@@ -554,6 +559,7 @@ class Orchestrator:
             "progress/total_tasks": self.progress.total_problems,
             "time/step": step_time,
             "time/save_ckpt": save_ckpt_time,
+            "time/wait_for_policy": self.wait_for_policy_time,
             "step": step,
         }
         for env_name, env_pool in batch.rollouts.by_env().items():
@@ -565,6 +571,7 @@ class Orchestrator:
             for name, count in self.train_sink.pre_filter_dropped_by_name.items():
                 metrics[f"pre_filters/all/{name}/rate"] = count / self.train_sink.pre_filter_seen
         self.monitor.log(metrics, step=step)
+        self.wait_for_policy_time = 0.0
         self.monitor.log_samples(effective.rollouts, step=step)
         self.monitor.log_distributions(
             distributions={
@@ -798,10 +805,14 @@ class Orchestrator:
                 get_logger().info(
                     "Pausing dispatcher to prevent orchestrator from racing from trainer. Waiting for new policy..."
                 )
+                self.gate_closed_at = time.perf_counter()
             gate.clear()
         else:
             if not was_set:
                 get_logger().info("Resuming dispatcher")
+                if self.gate_closed_at is not None:
+                    self.wait_for_policy_time += time.perf_counter() - self.gate_closed_at
+                    self.gate_closed_at = None
             gate.set()
 
     async def on_version_pending(self, step: int) -> None:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -165,9 +165,6 @@ class Orchestrator:
         # Trigger timestamps so eval success logs can report epoch duration
         self.eval_triggered_at = {}
         self.consecutive_empty_batches = 0
-        # Wall-clock the dispatcher spends paused at the dispatch gate waiting for
-        # the trainer to ship a new policy. Accumulated across pause/resume cycles,
-        # then logged as ``time/wait_for_policy`` and reset every shipped batch.
         self.gate_closed_at = None
         self.wait_for_policy_time = 0.0
         self.component_tasks = []

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -313,6 +313,7 @@ PERFORMANCE_METRICS = [
     "perf/mfu",
     "time/step",
     "time/wait_for_batch",
+    "time/wait_for_policy",
     "inference/agg/throughput",
     "inference/agg/running_requests",
     "inference/agg/waiting_requests",


### PR DESCRIPTION
## Summary

- Add a `time/wait_for_policy` orchestrator metric that measures the wall-clock the dispatch gate spends **paused** — i.e. how long the orchestrator is blocked because it would run more than `TARGET_LAG` batches ahead of the trainer's policy version.
- The gate (`dispatch_allowed`) is toggled by `update_dispatch_gate` (pause → *"Waiting for new policy..."*, resume → *"Resuming dispatcher"*). Until now its effect was invisible in metrics — the only signal was two `info` log lines.
- Implementation: stamp `gate_closed_at` on the open→closed transition, accumulate `wait_for_policy_time += now - gate_closed_at` on the closed→open transition, log it next to the other orchestrator `time/*` metrics, and reset each shipped batch. Accumulating across pause/resume cycles means multiple pauses between two ships are summed.
- Add `time/wait_for_policy` to the curated W&B overview view's **performance** section (next to `time/wait_for_batch`), so the two starvation signals sit side by side.

When the trainer is the bottleneck, `time/wait_for_policy` ≈ `time/step` (the orchestrator step is dominated by idling for the next policy); when the trainer keeps up, it's `0`.

Related to #2812 — that issue notes the dispatch gate (`TARGET_LAG`) is a silent, hardcoded mechanism; this makes its runtime impact observable.

## Verification

Full debug run `reverse-text-v1` (`configs/debug/v1/reverse_text.toml`, 0.6B, 1 infer + 1 train GPU, 15 steps). Generation runs a few batches ahead, so the gate closes periodically and the orchestrator waits for the trainer to catch up — 5 pause/resume cycles over the 3m25s run, e.g.:

```
19:07:30  Pausing dispatcher ... Waiting for new policy...
19:08:11  Resuming dispatcher
```

W&B history for the new key (`time/step` shown for reference):

```
 step    wait_for_policy    time/step
    0             0.0000       9.6217
    1             0.0000       3.9892
    2             0.0000       3.1449
    3            40.5590      42.6323   <- stall, dominates the step
    4             0.0000       3.8477
    5             0.0000       2.3758
    6            30.8263      33.8307   <- stall
    7             0.0000       3.3716
    8             0.0000       2.7407
    9            28.2705      30.7598   <- stall
   10             0.0000       2.6365
   11             0.0000       3.8834
   12            26.5370      27.7802   <- stall
   13             0.0000       2.7030
   14             0.0000       3.3959

count=15  nonzero=4  max=40.56s  sum=126.19s
```

Each non-zero value matches its pause→resume interval and accounts for nearly all of that step's wall-clock; steps where the trainer keeps up report `0`. ~126s of the run was spent waiting for the policy — the "trainer too slow" cost, now visible.

## Notes

- Complements the trainer-side `time/wait_for_batch` (the trainer's blocking wait for the next batch): `wait_for_policy` high = orchestrator starved by a slow trainer; `wait_for_batch` high = trainer starved by a slow orchestrator. Both now render together in the overview performance section.
- Not added to the fixed benchmark-summary table in `trainer/utils.py` (a separate rich-table that selects a specific key subset for trainer benchmarking); the metric flows to W&B / the monitor as-is.
- Merged `main` (picks up the curated overview view #2933 this hooks into, and the gating fix #2937). The metric is transition-based wall-clock, so it's unaffected by #2937's lead-formula change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only timing around existing gate logic; no changes to dispatch, training, or data paths.
> 
> **Overview**
> Adds **`time/wait_for_policy`**, an orchestrator metric for wall-clock time spent with the dispatch gate **closed** while the orchestrator waits for the trainer’s policy version to catch up (`TARGET_LAG`).
> 
> In **`update_dispatch_gate`**, the change records `gate_closed_at` when pausing and adds elapsed time to `wait_for_policy_time` on resume (summing multiple pause cycles between batch ships). That value is logged with other `time/*` metrics each train step and reset after logging.
> 
> **`time/wait_for_policy`** is included in the W&B overview **performance** section next to **`time/wait_for_batch`**, so trainer-starved vs orchestrator-starved stalls are visible side by side.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9721d690406ac9c1a42ab050b90e13ba67e82dba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->