### PR TITLE
feat(trainer): seq_lens as the packed-sample boundary contract (SFT + RL)

### DIFF
--- a/configs/ci/integration/reverse_text_sft/resume.toml
+++ b/configs/ci/integration/reverse_text_sft/resume.toml
@@ -1,7 +1,7 @@
-max_steps = 10
+max_steps = 15
 
 [ckpt]
-resume_step = 5
+resume_step = 10
 
 [model]
 name = "PrimeIntellect/Qwen3-0.6B"

--- a/configs/ci/integration/reverse_text_sft/start.toml
+++ b/configs/ci/integration/reverse_text_sft/start.toml
@@ -1,4 +1,4 @@
-max_steps = 5
+max_steps = 10
 
 [ckpt]
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -287,20 +287,6 @@ class SFTConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
-    def validate_qwen3_5_stack_flash(self):
-        name = self.model.name.lower()
-        is_qwen3_5 = "qwen3.5" in name or "qwen3_5" in name
-        is_flash = self.model.attn in ("flash_attention_2", "flash_attention_3", "fa4")
-        if is_qwen3_5 and self.model.impl != "hf" and is_flash:
-            if self.data.pack_function == "stack":
-                raise ValueError("Qwen3.5 custom flash attention does not support pack_function='stack'; use 'cat'")
-            if self.val is not None and self.val.data.pack_function == "stack":
-                raise ValueError(
-                    "Qwen3.5 custom flash attention does not support pack_function='stack' for validation data; use 'cat'"
-                )
-        return self
-
-    @model_validator(mode="after")
     def validate_cp_seq_len(self):
         if self.model.cp > 1:
             if self.data.seq_len % self.model.cp != 0:

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -287,6 +287,20 @@ class SFTConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def validate_qwen3_5_stack_flash(self):
+        name = self.model.name.lower()
+        is_qwen3_5 = "qwen3.5" in name or "qwen3_5" in name
+        is_flash = self.model.attn in ("flash_attention_2", "flash_attention_3", "fa4")
+        if is_qwen3_5 and self.model.impl != "hf" and is_flash:
+            if self.data.pack_function == "stack":
+                raise ValueError("Qwen3.5 custom flash attention does not support pack_function='stack'; use 'cat'")
+            if self.val is not None and self.val.data.pack_function == "stack":
+                raise ValueError(
+                    "Qwen3.5 custom flash attention does not support pack_function='stack' for validation data; use 'cat'"
+                )
+        return self
+
+    @model_validator(mode="after")
     def validate_cp_seq_len(self):
         if self.model.cp > 1:
             if self.data.seq_len % self.model.cp != 0:

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -214,6 +214,7 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         rl_weights=rl_weights,
         ce_weights=ce_weights,
         ref_kl_weights=ref_kl_weights,
+        seq_lens=[len(input_ids)],
     )
 
 
@@ -291,6 +292,7 @@ def _materialize_bin(bin_content: _MicroBatchBin, num_loras: int) -> MicroBatch:
     ref_logprobs: list[float] | None = [] if has_ref_logprobs else None
     mm_token_type_ids: list[int] | None = [] if has_mm_token_type_ids else None
     streams: dict[str, list[float] | None] = {name: ([] if has_stream[name] else None) for name in STREAM_FILL}
+    seq_lens: list[int] = []
     routed_experts: RoutedExperts | None = None
     lora_num_tokens = [0] * num_loras
 
@@ -322,10 +324,12 @@ def _materialize_bin(bin_content: _MicroBatchBin, num_loras: int) -> MicroBatch:
                 assert routed_experts.shape[1:] == sample.routed_experts.shape[1:]
                 routed_experts.data += sample.routed_experts.data
                 routed_experts.shape[0] += sample.routed_experts.shape[0]
+        seq_lens.extend(sample.seq_lens if sample.seq_lens is not None else [sample_len])
         lora_num_tokens[lora_idx] += sample_len
 
     sequence_lengths = [len(sample.input_ids) for _, sample in bin_content.samples]
     assert sum(sequence_lengths) == len(input_ids), (sequence_lengths, len(input_ids))
+    assert sum(seq_lens) == len(input_ids), (seq_lens, len(input_ids))
     first_sample = bin_content.first_sample
 
     return MicroBatch(
@@ -345,6 +349,7 @@ def _materialize_bin(bin_content: _MicroBatchBin, num_loras: int) -> MicroBatch:
         rl_weights=streams["rl_weights"],
         ce_weights=streams["ce_weights"],
         ref_kl_weights=streams["ref_kl_weights"],
+        seq_lens=seq_lens,
     )
 
 
