### PR TITLE
fix(deps): refresh flash-linear-attention lock to unbreak GDN training on Hopper

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "flash-linear-attention"
 version = "0.5.2"
-source = { git = "https://github.com/fla-org/flash-linear-attention#bd67d11782696e4ff54ee6cb411483621ed3d93d" }
+source = { git = "https://github.com/fla-org/flash-linear-attention#a95475391465272cd3dc11e47d4a7772522dc9b7" }
 dependencies = [
     { name = "einops" },
     { name = "transformers" },


### PR DESCRIPTION
## Purpose

Unbreak GDN-model training (Qwen3.5-MoE, Qwen3-Next) on Hopper (H100/H200). At the current fla lock rev (`bd67d11`, June 22), **any GDN backward crashes on sm_90**:

- fla's tilelang backend for `chunk_bwd_dqkwg` fails to JIT for `sm_90a` with `tvm.error.InternalError: Get different layout for b_dq` — two `T.gemm` accumulations into the same fragment infer conflicting WGMMA accumulator layouts on Hopper only (other archs' MMA atom layouts coincide, which is why CI's non-Hopper runners never see it).
- The Triton fallback is not an option: fla hard-raises on Hopper with Triton ≥ 3.4 because that path silently computes wrong `dg`/`db`/`dk` gradients (fla-org/flash-linear-attention#640) — the tilelang backend exists precisely to work around it.
- tilelang itself can't be bumped past 0.1.9 (vLLM pins `tilelang==0.1.9`, on 0.23, 0.24, and main).

Upstream fixed the kernel in fla-org/flash-linear-attention#975 (June 29, GVA support + adaptive warp selection). `flash-linear-attention` is an unpinned git dependency, so the fix is a **lock-only refresh**: `bd67d11` → `a954753` via `uv lock --upgrade-package flash-linear-attention`.

### Lock regeneration

`uv lock --upgrade-package flash-linear-attention` resolves to exactly this rev swap, but every current uv release also reformats main's lock in passing (≤0.11.24 re-expands platform markers, ~3000 lines; ≥0.11.25 strips blank lines, ~460 lines) — no released uv reproduces main's exact formatting under re-resolution. Since the tool-produced semantic change is the single `source` line, this PR applies just that line and validates the result with uv itself: `uv lock --check` passes on 0.11.25 and 0.11.26, and `uv sync --all-extras --locked` installs clean. Whoever next regenerates the lock wholesale will pick up the formatting normalization then.

## Validation (this branch, 8×H200 / SM90)

- `pytest tests/unit -m gpu`: **74 passed, 0 failed** — on main at the old rev the four `test_qwen3_5_moe*` tests fail with the layout error (repro: `srun --gres=gpu:1 uv run pytest tests/unit/train/models/test_qwen3_5_moe.py -m gpu` on any H100/H200). The passing tests assert full-model logits and gradients against the HF torch-native reference.
- `pytest tests/unit -m "not gpu"`: 469 passed — fla API surface used by the trainer (`chunk_gated_delta_rule`, `FLACPContext`, `FusedRMSNormGated`) unchanged.
- Kernel-vs-naive-reference probe at production head dims (K=V=128 — exercises the `NK=2` multi-K-block path real Qwen3.5/Qwen3-Next hit, which the small unit-test models don't; also 64/64): max gradient delta ≤ 4e-3 in bf16, forward ≤ 7e-4, zero non-finite values.

## Follow-up (not this PR)

Consider pinning the fla git dep to a 7-char `rev` in `pyproject.toml` — it currently floats on default-branch HEAD, so every re-lock silently picks up whatever upstream merged that day (this bug rode in exactly that way, and so did its fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the unpinned git dep that supplies gated-delta training kernels; behavior change is confined to Hopper backward paths, with trainer fla APIs unchanged per validation.
> 
> **Overview**
> **Refreshes the locked `flash-linear-attention` git revision** in `uv.lock` from `bd67d11` to `a954753` so GDN-based training (e.g. Qwen3.5-MoE, Qwen3-Next) can run backward passes on Hopper (H100/H200).
> 
> The older rev’s tilelang `chunk_bwd_dqkwg` path fails to JIT on `sm_90a` with conflicting WGMMA accumulator layouts; Triton fallback is intentionally blocked on Hopper for incorrect gradients. Upstream fixed the kernel in fla-org/flash-linear-attention#975; this PR applies **only** that lock `source` line—no `pyproject.toml` or trainer code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a2491a0ddb1d22a94bcba3aa34e1a4cf3155a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->