### PR TITLE
chore(ci): drop uv extras that aren't required from CPU unit tests to fix disk exhaustion

### DIFF
--- a/.github/workflows/cpu_tests.yaml
+++ b/.github/workflows/cpu_tests.yaml
@@ -25,16 +25,6 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Install dependencies
-        # CPU unit tests need base + dev + two extras:
-        #   - flash-attn: `ring_flash_attn` (a base dep) hard-imports `flash_attn`
-        #     at module load; it ships only via this extra (prebuilt wheel on
-        #     x86_64, no build).
-        #   - envs: `test_load_configs` loads every config TOML, and configs that
-        #     reference a v1 taskset make `verifiers.v1.loaders` import that
-        #     taskset package by name at runtime (e.g. `scaleswe_v1`, `math500_v1`).
-        # We deliberately skip the GPU-only extras (flash-attn-3, disagg, quack,
-        # gpt-oss, modelexpress, flash-attn-cute) — ~several GB no unit test uses,
-        # which was overflowing the runner's root disk.
         run: uv sync --extra flash-attn --extra envs --locked
       - name: Run tests
         env:

--- a/.github/workflows/cpu_tests.yaml
+++ b/.github/workflows/cpu_tests.yaml
@@ -25,10 +25,6 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Install dependencies
-        # CPU unit tests only need base + dev deps. --all-extras additionally
-        # pulls the envs/flash-attn-3/disagg/quack/etc. extras (~2-3GB of GPU
-        # kernels and env deps that no `tests/unit` test imports), which
-        # overflows the runner's root disk. See ENG: no space left on device.
         run: uv sync --locked
       - name: Run tests
         env:

--- a/.github/workflows/cpu_tests.yaml
+++ b/.github/workflows/cpu_tests.yaml
@@ -25,13 +25,17 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Install dependencies
-        # CPU unit tests need base + dev + the flash-attn extra: `ring_flash_attn`
-        # (a base dep) hard-imports `flash_attn` at module load, and `flash_attn`
-        # ships only via the flash-attn extra (a prebuilt wheel on x86_64, no
-        # build). We deliberately skip the rest of --all-extras (envs,
-        # flash-attn-3, disagg, quack, ...) — ~2-3GB no unit test uses, which was
-        # overflowing the runner's root disk.
-        run: uv sync --extra flash-attn --locked
+        # CPU unit tests need base + dev + two extras:
+        #   - flash-attn: `ring_flash_attn` (a base dep) hard-imports `flash_attn`
+        #     at module load; it ships only via this extra (prebuilt wheel on
+        #     x86_64, no build).
+        #   - envs: `test_load_configs` loads every config TOML, and configs that
+        #     reference a v1 taskset make `verifiers.v1.loaders` import that
+        #     taskset package by name at runtime (e.g. `scaleswe_v1`, `math500_v1`).
+        # We deliberately skip the GPU-only extras (flash-attn-3, disagg, quack,
+        # gpt-oss, modelexpress, flash-attn-cute) — ~several GB no unit test uses,
+        # which was overflowing the runner's root disk.
+        run: uv sync --extra flash-attn --extra envs --locked
       - name: Run tests
         env:
           USERNAME_CI: CI_RUNNER

--- a/.github/workflows/cpu_tests.yaml
+++ b/.github/workflows/cpu_tests.yaml
@@ -25,7 +25,13 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Install dependencies
-        run: uv sync --locked
+        # CPU unit tests need base + dev + the flash-attn extra: `ring_flash_attn`
+        # (a base dep) hard-imports `flash_attn` at module load, and `flash_attn`
+        # ships only via the flash-attn extra (a prebuilt wheel on x86_64, no
+        # build). We deliberately skip the rest of --all-extras (envs,
+        # flash-attn-3, disagg, quack, ...) — ~2-3GB no unit test uses, which was
+        # overflowing the runner's root disk.
+        run: uv sync --extra flash-attn --locked
       - name: Run tests
         env:
           USERNAME_CI: CI_RUNNER