@@ -464,6 +469,8 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
         )
     if micro_batch.mm_token_type_ids is not None:
         micro_batch.mm_token_type_ids.extend([0] * padding_size)
+    if micro_batch.seq_lens is not None:
+        micro_batch.seq_lens.append(padding_size)
     if micro_batch.routed_experts is not None:
         _pad_routed_experts(micro_batch, padding_size)
     micro_batch.env_names.extend([""] * padding_size)

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1179,6 +1179,7 @@ def forward(
     # not a renderer/processor output.
     mm_kwargs: dict[str, Tensor] | None = None,
     mm_token_type_ids: Int[Tensor, "batch seq"] | None = None,
+    seq_lens: Int[Tensor, "segments"] | None = None,
 ) -> PrimeLmOutput:
     # Build kwargs for model forward
     kwargs = {
@@ -1202,6 +1203,10 @@ def forward(
             kwargs["position_ids"] = position_ids
     else:
         kwargs["position_ids"] = position_ids
+
+    if isinstance(model, PreTrainedModelPrimeRL):
+        # Universal contract: every custom model declares the typed seq_lens param.
+        kwargs["seq_lens"] = seq_lens
 
     if routed_experts is not None:
         kwargs["routed_experts"] = routed_experts

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -464,6 +464,7 @@ class AfmoeModel(AfmoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> MoeModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
@@ -479,6 +480,10 @@ class AfmoeModel(AfmoePreTrainedModel):
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
         use_flash = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not use_flash:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Afmoe batches require flash attention")
 
         if use_flash:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
@@ -573,6 +578,7 @@ class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
         token_type_ids: Optional[torch.Tensor] = None,  # will be ignored
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
@@ -593,6 +599,7 @@ class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -205,10 +205,13 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -216,7 +219,12 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Glm4Moe batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -272,9 +280,12 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -317,6 +328,7 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -308,9 +308,15 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        # Document boundaries derive from position_ids (sparse MLA builds its
+        # varlen indices from them); seq_lens is accepted to satisfy the
+        # trainer's universal contract.
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not

--- a/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
@@ -305,9 +305,14 @@ class GptOssForCausalLM(GptOssPreTrainedModel, GenerationMixin):
         use_cache: bool | None = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: torch.Tensor | None = None,
+        # Document boundaries derive from position_ids (HF packed-sequence masks);
+        # seq_lens is accepted to satisfy the trainer's universal contract.
+        seq_lens: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Per-token temperatures for logprobs/entropy computation when `labels` are provided.
         """

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -345,6 +345,7 @@ class LagunaModel(LagunaPreTrainedModel):
         position_ids: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         routed_experts: torch.LongTensor | None = None,
+        seq_lens: torch.LongTensor | None = None,
     ) -> MoeModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -354,7 +355,12 @@ class LagunaModel(LagunaPreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Laguna batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
             causal_mask_mapping = dict.fromkeys(set(self.config.layer_types), None)
@@ -433,6 +439,7 @@ class LagunaForCausalLM(LagunaPreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: torch.Tensor | None = None,
         routed_experts: torch.LongTensor | None = None,
+        seq_lens: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom Laguna"
@@ -444,6 +451,7 @@ class LagunaForCausalLM(LagunaPreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
         hidden_states = outputs.last_hidden_state
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -181,14 +181,24 @@ class LlamaModel(LlamaPreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
+        r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Llama batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -241,9 +251,12 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
         cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -283,6 +296,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
             input_ids=input_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -166,10 +166,13 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -177,7 +180,12 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed MiniMaxM2 batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -230,9 +238,12 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -258,6 +269,7 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -502,11 +502,14 @@ class NemotronHModel(NemotronHPreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token, indexed by global layer index. Only used for router replay; slots
             for non-MoE (Mamba/attention) layers are ignored.
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -515,7 +518,12 @@ class NemotronHModel(NemotronHPreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         # Compute cu_seqlens and max_seqlen for flash attention
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed NemotronH batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -563,6 +571,7 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
         logits_to_keep: int = 0,
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs,
     ) -> PrimeLmOutput:
         if position_ids is None:
@@ -576,6 +585,7 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
+++ b/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
@@ -156,7 +156,12 @@ class Qwen3Model(Qwen3PreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
+        r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
@@ -165,7 +170,12 @@ class Qwen3Model(Qwen3PreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Qwen3 batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -221,9 +231,12 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
         cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility; prime-rl asserts `use_cache is None` since training does not
@@ -241,6 +254,7 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
             input_ids=input_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
+            seq_lens=seq_lens,
         )
         hidden_states = outputs.last_hidden_state
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -26,7 +26,7 @@ from prime_rl.trainer.models.qwen3_5_moe.modeling_qwen3_5_moe import (
     Qwen3_5MoeRotaryEmbedding,
     normalize_qwen3_5_attn_implementation,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
 
 
 class Qwen3_5GatedSDPAAttention(Qwen3_5MoeGatedSDPAAttention):
@@ -196,6 +196,7 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -210,6 +211,13 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        elif seq_lens is not None:
+            # seq_lens is only populated for batch size 1 (see cat_collate), so a
+            # single boundary list covers the whole packed row.
+            seq_lens = seq_lens.to(device=inputs_embeds.device)
+            if seq_lens.numel() > 1 and "full_attention" in self.config.layer_types:
+                raise ValueError("Packed Qwen3.5 batches with full_attention layers require flash attention")
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(seq_lens, total_tokens=inputs_embeds.shape[1])
         else:
             cu_seqlens = None
             max_seqlen = None
@@ -265,6 +273,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         use_cache: Optional[bool] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom qwen3_5 for now"
@@ -280,6 +289,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
             input_ids=input_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -893,10 +893,12 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
             else:
                 cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        elif position_ids.ndim == 3 and seq_lens is not None:
+        elif seq_lens is not None:
+            # seq_lens is only populated for batch size 1 (see cat_collate), so this
+            # covers both 2D text-only packs and 3D MRoPE packs identically.
             seq_lens = seq_lens.to(device=inputs_embeds.device)
             if seq_lens.numel() > 1 and "full_attention" in self.config.layer_types:
-                raise ValueError("Packed Qwen3.5 MRoPE batches with full_attention layers require flash attention")
+                raise ValueError("Packed Qwen3.5 batches with full_attention layers require flash attention")
             cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(seq_lens, total_tokens=inputs_embeds.shape[1])
         else:
             max_seqlen = None

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -206,10 +206,13 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> MoeModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -217,7 +220,12 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Qwen3Moe batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -282,9 +290,12 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -332,6 +343,7 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -34,6 +34,7 @@ class TensorMicroBatch(TypedDict):
 
     # Batch level
     lora_num_tokens: Int[Tensor, "n_loras"]
+    seq_lens: Int[Tensor, "segments"] | None
 
     # MoE router replay
     routed_experts: Int[Tensor, "batch seq layers topk"] | None
@@ -129,6 +130,7 @@ class FakeDataLoader:
             "sequence_lengths": sequence_lengths,
             "loss_mask": loss_mask.unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
+            "seq_lens": torch.tensor(sequence_lengths, dtype=torch.long),
             "routed_experts": None,
             "mm_kwargs": None,
             "mm_token_type_ids": None,
@@ -161,6 +163,7 @@ class FakeDataLoader:
             "sequence_lengths": [self.seq_len],
             "loss_mask": torch.ones(self.seq_len, dtype=torch.bool).unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
+            "seq_lens": torch.tensor([self.seq_len], dtype=torch.long),
             "routed_experts": None,
             "mm_kwargs": None,
             "mm_token_type_ids": None,
@@ -256,6 +259,7 @@ class DataLoader:
             env_names=micro_batch.env_names,
             sequence_lengths=micro_batch.sequence_lengths,
             lora_num_tokens=torch.tensor(micro_batch.lora_num_tokens, dtype=torch.int32),
+            seq_lens=torch.tensor(micro_batch.seq_lens, dtype=torch.long) if micro_batch.seq_lens is not None else None,
             mm_kwargs=mm_kwargs,
             mm_token_type_ids=torch.tensor(micro_batch.mm_token_type_ids, dtype=torch.long).unsqueeze(0)
             if micro_batch.mm_token_type_ids is not None

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -421,6 +421,8 @@ def train(config: TrainerConfig):
                 else None
             )
 
+            seq_lens = micro_batch["seq_lens"].to("cuda") if micro_batch.get("seq_lens") is not None else None
+
             labels = shift_tensor_left(input_ids)
 
             # VLM + CP is not supported: MRoPE requires global positions but CP shards the sequence
@@ -428,6 +430,9 @@ def train(config: TrainerConfig):
                 raise NotImplementedError("Context parallelism is not supported with VLM/multimodal training")
 
             if cp_enabled:
+                # seq_lens spans the pre-shard sequence; consuming it under CP needs
+                # global-boundary handling that isn't wired up here yet.
+                seq_lens = None
                 input_ids, forward_position_ids = setup_cp_params(
                     input_ids, position_ids, cp_rank, cp_size, cp_group, cp_style=config.model.cp_style
                 )
@@ -465,6 +470,7 @@ def train(config: TrainerConfig):
                     temperature=temperatures,
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_token_type_ids,
+                    seq_lens=seq_lens,
                     routed_experts=routed_experts,
                 )
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -116,26 +116,6 @@ class FakeDataset(StatefulIterableDataset):
             yield fake_sample
 
 
-def _new_pack() -> dict[str, Any]:
-    return {
-        "input_ids": [],
-        "position_ids": [],
-        "loss_mask": [],
-        "target_ids": [],
-        "seq_lens": [],
-    }
-
-
-def _append_sample_to_pack(pack: dict[str, Any], sample: dict[str, Any]) -> None:
-    sample_len = len(sample["input_ids"])
-
-    for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
-        value = sample[key]
-        assert isinstance(value, list)
-        pack[key].extend(value)
-    pack["seq_lens"].append(sample_len)
-
-
 def _drop_null_fields(value: Any) -> Any:
     """Recursively strip ``None``-valued keys from dict structures.
 
@@ -382,22 +362,26 @@ class CatDataset(StatefulIterableDataset):
         self.dataset.load_state_dict(state_dict["dataset"])
 
     def __iter__(self):
-        packed_samples = _new_pack()
+        packed_samples = defaultdict(list)
         seq_len = 0
         for sample in self.dataset:
             sample_len = len(sample["input_ids"])
             would_overflow = seq_len + sample_len > self.seq_len
             if seq_len > 0 and would_overflow:
                 yield self._finalize_pack(packed_samples, self.seq_len)
-                packed_samples = _new_pack()
+                packed_samples = defaultdict(list)
                 seq_len = 0
 
-            _append_sample_to_pack(packed_samples, sample)
+            for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
+                value = sample[key]
+                assert isinstance(value, list)
+                packed_samples[key].extend(value)
+            packed_samples["seq_lens"].append(sample_len)
             seq_len += sample_len
 
             if seq_len >= self.seq_len:
                 yield self._finalize_pack(packed_samples, self.seq_len)
-                packed_samples = _new_pack()
+                packed_samples = defaultdict(list)
                 seq_len = 0
 
         if seq_len > 0:

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -31,6 +31,7 @@ class Sample(TypedDict):
     position_ids: list[int]
     loss_mask: list[bool]
     target_ids: list[int]
+    seq_lens: list[int]
 
 
 class Batch(TypedDict):
@@ -38,6 +39,7 @@ class Batch(TypedDict):
     position_ids: Int[Tensor, "batch seq"]
     target_ids: Int[Tensor, "batch seq"]
     loss_mask: Bool[Tensor, "batch seq"]
+    seq_lens: Int[Tensor, "packed"] | None
 
 
 class StatefulIterableDataset(Stateful, IterableDataset):
@@ -107,10 +109,31 @@ class FakeDataset(StatefulIterableDataset):
                 "target_ids": input_ids[1:],
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
+                "seq_lens": [seq_len],
             }
             self.num_samples["fake"] += 1
             self.num_tokens["fake"] += len(input_ids)
             yield fake_sample
+
+
+def _new_pack() -> dict[str, Any]:
+    return {
+        "input_ids": [],
+        "position_ids": [],
+        "loss_mask": [],
+        "target_ids": [],
+        "seq_lens": [],
+    }
+
+
+def _append_sample_to_pack(pack: dict[str, Any], sample: dict[str, Any]) -> None:
+    sample_len = len(sample["input_ids"])
+
+    for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
+        value = sample[key]
+        assert isinstance(value, list)
+        pack[key].extend(value)
+    pack["seq_lens"].append(sample_len)
 
 
 def _drop_null_fields(value: Any) -> Any:
@@ -295,6 +318,7 @@ class SFTDataset(StatefulIterableDataset):
             "target_ids": target_ids,
             "loss_mask": loss_mask,
             "position_ids": list(range(len(input_ids))),
+            "seq_lens": [len(input_ids)],
         }
 
     def __iter__(self):
@@ -349,29 +373,57 @@ class CatDataset(StatefulIterableDataset):
         self.seq_len = seq_len
 
     def state_dict(self) -> dict:
+        # Known limitation: the overflow sample pending at a yield boundary is
+        # not persisted, so a checkpoint resume drops at most one sample per
+        # dataloader worker.
         return {"dataset": self.dataset.state_dict()}
 
     def load_state_dict(self, state_dict: dict):
         self.dataset.load_state_dict(state_dict["dataset"])
 
     def __iter__(self):
-        packed_samples, seq_len = defaultdict(list), 0
+        packed_samples = _new_pack()
+        seq_len = 0
         for sample in self.dataset:
-            # Add sample to packed samples
-            for key, value in sample.items():
-                assert isinstance(value, list), f"Value for key {key} must be a list"
-                packed_samples[key].extend(value)
+            sample_len = len(sample["input_ids"])
+            would_overflow = seq_len + sample_len > self.seq_len
+            if seq_len > 0 and would_overflow:
+                yield self._finalize_pack(packed_samples, self.seq_len)
+                packed_samples = _new_pack()
+                seq_len = 0
 
-            # Update sequence length
-            seq_len += len(sample["input_ids"])
+            _append_sample_to_pack(packed_samples, sample)
+            seq_len += sample_len
 
-            # If batch is full, truncate and yield it
             if seq_len >= self.seq_len:
-                for key, value in packed_samples.items():
-                    assert isinstance(value, list), f"Value for key {key} must be a list"
-                    packed_samples[key] = value[: self.seq_len]
-                yield packed_samples
-                packed_samples, seq_len = defaultdict(list), 0
+                yield self._finalize_pack(packed_samples, self.seq_len)
+                packed_samples = _new_pack()
+                seq_len = 0
+
+        if seq_len > 0:
+            yield self._finalize_pack(packed_samples, self.seq_len)
+
+    def _finalize_pack(self, packed: dict[str, Any], seq_len: int) -> dict:
+        result: dict[str, Any] = {
+            k: packed[k][:seq_len] for k in ("input_ids", "position_ids", "loss_mask", "target_ids")
+        }
+        result["seq_lens"] = []
+        remaining = len(result["input_ids"])
+        for sample_len in packed["seq_lens"]:
+            if remaining <= 0:
+                break
+            kept = min(sample_len, remaining)
+            if kept > 0:
+                result["seq_lens"].append(kept)
+            remaining -= kept
+        pad_len = seq_len - len(result["input_ids"])
+        if pad_len > 0:
+            result["input_ids"].extend([0] * pad_len)
+            result["position_ids"].extend(range(pad_len))
+            result["loss_mask"].extend([False] * pad_len)
+            result["target_ids"].extend([0] * pad_len)
+            result["seq_lens"].append(pad_len)
+        return result
 
 
 class StackDataset(StatefulIterableDataset):
@@ -411,9 +463,10 @@ class StackDataset(StatefulIterableDataset):
             # Truncate sample if it's longer than max area
             len_sample = len(sample["input_ids"])
             if len_sample > self.max_area:
-                for key, value in sample.items():
+                for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
+                    value = sample[key]
                     assert isinstance(value, list)
-                    sample[key] = sample[key][: self.max_area]
+                    sample[key] = value[: self.max_area]
                 len_sample = self.max_area
 
             # Add sample to bucket
@@ -453,15 +506,17 @@ class StackDataset(StatefulIterableDataset):
 
                     while self.bucket_sizes[bucket_idx] * len(self.buckets[bucket_idx]) < self.max_area:
                         dummy_sample = {}
-                        for key, value in sample.items():
+                        for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
                             dummy_sample[key] = [0]
+                        dummy_sample["seq_lens"] = [1]
                         self.buckets[bucket_idx].append(dummy_sample)
 
                 packed_samples = defaultdict(list)
                 num_samples, num_tokens, num_trainable_tokens, num_pad_tokens = 0, 0, 0, 0
                 for bucket_item in self.buckets[bucket_idx]:
                     num_samples += 1
-                    for key, value in bucket_item.items():
+                    for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
+                        value = bucket_item[key]
                         pad_tokens = [0] * (self.bucket_sizes[bucket_idx] - len(value))
                         if key == "loss_mask":
                             num_tokens += len(value)
@@ -474,6 +529,7 @@ class StackDataset(StatefulIterableDataset):
                 self.logger.debug(
                     f"Yield bucket {bucket_idx} because {reason} with {num_samples=}, {num_tokens=}, {num_trainable_tokens=}, {num_pad_tokens=}"
                 )
+                packed_samples["seq_lens"] = None
                 yield packed_samples
                 self.step += 1
                 self.buckets[bucket_idx] = []
@@ -489,6 +545,7 @@ def stack_collate(samples: list[Sample]) -> Batch:
         "position_ids": torch.tensor(samples[0]["position_ids"], dtype=torch.long, device="cuda"),
         "loss_mask": torch.tensor(samples[0]["loss_mask"], dtype=torch.bool, device="cuda"),
         "target_ids": torch.tensor(samples[0]["target_ids"], dtype=torch.long, device="cuda"),
+        "seq_lens": None,
     }
 
 
