### PR TITLE
feat(sft): renderer-only SFT tokenization + local data files

### DIFF
--- a/configs/ci/integration/reverse_text_sft/resume.toml
+++ b/configs/ci/integration/reverse_text_sft/resume.toml
@@ -6,6 +6,9 @@ resume_step = 5
 [model]
 name = "PrimeIntellect/Qwen3-0.6B"
 
+[renderer]
+name = "qwen3"
+
 [data]
 name = "PrimeIntellect/Reverse-Text-SFT"
 batch_size = 4

--- a/configs/ci/integration/reverse_text_sft/start.toml
+++ b/configs/ci/integration/reverse_text_sft/start.toml
@@ -5,6 +5,9 @@ max_steps = 5
 [model]
 name = "PrimeIntellect/Qwen3-0.6B"
 
+[renderer]
+name = "qwen3"
+
 [data]
 name = "PrimeIntellect/Reverse-Text-SFT"
 batch_size = 4

--- a/configs/ci/integration/reverse_text_sft_lora/resume.toml
+++ b/configs/ci/integration/reverse_text_sft_lora/resume.toml
@@ -9,6 +9,9 @@ save_adapter_separately = true
 [model]
 name = "PrimeIntellect/Qwen3-0.6B"
 
+[renderer]
+name = "qwen3"
+
 [model.lora]
 rank = 8
 target_modules = [

--- a/configs/ci/integration/reverse_text_sft_lora/start.toml
+++ b/configs/ci/integration/reverse_text_sft_lora/start.toml
@@ -8,6 +8,9 @@ save_adapter_separately = true
 [model]
 name = "PrimeIntellect/Qwen3-0.6B"
 
+[renderer]
+name = "qwen3"
+
 [model.lora]
 rank = 8
 target_modules = [

--- a/docs/training.md
+++ b/docs/training.md
@@ -144,12 +144,21 @@ Two accepted layouts:
 
 If both columns are present, `messages` takes precedence.
 
-**Tool definitions.** For tool-use SFT, add a `tools` column (OpenAI function-calling format) or `tool_defs` ([`verifiers`](https://github.com/PrimeIntellect-ai/verifiers) rollout format). Each row's value can be either a list of dicts or a JSON-encoded string of a list — both are accepted, and `tool_defs` rows are auto-converted to OAI shape before being passed into the chat template's `tools=...` argument. The `chat_template_kwargs` column, if present, is forwarded verbatim into `apply_chat_template`.
+**Local data files.** `data.data_files` loads local JSONL files instead of a hub dataset (requires a loader-style `data.name` such as `"json"`). Glob patterns expand, `.zst` files decompress, and rows are normalized for Arrow schema stability into a per-node cache before loading. `data_files` cannot be combined with `subsets`/`splits`.
 
-**Position-dependent chat templates.** Multi-turn SFT under the default tokenization path (`build_incremental_token_mask`) requires that tokenizing the first _k_ turns of a conversation be a strict prefix of tokenizing all _n ≥ k_ turns. Qwen3's upstream template _violates_ this — it strips past `<think>` blocks across user turns, silently corrupting the loss mask. Two fixes:
+**Tool definitions and renderer controls.** For tool-use SFT, add a `tools` column (OpenAI function-calling format) or `tool_defs` ([`verifiers`](https://github.com/PrimeIntellect-ai/verifiers) rollout format). Each row's value can be either a list of dicts or a JSON-encoded string of a list — both are accepted, and `tool_defs` rows are auto-converted to OAI shape before being passed into the renderer.
 
-- **Enable the renderer** (set a typed `[renderer]` config, e.g. `name = "qwen3"`, recommended; defaults to `"auto"` for RL). The [`renderers`](algorithms.md#renderers) package owns tokenization end-to-end and is robust to position-dependent templates. Hand-coded renderers ship for Qwen3, Qwen3.5, GLM-5, GLM-4.5, Kimi K2/K2.5, MiniMax M2, DeepSeek V3, Nemotron 3, GPT-OSS. Not supported for VLMs.
-- **Patched chat template** — the prime-rl–patched checkpoints (e.g. `PrimeIntellect/Qwen3-0.6B`, used in `examples/reverse_text/sft.toml`) ship a chat template that preserves thinking. Or supply your own.
+Renderer-backed SFT reads template controls from the typed `[renderer]` config in the SFT TOML. For example:
+
+```toml
+[renderer]
+name = "qwen3"
+enable_thinking = false
+```
+
+If a model needs another template control, add it to that model's renderer config in `renderers` (for example a new field on the relevant `*RendererConfig`) and consume it in the renderer implementation.
+
+**Renderer-backed tokenization.** SFT tokenization is renderer-only. The [`renderers`](algorithms.md#renderers) package owns message-to-token conversion and loss attribution end-to-end, so position-dependent chat templates (for example templates that strip past `<think>` blocks across user turns) do not corrupt the loss mask. `[renderer]` defaults to `name = "auto"`; set a typed renderer config only when you need model-specific template controls. Hand-coded renderers ship for Qwen3, Qwen3.5, GLM-5, GLM-4.5, Kimi K2/K2.5, MiniMax M2, DeepSeek V3, Nemotron 3, GPT-OSS.
 
 See [Algorithms § Multi-Turn Trajectories](algorithms.md#multi-turn-trajectories) for the full picture.
 

--- a/examples/reverse_text/sft.toml
+++ b/examples/reverse_text/sft.toml
@@ -5,6 +5,9 @@ max_steps = 100
 [model]
 name = "PrimeIntellect/Qwen3-0.6B"
 
+[renderer]
+name = "qwen3"
+
 [data]
 name = "willcb/R1-reverse-wikipedia-paragraphs-v1-1000"
 seq_len = 4096

--- a/examples/wordle/sft.toml
+++ b/examples/wordle/sft.toml
@@ -5,6 +5,9 @@ max_steps = 20
 [model]
 name = "PrimeIntellect/Qwen3-1.7B"
 
+[renderer]
+name = "qwen3"
+
 [data]
 name = "willcb/V3-wordle"
 seq_len = 1024

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
 from pydantic import Field, model_validator
-from renderers import RendererConfig
+from renderers import AutoRendererConfig, RendererConfig
 
 from prime_rl.configs.shared import (
     EnvVars,
@@ -30,7 +30,7 @@ class BaseDataConfig(BaseConfig):
     batch_size: int = Field(128, ge=1)
     """Global batch size."""
 
-    seq_len: int = Field(128, ge=1)
+    seq_len: int = Field(256, ge=1)
     """Sequence length."""
 
     pack_function: Literal["cat", "stack"] = "cat"
@@ -50,6 +50,12 @@ class BaseDataConfig(BaseConfig):
 
 class FakeDataConfig(BaseDataConfig):
     type: Literal["fake"] = "fake"
+
+    seq_len: int = Field(128, ge=1)
+    """Sequence length."""
+
+    pack_function: Literal["cat", "stack"] = "cat"
+    """Sample packing strategy."""
 
     length: Literal["fixed", "variable"] = "fixed"
     """Use fixed-length samples or variable-length samples."""
@@ -78,6 +84,9 @@ class SFTDataConfig(BaseDataConfig):
     name: str = "PrimeIntellect/Reverse-Text-SFT"
     """HF dataset name or path."""
 
+    data_files: list[str] | None = None
+    """Optional local dataset files passed to ``load_dataset``."""
+
     subsets: list[str] | None = None
     """Subsets to load from the HF dataset."""
 
@@ -102,6 +111,8 @@ class SFTDataConfig(BaseDataConfig):
 
     @model_validator(mode="after")
     def validate_subsets_and_splits(self):
+        if self.data_files is not None and (self.subsets is not None or self.splits is not None):
+            raise ValueError("data_files cannot be combined with subsets/splits")
         if self.subsets is not None or self.splits is not None:
             if self.subsets is not None and self.splits is not None:
                 if len(self.subsets) != len(self.splits):
@@ -175,13 +186,8 @@ class SFTConfig(BaseConfig):
 
     tokenizer: TokenizerConfig = TokenizerConfig()
 
-    renderer: RendererConfig | None = None
-    """Typed renderer config (``renderers.RendererConfig`` discriminated
-    union). When set, SFT tokenizes samples through the ``renderers``
-    library (single ``render()`` + ``message_indices`` mask) instead of
-    the default ``build_incremental_token_mask`` path. Required for chat
-    templates that render position-dependently (e.g. Qwen3, Qwen3.5).
-    ``None`` (default) uses the legacy tokenization path."""
+    renderer: RendererConfig = AutoRendererConfig()
+    """Renderer config. Defaults to auto-selecting from the tokenizer model name."""
 
     data: DataConfig = SFTDataConfig()
 
@@ -225,8 +231,8 @@ class SFTConfig(BaseConfig):
     dist_timeout_seconds: int = 3600
     """Timeout in seconds for torch distributed ops."""
 
-    loss_impl: Literal["liger", "torch", "liger_fused", "quack_fused"] = "torch"
-    """Cross-entropy loss implementation. ``liger_fused`` fuses the lm_head projection with the CE loss to avoid materializing full logits. ``quack_fused`` uses quack-kernels for chunked linear + CE with CuTe DSL CUDA kernels."""
+    loss_impl: Literal["liger", "torch", "liger_fused", "quack_fused"] = "liger_fused"
+    """Cross-entropy loss implementation. Defaults to fused Liger loss to avoid materializing full logits."""
 
     heartbeat: HeartbeatConfig | None = None
     """BetterStack heartbeat configuration for monitoring training progress."""
@@ -299,6 +305,15 @@ class SFTConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def validate_renderer_vs_vlm(self):
+        if self.model.vlm is not None:
+            raise ValueError(
+                "renderer-only SFT does not support VLMs yet. The renderer tokenizes "
+                "text-only message dicts client-side and cannot handle image inputs."
+            )
+        return self
+
+    @model_validator(mode="after")
     def validate_seq_len(self):
         if self.data.pack_function == "stack" and self.data.seq_len % 256 != 0:
             raise ValueError("The sequence length must be divisible by 256 when using pack function stack")
@@ -315,15 +330,6 @@ class SFTConfig(BaseConfig):
                 raise ValueError(
                     "Tracing more than 10 steps is not recommended as your trace will be massive. Remove this line if you really want to trace more steps."
                 )
-        return self
-
-    @model_validator(mode="after")
-    def validate_renderer_vs_vlm(self):
-        if self.renderer is not None and self.model.vlm is not None:
-            raise ValueError(
-                "renderer is not supported for VLMs in SFT. The renderer tokenizes "
-                "text-only message dicts client-side and cannot handle image inputs."
-            )
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -8,6 +8,7 @@ from transformers.models.auto.auto_factory import _BaseAutoModelClass, _LazyAuto
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
 
 from prime_rl.trainer.models.afmoe import AfmoeConfig, AfmoeForCausalLM
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
@@ -20,6 +21,7 @@ from prime_rl.trainer.models.llama import LlamaForCausalLM
 from prime_rl.trainer.models.minimax_m2 import MiniMaxM2Config, MiniMaxM2ForCausalLM
 from prime_rl.trainer.models.nemotron_h import NemotronHConfig, NemotronHForCausalLM
 from prime_rl.trainer.models.qwen3 import Qwen3ForCausalLM
+from prime_rl.trainer.models.qwen3_5 import Qwen3_5ForCausalLM
 from prime_rl.trainer.models.qwen3_5_moe import Qwen3_5MoeConfig, Qwen3_5MoeForCausalLM
 from prime_rl.trainer.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalLM
 
@@ -31,6 +33,7 @@ AutoConfig.register("laguna", LagunaConfig, exist_ok=True)
 AutoConfig.register("minimax_m2", MiniMaxM2Config, exist_ok=True)
 AutoConfig.register("nemotron_h", NemotronHConfig, exist_ok=True)
 AutoConfig.register("qwen3_moe", Qwen3MoeConfig, exist_ok=True)
+AutoConfig.register("qwen3_5_text", Qwen3_5TextConfig, exist_ok=True)
 AutoConfig.register("qwen3_5_moe_text", Qwen3_5MoeConfig, exist_ok=True)
 # GptOssConfig is just HF's class - already registered by transformers, no override needed.
 
@@ -44,6 +47,7 @@ _CUSTOM_CAUSAL_LM_MAPPING.register(LagunaConfig, LagunaForCausalLM, exist_ok=Tru
 _CUSTOM_CAUSAL_LM_MAPPING.register(MiniMaxM2Config, MiniMaxM2ForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(NemotronHConfig, NemotronHForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Qwen3MoeConfig, Qwen3MoeForCausalLM, exist_ok=True)
+_CUSTOM_CAUSAL_LM_MAPPING.register(Qwen3_5TextConfig, Qwen3_5ForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Qwen3_5MoeConfig, Qwen3_5MoeForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(GptOssConfig, GptOssForCausalLM, exist_ok=True)
 

--- a/src/prime_rl/trainer/models/layers/attn.py
+++ b/src/prime_rl/trainer/models/layers/attn.py
@@ -340,3 +340,7 @@ def substitute_ring_attn(
     from prime_rl.trainer.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeGatedFlashAttention
 
     Qwen3_5MoeGatedFlashAttention._compute_attention = _ring_compute_attention
+
+    from prime_rl.trainer.models.qwen3_5.modeling_qwen3_5 import Qwen3_5GatedFlashAttention
+
+    Qwen3_5GatedFlashAttention._compute_attention = _ring_compute_attention

--- a/src/prime_rl/trainer/models/layers/ulysses_attn.py
+++ b/src/prime_rl/trainer/models/layers/ulysses_attn.py
@@ -189,6 +189,10 @@ def substitute_ulysses_attn(
 
     Qwen3_5MoeGatedFlashAttention._compute_attention = _ulysses_compute_attention
 
+    from prime_rl.trainer.models.qwen3_5.modeling_qwen3_5 import Qwen3_5GatedFlashAttention
+
+    Qwen3_5GatedFlashAttention._compute_attention = _ulysses_compute_attention
+
 
 def substitute_hf_ulysses_attn(process_group: dist.ProcessGroup) -> None:
     """Patch HF's `_flash_attention_forward` to use Ulysses all-to-all + local FA2.

--- a/src/prime_rl/trainer/models/qwen3_5/__init__.py
+++ b/src/prime_rl/trainer/models/qwen3_5/__init__.py
@@ -1,0 +1,3 @@
+from .modeling_qwen3_5 import Qwen3_5ForCausalLM, Qwen3_5Model, Qwen3_5PreTrainedModel
+
+__all__ = ["Qwen3_5ForCausalLM", "Qwen3_5Model", "Qwen3_5PreTrainedModel"]

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -1,0 +1,305 @@
+import functools
+from typing import Optional, Union
+
+import torch
+from torch import Tensor, nn
+from transformers.cache_utils import Cache
+from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
+from transformers.modeling_outputs import BaseModelOutputWithPast
+from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
+from transformers.models.qwen3_5.modeling_qwen3_5 import (
+    Qwen3_5PreTrainedModel as HFQwen3_5PreTrainedModel,
+)
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs
+
+from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
+from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
+from prime_rl.trainer.models.qwen3_5_moe.modeling_qwen3_5_moe import (
+    Qwen3_5MoeGatedAttentionConfig,
+    Qwen3_5MoeGatedDeltaNet,
+    Qwen3_5MoeGatedFlashAttention,
+    Qwen3_5MoeGatedSDPAAttention,
+    Qwen3_5MoeRMSNorm,
+    Qwen3_5MoeRotaryEmbedding,
+    normalize_qwen3_5_attn_implementation,
+)
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+
+
+class Qwen3_5GatedSDPAAttention(Qwen3_5MoeGatedSDPAAttention):
+    pass
+
+
+class Qwen3_5GatedFlashAttention(Qwen3_5MoeGatedFlashAttention):
+    pass
+
+
+QWEN35_ATTN_IMPL2CLASS = {
+    "sdpa": Qwen3_5GatedSDPAAttention,
+    "flash_attention_2": functools.partial(Qwen3_5GatedFlashAttention, flash_attn_version=2),
+    "flash_attention_3": functools.partial(Qwen3_5GatedFlashAttention, flash_attn_version=3),
+    "fa4": functools.partial(Qwen3_5GatedFlashAttention, flash_attn_version=4),
+}
+
+
+def _get_gated_attention(config: Qwen3_5TextConfig) -> nn.Module:
+    attn_config = Qwen3_5MoeGatedAttentionConfig(
+        hidden_size=config.hidden_size,
+        head_dim=config.head_dim,
+        num_attention_heads=config.num_attention_heads,
+        num_key_value_heads=config.num_key_value_heads,
+        rms_norm_eps=config.rms_norm_eps,
+        attention_bias=config.attention_bias,
+        attention_dropout=config.attention_dropout,
+    )
+
+    attn_impl = normalize_qwen3_5_attn_implementation(config._attn_implementation)
+    config._attn_implementation = attn_impl
+
+    if attn_impl not in QWEN35_ATTN_IMPL2CLASS:
+        supported = list(QWEN35_ATTN_IMPL2CLASS.keys())
+        raise ValueError(
+            f"Qwen3.5 attention does not support '{config._attn_implementation}'. "
+            f"Supported implementations: {supported}."
+        )
+
+    return QWEN35_ATTN_IMPL2CLASS[attn_impl](attn_config)
+
+
+def _create_rotary_emb(config: Qwen3_5TextConfig) -> Qwen3_5MoeRotaryEmbedding:
+    return Qwen3_5MoeRotaryEmbedding(config)
+
+
+class Qwen3_5DecoderLayer(GradientCheckpointingLayer):
+    def __init__(self, config: Qwen3_5TextConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.layer_type = config.layer_types[layer_idx]
+
+        if self.layer_type == "linear_attention":
+            self.linear_attn = Qwen3_5MoeGatedDeltaNet(config)
+        elif self.layer_type == "full_attention":
+            self.self_attn = _get_gated_attention(config)
+        else:
+            raise ValueError(f"Unsupported Qwen3.5 layer type: {self.layer_type}")
+
+        mlp_config = MLPConfig(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            gate_act=config.hidden_act,
+            bias=False,
+        )
+        self.mlp = MLP(mlp_config)
+        self.input_layernorm = Qwen3_5MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Qwen3_5MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        cu_seqlens: torch.LongTensor | None = None,
+        max_seqlen: int | None = None,
+    ) -> torch.FloatTensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        if self.layer_type == "linear_attention":
+            hidden_states = self.linear_attn(hidden_states, cu_seqlens=cu_seqlens)
+        else:
+            hidden_states, _ = self.self_attn(
+                hidden_states=hidden_states,
+                position_embeddings=position_embeddings,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+            )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+
+class Qwen3_5PreTrainedModel(PreTrainedModelPrimeRL, HFQwen3_5PreTrainedModel):
+    config_class = Qwen3_5TextConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["Qwen3_5DecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn = True
+    _supports_sdpa = True
+    _supports_flex_attn = False
+    _supports_attention_backend = True
+    _can_compile_fullgraph = False
+    _can_record_outputs = {
+        "hidden_states": Qwen3_5DecoderLayer,
+    }
+
+    def _check_and_adjust_attn_implementation(
+        self, attn_implementation: str | None, is_init_check: bool = False, allow_all_kernels: bool = False
+    ) -> str:
+        attn_impl = normalize_qwen3_5_attn_implementation(attn_implementation or "sdpa")
+        if attn_impl not in QWEN35_ATTN_IMPL2CLASS:
+            supported = list(QWEN35_ATTN_IMPL2CLASS.keys())
+            raise ValueError(
+                f"Qwen3.5 attention does not support '{attn_implementation}'. Supported implementations: {supported}."
+            )
+        return attn_impl
+
+    @classmethod
+    def is_hf_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return True
+
+    @classmethod
+    def is_prime_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return True
+
+    @classmethod
+    def convert_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        return state_dict
+
+    @classmethod
+    def convert_to_prime(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        return state_dict
+
+    @classmethod
+    def convert_layer_to_hf(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        return state_dict
+
+    @classmethod
+    def convert_layer_to_prime(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        return state_dict
+
+
+class Qwen3_5Model(Qwen3_5PreTrainedModel):
+    def __init__(self, config: Qwen3_5TextConfig):
+        config._attn_implementation = normalize_qwen3_5_attn_implementation(config._attn_implementation)
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [Qwen3_5DecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = Qwen3_5MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = _create_rotary_emb(config)
+        self.gradient_checkpointing = False
+
+        self.post_init()
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+    ) -> BaseModelOutputWithPast:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if position_ids is None:
+            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if flash_attn_enabled:
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        else:
+            cu_seqlens = None
+            max_seqlen = None
+
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        for decoder_layer in self.layers:
+            hidden_states = decoder_layer(
+                hidden_states,
+                position_embeddings=position_embeddings,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return BaseModelOutputWithPast(last_hidden_state=hidden_states)
+
+
+class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
+    _checkpoint_conversion_mapping = {}
+    _tp_plan = {"lm_head": "colwise_gather_output"}
+    _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+
+    def __init__(self, config, **kwargs):
+        super().__init__(config, **kwargs)
+        self.model = Qwen3_5Model(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        temperature: Union[torch.Tensor, None] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> PrimeLmOutput:
+        assert use_cache is None, "use_cache is not supported for custom qwen3_5 for now"
+        assert past_key_values is None, "past_key_values is not supported for custom qwen3_5 for now"
+
+        if position_ids is None:
+            if inputs_embeds is not None:
+                position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+            elif input_ids is not None:
+                position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).unsqueeze(0)
+
+        outputs = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        return self.lm_head(
+            hidden_states[:, slice_indices, :],
+            labels[:, slice_indices] if labels is not None else None,
+            temperature=temperature,
+        )
+
+    def init_buffers_post_meta(self):
+        lm_rope = self.model.rotary_emb
+        if hasattr(lm_rope, "rope_init_fn"):
+            inv_freq, lm_rope.attention_scaling = lm_rope.rope_init_fn(lm_rope.config, lm_rope.inv_freq.device)
+            lm_rope.inv_freq.copy_(inv_freq)
+
+
+__all__ = [
+    "Qwen3_5ForCausalLM",
+    "Qwen3_5GatedFlashAttention",
+    "Qwen3_5Model",
+    "Qwen3_5PreTrainedModel",
+]

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -551,6 +551,14 @@ QWEN35MOE_ATTN_IMPL2CLASS = {
 }
 
 
+def normalize_qwen3_5_attn_implementation(attn_impl: str) -> str:
+    if attn_impl == "eager":
+        return "sdpa"
+    if attn_impl == "kernels-community/vllm-flash-attn3":
+        return "flash_attention_3"
+    return attn_impl
+
+
 # ---------------------------------------------------------------------------
 # Decoder layer
 # ---------------------------------------------------------------------------
@@ -567,9 +575,8 @@ def _get_gated_attention(config: Qwen3_5MoeConfig) -> nn.Module:
         attention_dropout=config.attention_dropout,
     )
 
-    attn_impl = config._attn_implementation
-    if attn_impl == "eager":
-        attn_impl = "sdpa"
+    attn_impl = normalize_qwen3_5_attn_implementation(config._attn_implementation)
+    config._attn_implementation = attn_impl
 
     if attn_impl not in QWEN35MOE_ATTN_IMPL2CLASS:
         supported = list(QWEN35MOE_ATTN_IMPL2CLASS.keys())
@@ -783,6 +790,17 @@ class Qwen3_5MoePreTrainedModel(PreTrainedModelPrimeRL):
         "hidden_states": Qwen3_5MoeDecoderLayer,
     }
 
+    def _check_and_adjust_attn_implementation(
+        self, attn_implementation: str | None, is_init_check: bool = False, allow_all_kernels: bool = False
+    ) -> str:
+        attn_impl = normalize_qwen3_5_attn_implementation(attn_implementation or "sdpa")
+        if attn_impl not in QWEN35MOE_ATTN_IMPL2CLASS:
+            supported = list(QWEN35MOE_ATTN_IMPL2CLASS.keys())
+            raise ValueError(
+                f"Qwen3.5-MoE attention does not support '{attn_implementation}'. Supported implementations: {supported}."
+            )
+        return attn_impl
+
     @classmethod
     def is_hf_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
         return any(
@@ -819,6 +837,7 @@ class Qwen3_5MoePreTrainedModel(PreTrainedModelPrimeRL):
 
 class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
     def __init__(self, config: Qwen3_5MoeConfig):
+        config._attn_implementation = normalize_qwen3_5_attn_implementation(config._attn_implementation)
         super().__init__(config)
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -1,7 +1,12 @@
+import glob
+import hashlib
 import json
+import subprocess
+import tempfile
 import uuid
 from collections import defaultdict
-from typing import Literal, TypedDict, cast
+from pathlib import Path
+from typing import Any, Literal, TypedDict, cast
 
 import torch
 from datasets import Dataset, interleave_datasets, load_dataset
@@ -15,13 +20,7 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.configs.sft import DataConfig, LossMaskConfig, SFTDataConfig
 from prime_rl.trainer.world import get_world
-from prime_rl.utils.chat_template import (
-    IncrementalTokenizationError,
-    build_incremental_token_mask,
-    deserialize_tool_calls,
-    normalize_messages,
-    strip_message_content,
-)
+from prime_rl.utils.chat_template import deserialize_tool_calls, normalize_messages
 from prime_rl.utils.logger import get_logger
 
 STACKING_DATASET_BUCKET_TIMEOUT = 10
@@ -114,6 +113,23 @@ class FakeDataset(StatefulIterableDataset):
             yield fake_sample
 
 
+def _drop_null_fields(value: Any) -> Any:
+    """Recursively strip ``None``-valued keys from dict structures.
+
+    PyArrow's JSON loader unifies schemas across rows, so heterogeneous
+    OAI content blocks (text vs image_url) end up with all union keys
+    filled with ``None`` where absent. That confuses permissive
+    content-type predicates inside renderers (e.g. ``"image_url" in item``
+    returns ``True`` even when the value is null). Strip the noise before
+    handing messages off to the renderer.
+    """
+    if isinstance(value, dict):
+        return {k: _drop_null_fields(v) for k, v in value.items() if v is not None}
+    if isinstance(value, list):
+        return [_drop_null_fields(v) for v in value]
+    return value
+
+
 class SFTDataset(StatefulIterableDataset):
     """A dataset wrapping a HF SFT dataset with prompt/completion or raw messages format."""
 
@@ -121,6 +137,7 @@ class SFTDataset(StatefulIterableDataset):
         self,
         dataset: Dataset,
         tokenizer: PreTrainedTokenizer | None,
+        renderer: Renderer | None = None,
         shuffle: bool = True,
         seed: int = 0,
         seq_len: int = 128,
@@ -128,7 +145,6 @@ class SFTDataset(StatefulIterableDataset):
         loss_mask_config: LossMaskConfig = LossMaskConfig(),
         max_examples: int | None = None,
         max_epochs: int | None = None,
-        renderer: Renderer | None = None,
     ):
         super().__init__()
         self.logger = get_logger()
@@ -143,9 +159,6 @@ class SFTDataset(StatefulIterableDataset):
         self.max_epochs = max_epochs
         self.renderer = renderer
         self._warned_chat_template_kwargs = False
-
-        if self.tokenizer is None:
-            self.logger.warning("No tokenizer provided, will not process examples")
 
         # If specified, select a subset of the dataset
         if self.max_examples is not None:
@@ -163,16 +176,19 @@ class SFTDataset(StatefulIterableDataset):
         self.data_world_size = get_world().world_size // non_dp_size * num_workers
 
     def _process(self, example: dict) -> dict | None:
-        # Skip processing if no tokenizer was provided
         if self.tokenizer is None:
             return example
+        if self.renderer is None:
+            raise ValueError("SFT processing requires a renderer.")
 
         def resolve_messages(example: dict) -> list[dict]:
             # `messages` takes precedence over explicit split fields and is interpreted
-            # as a whole-chat training sample with an empty prompt.
-            if "messages" in example:
+            # as a whole-chat training sample with an empty prompt. Null-check rather
+            # than key-check: Arrow schema union adds `messages: null` to
+            # prompt/completion rows whenever other rows have a `messages` column.
+            if example.get("messages") is not None:
                 messages = normalize_messages(example["messages"], default_role="assistant")
-            elif "prompt" in example and "completion" in example:
+            elif example.get("prompt") is not None and example.get("completion") is not None:
                 messages = normalize_messages(example["prompt"], default_role="user") + normalize_messages(
                     example["completion"], default_role="assistant"
                 )
@@ -182,22 +198,17 @@ class SFTDataset(StatefulIterableDataset):
                     "or both 'prompt' and 'completion' columns for SFT"
                 )
 
-            # Deserialize tool call arguments from message list, if present - assumes OAI format
-            # Reference: https://platform.openai.com/docs/guides/function-calling#handling-function-calls
-            messages = deserialize_tool_calls(messages)
-
-            # Strip content from all messages so that incremental tokenization works
-            # NOTE: This has the side effect that we do never train on leading or trailing whitespace
-            return strip_message_content(messages)
+            # Strip nulls before deserializing so genuine nulls inside tool-call
+            # argument strings survive.
+            messages = [_drop_null_fields(m) for m in messages]
+            return deserialize_tool_calls(messages)
 
         messages = resolve_messages(example)
 
-        # Parse available tools, if present - assumes OAI format
-        # Reference: https://platform.openai.com/docs/guides/function-calling#function-tool-example
-        # Accepts either `tools` or `tool_defs` (the verifiers rollout format),
-        # as either a JSON-encoded string of a list or a list of dicts. Tools
-        # arriving in the verifiers shape are converted to OAI form so any
-        # downstream chat template can consume them.
+        # Parse available tools, if present - assumes OAI format. Accepts either
+        # `tools` or `tool_defs` (the verifiers rollout format), as either a
+        # JSON-encoded string of a list or a list of dicts; verifiers-shaped
+        # tools are converted to OAI form for the chat template.
         raw_tools = example.get("tools", example.get("tool_defs"))
         if not raw_tools:
             tools = []
@@ -223,45 +234,36 @@ class SFTDataset(StatefulIterableDataset):
             assert "role" in message, "Message must have a role"
             match message["role"]:
                 case "user":
-                    return True if self.loss_mask_config.user else False
+                    return self.loss_mask_config.user
                 case "assistant":
-                    return True if self.loss_mask_config.assistant else False
+                    return self.loss_mask_config.assistant
                 case "system":
-                    return True if self.loss_mask_config.system else False
+                    return self.loss_mask_config.system
                 case "tool":
-                    return True if self.loss_mask_config.tool else False
+                    return self.loss_mask_config.tool
                 case _:
                     raise ValueError(f"Invalid message role: {message['role']}")
 
-        if self.renderer is not None:
-            if example.get("chat_template_kwargs") and not self._warned_chat_template_kwargs:
-                self.logger.warning(
-                    "Example carries chat_template_kwargs but a renderer is configured; "
-                    "renderers don't forward chat_template_kwargs (model-specific "
-                    "renderers bake their template behavior in). These kwargs will "
-                    "be ignored. Further warnings suppressed for this dataset."
-                )
-                self._warned_chat_template_kwargs = True
-
-            input_ids, loss_mask = build_training_sample(
-                self.renderer,
-                messages,
-                role_to_mask=should_mask,
-                tools=tools,
+        if example.get("chat_template_kwargs") and not self._warned_chat_template_kwargs:
+            self.logger.warning(
+                "Ignoring per-example chat_template_kwargs; renderers only take "
+                "template kwargs run-wide via the [renderer] config."
             )
-        else:
-            try:
-                input_ids, loss_mask = build_incremental_token_mask(
-                    self.tokenizer,
-                    messages,
-                    role_to_mask=should_mask,
-                    tools=tools,
-                    chat_template_kwargs=example.get("chat_template_kwargs", {}),
-                    collapse_consecutive_tool_messages=True,
-                )
-            except IncrementalTokenizationError as e:
-                self.logger.warning(f"Skipping example {example.get('__index', '')}: {e}")
-                return None
+            self._warned_chat_template_kwargs = True
+
+        # Non-assistant roles are opted into the loss via the renderer's
+        # body-only path: the message content is trained, not the role
+        # scaffolding (e.g. <tool_response> tags) the harness emits.
+        content_sft_roles = {role for role in ("user", "system", "tool") if getattr(self.loss_mask_config, role)}
+        sample = build_training_sample(
+            self.renderer,
+            messages,
+            role_to_mask=should_mask,
+            tools=tools,
+            content_sft_roles=content_sft_roles or None,
+        )
+        input_ids = list(sample.token_ids)
+        loss_mask = list(sample.loss_mask)
 
         # If EOS token is not found, manually append it
         if not self.tokenizer.eos_token_id in input_ids:
@@ -271,7 +273,7 @@ class SFTDataset(StatefulIterableDataset):
             input_ids.append(cast(int, self.tokenizer.eos_token_id))
             loss_mask.append(True)
 
-        # Prepare inputs
+        # Causal shift: model predicts next token from current.
         target_ids = input_ids.copy()[1:]
         loss_mask = loss_mask[1:]
         input_ids = input_ids[:-1]
@@ -280,7 +282,7 @@ class SFTDataset(StatefulIterableDataset):
             self.logger.warning(
                 f"Skipping example {example.get('__index', '')} because no trainable tokens were found within the context window ({self.seq_len}). This is to prevent NaN loss."
             )
-            return
+            return None
 
         assert len(input_ids) == len(loss_mask) == len(target_ids), (
             f"input_ids, loss_mask and target_ids must have the same length, but got {len(input_ids)=}, {len(loss_mask)=}, {len(target_ids)=}"
@@ -288,7 +290,6 @@ class SFTDataset(StatefulIterableDataset):
         assert sum(loss_mask) > 0, "There are no tokens in this sample that contribute to the loss"
         assert self.tokenizer.eos_token_id in target_ids, "EOS token ID must be present in target_ids"
 
-        # Create sample (with one fake target for the last token)
         return {
             "input_ids": input_ids,
             "target_ids": target_ids,
@@ -297,9 +298,6 @@ class SFTDataset(StatefulIterableDataset):
         }
 
     def __iter__(self):
-        """
-        Apply chat template and tokenize a single example in prompt + completion format (https://github.com/huggingface/trl/blob/de27d612b026526ba39b88eee348994d7636e033/trl/trainer/sft_trainer.py#L661)
-        """
         dataset = self.dataset.shuffle(seed=self.epoch + self.seed) if self.shuffle else self.dataset
         while True:
             self.step += 1
@@ -326,7 +324,6 @@ class SFTDataset(StatefulIterableDataset):
             # Process example
             processed_example = self._process(cast(dict, example))
 
-            # If processed example is None, skip it (e.g. if tokenized sample exceeds context window)
             if processed_example is None:
                 continue
 
@@ -512,12 +509,16 @@ def setup_and_interleave_datasets(
     probabilities: list[float] | None,
     stopping_strategy: Literal["first_exhausted", "all_exhausted"],
     seed: int = 0,
+    data_files: str | list[str] | None = None,
 ) -> Dataset:
     logger = get_logger()
     datasets = []
     for subset, split in subsets_and_splits:
-        logger.debug(f"Loading dataset {dataset_name} with {subset=} and {split=}")
-        dataset = cast(Dataset, load_dataset(dataset_name, subset, split=split))
+        logger.debug(f"Loading dataset {dataset_name} with {subset=}, {split=}, {data_files=}")
+        if data_files is not None:
+            dataset = cast(Dataset, load_dataset(dataset_name, data_files=data_files, split=split))
+        else:
+            dataset = cast(Dataset, load_dataset(dataset_name, subset, split=split))
         num_examples = len(dataset)
         dataset = dataset.add_column("__subset", [subset] * num_examples, new_fingerprint=str(uuid.uuid4()))
         dataset = dataset.add_column("__split", [split] * num_examples, new_fingerprint=str(uuid.uuid4()))
@@ -537,15 +538,141 @@ def setup_and_interleave_datasets(
     return dataset
 
 
+def _normalize_oai_record(record: dict) -> dict:
+    """Coerce variable JSON shapes to forms PyArrow's JSON loader can handle.
+
+    PyArrow infers schemas across rows and crashes on shape drift:
+    ``tool_calls`` (via ``function.arguments`` and heterogeneous per-tool
+    metadata) and the ``tools`` / ``tool_defs`` arrays carry per-row schemas
+    that Arrow can't represent, and even shape-stable tool_calls crash when
+    early batches are all-null (Arrow infers ``null`` and can't cast later
+    ``list<struct>`` batches to it). Stringify each to a JSON string — a
+    string column always unifies — with null/empty ``tool_calls`` coerced to
+    ``""``. ``deserialize_tool_calls`` reverses this downstream.
+
+    Both the ``messages`` layout and the TRL ``prompt``/``completion`` layout
+    (where each column is itself a message list) are normalized.
+    """
+    new_record = dict(record)
+
+    for key in ("messages", "prompt", "completion"):
+        messages = new_record.get(key)
+        if isinstance(messages, list):
+            new_record[key] = [_normalize_oai_message(m) for m in messages]
+
+    for key in ("tools", "tool_defs"):
+        tools = new_record.get(key)
+        if isinstance(tools, (list, dict)):
+            new_record[key] = json.dumps(tools)
+
+    return new_record
+
+
+def _normalize_oai_message(message: Any) -> Any:
+    if not isinstance(message, dict) or "tool_calls" not in message:
+        return message
+    message = dict(message)
+    tool_calls = message["tool_calls"]
+    if not isinstance(tool_calls, str):
+        # "" (not None) for no-tool messages: an all-null column chunk infers
+        # Arrow type null, which can't unify with string chunks
+        message["tool_calls"] = json.dumps(tool_calls) if tool_calls else ""
+    return message
+
+
+def _resolve_local_data_files(data_files: list[str] | None) -> list[str] | None:
+    """Materialize local files HF datasets can ingest.
+
+    Glob patterns are expanded first (each match is materialized separately),
+    then two transforms are applied side-by-side under ``$TMPDIR``:
+    - ``.zst`` files are decompressed (HF handles gz/bz2/xz transparently
+      but not zstd).
+    - JSONL files are normalized via :func:`_normalize_oai_record` so the
+      Arrow JSON loader can infer a stable schema across rows.
+
+    Both steps stream line-by-line — no full-file load into memory — so large
+    full datasets go through the same path as smaller samples.
+
+    The temp filename embeds a digest of the source's absolute path, mtime,
+    and size, so same-basename files from different directories (or a
+    changed/stale source) never collide on or silently reuse a previous run's
+    materialized output.
+
+    Each node materializes into its own (node-local) ``$TMPDIR``, so only the
+    local-rank-0 process on each node performs the work; a global barrier then
+    syncs all ranks. Gating per-node (not on global rank 0 alone) means ranks
+    on other nodes find their files instead of waiting on a path that was only
+    written on node 0. The gate also avoids parallel ranks racing to write the
+    same path (byte-interleaved output PyArrow rejects).
+    """
+    if not data_files:
+        return data_files
+    expanded: list[str] = []
+    for path in data_files:
+        if any(char in path for char in "*?["):
+            matches = sorted(glob.glob(path))
+            if not matches:
+                raise FileNotFoundError(f"No files match data_files pattern {path!r}")
+            expanded.extend(matches)
+        else:
+            expanded.append(path)
+    is_writer = not torch.distributed.is_initialized() or get_world().local_rank == 0
+    resolved: list[str] = []
+    for path in expanded:
+        p = Path(path)
+        if p.suffix in (".zst", ".jsonl"):
+            stat = p.stat()
+            digest = hashlib.sha1(f"{p.resolve()}:{stat.st_mtime_ns}:{stat.st_size}".encode()).hexdigest()[:12]
+            tmp = Path(tempfile.gettempdir()) / f"{p.stem}.{digest}.prime_rl_normalized.jsonl"
+            if is_writer and (not tmp.exists() or tmp.stat().st_size == 0):
+                if p.suffix == ".zst":
+                    get_logger().info(f"Decompressing + normalizing {p} → {tmp}")
+                    decompressed = Path(tempfile.gettempdir()) / f"{p.stem}.{digest}.prime_rl_raw"
+                    if not decompressed.exists() or decompressed.stat().st_size == 0:
+                        part = decompressed.with_name(decompressed.name + ".part")
+                        subprocess.run(["zstd", "-d", "-f", "-o", str(part), str(p)], check=True)
+                        part.replace(decompressed)
+                    _normalize_jsonl(decompressed, tmp)
+                else:
+                    get_logger().info(f"Normalizing {p} → {tmp}")
+                    _normalize_jsonl(p, tmp)
+            resolved.append(str(tmp))
+        else:
+            resolved.append(str(p))
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+    return resolved
+
+
+def _normalize_jsonl(src: Path, dst: Path) -> None:
+    """Stream-rewrite ``src`` JSONL to ``dst`` with uniform OAI message shape.
+
+    Writes to a sidecar path and atomically renames into place, so an
+    interrupted run never leaves a truncated file that a later run would
+    mistake for a valid cache.
+    """
+    part = dst.with_name(dst.name + ".part")
+    with src.open("r") as f_in, part.open("w") as f_out:
+        for line in f_in:
+            if not line.strip():
+                continue
+            record = _normalize_oai_record(json.loads(line))
+            f_out.write(json.dumps(record))
+            f_out.write("\n")
+    part.replace(dst)
+
+
 def load_sft_dataset(config: SFTDataConfig) -> Dataset:
     """Load and interleave the raw HF dataset. This is the expensive I/O step."""
     logger = get_logger()
+    data_files = _resolve_local_data_files(config.data_files)
     if config.subsets is None and config.splits is None:
         return setup_and_interleave_datasets(
             dataset_name=config.name,
             subsets_and_splits=[(None, "train")],
             probabilities=config.probabilities,
             stopping_strategy=config.stopping_strategy,
+            data_files=data_files,
         )
     elif config.subsets is not None and config.splits is None:
         logger.debug(f"Loading datasets for subsets {config.subsets} with default split 'train'")
@@ -554,6 +681,7 @@ def load_sft_dataset(config: SFTDataConfig) -> Dataset:
             subsets_and_splits=[(subset, "train") for subset in config.subsets],
             probabilities=config.probabilities,
             stopping_strategy=config.stopping_strategy,
+            data_files=data_files,
         )
     elif config.subsets is None and config.splits is not None:
         logger.debug(f"Loading datasets for splits {config.splits} with default subset 'None'")
@@ -562,6 +690,7 @@ def load_sft_dataset(config: SFTDataConfig) -> Dataset:
             subsets_and_splits=[(None, split) for split in config.splits],
             probabilities=config.probabilities,
             stopping_strategy=config.stopping_strategy,
+            data_files=data_files,
         )
     else:
         assert config.subsets is not None and config.splits is not None
@@ -571,6 +700,7 @@ def load_sft_dataset(config: SFTDataConfig) -> Dataset:
             subsets_and_splits=list(zip(config.subsets, config.splits)),
             probabilities=config.probabilities,
             stopping_strategy=config.stopping_strategy,
+            data_files=data_files,
         )
 
 
@@ -585,9 +715,14 @@ def setup_dataset(
 ) -> StatefulIterableDataset:
     if config.type == "fake":
         return FakeDataset(
-            vocab_size=tokenizer.vocab_size, seq_len=config.seq_len, length=config.length, input_ids=config.input_ids
+            vocab_size=tokenizer.vocab_size,
+            seq_len=config.seq_len,
+            length=config.length,
+            input_ids=config.input_ids,
         )
     elif config.type == "sft":
+        if renderer is None:
+            raise ValueError("SFT data requires a renderer.")
         if raw_dataset is None:
             raw_dataset = load_sft_dataset(config)
         return SFTDataset(

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -29,8 +29,8 @@ from prime_rl.trainer.model import (
     forward,
     get_load_balance_stats,
     is_tt_moe_model,
-    setup_tokenizer,
     setup_model,
+    setup_tokenizer,
 )
 from prime_rl.trainer.parallel_dims import get_parallel_dims, resolve_ep
 from prime_rl.trainer.perf import get_perf_counter
@@ -56,6 +56,19 @@ from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss
 from prime_rl.trainer.models.layers.lm_head import FUSED_CE_IGNORE_INDEX
 
 from torchtitan.distributed.utils import clip_grad_norm_
+
+
+def setup_renderer(tokenizer, config):
+    """Create the SFT renderer, rejecting the DefaultRenderer fallback."""
+    renderer = create_renderer(tokenizer, config)
+    if isinstance(renderer, DefaultRenderer):
+        raise ValueError(
+            f"SFT renderer for {tokenizer.name_or_path!r} resolved to DefaultRenderer. "
+            "SFT is renderer-only and requires a hand-coded renderer for stable "
+            "message-to-token attribution. Use a model with a hand-coded renderer "
+            "(see renderers.base.MODEL_RENDERER_MAP), or set [renderer] name=<hand-coded renderer> explicitly."
+        )
+    return renderer
 
 
 @clean_exit
@@ -162,17 +175,12 @@ def train(config: SFTConfig):
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)
 
+    # Fake data never renders messages, so a model without a hand-coded renderer
+    # can still be used to benchmark step time / memory. Validation data is
+    # always real, so it needs the renderer even when training data is fake.
     renderer = None
-    if config.renderer is not None:
-        renderer = create_renderer(tokenizer, config.renderer)
-        if isinstance(renderer, DefaultRenderer):
-            raise ValueError(
-                f"renderer set for {config.tokenizer.name!r} resolved to DefaultRenderer. "
-                "DefaultRenderer falls back to incremental apply_chat_template and does NOT "
-                "fix position-dependent chat templates — the bug the renderer client is meant to solve. "
-                "Either use a model with a hand-coded renderer (see renderers.base.MODEL_RENDERER_MAP), "
-                "set [renderer] name=<hand-coded renderer> explicitly, or remove the [renderer] block."
-            )
+    if config.data.type != "fake" or config.val is not None:
+        renderer = setup_renderer(tokenizer, config.renderer)
         logger.info(f"Initialized {type(renderer).__name__} for {config.tokenizer.name}")
 
     # Set up the optimizer

--- a/src/prime_rl/utils/chat_template.py
+++ b/src/prime_rl/utils/chat_template.py
@@ -1,13 +1,5 @@
 import json
-from typing import Any, Callable
-
-from transformers.tokenization_utils import PreTrainedTokenizer
-
-
-class IncrementalTokenizationError(ValueError):
-    """Raised when incremental tokenization produces inconsistent token prefixes."""
-
-    pass
+from typing import Any
 
 
 def normalize_messages(messages: Any, default_role: str) -> list[dict[str, Any]]:
@@ -48,6 +40,10 @@ def deserialize_tool_calls(messages: list[dict[str, Any]]) -> list[dict[str, Any
             continue
 
         tool_calls = message.get("tool_calls") or []
+        if isinstance(tool_calls, str):
+            # data_files normalization stringifies the whole list (see
+            # _normalize_oai_record) so Arrow sees a nullable string column
+            tool_calls = json.loads(tool_calls)
         deserialized_messages.append(
             {
                 **message,
@@ -56,79 +52,3 @@ def deserialize_tool_calls(messages: list[dict[str, Any]]) -> list[dict[str, Any
         )
 
     return deserialized_messages
-
-
-def strip_message_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    def _strip(message: dict[str, Any]) -> dict[str, Any]:
-        content = message.get("content")
-        if isinstance(content, str):
-            return {**message, "content": content.strip()}
-        return message
-
-    return [_strip(message) for message in messages]
-
-
-def should_add_generation_prompt(messages: list[dict[str, Any]], idx: int) -> bool:
-    role = messages[idx].get("role")
-    if role not in ("user", "tool"):
-        return False
-    if idx + 1 >= len(messages):
-        return False
-    return messages[idx + 1].get("role") == "assistant"
-
-
-def render_messages(
-    tokenizer: PreTrainedTokenizer,
-    messages: list[dict[str, Any]],
-    *,
-    tools: list[dict[str, Any]] | None = None,
-    chat_template_kwargs: dict[str, Any] | None = None,
-    add_generation_prompt: bool = False,
-) -> list[int]:
-    kwargs = dict(chat_template_kwargs or {})
-    kwargs["add_generation_prompt"] = add_generation_prompt
-    if tools is not None:
-        kwargs["tools"] = tools
-    kwargs["return_dict"] = False
-    return list(tokenizer.apply_chat_template(messages, **kwargs))
-
-
-def build_incremental_token_mask(
-    tokenizer: PreTrainedTokenizer,
-    messages: list[dict[str, Any]],
-    *,
-    role_to_mask: Callable[[dict[str, Any]], bool],
-    tools: list[dict[str, Any]] | None = None,
-    chat_template_kwargs: dict[str, Any] | None = None,
-    collapse_consecutive_tool_messages: bool = False,
-) -> tuple[list[int], list[bool]]:
-    token_mask: list[bool] = []
-    prev_ids: list[int] = []
-    prev_len = 0
-
-    for idx, message in enumerate(messages):
-        role = message.get("role")
-        if collapse_consecutive_tool_messages and role == "tool" and idx + 1 < len(messages):
-            if messages[idx + 1].get("role") == "tool":
-                continue
-
-        cur_ids = render_messages(
-            tokenizer,
-            messages[: idx + 1],
-            tools=tools,
-            chat_template_kwargs=chat_template_kwargs,
-            add_generation_prompt=should_add_generation_prompt(messages, idx),
-        )
-
-        if prev_ids != cur_ids[:prev_len]:
-            raise IncrementalTokenizationError(
-                f"Mismatch in incremental tokenization with chat template at message {idx} (role={role}). "
-                "This usually means the chat template is not stable under incremental application. "
-                "The sample will be skipped."
-            )
-
-        token_mask.extend([role_to_mask(message)] * (len(cur_ids) - prev_len))
-        prev_ids = cur_ids
-        prev_len = len(cur_ids)
-
-    return prev_ids, token_mask

--- a/tests/unit/train/models/test_qwen3_5.py
+++ b/tests/unit/train/models/test_qwen3_5.py
@@ -1,0 +1,110 @@
+import inspect
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
+from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5ForCausalLM as HFQwen3_5ForCausalLM
+
+from prime_rl.trainer.models.layers.attn import FlashAttention, substitute_ring_attn
+from prime_rl.trainer.models.qwen3_5 import Qwen3_5ForCausalLM, Qwen3_5Model
+from prime_rl.trainer.models.qwen3_5.modeling_qwen3_5 import Qwen3_5GatedFlashAttention
+from prime_rl.trainer.models.qwen3_5_moe import Qwen3_5MoeConfig
+
+
+def _tiny_text_config(attn_impl: str = "sdpa") -> Qwen3_5TextConfig:
+    config = Qwen3_5TextConfig(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        layer_types=["linear_attention", "full_attention"],
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=128,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_num_key_heads=4,
+        linear_num_value_heads=8,
+        linear_conv_kernel_dim=4,
+    )
+    config._attn_implementation = attn_impl
+    return config
+
+
+def _tiny_moe_config(attn_impl: str = "sdpa") -> Qwen3_5MoeConfig:
+    config = Qwen3_5MoeConfig(
+        vocab_size=128,
+        hidden_size=64,
+        num_hidden_layers=2,
+        layer_types=["linear_attention", "full_attention"],
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=128,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_num_key_heads=4,
+        linear_num_value_heads=8,
+        linear_conv_kernel_dim=4,
+        moe_intermediate_size=128,
+        shared_expert_intermediate_size=128,
+        num_experts=4,
+        num_experts_per_tok=2,
+        use_grouped_mm=False,
+    )
+    config._attn_implementation = attn_impl
+    return config
+
+
+def test_qwen3_5_dense_matches_hf_state_keys_on_meta():
+    config = _tiny_text_config()
+    with torch.device("meta"):
+        hf_model = HFQwen3_5ForCausalLM(config)
+        prime_model = Qwen3_5ForCausalLM(config)
+
+    assert set(prime_model.state_dict()) == set(hf_model.state_dict())
+    for name, tensor in prime_model.state_dict().items():
+        assert tensor.shape == hf_model.state_dict()[name].shape, name
+
+
+@pytest.mark.parametrize("attn_impl", ["flash_attention_3", "kernels-community/vllm-flash-attn3"])
+def test_qwen3_5_full_attention_uses_custom_class(attn_impl: str):
+    config = _tiny_text_config(attn_impl=attn_impl)
+    with torch.device("meta"):
+        model = Qwen3_5Model(config)
+
+    assert isinstance(model.layers[1].self_attn, Qwen3_5GatedFlashAttention)
+    assert model.config._attn_implementation == "flash_attention_3"
+    assert "ALL_ATTENTION_FUNCTIONS" not in inspect.getsource(type(model.layers[1].self_attn).forward)
+
+
+def test_qwen3_5_moe_full_attention_normalizes_fa3_hub_alias():
+    from prime_rl.trainer.models.qwen3_5_moe.modeling_qwen3_5_moe import (
+        Qwen3_5MoeGatedFlashAttention,
+        Qwen3_5MoeModel,
+    )
+
+    config = _tiny_moe_config(attn_impl="kernels-community/vllm-flash-attn3")
+    with torch.device("meta"):
+        model = Qwen3_5MoeModel(config)
+
+    assert isinstance(model.layers[1].self_attn, Qwen3_5MoeGatedFlashAttention)
+    assert model.config._attn_implementation == "flash_attention_3"
+
+
+def test_qwen3_5_ring_patches_dense_flash_attention():
+    from prime_rl.trainer.models.afmoe.modeling_afmoe import AfmoeFlashAttention
+    from prime_rl.trainer.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeGatedFlashAttention
+
+    originals = {
+        cls: cls._compute_attention
+        for cls in (FlashAttention, AfmoeFlashAttention, Qwen3_5MoeGatedFlashAttention, Qwen3_5GatedFlashAttention)
+    }
+    try:
+        substitute_ring_attn(process_group=MagicMock(), heads_k_stride=1)
+        assert Qwen3_5GatedFlashAttention._compute_attention is not originals[Qwen3_5GatedFlashAttention]
+    finally:
+        for cls, method in originals.items():
+            cls._compute_attention = method

--- a/tests/unit/train/sft/test_sft_dataset.py
+++ b/tests/unit/train/sft/test_sft_dataset.py
@@ -2,10 +2,12 @@ from collections import Counter
 
 import pytest
 from datasets import Dataset, interleave_datasets
+from renderers import create_renderer
 from transformers import AutoTokenizer
 
-from prime_rl.trainer.sft.data import SFTDataset
+from prime_rl.trainer.sft.data import SFTDataset, _normalize_oai_record
 from prime_rl.trainer.utils import print_sample
+from prime_rl.utils.chat_template import deserialize_tool_calls
 
 
 @pytest.fixture(scope="module")
@@ -24,7 +26,7 @@ def test_raise_error_if_no_prompt_and_completion(build_dummy_dataset):
     """Tests that an error is raised if no supported SFT message fields are provided."""
     dataset = build_dummy_dataset("a", 1)
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
-    sft_dataset = SFTDataset(dataset, tokenizer=tokenizer)
+    sft_dataset = SFTDataset(dataset, tokenizer=tokenizer, renderer=create_renderer(tokenizer))
     with pytest.raises(ValueError):
         next(iter(sft_dataset))
 
@@ -194,7 +196,7 @@ def test_multiturn_loss_mask():
         ]
     )
     tokenizer = AutoTokenizer.from_pretrained("PrimeIntellect/Qwen3-0.6B")  # Properly handles multi-turn think
-    dataset = SFTDataset(dataset, tokenizer=tokenizer, max_examples=1)
+    dataset = SFTDataset(dataset, tokenizer=tokenizer, renderer=create_renderer(tokenizer), max_examples=1)
     sample = next(iter(dataset))
     print_sample(sample["input_ids"], sample["loss_mask"], tokenizer)
 
@@ -257,7 +259,7 @@ def test_multiturn_loss_mask_with_tools():
 
     dataset = Dataset.from_list([tool_example])
     tokenizer = AutoTokenizer.from_pretrained("PrimeIntellect/Qwen3-0.6B")  # Properly handles multi-turn think
-    dataset = SFTDataset(dataset, tokenizer=tokenizer, max_examples=1)
+    dataset = SFTDataset(dataset, tokenizer=tokenizer, renderer=create_renderer(tokenizer), max_examples=1)
     sample = next(iter(dataset))
     print_sample(sample["input_ids"], sample["loss_mask"], tokenizer)
 
@@ -282,10 +284,16 @@ def test_messages_rows_are_equivalent_to_empty_prompt_completion():
     ]
 
     tokenizer = AutoTokenizer.from_pretrained("PrimeIntellect/Qwen3-0.6B")
-    messages_dataset = SFTDataset(Dataset.from_list([{"messages": messages}]), tokenizer=tokenizer, max_examples=1)
+    messages_dataset = SFTDataset(
+        Dataset.from_list([{"messages": messages}]),
+        tokenizer=tokenizer,
+        renderer=create_renderer(tokenizer),
+        max_examples=1,
+    )
     split_dataset = SFTDataset(
         Dataset.from_list([{"prompt": [], "completion": messages}]),
         tokenizer=tokenizer,
+        renderer=create_renderer(tokenizer),
         max_examples=1,
     )
 
@@ -304,11 +312,65 @@ def test_messages_take_precedence_over_prompt_and_completion():
         "completion": [{"role": "assistant", "content": "Ignored completion"}],
     }
 
-    messages_dataset = SFTDataset(Dataset.from_list([row]), tokenizer=tokenizer, max_examples=1)
+    messages_dataset = SFTDataset(
+        Dataset.from_list([row]),
+        tokenizer=tokenizer,
+        renderer=create_renderer(tokenizer),
+        max_examples=1,
+    )
     expected_dataset = SFTDataset(
         Dataset.from_list([{"prompt": [], "completion": row["messages"]}]),
         tokenizer=tokenizer,
+        renderer=create_renderer(tokenizer),
         max_examples=1,
     )
 
     assert next(iter(messages_dataset)) == next(iter(expected_dataset))
+
+
+def test_null_messages_falls_back_to_prompt_and_completion():
+    # Arrow schema union adds `messages: None` to prompt/completion rows when
+    # other rows in the file have a `messages` column
+    tokenizer = AutoTokenizer.from_pretrained("PrimeIntellect/Qwen3-0.6B")
+    prompt = [{"role": "user", "content": "What is 2+2?"}]
+    completion = [{"role": "assistant", "content": "4"}]
+
+    mixed_row_dataset = SFTDataset(
+        Dataset.from_list([{"messages": None, "prompt": prompt, "completion": completion}]),
+        tokenizer=tokenizer,
+        renderer=create_renderer(tokenizer),
+        max_examples=1,
+    )
+    expected_dataset = SFTDataset(
+        Dataset.from_list([{"prompt": prompt, "completion": completion}]),
+        tokenizer=tokenizer,
+        renderer=create_renderer(tokenizer),
+        max_examples=1,
+    )
+
+    assert next(iter(mixed_row_dataset)) == next(iter(expected_dataset))
+
+
+def test_normalize_oai_record_stringifies_tool_calls_in_all_message_columns():
+    tool_calls = [
+        {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": {"location": "SF"}}}
+    ]
+    record = {
+        "prompt": [{"role": "user", "content": "What's the weather?", "tool_calls": None}],
+        "completion": [{"role": "assistant", "content": None, "tool_calls": tool_calls}],
+        "messages": [{"role": "assistant", "content": None, "tool_calls": []}],
+        "tools": [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}],
+    }
+
+    normalized = _normalize_oai_record(record)
+
+    # tool_calls become a string column everywhere: "" when null/empty, JSON otherwise
+    assert normalized["prompt"][0]["tool_calls"] == ""
+    assert normalized["messages"][0]["tool_calls"] == ""
+    assert isinstance(normalized["completion"][0]["tool_calls"], str)
+    assert isinstance(normalized["tools"], str)
+
+    # deserialize_tool_calls restores the original payload downstream
+    roundtripped = deserialize_tool_calls(normalized["completion"])
+    assert roundtripped[0]["tool_calls"] == tool_calls
+    assert deserialize_tool_calls(normalized["prompt"])[0]["tool_calls"] == []


### PR DESCRIPTION
## Summary

Part 1/7 of the split of #2485 (see that PR for review history). **Based on `main`; no dependencies.**

Makes SFT tokenization renderer-only and adds local dataset ingestion:

- **Renderer-only SFT**: `build_training_sample` with a hand-coded renderer replaces the incremental `apply_chat_template` masking path, which corrupted loss masks under position-dependent chat templates (e.g. Qwen3 stripping past `<think>` blocks across user turns). `DefaultRenderer` is rejected in `setup_renderer` (it falls back to incremental tokenization and doesn't fix the problem); fake data skips renderer construction so models without a hand-coded renderer can still benchmark step time. Non-assistant roles opt into the loss via the renderer's body-only path (`content_sft_roles`).
- **`[renderer]` config** defaults to auto-resolution from the tokenizer name; template controls (e.g. `enable_thinking`) are set run-wide via the typed renderer config. Per-example `chat_template_kwargs` columns are ignored with a warning.
- **Local `data_files`**: glob patterns expand before materialization; `.zst` decompresses via the zstd CLI (HF handles gz/bz2/xz natively but not zstd); JSONL rows are stream-normalized for Arrow schema stability (`tool_calls` and `tools`/`tool_defs` stringified to JSON string columns — heterogeneous nested JSON otherwise hard-crashes `load_dataset` or injects phantom nulls; `deserialize_tool_calls` reverses it downstream), written atomically to a digest-keyed per-node cache with local-rank-0 gating. Normalization covers both the `messages` layout and the TRL `prompt`/`completion` layout (review finding: the latter previously passed through raw), and stringifies the *whole* `tool_calls` list with `""` for no-tool messages — per-batch Arrow inference types an all-null column chunk as `null`, which can't unify with later `list<struct>` (or even `string`) chunks, so files whose first ~10 MB contain no tool calls crashed with `DatasetGenerationError` (reproduced and fixed against a real 60k-row prompt/completion dataset). `data_files` cannot combine with `subsets`/`splits`.
- `_drop_null_fields` strips Arrow phantom nulls before tool-call deserialization so genuine nulls inside argument strings survive.
- Mixed-layout files resolve correctly (review finding): `messages` takes precedence only when non-null — Arrow schema union adds `messages: null` to prompt/completion rows whenever other rows have a `messages` column, and the previous key-presence check silently resolved those rows to empty message lists.
- Defaults: `seq_len` 256 (FakeDataConfig keeps 128), `loss_impl` `liger_fused`; CI + example reverse-text/wordle configs pin `[renderer] name = "qwen3"` (PrimeIntellect/* fine-tunes miss the auto-renderer's exact-match lookup); `deps/renderers` pin bumped to `5904fa24a` (upstream main, contains the multimodal `build_training_sample` change previously pinned as `99bedaf4b`).
- The renderer is also built when only `[val]` uses real data (fake training data + validation would otherwise crash at the first val step), and the now-dead incremental-tokenization helpers (`build_incremental_token_mask` and friends) are deleted from `utils/chat_template.py`.

VLM SFT remains rejected at config here (`validate_renderer_vs_vlm`) — multimodal support lands later in the stack.

## E2E (W&B project [`pr2485`](https://wandb.ai/primeintellect/pr2485))

- [x] **Baseline on `main`, same dataset**: cannot train at all — incremental tokenization rejects the Qwen3.5 chat template on effectively every example (**54,261 of 60,000 skipped, 0 training steps** before we killed it: `Mismatch in incremental tokenization at message 1 (role=assistant)`). This PR is the fix.
- [x] Text SFT at this tip (Qwen3.5-0.8B, hf impl, renderer path + `data_files`, 8×H100, seq 8192, batch 64, seed 0): 10/10 steps, loss 0.78–0.86 — [6zkfiy1r](https://wandb.ai/primeintellect/pr2485/runs/6zkfiy1r). All later stack runs reuse this dataset/seed for comparability.
- [x] Integration suite (SFT subset) at this tip: **10/10 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> SFT is a breaking change to tokenization and defaults (renderer required for real data, new loss/seq_len defaults), and adds substantial new model and data-loading paths that affect training correctness and distributed I/O.
> 
> **Overview**
> **SFT tokenization is now renderer-only.** The incremental `apply_chat_template` path and `build_incremental_token_mask` are removed; samples go through `build_training_sample` with a required hand-coded renderer (`setup_renderer` rejects `DefaultRenderer`). `[renderer]` defaults to auto-resolution; per-example `chat_template_kwargs` are ignored. Mixed Arrow layouts use null checks so `messages: null` rows still use `prompt`/`completion`.
> 
> **Local `data.data_files`** adds glob expansion, `.zst` decompression, stream JSONL normalization (stringified `tool_calls` / `tools` for stable Arrow), and digest-keyed per-node caches; it cannot be combined with `subsets`/`splits`.
> 
> **Config and examples:** default `seq_len` 256 (fake data keeps 128), default `loss_impl` `liger_fused`, CI/example TOMLs pin `[renderer] name = "qwen3"`, and training docs describe renderer controls and `data_files`.
> 
> **Qwen3.5 dense** gets a custom `Qwen3_5ForCausalLM` (reusing MoE gated attention blocks), AutoModel registration, shared `normalize_qwen3_5_attn_implementation`, and ring/Ulysses patches for dense flash attention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29b63aadbb49e4e7ea5b8933dc9d120095c2e766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->