--- a/.github/workflows/cpu_tests.yaml
+++ b/.github/workflows/cpu_tests.yaml
@@ -25,7 +25,11 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Install dependencies
-        run: uv sync --all-extras --locked
+        # CPU unit tests only need base + dev deps. --all-extras additionally
+        # pulls the envs/flash-attn-3/disagg/quack/etc. extras (~2-3GB of GPU
+        # kernels and env deps that no `tests/unit` test imports), which
+        # overflows the runner's root disk. See ENG: no space left on device.
+        run: uv sync --locked
       - name: Run tests
         env:
           USERNAME_CI: CI_RUNNER


### PR DESCRIPTION
## Problem

The **CPU Tests → Unit tests** job installs dependencies with `uv sync --all-extras --locked`, pulling the *entire* dependency universe just to run `pytest tests/unit -m "not gpu"`. On top of the unavoidable base CUDA stack (torch+cu128, vllm, all `nvidia-*`), `--all-extras` also builds/installs GPU-only extras that no CPU unit test uses (`flash-attn-3` (421 MB), `disagg` = `deep-ep`/`deep-gemm`/`nixl`, `quack`, `gpt-oss`, `modelexpress`, `flash-attn-cute`). This overflows the runner's root disk (`/dev/root`, ~21–29 GB free); the failing run died extracting `triton`:

```
× Failed to download `triton==3.6.0`
╰─▶ No space left on device (os error 28)
```

## Fix

Install base + dev + only the two extras the CPU tests actually need:

```diff
- run: uv sync --all-extras --locked
+ run: uv sync --extra flash-attn --extra envs --locked
```

## Why exactly these two extras

Both are needed via **runtime** imports that static analysis misses:

- **`flash-attn`** — `ring_flash_attn` (a *base* dep) hard-imports `flash_attn` at module load (`ring_flash_attn/__init__.py → llama3_flash_attn_varlen.py → from flash_attn...`). Without it, 12 model/train tests fail collection with `ModuleNotFoundError: No module named 'flash_attn'`. On x86_64 the extra resolves to a **prebuilt wheel** (no CUDA build).
- **`envs`** — `test_configs.py::test_load_configs` loads every config TOML, and any config referencing a v1 taskset makes `verifiers.v1.loaders` import that taskset package *by name at runtime* (`scaleswe_v1`, `math500_v1`, `aime24_v1`, `color_codeword_v1`, …). Those packages ship via the `envs` extra.

Everything else in `--all-extras` stays dropped. This was verified empirically: the intermediate `--extra flash-attn` run had **454 passed / 15 failed**, and every failure was an `envs` taskset miss — nothing needed `flash-attn-3`, `disagg`, `quack`, `gpt-oss`, or `modelexpress`.

Net effect: same tests run, several GB less to download/build, and it fits on the runner disk.

> Note: the base torch+cuda+vllm stack (~8–12 GB unpacked) is still required — the code imports `vllm`/`torch` at module level and the `tests/unit/inference/*` tests import `vllm` directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency install change; no application runtime or test selection logic modified.
> 
> **Overview**
> Fixes **CPU Tests → Unit tests** failing on GitHub runners with **No space left on device** when `uv` tried to pull the full optional-dependency set (e.g. `triton`, `flash-attn-3`, `disagg`, etc.).
> 
> The install step in `.github/workflows/cpu_tests.yaml` now runs `uv sync --extra flash-attn --extra envs --locked` instead of `uv sync --all-extras --locked`. **`flash-attn`** satisfies the hard import chain from `ring-flash-attn`; **`envs`** supplies v1 taskset packages loaded at runtime when config tests walk TOMLs. The same `pytest tests/unit -m "not gpu"` command is unchanged—only what gets installed is narrower.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de2b249eb7ab10be86192a058bdf5c70ab37036e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->