@@ -500,6 +557,10 @@ def cat_collate(samples: list[Sample]) -> Batch:
         .to("cuda"),
         "loss_mask": torch.stack([torch.tensor(sample["loss_mask"]) for sample in samples], dim=0).bool().to("cuda"),
         "target_ids": torch.stack([torch.tensor(sample["target_ids"]) for sample in samples], dim=0).long().to("cuda"),
+        # CatDataset emits exactly one packed sample per dataloader item.
+        "seq_lens": torch.tensor(samples[0]["seq_lens"], dtype=torch.long, device="cuda")
+        if len(samples) == 1
+        else None,
     }
 
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -253,8 +253,12 @@ def train(config: SFTConfig):
         position_ids = micro_batch["position_ids"].to("cuda")
         target_ids = micro_batch["target_ids"].to("cuda")
         loss_mask = micro_batch["loss_mask"].to("cuda")
+        seq_lens = micro_batch.get("seq_lens")
 
         if cp_enabled:
+            # seq_lens spans the pre-shard pack; CP consumption needs global
+            # boundary semantics the models don't have yet.
+            seq_lens = None
             input_ids, position_ids = setup_cp_params(
                 input_ids, position_ids, cp_rank, cp_size, cp_group, cp_style=config.model.cp_style
             )
@@ -270,10 +274,10 @@ def train(config: SFTConfig):
             if config.loss_impl in ("liger_fused", "quack_fused"):
                 masked_target_ids = target_ids.clone()
                 masked_target_ids[~loss_mask] = FUSED_CE_IGNORE_INDEX
-                out = forward(model, input_ids, position_ids, labels=masked_target_ids)
+                out = forward(model, input_ids, position_ids, labels=masked_target_ids, seq_lens=seq_lens)
                 loss_sum = out["loss"] * token_count
             else:
-                out = forward(model, input_ids, position_ids)
+                out = forward(model, input_ids, position_ids, seq_lens=seq_lens)
                 logits = out["logits"]
                 B, L, V = logits.shape
                 token_loss = ce_loss(logits.view(-1, V), target_ids.view(-1)).view(B, L)

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -108,3 +108,6 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     # Packer-derived metadata used for run-local token exports.
     run_id: str | None = None
     run_step: int | None = None
+
+    # Packed sample boundaries. Sum equals len(input_ids) when present.
+    seq_lens: list[int] | None = None

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -161,6 +161,7 @@ def test_randomized_packing_invariants():
         for batch in flat_batches:
             assert len(batch.input_ids) <= seq_len
             assert sum(batch.sequence_lengths) == len(batch.input_ids)
+            assert batch.seq_lens == batch.sequence_lengths
             assert sum(batch.lora_num_tokens) == len(batch.input_ids)
             assert len(batch.env_names) == len(batch.input_ids)
 
@@ -176,6 +177,7 @@ def test_pad_micro_batch_preserves_explicit_sequence_lengths():
 
     assert len(padded.input_ids) == 6
     assert padded.sequence_lengths == [4, 2]
+    assert padded.seq_lens == [4, 2]
     assert sum(padded.sequence_lengths) == len(padded.input_ids)
     assert padded.loss_mask[-2:] == [False, False]
 
@@ -271,6 +273,7 @@ def test_prepare_batch_packs_different_temperatures(make_training_example):
     # Second sample (4 tokens): all get temp 1.1
     assert flat_batches[0].temperatures[4:8] == [1.1, 1.1, 1.1, 1.1]
     assert flat_batches[0].env_names == ["env-a"] * 4 + ["env-b"] * 4
+    assert flat_batches[0].seq_lens == [4, 4]
 
 
 def test_prepare_sample_propagates_weight_streams(make_training_example):

--- a/tests/unit/train/test_model_forward.py
+++ b/tests/unit/train/test_model_forward.py
@@ -2,8 +2,10 @@ from types import SimpleNamespace
 
 import torch
 import torch.nn as nn
+from transformers import PretrainedConfig
 
 from prime_rl.trainer.model import forward
+from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 
 
 class _CaptureModel(nn.Module):
@@ -14,6 +16,19 @@ class _CaptureModel(nn.Module):
 
     def forward(self, **kwargs):
         self.kwargs = kwargs
+        input_ids = kwargs["input_ids"]
+        return {"logits": torch.zeros(*input_ids.shape, 4)}
+
+
+class _PrimeCaptureModel(PreTrainedModelPrimeRL):
+    config_class = PretrainedConfig
+
+    def __init__(self):
+        super().__init__(PretrainedConfig())
+        self.kwargs = None
+
+    def forward(self, seq_lens: torch.Tensor | None = None, **kwargs):
+        self.kwargs = {**kwargs, "seq_lens": seq_lens}
         input_ids = kwargs["input_ids"]
         return {"logits": torch.zeros(*input_ids.shape, 4)}
 
@@ -81,3 +96,27 @@ def test_forward_keeps_position_ids_for_non_mrope_vlm():
 
     assert model.kwargs is not None
     torch.testing.assert_close(model.kwargs["position_ids"], position_ids)
+
+
+def test_forward_does_not_leak_seq_lens_to_generic_text_models():
+    model = _CaptureModel(SimpleNamespace(model_type="qwen3"))
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+    position_ids = torch.arange(input_ids.shape[1]).unsqueeze(0)
+    seq_lens = torch.tensor([2, 2])
+
+    forward(model, input_ids, position_ids, seq_lens=seq_lens)
+
+    assert model.kwargs is not None
+    assert "seq_lens" not in model.kwargs
+
+
+def test_forward_passes_typed_seq_lens_to_custom_models():
+    model = _PrimeCaptureModel()
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+    position_ids = torch.arange(input_ids.shape[1]).unsqueeze(0)
+    seq_lens = torch.tensor([2, 2])
+
+    forward(model, input_ids, position_ids, seq_lens=seq_lens)
+
+    assert model.kwargs is not None
+    torch.testing.assert_close(model.kwargs["seq_lens"], seq_lens)


### PR DESCRIPTION
## Summary

Part 3/7 of the split of #2485 + #2889. **Based on #2943 (`feat/qwen35-dense-attention`)** — needs the dense Qwen3.5 model for its seq_lens consumption; the renderer-only SFT data path comes from #2942.

`seq_lens` becomes the packed-sample boundary contract for both trainers; models consume it for varlen attention.

**SFT + models (first commit):**
- CatDataset rework: `_finalize_pack` pads every pack to `seq_len` (pad tokens form their own loss-masked document, so packs are always full-length and CP-divisible), yields the tail pack instead of dropping it, and overflow samples start the next pack instead of being truncated mid-sample.
- `Sample`/`Batch` gain `seq_lens`; `cat_collate` forwards it for batch-size-1 packs; stack bucketing yields `seq_lens=None`.
- **`seq_lens` is a universal contract**: every custom `ForCausalLM` declares the typed `seq_lens` forward parameter and the trainer passes it unconditionally to any `PreTrainedModelPrimeRL` (generic HF models never receive it). Standard-attention families keep deriving `cu_seqlens` from `position_ids` on the flash path (boundary-equivalent — the packer resets positions per document) and now **reject packed rows loudly on non-flash paths** instead of silently attending across documents; gpt_oss/glm_moe_dsa honor boundaries via `position_ids` (HF packed-sequence masks / sparse MLA varlen indices) and accept the param; Qwen3.5 dense + MoE consume it for varlen attention and fla state resets.
- Dense + MoE Qwen3.5 build `cu_seqlens` from `seq_lens` on the **non-flash** path. Previously `cu_seqlens` stayed `None` there: fla's GatedDeltaNet carried conv/SSM state across packed samples and SDPA attended across document boundaries — silent cross-sample contamination for sdpa/eager + cat packing. Packed hybrid batches with `full_attention` layers require flash and raise otherwise.
- Config validator rejects `pack_function="stack"` for Qwen3.5 custom flash attention (its varlen kernel assumes batch 1; stack produces genuine batches).
- Under CP both trainers pass `seq_lens=None` for now — boundaries span the pre-shard pack; global semantics land in #2946.
- The HF-impl monkey-patch keeps deriving `cu_seqlens` from position_ids only; it never receives `seq_lens` (only custom `PreTrainedModelPrimeRL` models do), so no seq_lens branch is added there.

**RL (second commit, from #2889):** packed RL micro-batches carry the same boundaries end to end — `prepare_sample` stamps them, `_materialize_bin` accumulates and asserts them, `pad_micro_batch` records padding as its own segment, the RL dataloader tensorizes them into `forward()`.

## Data efficiency: old vs new packing (offline replay, 12k docs, real tokenizer path, seq 8192)

The dataset (long CoT, mean doc 6,783 tokens) makes the trade stark:

| | old packing (main) | new packing (this PR) |
|---|---|---|
| tokens trained per epoch | 41.4M | **52.9M (+27.7%)** |
| data discarded per epoch | **49.1%** (chopped remainders) | 0% (only the inherent overlong cap) |
| docs ending mid-sample | **42.1%** | 0% |
| pad overhead per row | 0% | 21.4% |

The old packer's "zero padding" chops nearly every pack's last document and discards its remainder — half the dataset's tokens are never trained, and 42% of docs train without their endings/EOS. The new packer pays 21.4% pad compute (hardware tok/s is unchanged: pads flow through as a masked document) to train 28% more tokens with correct boundaries. Pad fraction shrinks on shorter-doc datasets.

## E2E (W&B project [`pr2485`](https://wandb.ai/primeintellect/pr2485))

- [x] Text SFT dense + MoE with reworked cat packing: dense [9gjfrcx5](https://wandb.ai/primeintellect/pr2485/runs/9gjfrcx5), MoE [jyaqjzo1](https://wandb.ai/primeintellect/pr2485/runs/jyaqjzo1) — 10/10 steps each
- [x] RL text run at this tip (seq_lens end-to-end through transport → packer → dataloader → forward): 10/10 steps — [bec3d2415a](https://wandb.ai/primeintellect/pr2485/runs/bec3d2415afb47e6b7de0feb2648bba7)
- [x] Integration suite (SFT+RL subset) at this tip: 7/8 passed; the one failure is `test_loss_goes_down` — a marginal 5-step assertion (loss delta +0.0018) whose values match the #2485 reference bit-for-bit; see #2948 for the full-suite/main-control analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes packed-sequence attention boundaries and SFT cat packing across the core training forward path; mis-wiring could contaminate attention across documents, though multi-doc non-flash paths now fail loudly.
> 
> **Overview**
> Introduces **`seq_lens`** as the per-document length list for packed rows (sum equals row length), threaded from dataloaders through **`forward()`** into custom **`PreTrainedModelPrimeRL`** models only; generic HF models never receive it.
> 
> **SFT:** **`CatDataset`** no longer truncates mid-document on overflow—it yields full packs via **`_finalize_pack`** (pad tokens become their own masked segment), emits the tail pack, and **`cat_collate`** passes **`seq_lens`** for batch-size-1 cat packs; stack bucketing sets **`seq_lens=None`**.
> 
> **RL:** Packing stamps and merges **`seq_lens`** in **`prepare_sample`**, **`_materialize_bin`**, and **`pad_micro_batch`** (padding appended as its own segment); RL batches tensorize it into the model forward.
> 
> **Models:** Most custom attention stacks **error on multi-segment packs without flash** (avoids cross-document SDPA/eager attention). **Qwen3.5** dense/MoE build **`cu_seqlens`** from **`seq_lens`** on the non-flash path for hybrid layers (linear attention / fla state). **SFT and RL** drop **`seq_lens`** under context parallelism until global boundaries are wired.
> 
> CI reverse-text SFT integration configs bump **`max_steps`** / **`resume_step`** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b35e828e5fbbacc67c8e3f90cfbd0a7554e6b571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->