### PR TITLE
feat(sft): multimodal (VLM) SFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ With `[model] impl = "auto"` (the default), the trainer selects that custom stac
 | GLM-5 (`glm_moe_dsa`) | `zai-org/GLM-5`, `zai-org/GLM-5-FP8` | yes | ✅ | ✅ |
 | Qwen3 MoE (`qwen3_moe`) | `Qwen/Qwen3-30B-A3B`, … | yes | ✅ | ✅ |
 | Qwen3.5 MoE (`qwen3_5_moe`) | `Qwen/Qwen3.5-35B-A3B`, … | yes | ✅ | ✅ |
-| Qwen3 / Qwen3.5 VLMs | see [advanced.md](docs/advanced.md#vision-language-models) (`qwen3_vl`, `qwen3_5`, `qwen3_5_moe`) | MoE only on MoE VLMs | MoE only | ✅ |
+| Qwen3 / Qwen3.5 VLMs | see [advanced.md](docs/advanced.md#vision-language-models) (`qwen3_vl`, `qwen3_5`, `qwen3_5_moe`) | MoE only on MoE VLMs | MoE only | ❌ |
 | Poolside Laguna (`laguna`) | `poolside/Laguna-XS.2` | yes | ✅ | ✅ |
 | MiniMax M2 (`minimax_m2`) | `MiniMax/MiniMax-M2` | yes | ✅ | ✅ |
 | Nemotron H (`nemotron_h`) | `nvidia/Nemotron-3-Nano-30B-A3B`, `nvidia/Nemotron-3-Super-120B-A12B`, … | yes | ✅ | ✅ |

--- a/configs/ci/integration/reverse_text_sft/resume.toml
+++ b/configs/ci/integration/reverse_text_sft/resume.toml
@@ -1,4 +1,4 @@
-max_steps = 15
+max_steps = 20
 
 [ckpt]
 resume_step = 10

--- a/configs/ci/integration/reverse_text_sft/resume.toml
+++ b/configs/ci/integration/reverse_text_sft/resume.toml
@@ -1,7 +1,7 @@
-max_steps = 10
+max_steps = 15
 
 [ckpt]
-resume_step = 5
+resume_step = 10
 
 [model]
 name = "PrimeIntellect/Qwen3-0.6B"

--- a/configs/ci/integration/reverse_text_sft/start.toml
+++ b/configs/ci/integration/reverse_text_sft/start.toml
@@ -1,4 +1,4 @@
-max_steps = 5
+max_steps = 10
 
 [ckpt]
 

--- a/configs/ci/nightly/multimodal_color_codeword.toml
+++ b/configs/ci/nightly/multimodal_color_codeword.toml
@@ -1,5 +1,4 @@
 # Based on configs/debug/multimodal.toml but tuned for CI.
-# Runs the custom Qwen3.5 VLM (VLM training is custom-implementation-only).
 max_steps = 25
 seq_len = 4096
 

--- a/configs/ci/nightly/multimodal_color_codeword.toml
+++ b/configs/ci/nightly/multimodal_color_codeword.toml
@@ -1,4 +1,5 @@
-# Based on configs/multimodal/rl_color_codeword.toml but tuned for CI
+# Based on configs/debug/multimodal.toml but tuned for CI.
+# Runs the custom Qwen3.5 VLM (VLM training is custom-implementation-only).
 max_steps = 25
 seq_len = 4096
 
@@ -7,7 +8,7 @@ num_train_gpus = 4
 num_infer_gpus = 4
 
 [model]
-name = "Qwen/Qwen3-VL-4B-Instruct"
+name = "Qwen/Qwen3.5-0.8B"
 
 [model.vlm]
 vision_encoder_attr = "model.visual"

--- a/configs/ci/nightly/multimodal_color_codeword.toml
+++ b/configs/ci/nightly/multimodal_color_codeword.toml
@@ -8,7 +8,7 @@ num_train_gpus = 4
 num_infer_gpus = 4
 
 [model]
-name = "Qwen/Qwen3.5-0.8B"
+name = "Qwen/Qwen3.5-4B"
 
 [model.vlm]
 vision_encoder_attr = "model.visual"

--- a/configs/debug/multimodal.toml
+++ b/configs/debug/multimodal.toml
@@ -1,12 +1,14 @@
-# 2-GPU debug RL run for the multimodal (renderer) path: Qwen3-VL-4B on
+# 2-GPU debug RL run for the multimodal (renderer) path: Qwen3.5-0.8B on
 # color-codeword. Sized to actually learn (reward should trend up) while
-# staying 2-GPU friendly. Exercises RendererClient + Qwen3VLRenderer end-to-end.
+# staying 2-GPU friendly. Exercises RendererClient + Qwen35Renderer end-to-end.
+# VLM training is custom-implementation-only, so this runs the custom Qwen3.5
+# VLM (Qwen3-VL has no custom implementation and can no longer be RL-trained).
 
 max_steps = 15
 seq_len = 4096
 
 [model]
-name = "Qwen/Qwen3-VL-4B-Instruct"
+name = "Qwen/Qwen3.5-0.8B"
 
 [model.vlm]
 vision_encoder_attr = "model.visual"
@@ -23,9 +25,8 @@ group_size = 16
 # Image processor is CPU-bound and dominates for VLMs; returns diminish past 4.
 pool_size = 4
 
-# Step 0 on Qwen3-VL-4B vs color-codeword can be uniform (all-correct or
-# all-wrong), so don't enforce zero-advantage dropping or training would crash
-# before any progress.
+# Step 0 on color-codeword can be uniform (all-correct or all-wrong), so don't
+# enforce zero-advantage dropping or training would crash before any progress.
 [[orchestrator.post_batch_filters]]
 type = "gibberish"
 
@@ -44,8 +45,8 @@ name = "color-codeword"
 taskset = { id = "color-codeword-v1", images_per_turn = 1 }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
-# Default renderer (AutoRendererConfig) resolves Qwen3-VL-4B-Instruct from
-# MODEL_RENDERER_MAP to Qwen3VLRenderer at runtime; no explicit name needed.
+# Default renderer (AutoRendererConfig) resolves Qwen/Qwen3.5-0.8B from
+# MODEL_RENDERER_MAP at runtime; no explicit name needed.
 
 [trainer]
 
@@ -58,14 +59,6 @@ lr = 3e-6
 
 [inference]
 
-[inference.model]
-# Workaround for vLLM 0.20.1 Qwen3-VL deepstack buffer bug: when num_scheduled_tokens
-# (188) gets padded up to the next cudagraph_capture_size (192), the model's
-# _set_deepstack_input_embeds sizes the buffer to 188 but forward() runs with 192,
-# triggering "Requested more deepstack tokens than available in buffer". Eager mode
-# skips the padding so num_input_tokens == num_scheduled_tokens.
-enforce_eager = true
-
 [inference.parallel]
 dp = 1
 tp = 1
@@ -73,4 +66,4 @@ tp = 1
 [wandb]
 project = "debug"
 name = "multimodal"
-tags = ["qwen3vl-4b", "color-codeword", "renderer"]
+tags = ["qwen3.5-0.8b", "color-codeword", "renderer"]

--- a/configs/debug/multimodal.toml
+++ b/configs/debug/multimodal.toml
@@ -1,8 +1,6 @@
 # 2-GPU debug RL run for the multimodal (renderer) path: Qwen3.5-0.8B on
 # color-codeword. Sized to actually learn (reward should trend up) while
 # staying 2-GPU friendly. Exercises RendererClient + Qwen35Renderer end-to-end.
-# VLM training is custom-implementation-only, so this runs the custom Qwen3.5
-# VLM (Qwen3-VL has no custom implementation and can no longer be RL-trained).
 
 max_steps = 15
 seq_len = 4096

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -28,7 +28,7 @@ impl = "custom"        # or "hf" to force the HF path
 | GLM-5 / GLM-5.2 (`glm_moe_dsa`) | `zai-org/GLM-5`, `zai-org/GLM-5-FP8`, `zai-org/GLM-5.2`, `zai-org/GLM-5.2-FP8` | ✅ | ✅ |
 | Qwen3 MoE | `Qwen/Qwen3-30B-A3B`, … | ✅ | ✅ |
 | Qwen3.5 MoE | `Qwen/Qwen3.5-35B-A3B`, … | ✅ | ✅ |
-| Qwen3 / Qwen3.5 VLMs | see [Multimodal training](#multimodal-training) | MoE only | ✅ |
+| Qwen3 / Qwen3.5 VLMs | see [Multimodal training](#multimodal-training) | MoE only | ❌ |
 | Laguna | `poolside/Laguna-XS.2` | ✅ | ✅ |
 | MiniMax M2 | `MiniMax/MiniMax-M2` | ✅ | ✅ |
 | Nemotron H | `nvidia/Nemotron-3-Nano-30B-A3B`, … | ✅ | ❌ |
@@ -88,7 +88,6 @@ To add a new model family permanently, append an entry to `VLM_REGISTRY` in `src
 ### Limitations
 
 - **Vision encoder frozen by default.** Frozen vision subtrees are excluded from LoRA targeting. Set `freeze_vision_encoder = false` to fine-tune the encoder; this is incompatible with LoRA because LoRA freezes all non-adapter parameters.
-- **No multimodal-safe truncation.** Token sequences are truncated to `seq_len`, but `pixel_values` and `image_grid_thw` pass through unchanged. If a sample's tokens overflow, image tokens may get dropped while image tensors still describe the full image set. Set `seq_len` to cover your longest sample.
 - **bfloat16 mandatory.** The trainer config validator refuses any other `optimization_dtype` / `reduce_dtype` for VLMs — vLLM serves VLMs in bfloat16 and a mismatch breaks the importance ratio.
 - **Higher KL mismatch with multi-image inputs.** Expect noisier `mismatch_kl` than text-only; this is from minor numerical differences between the trainer's and vLLM's image processing.
 - **Images aren't logged to monitors.** Sample logging captures the prompt text but not the actual images.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -87,7 +87,7 @@ To add a new model family permanently, append an entry to `VLM_REGISTRY` in `src
 
 ### Limitations
 
-- **Vision encoder frozen by default.** Set `freeze_vision_encoder = false` to fine-tune it; in that case it's FSDP-sharded per block. The combination `freeze_vision_encoder = false` + LoRA is rejected by a config validator — LoRA freezes everything non-adapter, so unfreezing the encoder under LoRA would be a silent no-op.
+- **Vision encoder frozen by default.** Frozen vision subtrees are excluded from LoRA targeting. Set `freeze_vision_encoder = false` to fine-tune the encoder; this is incompatible with LoRA because LoRA freezes all non-adapter parameters.
 - **No multimodal-safe truncation.** Token sequences are truncated to `seq_len`, but `pixel_values` and `image_grid_thw` pass through unchanged. If a sample's tokens overflow, image tokens may get dropped while image tensors still describe the full image set. Set `seq_len` to cover your longest sample.
 - **bfloat16 mandatory.** The trainer config validator refuses any other `optimization_dtype` / `reduce_dtype` for VLMs — vLLM serves VLMs in bfloat16 and a mismatch breaks the importance ratio.
 - **Higher KL mismatch with multi-image inputs.** Expect noisier `mismatch_kl` than text-only; this is from minor numerical differences between the trainer's and vLLM's image processing.

--- a/docs/training.md
+++ b/docs/training.md
@@ -156,8 +156,9 @@ enable_thinking = false
 
 If a model needs another template control, add it to that model's renderer config in `renderers` (for example a new field on the relevant `*RendererConfig`) and consume it in the renderer implementation.
 
-**Renderer-backed tokenization.** SFT tokenization is renderer-only. The [`renderers`](algorithms.md#renderers) package owns message-to-token conversion and loss attribution end-to-end, so position-dependent chat templates (for example templates that strip past `—` blocks across user turns) do not corrupt the loss mask. `[renderer]` defaults to `name = "auto"`; set a typed renderer config only when you need model-specific template controls. Hand-coded renderers ship for Qwen3, Qwen3.5, GLM-5, GLM-4.5, Kimi K2/K2.5, MiniMax M2, DeepSeek V3, Nemotron 3, GPT-OSS.
+**Renderer-backed tokenization.** SFT tokenization is renderer-only. The [`renderers`](algorithms.md#renderers) package owns message-to-token conversion and loss attribution end-to-end, so position-dependent chat templates (for example templates that strip past `<think>` blocks across user turns) do not corrupt the loss mask. `[renderer]` defaults to `name = "auto"`; set a typed renderer config only when you need model-specific template controls. Hand-coded renderers ship for Qwen3, Qwen3.5, GLM-5, GLM-4.5, Kimi K2/K2.5, MiniMax M2, DeepSeek V3, Nemotron 3, GPT-OSS, and VLM families such as Qwen3-VL/Qwen3.5.
 
+**VLM training requires a custom PrimeRL implementation.** Training a model with `[model.vlm]` set (SFT or RL) only works for models with a custom PrimeRL VLM class (currently Qwen3.5 dense and MoE) — `get_model` rejects hf-only VLMs at load time. Text-only training of a VLM checkpoint (no `[model.vlm]`) still loads via the hf implementation.
 
 See [Algorithms § Multi-Turn Trajectories](algorithms.md#multi-turn-trajectories) for the full picture.
 

--- a/examples/vlm_sft/sft.toml
+++ b/examples/vlm_sft/sft.toml
@@ -1,0 +1,34 @@
+max_steps = 20
+
+[ckpt]
+[ckpt.weights]
+save_adapter_separately = true
+
+[model]
+name = "Qwen/Qwen3.5-0.8B"
+optimization_dtype = "bfloat16"
+reduce_dtype = "bfloat16"
+
+[renderer]
+name = "auto"
+
+[model.vlm]
+vision_encoder_attr = "model.visual"
+language_model_attr = "model.language_model"
+freeze_vision_encoder = true
+
+[model.lora]
+rank = 16
+
+[model.ac]
+freq = 1
+
+[data]
+type = "sft"
+name = "your-org/your-multimodal-dataset"
+batch_size = 1
+micro_batch_size = 1
+seq_len = 16384
+
+[optim]
+lr = 1e-5

--- a/examples/vlm_sft_moe/sft.toml
+++ b/examples/vlm_sft_moe/sft.toml
@@ -1,0 +1,56 @@
+# Multimodal (VLM) SFT on a Mixture-of-Experts model — single 8xH200 node.
+max_steps = 1000
+dist_timeout_seconds = 3600
+loss_impl = "liger_fused"
+
+[model]
+name = "Qwen/Qwen3.6-35B-A3B"
+optimization_dtype = "bfloat16"
+reduce_dtype = "bfloat16"
+impl = "custom"
+attn = "flash_attention_2"
+ep = 8                      # keep in sync with deployment.num_gpus
+
+[renderer]
+name = "auto"
+
+[model.vlm]
+vision_encoder_attr = "model.visual"
+language_model_attr = "model.language_model"
+freeze_vision_encoder = true
+
+[model.lora]
+rank = 32
+alpha = 32
+target_modules = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj", "experts"]
+
+# MoE + mode="full" recomputes the router, whose non-deterministic top-k routing
+# raises CheckpointError; selective AC excluding routed_experts avoids that.
+[model.ac]
+mode = "selective"
+targets = ["norm", "attn_proj", "linear_attn"]
+
+[data]
+type = "sft"
+name = "your-org/your-multimodal-dataset"
+batch_size = 8
+micro_batch_size = 1       # required for VLM SFT
+seq_len = 16384
+
+[data.loss_mask]
+system = false
+user = false
+assistant = true
+tool = false
+
+[optim]
+lr = 1e-5
+
+[ckpt]
+interval = 200
+[ckpt.weights]
+save_adapter_separately = true
+
+[deployment]
+type = "single_node"
+num_gpus = 8

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -317,16 +317,17 @@ class SFTConfig(BaseConfig):
     def validate_vlm_constraints(self):
         if self.model.vlm is None:
             return self
+        if self.model.optimization_dtype != "bfloat16" or self.model.reduce_dtype != "bfloat16":
+            raise ValueError(
+                "VLM models must use optimization_dtype='bfloat16' and reduce_dtype='bfloat16' "
+                "to match vLLM inference."
+            )
         if self.model.cp > 1:
             raise ValueError("VLM SFT does not support context parallelism yet.")
         if self.data.micro_batch_size != 1:
-            raise ValueError(
-                "VLM SFT requires data.micro_batch_size = 1 (image samples can't be packed across samples)."
-            )
+            raise ValueError("VLM SFT requires data.micro_batch_size = 1.")
         if self.val is not None and self.val.data.micro_batch_size != 1:
-            raise ValueError(
-                "VLM SFT requires val.data.micro_batch_size = 1 (image samples can't be packed across samples)."
-            )
+            raise ValueError("VLM SFT requires val.data.micro_batch_size = 1.")
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -34,9 +34,6 @@ class BaseDataConfig(BaseConfig):
     seq_len: int = Field(128, ge=1)
     """Sequence length."""
 
-    pack_function: Literal["cat", "stack"] = "cat"
-    """Sample packing strategy. ``cat`` concatenates; ``stack`` requires ``seq_len`` divisible by 256."""
-
     micro_batch_size: int = Field(1, ge=1)
     """Per-step micro batch size. ``batch_size`` must be divisible by this."""
 
@@ -290,15 +287,6 @@ class SFTConfig(BaseConfig):
         )
 
     @model_validator(mode="after")
-    def validate_pack_function(self):
-        if self.model.cp > 1:
-            if self.data.pack_function != "cat":
-                raise ValueError("Packing function must be 'cat' when CP is enabled")
-            if self.val is not None and self.val.data.pack_function != "cat":
-                raise ValueError("Validation packing function must be 'cat' when CP is enabled")
-        return self
-
-    @model_validator(mode="after")
     def validate_cp_seq_len(self):
         if self.model.cp > 1:
             if self.data.seq_len % self.model.cp != 0:
@@ -314,14 +302,6 @@ class SFTConfig(BaseConfig):
                 raise ValueError("Micro batch size must be 1 when CP is enabled")
             if self.val is not None and self.val.data.micro_batch_size != 1:
                 raise ValueError("Validation micro batch size must be 1 when CP is enabled")
-        return self
-
-    @model_validator(mode="after")
-    def validate_seq_len(self):
-        if self.data.pack_function == "stack" and self.data.seq_len % 256 != 0:
-            raise ValueError("The sequence length must be divisible by 256 when using pack function stack")
-        if self.val is not None and self.val.data.pack_function == "stack" and self.val.data.seq_len % 256 != 0:
-            raise ValueError("The validation sequence length must be divisible by 256 when using pack function stack")
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -305,6 +305,31 @@ class SFTConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def vlm_freeze_incompatible_with_lora(self):
+        if self.model.vlm is not None and not self.model.vlm.freeze_vision_encoder and self.model.lora is not None:
+            raise ValueError(
+                "freeze_vision_encoder=false is incompatible with LoRA. "
+                "LoRA freezes all non-adapter parameters including the vision encoder."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_vlm_constraints(self):
+        if self.model.vlm is None:
+            return self
+        if self.model.cp > 1:
+            raise ValueError("VLM SFT does not support context parallelism yet.")
+        if self.data.micro_batch_size != 1:
+            raise ValueError(
+                "VLM SFT requires data.micro_batch_size = 1 (image samples can't be packed across samples)."
+            )
+        if self.val is not None and self.val.data.micro_batch_size != 1:
+            raise ValueError(
+                "VLM SFT requires val.data.micro_batch_size = 1 (image samples can't be packed across samples)."
+            )
+        return self
+
+    @model_validator(mode="after")
     def dont_do_massive_traces(self):
         if self.trace_path:
             if self.max_steps is None:
@@ -313,15 +338,6 @@ class SFTConfig(BaseConfig):
                 raise ValueError(
                     "Tracing more than 10 steps is not recommended as your trace will be massive. Remove this line if you really want to trace more steps."
                 )
-        return self
-
-    @model_validator(mode="after")
-    def validate_renderer_vs_vlm(self):
-        if self.model.vlm is not None:
-            raise ValueError(
-                "renderer-only SFT does not support VLMs yet. The renderer tokenizes "
-                "text-only message dicts client-side and cannot handle image inputs."
-            )
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -319,8 +319,7 @@ class SFTConfig(BaseConfig):
             return self
         if self.model.optimization_dtype != "bfloat16" or self.model.reduce_dtype != "bfloat16":
             raise ValueError(
-                "VLM models must use optimization_dtype='bfloat16' and reduce_dtype='bfloat16' "
-                "to match vLLM inference."
+                "VLM models must use optimization_dtype='bfloat16' and reduce_dtype='bfloat16' to match vLLM inference."
             )
         if self.model.cp > 1:
             raise ValueError("VLM SFT does not support context parallelism yet.")

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -299,20 +299,6 @@ class SFTConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
-    def validate_qwen3_5_stack_flash(self):
-        name = self.model.name.lower()
-        is_qwen3_5 = "qwen3.5" in name or "qwen3_5" in name
-        is_flash = self.model.attn in ("flash_attention_2", "flash_attention_3", "fa4")
-        if is_qwen3_5 and self.model.impl != "hf" and is_flash:
-            if self.data.pack_function == "stack":
-                raise ValueError("Qwen3.5 custom flash attention does not support pack_function='stack'; use 'cat'")
-            if self.val is not None and self.val.data.pack_function == "stack":
-                raise ValueError(
-                    "Qwen3.5 custom flash attention does not support pack_function='stack' for validation data; use 'cat'"
-                )
-        return self
-
-    @model_validator(mode="after")
     def validate_cp_seq_len(self):
         if self.model.cp > 1:
             if self.data.seq_len % self.model.cp != 0:

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -299,6 +299,20 @@ class SFTConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def validate_qwen3_5_stack_flash(self):
+        name = self.model.name.lower()
+        is_qwen3_5 = "qwen3.5" in name or "qwen3_5" in name
+        is_flash = self.model.attn in ("flash_attention_2", "flash_attention_3", "fa4")
+        if is_qwen3_5 and self.model.impl != "hf" and is_flash:
+            if self.data.pack_function == "stack":
+                raise ValueError("Qwen3.5 custom flash attention does not support pack_function='stack'; use 'cat'")
+            if self.val is not None and self.val.data.pack_function == "stack":
+                raise ValueError(
+                    "Qwen3.5 custom flash attention does not support pack_function='stack' for validation data; use 'cat'"
+                )
+        return self
+
+    @model_validator(mode="after")
     def validate_cp_seq_len(self):
         if self.model.cp > 1:
             if self.data.seq_len % self.model.cp != 0:

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -94,7 +94,7 @@ class VLMConfig(BaseConfig):
     """Dotted attribute path to the language model module (e.g. ``model.language_model``)."""
 
     freeze_vision_encoder: bool = True
-    """Freeze the vision encoder. When False, it is trainable and FSDP-sharded per-block. No effect with LoRA (LoRA freezes all non-adapter parameters)."""
+    """Freeze the complete vision encoder subtree, including excluding it from LoRA targeting."""
 
 
 class BaseModelConfig(BaseConfig):

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -94,7 +94,7 @@ class VLMConfig(BaseConfig):
     """Dotted attribute path to the language model module (e.g. ``model.language_model``)."""
 
     freeze_vision_encoder: bool = True
-    """Freeze the complete vision encoder subtree, including excluding it from LoRA targeting."""
+    """Freeze the vision encoder and exclude its subtree from LoRA targeting."""
 
 
 class BaseModelConfig(BaseConfig):

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -215,6 +215,7 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         ce_weights=ce_weights,
         ref_kl_weights=ref_kl_weights,
         seq_lens=[len(input_ids)],
+        padding_len=0,
     )
 
 
@@ -324,7 +325,7 @@ def _materialize_bin(bin_content: _MicroBatchBin, num_loras: int) -> MicroBatch:
                 assert routed_experts.shape[1:] == sample.routed_experts.shape[1:]
                 routed_experts.data += sample.routed_experts.data
                 routed_experts.shape[0] += sample.routed_experts.shape[0]
-        seq_lens.extend(sample.seq_lens if sample.seq_lens is not None else [sample_len])
+        seq_lens.extend(sample.seq_lens)
         lora_num_tokens[lora_idx] += sample_len
 
     sequence_lengths = [len(sample.input_ids) for _, sample in bin_content.samples]
@@ -350,6 +351,7 @@ def _materialize_bin(bin_content: _MicroBatchBin, num_loras: int) -> MicroBatch:
         ce_weights=streams["ce_weights"],
         ref_kl_weights=streams["ref_kl_weights"],
         seq_lens=seq_lens,
+        padding_len=0,
     )
 
 
@@ -451,6 +453,8 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
     micro_batch.loss_mask.extend([False] * padding_size)
     micro_batch.position_ids.extend(list(range(padding_size)))
     micro_batch.sequence_lengths.append(padding_size)
+    micro_batch.seq_lens.append(padding_size)
+    micro_batch.padding_len = padding_size
     micro_batch.inference_logprobs.extend([0.0] * padding_size)
     # Use temperature 1.0 for padding tokens (doesn't matter since loss_mask is False)
     micro_batch.temperatures.extend([1.0] * padding_size)
@@ -469,8 +473,6 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
         )
     if micro_batch.mm_token_type_ids is not None:
         micro_batch.mm_token_type_ids.extend([0] * padding_size)
-    if micro_batch.seq_lens is not None:
-        micro_batch.seq_lens.append(padding_size)
     if micro_batch.routed_experts is not None:
         _pad_routed_experts(micro_batch, padding_size)
     micro_batch.env_names.extend([""] * padding_size)
@@ -504,6 +506,11 @@ def _assert_token_arrays_aligned(micro_batch: MicroBatch) -> None:
     assert sum(micro_batch.sequence_lengths) == num_tokens, (
         f"sequence_lengths sum {sum(micro_batch.sequence_lengths)} != {num_tokens} tokens"
     )
+    assert micro_batch.seq_lens and all(seq_len > 0 for seq_len in micro_batch.seq_lens)
+    assert sum(micro_batch.seq_lens) == num_tokens, f"seq_lens sum {sum(micro_batch.seq_lens)} != {num_tokens} tokens"
+    assert micro_batch.padding_len >= 0
+    if micro_batch.padding_len:
+        assert micro_batch.seq_lens[-1] == micro_batch.padding_len
     if micro_batch.routed_experts is not None:
         assert micro_batch.routed_experts.shape[0] == num_tokens, (
             f"routed_experts misaligned after packing: {micro_batch.routed_experts.shape[0]} != {num_tokens} tokens"

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -452,9 +452,9 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
     micro_batch.advantages.extend([0.0] * padding_size)
     micro_batch.loss_mask.extend([False] * padding_size)
     micro_batch.position_ids.extend(list(range(padding_size)))
-    micro_batch.sequence_lengths.append(padding_size)
-    micro_batch.seq_lens.append(padding_size)
-    micro_batch.padding_len = padding_size
+    micro_batch.sequence_lengths[-1] += padding_size
+    micro_batch.seq_lens[-1] += padding_size
+    micro_batch.padding_len += padding_size
     micro_batch.inference_logprobs.extend([0.0] * padding_size)
     # Use temperature 1.0 for padding tokens (doesn't matter since loss_mask is False)
     micro_batch.temperatures.extend([1.0] * padding_size)
@@ -510,7 +510,7 @@ def _assert_token_arrays_aligned(micro_batch: MicroBatch) -> None:
     assert sum(micro_batch.seq_lens) == num_tokens, f"seq_lens sum {sum(micro_batch.seq_lens)} != {num_tokens} tokens"
     assert micro_batch.padding_len >= 0
     if micro_batch.padding_len:
-        assert micro_batch.seq_lens[-1] == micro_batch.padding_len
+        assert micro_batch.seq_lens[-1] > micro_batch.padding_len
     if micro_batch.routed_experts is not None:
         assert micro_batch.routed_experts.shape[0] == num_tokens, (
             f"routed_experts misaligned after packing: {micro_batch.routed_experts.shape[0]} != {num_tokens} tokens"

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -214,6 +214,7 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         rl_weights=rl_weights,
         ce_weights=ce_weights,
         ref_kl_weights=ref_kl_weights,
+        seq_lens=[len(input_ids)],
     )
 
 
@@ -291,6 +292,7 @@ def _materialize_bin(bin_content: _MicroBatchBin, num_loras: int) -> MicroBatch:
     ref_logprobs: list[float] | None = [] if has_ref_logprobs else None
     mm_token_type_ids: list[int] | None = [] if has_mm_token_type_ids else None
     streams: dict[str, list[float] | None] = {name: ([] if has_stream[name] else None) for name in STREAM_FILL}
+    seq_lens: list[int] = []
     routed_experts: RoutedExperts | None = None
     lora_num_tokens = [0] * num_loras
 
@@ -322,10 +324,12 @@ def _materialize_bin(bin_content: _MicroBatchBin, num_loras: int) -> MicroBatch:
                 assert routed_experts.shape[1:] == sample.routed_experts.shape[1:]
                 routed_experts.data += sample.routed_experts.data
                 routed_experts.shape[0] += sample.routed_experts.shape[0]
+        seq_lens.extend(sample.seq_lens if sample.seq_lens is not None else [sample_len])
         lora_num_tokens[lora_idx] += sample_len
 
     sequence_lengths = [len(sample.input_ids) for _, sample in bin_content.samples]
     assert sum(sequence_lengths) == len(input_ids), (sequence_lengths, len(input_ids))
+    assert sum(seq_lens) == len(input_ids), (seq_lens, len(input_ids))
     first_sample = bin_content.first_sample
 
     return MicroBatch(
@@ -345,6 +349,7 @@ def _materialize_bin(bin_content: _MicroBatchBin, num_loras: int) -> MicroBatch:
         rl_weights=streams["rl_weights"],
         ce_weights=streams["ce_weights"],
         ref_kl_weights=streams["ref_kl_weights"],
+        seq_lens=seq_lens,
     )
 
 
@@ -464,6 +469,8 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
         )
     if micro_batch.mm_token_type_ids is not None:
         micro_batch.mm_token_type_ids.extend([0] * padding_size)
+    if micro_batch.seq_lens is not None:
+        micro_batch.seq_lens.append(padding_size)
     if micro_batch.routed_experts is not None:
         _pad_routed_experts(micro_batch, padding_size)
     micro_batch.env_names.extend([""] * padding_size)

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -18,6 +18,7 @@ from torch.nn import Module
 from torch.optim.lr_scheduler import LRScheduler
 from torch.optim.optimizer import Optimizer
 from torchdata.stateful_dataloader import StatefulDataLoader
+from transformers.processing_utils import ProcessorMixin
 from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.configs.trainer import CheckpointConfig, LoRAConfig, WeightCheckpointConfig
@@ -377,6 +378,7 @@ class WeightCheckpointManager:
         lora_state_dict: dict[str, Tensor] | None,
         model,
         tokenizer: PreTrainedTokenizer,
+        processor: ProcessorMixin | None = None,
     ):
         """Save HF-compatible weight checkpoint to a given path."""
         if self.world.is_master:
@@ -404,6 +406,8 @@ class WeightCheckpointManager:
                     gen_config.use_cache = True
                     gen_config.save_pretrained(path)
                 tokenizer.save_pretrained(path)
+                if processor is not None:
+                    processor.save_pretrained(path)
 
             if lora_state_dict is not None:
                 adapter_path = path / "lora_adapters"
@@ -426,6 +430,7 @@ class WeightCheckpointManager:
         step: int,
         model: nn.Module,
         tokenizer: PreTrainedTokenizer,
+        processor: ProcessorMixin | None = None,
     ):
         """Save a HF-compatible weight-only checkpoint for a given step."""
         step_path = self.get_step_path(step)
@@ -471,7 +476,7 @@ class WeightCheckpointManager:
             self.logger.debug(f"Reverted to HF hub format in {time.perf_counter() - start_time:.2f} seconds")
 
         # Save weight checkpoint on master rank
-        self.save_to_path(step_path, state_dict, lora_state_dict, model, tokenizer)
+        self.save_to_path(step_path, state_dict, lora_state_dict, model, tokenizer, processor)
         self.mark_stable(step)
         bisect.insort(self.ckpt_steps, step)
 

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -405,9 +405,11 @@ class WeightCheckpointManager:
                     gen_config = deepcopy(model.generation_config)
                     gen_config.use_cache = True
                     gen_config.save_pretrained(path)
-                tokenizer.save_pretrained(path)
+                # Processor first: it saves its own (unmodified) tokenizer, which the
+                # configured tokenizer (pad token, custom chat template) must override.
                 if processor is not None:
                     processor.save_pretrained(path)
+                tokenizer.save_pretrained(path)
 
             if lora_state_dict is not None:
                 adapter_path = path / "lora_adapters"

--- a/src/prime_rl/trainer/lora.py
+++ b/src/prime_rl/trainer/lora.py
@@ -67,7 +67,11 @@ def _matches_pattern(name: str, pattern: str) -> bool:
         return pattern in name.split(".")
 
 
-def _find_target_modules(model: nn.Module, target_patterns: List[str]) -> List[str]:
+def _find_target_modules(
+    model: nn.Module,
+    target_patterns: List[str],
+    excluded_modules: tuple[nn.Module, ...] = (),
+) -> List[str]:
     """Find all module names that match any of the target patterns.
 
     Patterns can be simple module names (e.g., "q_proj") or regex patterns
@@ -75,9 +79,12 @@ def _find_target_modules(model: nn.Module, target_patterns: List[str]) -> List[s
 
     Supports both nn.Linear layers and GroupedExperts (MoE) modules.
     """
+    excluded_module_ids = {id(module) for excluded in excluded_modules for module in excluded.modules()}
     target_modules = []
 
     for name, module in model.named_modules():
+        if id(module) in excluded_module_ids:
+            continue
         # Check if module is Linear or one of the supported expert classes
         if not isinstance(module, (nn.Linear, GroupedExperts, NonGatedGroupedExperts, GptOssGroupedExperts)):
             continue
@@ -129,7 +136,12 @@ def freeze_all_except_lora_and_specified(model: nn.Module, config: LoRAConfig) -
             param.requires_grad = False
 
 
-def apply_lora_to_model(model: nn.Module, config: LoRAConfig) -> None:
+def apply_lora_to_model(
+    model: nn.Module,
+    config: LoRAConfig,
+    *,
+    excluded_modules: tuple[nn.Module, ...] = (),
+) -> None:
     """
     Apply LoRA to target modules in the model and freeze non-LoRA parameters.
 
@@ -139,6 +151,7 @@ def apply_lora_to_model(model: nn.Module, config: LoRAConfig) -> None:
     Args:
         model: The model to apply LoRA to
         config: LoRA configuration
+        excluded_modules: Subtrees that must not receive LoRA adapters
     """
     logger = get_logger()
     from prime_rl.trainer.models import PreTrainedModelPrimeRL
@@ -156,7 +169,7 @@ def apply_lora_to_model(model: nn.Module, config: LoRAConfig) -> None:
         raise RuntimeError("Cannot apply LoRA to FSDP-wrapped model. Apply LoRA before setup_fsdp().")
 
     logger.debug(f"Applying LoRA to model: {model} for {config.target_modules}")
-    target_modules = _find_target_modules(model, config.target_modules)
+    target_modules = _find_target_modules(model, config.target_modules, excluded_modules)
     logger.debug(
         f"Found {len(target_modules)} target modules for LoRA: {target_modules[:10]} ... {target_modules[-10:]}"
     )

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1225,6 +1225,7 @@ def forward(
     # not a renderer/processor output.
     mm_kwargs: dict[str, Tensor] | None = None,
     mm_token_type_ids: Int[Tensor, "batch seq"] | None = None,
+    seq_lens: Int[Tensor, "segments"] | None = None,
 ) -> PrimeLmOutput:
     # Build kwargs for model forward
     kwargs = {
@@ -1248,6 +1249,10 @@ def forward(
             kwargs["position_ids"] = position_ids
     else:
         kwargs["position_ids"] = position_ids
+
+    if isinstance(model, PreTrainedModelPrimeRL):
+        # Universal contract: every custom model declares the typed seq_lens param.
+        kwargs["seq_lens"] = seq_lens
 
     if routed_experts is not None:
         kwargs["routed_experts"] = routed_experts

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -606,6 +606,12 @@ def get_model(
     else:
         impl_to_use = config.impl
 
+    if config.vlm is not None and not (is_vlm_arch and impl_to_use == "custom" and custom_vlm_cls):
+        raise ValueError(
+            "VLM training requires a custom PrimeRL VLM implementation; "
+            f"{getattr(model_config, 'model_type', config.name)!r} has none."
+        )
+
     with device:
         if impl_to_use == "custom" and custom_vlm_cls is not None:
             model_cls = custom_vlm_cls
@@ -662,6 +668,23 @@ def setup_tokenizer(config: TokenizerConfig) -> PreTrainedTokenizer:
     tokenizer.pad_token_id = tokenizer.eos_token_id
 
     return tokenizer
+
+
+def setup_processor(config: TokenizerConfig):
+    """Load an ``AutoProcessor`` for VLM models. Returns ``None`` for text-only models."""
+    from transformers import AutoProcessor
+
+    logger = get_logger()
+    try:
+        processor = AutoProcessor.from_pretrained(config.name, trust_remote_code=config.trust_remote_code)
+    except (ValueError, OSError, KeyError) as e:
+        logger.debug(f"No AutoProcessor available for {config.name} ({type(e).__name__}); treating as text-only.")
+        return None
+    if not (getattr(processor, "image_processor", None) or getattr(processor, "video_processor", None)):
+        logger.debug(f"AutoProcessor for {config.name} has no image/video processor; treating as text-only.")
+        return None
+    logger.info(f"Loaded multimodal processor: {type(processor).__name__}")
+    return processor
 
 
 def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims):
@@ -1212,28 +1235,31 @@ def setup_model(
 
 def forward(
     model: nn.Module,
-    input_ids: Int[Tensor, "batch seq"],
-    position_ids: Int[Tensor, "batch seq"],
+    input_ids: Int[Tensor, "batch seq"] | None,
+    position_ids: Int[Tensor, "batch seq"] | None,
     *,
     seq_lens: Int[Tensor, "segments"],
     labels: Int[Tensor, "batch seq"] | None = None,
     temperature: Tensor | None = None,
     routed_experts: Int[Tensor, "batch seq layers topk"] | None = None,
+    inputs_embeds: Tensor | None = None,
     # Generic multimodal kwargs (e.g. {"pixel_values": ...,
     # "image_grid_thw": ...} for Qwen3-VL; just {"pixel_values": ...}
     # for Gemma3). Passed straight through to ``model(**kwargs)`` so
     # the model's HF forward signature is the schema. ``mm_token_type_ids``
-    # is split out because it's prime-rl-computed (from token ids),
-    # not a renderer/processor output.
+    # is split out because it's prime-rl-computed (from token ids).
     mm_kwargs: dict[str, Tensor] | None = None,
     mm_token_type_ids: Int[Tensor, "batch seq"] | None = None,
 ) -> PrimeLmOutput:
     # Build kwargs for model forward
     kwargs = {
-        "input_ids": input_ids,
         "labels": labels,
         "temperature": temperature,
     }
+    if inputs_embeds is None:
+        kwargs["input_ids"] = input_ids
+    else:
+        kwargs["inputs_embeds"] = inputs_embeds
 
     if mm_kwargs:
         # Forward the per-model multimodal tensors verbatim, plus the
@@ -1242,10 +1268,6 @@ def forward(
         kwargs.update(mm_kwargs)
         if mm_token_type_ids is not None:
             kwargs["mm_token_type_ids"] = mm_token_type_ids
-        # ``position_ids`` for MRoPE families: Qwen3-VL's HF forward
-        # recomputes 3D positions from ``image_grid_thw`` and breaks if
-        # given the trainer's pre-computed 1D ``position_ids``. Detect
-        # via the mm_kwargs shape so we don't enumerate model_types.
         if "image_grid_thw" not in mm_kwargs:
             kwargs["position_ids"] = position_ids
     else:

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1214,6 +1214,9 @@ def forward(
     model: nn.Module,
     input_ids: Int[Tensor, "batch seq"],
     position_ids: Int[Tensor, "batch seq"],
+    *,
+    seq_lens: Int[Tensor, "segments"] | None,
+    padding_len: int,
     labels: Int[Tensor, "batch seq"] | None = None,
     temperature: Tensor | None = None,
     routed_experts: Int[Tensor, "batch seq layers topk"] | None = None,
@@ -1225,7 +1228,6 @@ def forward(
     # not a renderer/processor output.
     mm_kwargs: dict[str, Tensor] | None = None,
     mm_token_type_ids: Int[Tensor, "batch seq"] | None = None,
-    seq_lens: Int[Tensor, "segments"] | None = None,
 ) -> PrimeLmOutput:
     # Build kwargs for model forward
     kwargs = {
@@ -1251,8 +1253,15 @@ def forward(
         kwargs["position_ids"] = position_ids
 
     if isinstance(model, PreTrainedModelPrimeRL):
-        # Universal contract: every custom model declares the typed seq_lens param.
-        kwargs["seq_lens"] = seq_lens
+        # Padding is an explicit final segment in transport metadata, but it is
+        # not a document. Merge it into the final real document before model
+        # guards count boundaries; no trainable token follows the padding.
+        model_seq_lens = seq_lens
+        if model_seq_lens is not None and padding_len:
+            if model_seq_lens.numel() < 2:
+                raise ValueError("Padding metadata requires at least one real sequence")
+            model_seq_lens = torch.cat([model_seq_lens[:-2], (model_seq_lens[-2] + model_seq_lens[-1]).view(1)])
+        kwargs["seq_lens"] = model_seq_lens
 
     if routed_experts is not None:
         kwargs["routed_experts"] = routed_experts

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -339,8 +339,8 @@ def freeze_moe_router(model: nn.Module) -> None:
             for param in mlp.router.parameters():
                 param.requires_grad = False
                 num_frozen += 1
-        # HuggingFace implementation: gate attribute (nn.Linear)
-        elif hasattr(mlp, "gate") and isinstance(mlp.gate, nn.Linear):
+        # HuggingFace implementation: gate may have been wrapped with LoRA.
+        elif hasattr(mlp, "gate") and isinstance(mlp.gate, nn.Module):
             for param in mlp.gate.parameters():
                 param.requires_grad = False
                 num_frozen += 1
@@ -642,16 +642,6 @@ def get_model(
                 **dtype_kwarg,
             )
         logger.debug(f"Loaded model {config.name} in {time.perf_counter() - load_model_start_time:.2f} seconds")
-
-    # For VLM models, optionally freeze the vision encoder
-    if is_vlm_training and config.vlm.freeze_vision_encoder:
-        freeze_vision_encoder(model, override_attr=config.vlm.vision_encoder_attr)
-    elif config.vlm is None and custom_vlm_cls is not None and model_cls is custom_vlm_cls:
-        # Text-only training of a VLM checkpoint: the vision tower still runs
-        # (dummy input for collective symmetry), so its params get zero — not
-        # None — grads and AdamW weight decay would silently shrink them.
-        logger.info("Training a VLM checkpoint on text-only data; freezing the vision encoder")
-        freeze_vision_encoder(model)
 
     assert model.lm_head.weight.dtype == dtype, (
         f"LM head dtype wasnt loaded correctly {model.lm_head.weight.dtype} != {dtype}"
@@ -1082,6 +1072,40 @@ def apply_ep(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims)
             )
 
 
+def configure_trainable_parameters(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims) -> None:
+    """Apply parameter transforms, then enforce the final trainability policy."""
+    frozen_vision_encoder = None
+    if config.vlm is not None and config.vlm.freeze_vision_encoder:
+        frozen_vision_encoder = get_vision_encoder(model, override=config.vlm.vision_encoder_attr)
+    elif config.vlm is None:
+        frozen_vision_encoder = get_vision_encoder(model)
+        if frozen_vision_encoder is not None:
+            get_logger().info("Training a VLM checkpoint on text-only data; freezing the vision encoder")
+
+    if config.lora is not None:
+        excluded_modules = (frozen_vision_encoder,) if frozen_vision_encoder is not None else ()
+        apply_lora_to_model(model, config.lora, excluded_modules=excluded_modules)
+
+    if config.moe_router_dtype == "float32":
+        apply_fp32_moe_router(model)
+
+    if parallel_dims.ep_enabled:
+        apply_ep(model, config, parallel_dims)
+        if config.lora is not None:
+            # EP replaces parameters with DTensors that default to trainable.
+            freeze_all_except_lora_and_specified(model, config.lora)
+
+    # Explicit freezes take precedence over LoRA modules_to_save and EP replacements.
+    if config.freeze_moe_router:
+        freeze_moe_router(model)
+    freeze_sparse_indexer(model)
+    if frozen_vision_encoder is not None:
+        freeze_vision_encoder(
+            model,
+            override_attr=config.vlm.vision_encoder_attr if config.vlm is not None else None,
+        )
+
+
 def _move_buffers_to_cuda(model: nn.Module, config: ModelConfig) -> None:
     """FSDP CPU offloading only manages parameters, not buffers. Move buffers to CUDA."""
     if not config.fsdp_cpu_offload:
@@ -1176,30 +1200,10 @@ def setup_model(
     if config.fp8:
         replace_linear_with_fp8_blockwise_linear(model)
 
-    # Apply LoRA before FSDP setup
-    if config.lora is not None:
-        apply_lora_to_model(model, config.lora)
-
-    if config.freeze_moe_router:
-        freeze_moe_router(model)
-
-    if config.moe_router_dtype == "float32":
-        apply_fp32_moe_router(model)
-
-    # The DSA sparse-attention indexer runs its forward under torch.no_grad(), so it is
-    # never trainable. Freeze it so optimizer state stays symmetric across checkpoint
-    # save/resume. No-op for models without a sparse indexer.
-    freeze_sparse_indexer(model)
+    configure_trainable_parameters(model, config, parallel_dims)
 
     if config.debug.force_balanced_routing:
         apply_force_balanced_routing(model)
-
-    if parallel_dims.ep_enabled:
-        apply_ep(model, config, parallel_dims)
-        # EP replaces params with DTensors that default to requires_grad=True,
-        # re-freeze base params that LoRA froze earlier.
-        if config.lora is not None:
-            freeze_all_except_lora_and_specified(model, config.lora)
 
     # the right order is AC -> Compile -> FSDP
     if config.ac is not None:

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1215,8 +1215,7 @@ def forward(
     input_ids: Int[Tensor, "batch seq"],
     position_ids: Int[Tensor, "batch seq"],
     *,
-    seq_lens: Int[Tensor, "segments"] | None,
-    padding_len: int,
+    seq_lens: Int[Tensor, "segments"],
     labels: Int[Tensor, "batch seq"] | None = None,
     temperature: Tensor | None = None,
     routed_experts: Int[Tensor, "batch seq layers topk"] | None = None,
@@ -1253,15 +1252,7 @@ def forward(
         kwargs["position_ids"] = position_ids
 
     if isinstance(model, PreTrainedModelPrimeRL):
-        # Padding is an explicit final segment in transport metadata, but it is
-        # not a document. Merge it into the final real document before model
-        # guards count boundaries; no trainable token follows the padding.
-        model_seq_lens = seq_lens
-        if model_seq_lens is not None and padding_len:
-            if model_seq_lens.numel() < 2:
-                raise ValueError("Padding metadata requires at least one real sequence")
-            model_seq_lens = torch.cat([model_seq_lens[:-2], (model_seq_lens[-2] + model_seq_lens[-1]).view(1)])
-        kwargs["seq_lens"] = model_seq_lens
+        kwargs["seq_lens"] = seq_lens
 
     if routed_experts is not None:
         kwargs["routed_experts"] = routed_experts

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -646,6 +646,12 @@ def get_model(
     # For VLM models, optionally freeze the vision encoder
     if is_vlm_training and config.vlm.freeze_vision_encoder:
         freeze_vision_encoder(model, override_attr=config.vlm.vision_encoder_attr)
+    elif config.vlm is None and custom_vlm_cls is not None and model_cls is custom_vlm_cls:
+        # Text-only training of a VLM checkpoint: the vision tower still runs
+        # (dummy input for collective symmetry), so its params get zero — not
+        # None — grads and AdamW weight decay would silently shrink them.
+        logger.info("Training a VLM checkpoint on text-only data; freezing the vision encoder")
+        freeze_vision_encoder(model)
 
     assert model.lm_head.weight.dtype == dtype, (
         f"LM head dtype wasnt loaded correctly {model.lm_head.weight.dtype} != {dtype}"

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1261,7 +1261,6 @@ def forward(
     mm_kwargs: dict[str, Tensor] | None = None,
     mm_token_type_ids: Int[Tensor, "batch seq"] | None = None,
 ) -> PrimeLmOutput:
-    # Build kwargs for model forward
     kwargs = {
         "labels": labels,
         "temperature": temperature,

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1257,7 +1257,7 @@ def forward(
     # "image_grid_thw": ...} for Qwen3-VL; just {"pixel_values": ...}
     # for Gemma3). Passed straight through to ``model(**kwargs)`` so
     # the model's HF forward signature is the schema. ``mm_token_type_ids``
-    # is split out because it's prime-rl-computed (from token ids).
+    # is split out because it comes from the renderer rather than the processor.
     mm_kwargs: dict[str, Tensor] | None = None,
     mm_token_type_ids: Int[Tensor, "batch seq"] | None = None,
 ) -> PrimeLmOutput:

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -75,6 +75,7 @@ def supports_custom_impl(model_config: PretrainedConfig) -> bool:
 # Used by get_model() to dispatch VLMs that have a custom text model implementation.
 # Points to the same unified class — the config drives text-only vs VLM behavior.
 _CUSTOM_VLM_MAPPING: dict[str, type] = {
+    "qwen3_5": Qwen3_5ForCausalLM,
     "qwen3_5_moe": Qwen3_5MoeForCausalLM,
 }
 

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -33,7 +33,7 @@ from prime_rl.trainer.models.layers.rotary_emb import (
     RotaryEmbeddingConfig,
     apply_rotary_pos_emb,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 from .configuration_afmoe import AfmoeConfig
 from .converting_afmoe import (
@@ -464,7 +464,8 @@ class AfmoeModel(AfmoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> MoeModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
@@ -480,18 +481,15 @@ class AfmoeModel(AfmoePreTrainedModel):
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
         use_flash = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens is not None and seq_lens.numel() > 1 and not use_flash:
+        if seq_lens.numel() > 1 and not use_flash:
             # SDPA/eager attention has no varlen support and would attend across
             # packed document boundaries.
             raise ValueError("Packed Afmoe batches require flash attention")
 
         if use_flash:
-            if seq_lens is None:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            else:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-                )
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+            )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
             causal_mask_mapping = None
         else:
@@ -583,7 +581,8 @@ class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
         token_type_ids: Optional[torch.Tensor] = None,  # will be ignored
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -33,7 +33,7 @@ from prime_rl.trainer.models.layers.rotary_emb import (
     RotaryEmbeddingConfig,
     apply_rotary_pos_emb,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
 
 from .configuration_afmoe import AfmoeConfig
 from .converting_afmoe import (
@@ -486,7 +486,12 @@ class AfmoeModel(AfmoePreTrainedModel):
             raise ValueError("Packed Afmoe batches require flash attention")
 
         if use_flash:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            if seq_lens is None:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            else:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+                )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
             causal_mask_mapping = None
         else:

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -464,6 +464,7 @@ class AfmoeModel(AfmoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> MoeModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
@@ -479,6 +480,10 @@ class AfmoeModel(AfmoePreTrainedModel):
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
         use_flash = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not use_flash:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Afmoe batches require flash attention")
 
         if use_flash:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
@@ -573,6 +578,7 @@ class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
         token_type_ids: Optional[torch.Tensor] = None,  # will be ignored
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
@@ -593,6 +599,7 @@ class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -39,7 +39,7 @@ from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
 
 
 class Glm4MoeDecoderLayer(GradientCheckpointingLayer):
@@ -225,7 +225,12 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
             # packed document boundaries.
             raise ValueError("Packed Glm4Moe batches require flash attention")
         if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            if seq_lens is None:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            else:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+                )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -205,10 +205,13 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -216,7 +219,12 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Glm4Moe batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -272,9 +280,12 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -317,6 +328,7 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -39,7 +39,7 @@ from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 
 class Glm4MoeDecoderLayer(GradientCheckpointingLayer):
@@ -205,12 +205,13 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
-        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -220,17 +221,14 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
         flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
             # SDPA/eager attention has no varlen support and would attend across
             # packed document boundaries.
             raise ValueError("Packed Glm4Moe batches require flash attention")
         if flash_attn_enabled:
-            if seq_lens is None:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            else:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-                )
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+            )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None
@@ -285,11 +283,12 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
-        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -308,9 +308,15 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        # Document boundaries derive from position_ids (sparse MLA builds its
+        # varlen indices from them); seq_lens is accepted to satisfy the
+        # trainer's universal contract.
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -311,11 +311,12 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
         # Document boundaries derive from position_ids (sparse MLA builds its
         # varlen indices from them); seq_lens is accepted to satisfy the
         # trainer's universal contract.
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
-        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API

--- a/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
@@ -305,9 +305,14 @@ class GptOssForCausalLM(GptOssPreTrainedModel, GenerationMixin):
         use_cache: bool | None = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: torch.Tensor | None = None,
+        # Document boundaries derive from position_ids (HF packed-sequence masks);
+        # seq_lens is accepted to satisfy the trainer's universal contract.
+        seq_lens: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Per-token temperatures for logprobs/entropy computation when `labels` are provided.
         """

--- a/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
@@ -307,11 +307,12 @@ class GptOssForCausalLM(GptOssPreTrainedModel, GenerationMixin):
         temperature: torch.Tensor | None = None,
         # Document boundaries derive from position_ids (HF packed-sequence masks);
         # seq_lens is accepted to satisfy the trainer's universal contract.
-        seq_lens: torch.LongTensor | None = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
-        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Per-token temperatures for logprobs/entropy computation when `labels` are provided.

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -345,6 +345,7 @@ class LagunaModel(LagunaPreTrainedModel):
         position_ids: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         routed_experts: torch.LongTensor | None = None,
+        seq_lens: torch.LongTensor | None = None,
     ) -> MoeModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -354,7 +355,12 @@ class LagunaModel(LagunaPreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Laguna batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
             causal_mask_mapping = dict.fromkeys(set(self.config.layer_types), None)
@@ -433,6 +439,7 @@ class LagunaForCausalLM(LagunaPreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: torch.Tensor | None = None,
         routed_experts: torch.LongTensor | None = None,
+        seq_lens: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom Laguna"
@@ -444,6 +451,7 @@ class LagunaForCausalLM(LagunaPreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
         hidden_states = outputs.last_hidden_state
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -27,7 +27,7 @@ from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.moe import FeedForward, MoE, MoEArgs
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
 
 
 class LagunaRotaryEmbedding(nn.Module):
@@ -361,7 +361,12 @@ class LagunaModel(LagunaPreTrainedModel):
             # packed document boundaries.
             raise ValueError("Packed Laguna batches require flash attention")
         if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            if seq_lens is None:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            else:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+                )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
             causal_mask_mapping = dict.fromkeys(set(self.config.layer_types), None)
         else:

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -27,7 +27,7 @@ from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.moe import FeedForward, MoE, MoEArgs
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 
 class LagunaRotaryEmbedding(nn.Module):
@@ -345,7 +345,8 @@ class LagunaModel(LagunaPreTrainedModel):
         position_ids: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         routed_experts: torch.LongTensor | None = None,
-        seq_lens: torch.LongTensor | None = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> MoeModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -356,17 +357,14 @@ class LagunaModel(LagunaPreTrainedModel):
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
         flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
             # SDPA/eager attention has no varlen support and would attend across
             # packed document boundaries.
             raise ValueError("Packed Laguna batches require flash attention")
         if flash_attn_enabled:
-            if seq_lens is None:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            else:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-                )
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+            )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
             causal_mask_mapping = dict.fromkeys(set(self.config.layer_types), None)
         else:
@@ -444,7 +442,8 @@ class LagunaForCausalLM(LagunaPreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: torch.Tensor | None = None,
         routed_experts: torch.LongTensor | None = None,
-        seq_lens: torch.LongTensor | None = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom Laguna"

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -40,7 +40,7 @@ from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
 
 logger = logging.get_logger(__name__)
 
@@ -199,7 +199,12 @@ class LlamaModel(LlamaPreTrainedModel):
             # packed document boundaries.
             raise ValueError("Packed Llama batches require flash attention")
         if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            if seq_lens is None:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            else:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+                )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -181,14 +181,24 @@ class LlamaModel(LlamaPreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
+        r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Llama batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -241,9 +251,12 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
         cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -283,6 +296,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
             input_ids=input_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -40,7 +40,7 @@ from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 logger = logging.get_logger(__name__)
 
@@ -181,10 +181,11 @@ class LlamaModel(LlamaPreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> BaseModelOutputWithPast:
         r"""
-        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -194,17 +195,14 @@ class LlamaModel(LlamaPreTrainedModel):
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
         flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
             # SDPA/eager attention has no varlen support and would attend across
             # packed document boundaries.
             raise ValueError("Packed Llama batches require flash attention")
         if flash_attn_enabled:
-            if seq_lens is None:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            else:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-                )
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+            )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None
@@ -256,11 +254,12 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
         cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
-        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -22,7 +22,7 @@ from prime_rl.trainer.models.minimax_m2.converting_minimax_m2 import (
     convert_tt_layer_to_hf,
     convert_tt_to_hf_moe,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 logger = logging.get_logger(__name__)
 
@@ -166,12 +166,13 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
-        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -181,17 +182,14 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
             # SDPA/eager attention has no varlen support and would attend across
             # packed document boundaries.
             raise ValueError("Packed MiniMaxM2 batches require flash attention")
         if flash_attn_enabled:
-            if seq_lens is None:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            else:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-                )
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+            )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None
@@ -243,11 +241,12 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
-        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -166,10 +166,13 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -177,7 +180,12 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed MiniMaxM2 batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -230,9 +238,12 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -258,6 +269,7 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -22,7 +22,7 @@ from prime_rl.trainer.models.minimax_m2.converting_minimax_m2 import (
     convert_tt_layer_to_hf,
     convert_tt_to_hf_moe,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
 
 logger = logging.get_logger(__name__)
 
@@ -186,7 +186,12 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
             # packed document boundaries.
             raise ValueError("Packed MiniMaxM2 batches require flash attention")
         if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            if seq_lens is None:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            else:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+                )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -31,7 +31,7 @@ from prime_rl.trainer.models.nemotron_h.converting_nemotron_h import (
     convert_prime_layer_to_hf,
     convert_prime_to_hf,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 logger = logging.get_logger(__name__)
 
@@ -509,13 +509,14 @@ class NemotronHModel(NemotronHPreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token, indexed by global layer index. Only used for router replay; slots
             for non-MoE (Mamba/attention) layers are ignored.
-        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -526,17 +527,14 @@ class NemotronHModel(NemotronHPreTrainedModel):
 
         # Compute cu_seqlens and max_seqlen for flash attention
         flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
             # SDPA/eager attention has no varlen support and would attend across
             # packed document boundaries.
             raise ValueError("Packed NemotronH batches require flash attention")
         if flash_attn_enabled:
-            if seq_lens is None:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            else:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-                )
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+            )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None
@@ -583,7 +581,8 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
         logits_to_keep: int = 0,
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs,
     ) -> PrimeLmOutput:
         if position_ids is None:

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -31,7 +31,7 @@ from prime_rl.trainer.models.nemotron_h.converting_nemotron_h import (
     convert_prime_layer_to_hf,
     convert_prime_to_hf,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
 
 logger = logging.get_logger(__name__)
 
@@ -531,7 +531,12 @@ class NemotronHModel(NemotronHPreTrainedModel):
             # packed document boundaries.
             raise ValueError("Packed NemotronH batches require flash attention")
         if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            if seq_lens is None:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            else:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+                )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -509,11 +509,14 @@ class NemotronHModel(NemotronHPreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token, indexed by global layer index. Only used for router replay; slots
             for non-MoE (Mamba/attention) layers are ignored.
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -522,7 +525,12 @@ class NemotronHModel(NemotronHPreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         # Compute cu_seqlens and max_seqlen for flash attention
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed NemotronH batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -570,6 +578,7 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
         logits_to_keep: int = 0,
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs,
     ) -> PrimeLmOutput:
         if position_ids is None:
@@ -583,6 +592,7 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
+++ b/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
@@ -16,7 +16,7 @@ from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
 
 
 def _get_rope_type(config: Qwen3Config) -> str:
@@ -176,7 +176,12 @@ class Qwen3Model(Qwen3PreTrainedModel):
             # packed document boundaries.
             raise ValueError("Packed Qwen3 batches require flash attention")
         if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            if seq_lens is None:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            else:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+                )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             cu_seqlens = None

--- a/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
+++ b/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
@@ -16,7 +16,7 @@ from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 
 def _get_rope_type(config: Qwen3Config) -> str:
@@ -156,10 +156,11 @@ class Qwen3Model(Qwen3PreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> BaseModelOutputWithPast:
         r"""
-        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -171,17 +172,14 @@ class Qwen3Model(Qwen3PreTrainedModel):
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
         flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
             # SDPA/eager attention has no varlen support and would attend across
             # packed document boundaries.
             raise ValueError("Packed Qwen3 batches require flash attention")
         if flash_attn_enabled:
-            if seq_lens is None:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            else:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-                )
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+            )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             cu_seqlens = None
@@ -236,11 +234,12 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
         cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
-        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API

--- a/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
+++ b/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
@@ -156,7 +156,12 @@ class Qwen3Model(Qwen3PreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
+        r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
@@ -165,7 +170,12 @@ class Qwen3Model(Qwen3PreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Qwen3 batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -221,9 +231,12 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
         cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility; prime-rl asserts `use_cache is None` since training does not
@@ -241,6 +254,7 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
             input_ids=input_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
+            seq_lens=seq_lens,
         )
         hidden_states = outputs.last_hidden_state
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -277,12 +277,6 @@ class Qwen3_5VLMModel(nn.Module):
                 raise ValueError("input_ids are required when inputs_embeds are not provided")
             inputs_embeds = self.language_model.embed_tokens(input_ids)
 
-        if image_grid_thw is not None and input_ids is None:
-            raise ValueError("input_ids are required to compute Qwen3.5 multimodal MRoPE positions")
-        if image_grid_thw is not None and mm_token_type_ids is None:
-            raise ValueError(
-                "Qwen3.5 multimodal forward requires mm_token_type_ids to compute MRoPE positions correctly"
-            )
         if image_grid_thw is not None and position_ids is not None and position_ids.ndim != 3:
             raise ValueError(
                 f"Qwen3.5 multimodal forward requires 3D MRoPE position_ids; got shape={tuple(position_ids.shape)}"
@@ -322,6 +316,12 @@ class Qwen3_5VLMModel(nn.Module):
 
         if position_ids is None:
             if image_grid_thw is not None:
+                if input_ids is None:
+                    raise ValueError("input_ids are required to compute Qwen3.5 multimodal MRoPE positions")
+                if mm_token_type_ids is None:
+                    raise ValueError(
+                        "Qwen3.5 multimodal forward requires mm_token_type_ids to compute MRoPE positions correctly"
+                    )
                 position_ids = build_qwen3_5_mrope_position_ids(
                     input_ids=input_ids,
                     mm_token_type_ids=mm_token_type_ids,

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 import torch
 from torch import Tensor, nn
 from transformers.cache_utils import Cache
+from transformers.configuration_utils import PretrainedConfig
 from transformers.generation import GenerationMixin
 from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast
@@ -11,6 +12,7 @@ from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
 from transformers.models.qwen3_5.modeling_qwen3_5 import (
     Qwen3_5PreTrainedModel as HFQwen3_5PreTrainedModel,
 )
+from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5VisionModel
 from transformers.processing_utils import Unpack
 from transformers.utils import TransformersKwargs
 
@@ -26,7 +28,22 @@ from prime_rl.trainer.models.qwen3_5_moe.modeling_qwen3_5_moe import (
     Qwen3_5MoeRotaryEmbedding,
     normalize_qwen3_5_attn_implementation,
 )
+from prime_rl.trainer.models.qwen3_5_moe.mrope import build_qwen3_5_mrope_position_ids
 from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
+
+
+def _build_text_config(composite_config: PretrainedConfig) -> Qwen3_5TextConfig:
+    """Build dense Qwen3.5 text config from HF's composite VLM config."""
+    text_dict = composite_config.text_config.to_dict()
+    text_config = Qwen3_5TextConfig(**text_dict)
+    attn_impl = getattr(
+        composite_config.text_config,
+        "_attn_implementation",
+        getattr(composite_config, "_attn_implementation", None),
+    )
+    if attn_impl is not None:
+        text_config._attn_implementation = attn_impl
+    return text_config
 
 
 class Qwen3_5GatedSDPAAttention(Qwen3_5MoeGatedSDPAAttention):
@@ -234,7 +251,146 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         return BaseModelOutputWithPast(last_hidden_state=hidden_states)
 
 
+class Qwen3_5VLMModel(nn.Module):
+    """Composite VLM body: HF vision encoder + custom PrimeRL dense text model."""
+
+    def __init__(self, config: PretrainedConfig):
+        super().__init__()
+        self.config = config
+        self.visual = Qwen3_5VisionModel._from_config(config.vision_config)
+        self.language_model = Qwen3_5Model(_build_text_config(config))
+
+    def get_input_embeddings(self):
+        return self.language_model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.language_model.embed_tokens = value
+
+    def _dummy_vision_inputs(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+        vcfg = self.config.vision_config
+        m = vcfg.spatial_merge_size
+        num_patches = m * m
+        patch_dim = vcfg.in_channels * vcfg.temporal_patch_size * vcfg.patch_size * vcfg.patch_size
+        pixel_values = torch.zeros(num_patches, patch_dim, device=device, dtype=self.visual.dtype)
+        grid_thw = torch.tensor([[1, m, m]], dtype=torch.long, device=device)
+        return pixel_values, grid_thw
+
+    def prepare_inputs_embeds_and_position_ids(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        mm_token_type_ids: torch.LongTensor | None = None,
+        *,
+        seq_lens: torch.LongTensor,
+    ) -> tuple[torch.FloatTensor, torch.LongTensor]:
+        if inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError("input_ids are required when inputs_embeds are not provided")
+            inputs_embeds = self.language_model.embed_tokens(input_ids)
+
+        if image_grid_thw is not None and input_ids is None:
+            raise ValueError("input_ids are required to compute Qwen3.5 multimodal MRoPE positions")
+        if image_grid_thw is not None and mm_token_type_ids is None:
+            raise ValueError(
+                "Qwen3.5 multimodal forward requires mm_token_type_ids to compute MRoPE positions correctly"
+            )
+        if image_grid_thw is not None and position_ids is not None and position_ids.ndim != 3:
+            raise ValueError(
+                f"Qwen3.5 multimodal forward requires 3D MRoPE position_ids; got shape={tuple(position_ids.shape)}"
+            )
+
+        has_images = pixel_values is not None
+        vision_grid_thw = image_grid_thw
+        if has_images:
+            if input_ids is None:
+                raise ValueError("input_ids are required when scattering Qwen3.5 image features")
+            if image_grid_thw is None:
+                raise ValueError("image_grid_thw is required when pixel_values are provided")
+            pixel_values = pixel_values.type(self.visual.dtype)
+        else:
+            pixel_values, vision_grid_thw = self._dummy_vision_inputs(inputs_embeds.device)
+
+        vision_output = self.visual(pixel_values, grid_thw=vision_grid_thw, return_dict=True)
+        image_embeds = vision_output.pooler_output.to(inputs_embeds.device, inputs_embeds.dtype)
+
+        if has_images:
+            image_mask = input_ids == self.config.image_token_id
+            image_token_count = int(image_mask.sum().item())
+            image_feature_count = int(image_embeds.shape[0])
+            if image_token_count != image_feature_count:
+                raise ValueError(
+                    "Qwen VLM image token/feature mismatch before scatter: "
+                    f"image_token_id={self.config.image_token_id}, "
+                    f"image_tokens={image_token_count}, image_features={image_feature_count}, "
+                    f"input_ids_shape={tuple(input_ids.shape)}, "
+                    f"pixel_values_shape={tuple(pixel_values.shape)}, "
+                    f"image_grid_thw_shape={tuple(image_grid_thw.shape) if image_grid_thw is not None else None}"
+                )
+            image_mask = image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
+            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+        else:
+            inputs_embeds = inputs_embeds + image_embeds.sum() * 0.0
+
+        if position_ids is None:
+            if image_grid_thw is not None:
+                position_ids = build_qwen3_5_mrope_position_ids(
+                    input_ids=input_ids,
+                    mm_token_type_ids=mm_token_type_ids,
+                    image_grid_thw=image_grid_thw,
+                    spatial_merge_size=self.config.vision_config.spatial_merge_size,
+                    seq_lens=seq_lens,
+                )
+            else:
+                position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+
+        return inputs_embeds, position_ids
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        mm_token_type_ids: torch.LongTensor | None = None,
+        *,
+        seq_lens: torch.LongTensor,
+        **kwargs,
+    ) -> BaseModelOutputWithPast:
+        inputs_embeds, position_ids = self.prepare_inputs_embeds_and_position_ids(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+            mm_token_type_ids=mm_token_type_ids,
+            seq_lens=seq_lens,
+        )
+
+        return self.language_model(
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            seq_lens=seq_lens,
+        )
+
+
+def _has_vlm_keys(state_dict: dict[str, Tensor]) -> bool:
+    return any(k.startswith("model.language_model.") for k in state_dict)
+
+
+def _remap_lm_keys(state_dict: dict[str, Tensor], to_flat: bool = True) -> None:
+    src = "model.language_model." if to_flat else "model."
+    dst = "model." if to_flat else "model.language_model."
+    for k in [k for k in list(state_dict.keys()) if k.startswith(src) and not k.startswith("model.visual.")]:
+        state_dict[dst + k[len(src) :]] = state_dict.pop(k)
+
+
 class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
+    """Unified dense Qwen3.5 model for both text-only and VLM configs."""
+
     _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _checkpoint_conversion_mapping = {}
     _tp_plan = {"lm_head": "colwise_gather_output"}
@@ -242,22 +398,58 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
 
     def __init__(self, config, **kwargs):
         super().__init__(config, **kwargs)
-        self.model = Qwen3_5Model(config)
-        self.vocab_size = config.vocab_size
-        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self._is_vlm = hasattr(config, "vision_config")
+
+        if self._is_vlm:
+            self.model = Qwen3_5VLMModel(config)
+            text_config = config.text_config
+            self._tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
+        else:
+            self.model = Qwen3_5Model(config)
+            text_config = config
+
+        self.vocab_size = text_config.vocab_size
+        self.lm_head = nn.Linear(text_config.hidden_size, text_config.vocab_size, bias=False)
         self.post_init()
 
     def get_input_embeddings(self):
+        if self._is_vlm:
+            return self.model.get_input_embeddings()
         return self.model.embed_tokens
 
     def set_input_embeddings(self, value):
-        self.model.embed_tokens = value
+        if self._is_vlm:
+            self.model.set_input_embeddings(value)
+        else:
+            self.model.embed_tokens = value
 
     def set_decoder(self, decoder):
         self.model = decoder
 
     def get_decoder(self):
         return self.model
+
+    @classmethod
+    def convert_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        if _has_vlm_keys(state_dict):
+            _remap_lm_keys(state_dict, to_flat=True)
+            _remap_lm_keys(state_dict, to_flat=False)
+        return state_dict
+
+    @classmethod
+    def convert_to_prime(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        if _has_vlm_keys(state_dict):
+            _remap_lm_keys(state_dict, to_flat=True)
+            _remap_lm_keys(state_dict, to_flat=False)
+        return state_dict
+
+    @classmethod
+    def convert_layer_to_hf(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        return cls.convert_to_hf(state_dict)
+
+    @classmethod
+    def convert_layer_to_prime(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        return cls.convert_to_prime(state_dict)
 
     def forward(
         self,
@@ -270,6 +462,9 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         use_cache: Optional[bool] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        image_grid_thw: Optional[torch.LongTensor] = None,
+        mm_token_type_ids: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
@@ -277,18 +472,30 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         assert use_cache is None, "use_cache is not supported for custom qwen3_5 for now"
         assert past_key_values is None, "past_key_values is not supported for custom qwen3_5 for now"
 
-        if position_ids is None:
+        has_vlm_image_inputs = self._is_vlm and image_grid_thw is not None
+        if position_ids is None and not has_vlm_image_inputs:
             if inputs_embeds is not None:
                 position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
             elif input_ids is not None:
                 position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).unsqueeze(0)
 
-        outputs = self.model(
-            input_ids=input_ids,
-            position_ids=position_ids,
-            inputs_embeds=inputs_embeds,
-            seq_lens=seq_lens,
-        )
+        if self._is_vlm:
+            outputs = self.model(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                inputs_embeds=inputs_embeds,
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+                mm_token_type_ids=mm_token_type_ids,
+                seq_lens=seq_lens,
+            )
+        else:
+            outputs = self.model(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                inputs_embeds=inputs_embeds,
+                seq_lens=seq_lens,
+            )
 
         hidden_states = outputs.last_hidden_state
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
@@ -299,10 +506,24 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         )
 
     def init_buffers_post_meta(self):
-        lm_rope = self.model.rotary_emb
+        if self._is_vlm:
+            lm_rope = self.model.language_model.rotary_emb
+        else:
+            lm_rope = self.model.rotary_emb
+
         if hasattr(lm_rope, "rope_init_fn"):
             inv_freq, lm_rope.attention_scaling = lm_rope.rope_init_fn(lm_rope.config, lm_rope.inv_freq.device)
             lm_rope.inv_freq.copy_(inv_freq)
+
+        if self._is_vlm:
+            vis_rope = self.model.visual.rotary_pos_emb
+            if hasattr(vis_rope, "inv_freq"):
+                dim = vis_rope.inv_freq.shape[0]
+                inv_freq = 1.0 / (
+                    10000.0
+                    ** (torch.arange(0, dim * 2, 2, dtype=torch.float32, device=vis_rope.inv_freq.device) / (dim * 2))
+                )
+                vis_rope.inv_freq.copy_(inv_freq)
 
 
 __all__ = [

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -32,20 +32,6 @@ from prime_rl.trainer.models.qwen3_5_moe.mrope import build_qwen3_5_mrope_positi
 from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 
-def _build_text_config(composite_config: PretrainedConfig) -> Qwen3_5TextConfig:
-    """Build dense Qwen3.5 text config from HF's composite VLM config."""
-    text_dict = composite_config.text_config.to_dict()
-    text_config = Qwen3_5TextConfig(**text_dict)
-    attn_impl = getattr(
-        composite_config.text_config,
-        "_attn_implementation",
-        getattr(composite_config, "_attn_implementation", None),
-    )
-    if attn_impl is not None:
-        text_config._attn_implementation = attn_impl
-    return text_config
-
-
 class Qwen3_5GatedSDPAAttention(Qwen3_5MoeGatedSDPAAttention):
     pass
 
@@ -258,7 +244,7 @@ class Qwen3_5VLMModel(nn.Module):
         super().__init__()
         self.config = config
         self.visual = Qwen3_5VisionModel._from_config(config.vision_config)
-        self.language_model = Qwen3_5Model(_build_text_config(config))
+        self.language_model = Qwen3_5Model(config.text_config)
 
     def get_input_embeddings(self):
         return self.language_model.embed_tokens

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -26,7 +26,7 @@ from prime_rl.trainer.models.qwen3_5_moe.modeling_qwen3_5_moe import (
     Qwen3_5MoeRotaryEmbedding,
     normalize_qwen3_5_attn_implementation,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 
 class Qwen3_5GatedSDPAAttention(Qwen3_5MoeGatedSDPAAttention):
@@ -196,7 +196,8 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> BaseModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -209,24 +210,15 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
 
         flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
         if flash_attn_enabled:
-            if seq_lens is None:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            else:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-                )
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+            )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        elif seq_lens is not None:
-            # seq_lens is only populated for batch size 1 (see cat_collate), so a
-            # single boundary list covers the whole packed row.
+        else:
             seq_lens = seq_lens.to(device=inputs_embeds.device)
             if seq_lens.numel() > 1 and "full_attention" in self.config.layer_types:
                 raise ValueError("Packed Qwen3.5 batches with full_attention layers require flash attention")
             cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(seq_lens, total_tokens=inputs_embeds.shape[1])
-        else:
-            cu_seqlens = None
-            max_seqlen = None
-
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
@@ -278,7 +270,8 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         use_cache: Optional[bool] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom qwen3_5 for now"

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -209,7 +209,12 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
 
         flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
         if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            if seq_lens is None:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            else:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+                )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         elif seq_lens is not None:
             # seq_lens is only populated for batch size 1 (see cat_collate), so a

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -26,7 +26,7 @@ from prime_rl.trainer.models.qwen3_5_moe.modeling_qwen3_5_moe import (
     Qwen3_5MoeRotaryEmbedding,
     normalize_qwen3_5_attn_implementation,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
 
 
 class Qwen3_5GatedSDPAAttention(Qwen3_5MoeGatedSDPAAttention):
@@ -196,6 +196,7 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -210,6 +211,13 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        elif seq_lens is not None:
+            # seq_lens is only populated for batch size 1 (see cat_collate), so a
+            # single boundary list covers the whole packed row.
+            seq_lens = seq_lens.to(device=inputs_embeds.device)
+            if seq_lens.numel() > 1 and "full_attention" in self.config.layer_types:
+                raise ValueError("Packed Qwen3.5 batches with full_attention layers require flash attention")
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(seq_lens, total_tokens=inputs_embeds.shape[1])
         else:
             cu_seqlens = None
             max_seqlen = None
@@ -265,6 +273,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         use_cache: Optional[bool] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom qwen3_5 for now"
@@ -280,6 +289,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
             input_ids=input_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -363,17 +363,6 @@ class Qwen3_5VLMModel(nn.Module):
         )
 
 
-def _has_vlm_keys(state_dict: dict[str, Tensor]) -> bool:
-    return any(k.startswith("model.language_model.") for k in state_dict)
-
-
-def _remap_lm_keys(state_dict: dict[str, Tensor], to_flat: bool = True) -> None:
-    src = "model.language_model." if to_flat else "model."
-    dst = "model." if to_flat else "model.language_model."
-    for k in [k for k in list(state_dict.keys()) if k.startswith(src) and not k.startswith("model.visual.")]:
-        state_dict[dst + k[len(src) :]] = state_dict.pop(k)
-
-
 class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
     """Unified dense Qwen3.5 model for both text-only and VLM configs."""
 
@@ -414,28 +403,6 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    @classmethod
-    def convert_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
-        if _has_vlm_keys(state_dict):
-            _remap_lm_keys(state_dict, to_flat=True)
-            _remap_lm_keys(state_dict, to_flat=False)
-        return state_dict
-
-    @classmethod
-    def convert_to_prime(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
-        if _has_vlm_keys(state_dict):
-            _remap_lm_keys(state_dict, to_flat=True)
-            _remap_lm_keys(state_dict, to_flat=False)
-        return state_dict
-
-    @classmethod
-    def convert_layer_to_hf(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
-        return cls.convert_to_hf(state_dict)
-
-    @classmethod
-    def convert_layer_to_prime(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
-        return cls.convert_to_prime(state_dict)
 
     def forward(
         self,

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -960,7 +960,7 @@ class Qwen3_5MoeVLMModel(nn.Module):
         grid_thw = torch.tensor([[1, m, m]], dtype=torch.long, device=device)
         return pixel_values, grid_thw
 
-    def forward(
+    def prepare_inputs_embeds_and_position_ids(
         self,
         input_ids: torch.LongTensor | None = None,
         position_ids: torch.LongTensor | None = None,
@@ -968,12 +968,12 @@ class Qwen3_5MoeVLMModel(nn.Module):
         pixel_values: torch.Tensor | None = None,
         image_grid_thw: torch.LongTensor | None = None,
         mm_token_type_ids: torch.LongTensor | None = None,
-        routed_experts: torch.LongTensor | None = None,
         *,
         seq_lens: torch.LongTensor,
-        **kwargs,
-    ) -> MoeModelOutputWithPast:
+    ) -> tuple[torch.FloatTensor, torch.LongTensor]:
         if inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError("input_ids are required when inputs_embeds are not provided")
             inputs_embeds = self.language_model.embed_tokens(input_ids)
 
         if image_grid_thw is not None and input_ids is None:
@@ -987,8 +987,11 @@ class Qwen3_5MoeVLMModel(nn.Module):
                 f"Qwen3.5 multimodal forward requires 3D MRoPE position_ids; got shape={tuple(position_ids.shape)}"
             )
 
-        # Keep distributed collectives in the same order when a batch mixes text-only
-        # and image samples across ranks. The frozen dummy pass is discarded below.
+        # Always run the vision encoder for collective symmetry: under FSDP + EP
+        # all ranks share one process group, so every rank must issue the vision
+        # encoder's collectives in the same order each step. Text-only microbatches
+        # keep the dummy embeds in the graph with zero contribution so trainable
+        # vision modules also participate in backward collectives.
         has_images = pixel_values is not None
         vision_grid_thw = image_grid_thw
         if has_images:
@@ -1018,6 +1021,8 @@ class Qwen3_5MoeVLMModel(nn.Module):
                 )
             image_mask = image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
             inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+        else:
+            inputs_embeds = inputs_embeds + image_embeds.sum() * 0.0
 
         if position_ids is None:
             if image_grid_thw is not None:
@@ -1030,6 +1035,31 @@ class Qwen3_5MoeVLMModel(nn.Module):
                 )
             else:
                 position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+
+        return inputs_embeds, position_ids
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        mm_token_type_ids: torch.LongTensor | None = None,
+        routed_experts: torch.LongTensor | None = None,
+        *,
+        seq_lens: torch.LongTensor,
+        **kwargs,
+    ) -> MoeModelOutputWithPast:
+        inputs_embeds, position_ids = self.prepare_inputs_embeds_and_position_ids(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+            mm_token_type_ids=mm_token_type_ids,
+            seq_lens=seq_lens,
+        )
 
         return self.language_model(
             inputs_embeds=inputs_embeds,

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -974,12 +974,6 @@ class Qwen3_5MoeVLMModel(nn.Module):
                 raise ValueError("input_ids are required when inputs_embeds are not provided")
             inputs_embeds = self.language_model.embed_tokens(input_ids)
 
-        if image_grid_thw is not None and input_ids is None:
-            raise ValueError("input_ids are required to compute Qwen3.5 multimodal MRoPE positions")
-        if image_grid_thw is not None and mm_token_type_ids is None:
-            raise ValueError(
-                "Qwen3.5 multimodal forward requires mm_token_type_ids to compute MRoPE positions correctly"
-            )
         if image_grid_thw is not None and position_ids is not None and position_ids.ndim != 3:
             raise ValueError(
                 f"Qwen3.5 multimodal forward requires 3D MRoPE position_ids; got shape={tuple(position_ids.shape)}"
@@ -1024,6 +1018,12 @@ class Qwen3_5MoeVLMModel(nn.Module):
 
         if position_ids is None:
             if image_grid_thw is not None:
+                if input_ids is None:
+                    raise ValueError("input_ids are required to compute Qwen3.5 multimodal MRoPE positions")
+                if mm_token_type_ids is None:
+                    raise ValueError(
+                        "Qwen3.5 multimodal forward requires mm_token_type_ids to compute MRoPE positions correctly"
+                    )
                 position_ids = build_qwen3_5_mrope_position_ids(
                     input_ids=input_ids,
                     mm_token_type_ids=mm_token_type_ids,

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -888,8 +888,6 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
 
         flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
         if flash_attn_enabled:
-            if position_ids.ndim == 3 and inputs_embeds.shape[0] != 1:
-                raise ValueError("3D Qwen3.5 MRoPE positions require batch size 1 for varlen attention")
             cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
                 seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
             )

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -900,7 +900,12 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
                         total_tokens=seq_len,
                     )
             else:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+                if seq_lens is None:
+                    cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+                else:
+                    cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                        seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+                    )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         elif seq_lens is not None:
             # seq_lens is only populated for batch size 1 (see cat_collate), so this

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -902,10 +902,12 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
             else:
                 cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        elif position_ids.ndim == 3 and seq_lens is not None:
+        elif seq_lens is not None:
+            # seq_lens is only populated for batch size 1 (see cat_collate), so this
+            # covers both 2D text-only packs and 3D MRoPE packs identically.
             seq_lens = seq_lens.to(device=inputs_embeds.device)
             if seq_lens.numel() > 1 and "full_attention" in self.config.layer_types:
-                raise ValueError("Packed Qwen3.5 MRoPE batches with full_attention layers require flash attention")
+                raise ValueError("Packed Qwen3.5 batches with full_attention layers require flash attention")
             cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(seq_lens, total_tokens=inputs_embeds.shape[1])
         else:
             max_seqlen = None

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -25,7 +25,7 @@ from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.moe import FeedForward, MoE, MoEArgs
 from prime_rl.trainer.models.layers.rotary_emb import apply_rotary_pos_emb
 from prime_rl.trainer.models.layers.ulysses_attn import ULYSSES_PARAMS
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 from .configuration_qwen3_5_moe import Qwen3_5MoeConfig
 from .converting_qwen3_5_moe import (
@@ -874,7 +874,8 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> MoeModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -887,37 +888,17 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
 
         flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
         if flash_attn_enabled:
-            if position_ids.ndim == 3:
-                if inputs_embeds.shape[0] != 1:
-                    raise ValueError("3D Qwen3.5 MRoPE positions require batch size 1 for varlen attention")
-                seq_len = inputs_embeds.shape[1]
-                if seq_lens is None:
-                    cu_seqlens = torch.tensor([0, seq_len], dtype=torch.int32, device=inputs_embeds.device)
-                    max_seqlen = seq_len
-                else:
-                    cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                        seq_lens.to(device=inputs_embeds.device),
-                        total_tokens=seq_len,
-                    )
-            else:
-                if seq_lens is None:
-                    cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-                else:
-                    cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                        seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-                    )
+            if position_ids.ndim == 3 and inputs_embeds.shape[0] != 1:
+                raise ValueError("3D Qwen3.5 MRoPE positions require batch size 1 for varlen attention")
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+            )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        elif seq_lens is not None:
-            # seq_lens is only populated for batch size 1 (see cat_collate), so this
-            # covers both 2D text-only packs and 3D MRoPE packs identically.
+        else:
             seq_lens = seq_lens.to(device=inputs_embeds.device)
             if seq_lens.numel() > 1 and "full_attention" in self.config.layer_types:
                 raise ValueError("Packed Qwen3.5 batches with full_attention layers require flash attention")
             cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(seq_lens, total_tokens=inputs_embeds.shape[1])
-        else:
-            max_seqlen = None
-            cu_seqlens = None
-
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
@@ -988,7 +969,8 @@ class Qwen3_5MoeVLMModel(nn.Module):
         image_grid_thw: torch.LongTensor | None = None,
         mm_token_type_ids: torch.LongTensor | None = None,
         routed_experts: torch.LongTensor | None = None,
-        seq_lens: torch.LongTensor | None = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs,
     ) -> MoeModelOutputWithPast:
         if inputs_embeds is None:
@@ -1201,7 +1183,8 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
         pixel_values: Optional[torch.Tensor] = None,
         image_grid_thw: Optional[torch.LongTensor] = None,
         mm_token_type_ids: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom qwen3_5_moe for now"

--- a/src/prime_rl/trainer/models/qwen3_5_moe/mrope.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/mrope.py
@@ -34,7 +34,7 @@ def build_qwen3_5_mrope_position_ids(
     mm_token_type_ids: torch.LongTensor,
     image_grid_thw: torch.LongTensor | None,
     spatial_merge_size: int,
-    seq_lens: torch.Tensor | None = None,
+    seq_lens: torch.Tensor,
 ) -> torch.LongTensor:
     if input_ids.ndim != 2:
         raise ValueError(f"input_ids must be 2D, got shape={tuple(input_ids.shape)}")
@@ -47,10 +47,7 @@ def build_qwen3_5_mrope_position_ids(
         raise ValueError("Packed Qwen3.5 MRoPE builder currently supports batch size 1")
 
     total_seq_len = input_ids.shape[1]
-    if seq_lens is None:
-        seq_lens = torch.tensor([total_seq_len], dtype=torch.long, device=input_ids.device)
-    else:
-        seq_lens = seq_lens.to(device=input_ids.device, dtype=torch.long)
+    seq_lens = seq_lens.to(device=input_ids.device, dtype=torch.long)
 
     if seq_lens.ndim != 1:
         raise ValueError(f"seq_lens must be 1D, got shape={tuple(seq_lens.shape)}")

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -206,10 +206,13 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
     ) -> MoeModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -217,7 +220,12 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Qwen3Moe batches require flash attention")
+        if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -282,9 +290,12 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -332,6 +343,7 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -40,7 +40,7 @@ from prime_rl.trainer.models.qwen3_moe.converting_qwen3_moe import (
     convert_tt_layer_to_hf,
     convert_tt_to_hf_moe,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
 
 logger = logging.get_logger(__name__)
 
@@ -226,7 +226,12 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
             # packed document boundaries.
             raise ValueError("Packed Qwen3Moe batches require flash attention")
         if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            if seq_lens is None:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            else:
+                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+                )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -40,7 +40,7 @@ from prime_rl.trainer.models.qwen3_moe.converting_qwen3_moe import (
     convert_tt_layer_to_hf,
     convert_tt_to_hf_moe,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 logger = logging.get_logger(__name__)
 
@@ -206,12 +206,13 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> MoeModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
-        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -221,17 +222,14 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens is not None and seq_lens.numel() > 1 and not flash_attn_enabled:
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
             # SDPA/eager attention has no varlen support and would attend across
             # packed document boundaries.
             raise ValueError("Packed Qwen3Moe batches require flash attention")
         if flash_attn_enabled:
-            if seq_lens is None:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            else:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                    seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-                )
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+            )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None
@@ -295,11 +293,12 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
-        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -34,6 +34,7 @@ class TensorMicroBatch(TypedDict):
 
     # Batch level
     lora_num_tokens: Int[Tensor, "n_loras"]
+    seq_lens: Int[Tensor, "segments"] | None
 
     # MoE router replay
     routed_experts: Int[Tensor, "batch seq layers topk"] | None
@@ -129,6 +130,7 @@ class FakeDataLoader:
             "sequence_lengths": sequence_lengths,
             "loss_mask": loss_mask.unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
+            "seq_lens": torch.tensor(sequence_lengths, dtype=torch.long),
             "routed_experts": None,
             "mm_kwargs": None,
             "mm_token_type_ids": None,
@@ -161,6 +163,7 @@ class FakeDataLoader:
             "sequence_lengths": [self.seq_len],
             "loss_mask": torch.ones(self.seq_len, dtype=torch.bool).unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
+            "seq_lens": torch.tensor([self.seq_len], dtype=torch.long),
             "routed_experts": None,
             "mm_kwargs": None,
             "mm_token_type_ids": None,
@@ -256,6 +259,7 @@ class DataLoader:
             env_names=micro_batch.env_names,
             sequence_lengths=micro_batch.sequence_lengths,
             lora_num_tokens=torch.tensor(micro_batch.lora_num_tokens, dtype=torch.int32),
+            seq_lens=torch.tensor(micro_batch.seq_lens, dtype=torch.long) if micro_batch.seq_lens is not None else None,
             mm_kwargs=mm_kwargs,
             mm_token_type_ids=torch.tensor(micro_batch.mm_token_type_ids, dtype=torch.long).unsqueeze(0)
             if micro_batch.mm_token_type_ids is not None

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -34,7 +34,8 @@ class TensorMicroBatch(TypedDict):
 
     # Batch level
     lora_num_tokens: Int[Tensor, "n_loras"]
-    seq_lens: Int[Tensor, "segments"] | None
+    seq_lens: Int[Tensor, "segments"]
+    padding_len: int
 
     # MoE router replay
     routed_experts: Int[Tensor, "batch seq layers topk"] | None
@@ -131,6 +132,7 @@ class FakeDataLoader:
             "loss_mask": loss_mask.unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
             "seq_lens": torch.tensor(sequence_lengths, dtype=torch.long),
+            "padding_len": 0,
             "routed_experts": None,
             "mm_kwargs": None,
             "mm_token_type_ids": None,
@@ -164,6 +166,7 @@ class FakeDataLoader:
             "loss_mask": torch.ones(self.seq_len, dtype=torch.bool).unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
             "seq_lens": torch.tensor([self.seq_len], dtype=torch.long),
+            "padding_len": 0,
             "routed_experts": None,
             "mm_kwargs": None,
             "mm_token_type_ids": None,
@@ -259,7 +262,8 @@ class DataLoader:
             env_names=micro_batch.env_names,
             sequence_lengths=micro_batch.sequence_lengths,
             lora_num_tokens=torch.tensor(micro_batch.lora_num_tokens, dtype=torch.int32),
-            seq_lens=torch.tensor(micro_batch.seq_lens, dtype=torch.long) if micro_batch.seq_lens is not None else None,
+            seq_lens=torch.tensor(micro_batch.seq_lens, dtype=torch.long),
+            padding_len=micro_batch.padding_len,
             mm_kwargs=mm_kwargs,
             mm_token_type_ids=torch.tensor(micro_batch.mm_token_type_ids, dtype=torch.long).unsqueeze(0)
             if micro_batch.mm_token_type_ids is not None

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -65,6 +65,7 @@ from prime_rl.utils.metrics_server import HealthServer, MetricsServer, RunStats
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.config import cli
 from prime_rl.utils.process import set_proc_title
+from prime_rl.utils.sequence import get_cp_local_seq_lens
 from prime_rl.utils.utils import clean_exit, resolve_latest_ckpt_step, to_col_format
 from ring_flash_attn import substitute_hf_flash_attn
 from torchtitan.distributed.utils import clip_grad_norm_
@@ -369,7 +370,6 @@ def train(config: TrainerConfig):
             )
 
             seq_lens = micro_batch["seq_lens"].to("cuda")
-            padding_len = micro_batch["padding_len"]
 
             labels = shift_tensor_left(input_ids)
 
@@ -378,12 +378,17 @@ def train(config: TrainerConfig):
                 raise NotImplementedError("Context parallelism is not supported with VLM/multimodal training")
 
             if cp_enabled:
-                # seq_lens spans the pre-shard sequence; consuming it under CP needs
-                # global-boundary handling that isn't wired up here yet.
-                seq_lens = None
+                total_tokens = input_ids.shape[1]
                 input_ids, forward_position_ids = setup_cp_params(
-                    input_ids, position_ids, cp_rank, cp_size, cp_group, cp_style=config.model.cp_style
+                    input_ids,
+                    position_ids,
+                    cp_rank,
+                    cp_size,
+                    cp_group,
+                    seq_lens=seq_lens,
+                    cp_style=config.model.cp_style,
                 )
+                seq_lens = get_cp_local_seq_lens(seq_lens, total_tokens, cp_rank, cp_size)
                 labels = shard_for_cp(labels, cp_rank=cp_rank, cp_world_size=cp_size)
                 if routed_experts is not None:
                     routed_experts = shard_for_cp(routed_experts, cp_rank=cp_rank, cp_world_size=cp_size)
@@ -419,7 +424,6 @@ def train(config: TrainerConfig):
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_token_type_ids,
                     seq_lens=seq_lens,
-                    padding_len=padding_len,
                     routed_experts=routed_experts,
                 )
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -368,6 +368,8 @@ def train(config: TrainerConfig):
                 else None
             )
 
+            seq_lens = micro_batch["seq_lens"].to("cuda") if micro_batch.get("seq_lens") is not None else None
+
             labels = shift_tensor_left(input_ids)
 
             # VLM + CP is not supported: MRoPE requires global positions but CP shards the sequence
@@ -375,6 +377,9 @@ def train(config: TrainerConfig):
                 raise NotImplementedError("Context parallelism is not supported with VLM/multimodal training")
 
             if cp_enabled:
+                # seq_lens spans the pre-shard sequence; consuming it under CP needs
+                # global-boundary handling that isn't wired up here yet.
+                seq_lens = None
                 input_ids, forward_position_ids = setup_cp_params(
                     input_ids, position_ids, cp_rank, cp_size, cp_group, cp_style=config.model.cp_style
                 )
@@ -412,6 +417,7 @@ def train(config: TrainerConfig):
                     temperature=temperatures,
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_token_type_ids,
+                    seq_lens=seq_lens,
                     routed_experts=routed_experts,
                 )
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -368,7 +368,8 @@ def train(config: TrainerConfig):
                 else None
             )
 
-            seq_lens = micro_batch["seq_lens"].to("cuda") if micro_batch.get("seq_lens") is not None else None
+            seq_lens = micro_batch["seq_lens"].to("cuda")
+            padding_len = micro_batch["padding_len"]
 
             labels = shift_tensor_left(input_ids)
 
@@ -418,6 +419,7 @@ def train(config: TrainerConfig):
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_token_type_ids,
                     seq_lens=seq_lens,
+                    padding_len=padding_len,
                     routed_experts=routed_experts,
                 )
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -111,26 +111,6 @@ class FakeDataset(StatefulIterableDataset):
             yield fake_sample
 
 
-def _new_pack() -> dict[str, Any]:
-    return {
-        "input_ids": [],
-        "position_ids": [],
-        "loss_mask": [],
-        "target_ids": [],
-        "seq_lens": [],
-    }
-
-
-def _append_sample_to_pack(pack: dict[str, Any], sample: dict[str, Any]) -> None:
-    sample_len = len(sample["input_ids"])
-
-    for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
-        value = sample[key]
-        assert isinstance(value, list)
-        pack[key].extend(value)
-    pack["seq_lens"].append(sample_len)
-
-
 def _drop_null_fields(value: Any, path: tuple[str, ...] = ()) -> Any:
     """Recursively strip ``None``-valued keys from dict structures.
 
@@ -366,22 +346,26 @@ class CatDataset(StatefulIterableDataset):
         self.dataset.load_state_dict(state_dict["dataset"])
 
     def __iter__(self):
-        packed_samples = _new_pack()
+        packed_samples = defaultdict(list)
         seq_len = 0
         for sample in self.dataset:
             sample_len = len(sample["input_ids"])
             would_overflow = seq_len + sample_len > self.seq_len
             if seq_len > 0 and would_overflow:
                 yield self._finalize_pack(packed_samples, self.seq_len)
-                packed_samples = _new_pack()
+                packed_samples = defaultdict(list)
                 seq_len = 0
 
-            _append_sample_to_pack(packed_samples, sample)
+            for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
+                value = sample[key]
+                assert isinstance(value, list)
+                packed_samples[key].extend(value)
+            packed_samples["seq_lens"].append(sample_len)
             seq_len += sample_len
 
             if seq_len >= self.seq_len:
                 yield self._finalize_pack(packed_samples, self.seq_len)
-                packed_samples = _new_pack()
+                packed_samples = defaultdict(list)
                 seq_len = 0
 
         if seq_len > 0:

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -194,6 +194,7 @@ class SFTDataset(StatefulIterableDataset):
         loss_mask_config: LossMaskConfig = LossMaskConfig(),
         max_examples: int | None = None,
         max_epochs: int | None = None,
+        multimodal: bool = False,
     ):
         super().__init__()
         self.logger = get_logger()
@@ -206,6 +207,7 @@ class SFTDataset(StatefulIterableDataset):
         self.loss_mask_config = loss_mask_config
         self.max_examples = max_examples
         self.max_epochs = max_epochs
+        self.multimodal = multimodal
 
         # If specified, select a subset of the dataset
         if self.max_examples is not None:
@@ -307,6 +309,11 @@ class SFTDataset(StatefulIterableDataset):
         loss_mask = list(sample.loss_mask)
         mm = sample.multi_modal_data
         mm_token_type_ids = list(sample.mm_token_type_ids) if sample.mm_token_type_ids is not None else None
+        if mm is not None and mm.mm_items and not self.multimodal:
+            raise ValueError(
+                "Renderer produced multimodal data but [model.vlm] is not set. "
+                "Set [model.vlm] to train on multimodal samples."
+            )
 
         was_mm_truncated = False
         if mm is not None:
@@ -660,6 +667,7 @@ def setup_dataset(
             loss_mask_config=config.loss_mask,
             non_dp_size=non_dp_size,
             max_epochs=max_epochs,
+            multimodal=multimodal,
         )
     else:
         raise ValueError(f"Invalid dataset type: {config.type}")

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -3,10 +3,11 @@ import uuid
 from collections import defaultdict
 from typing import Any, Literal, TypedDict, cast
 
+import numpy as np
 import torch
 from datasets import Dataset, interleave_datasets, load_dataset
 from jaxtyping import Bool, Int
-from renderers.base import Renderer, build_training_sample
+from renderers.base import MultiModalData, PlaceholderRange, Renderer, build_training_sample
 from torch import Tensor
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.utils.data import IterableDataset, get_worker_info
@@ -26,6 +27,8 @@ class Sample(TypedDict):
     target_ids: list[int]
     seq_lens: list[int]
     padding_len: int
+    mm_kwargs: dict[str, Tensor] | None
+    mm_token_type_ids: list[int] | None
 
 
 class Batch(TypedDict):
@@ -35,6 +38,8 @@ class Batch(TypedDict):
     loss_mask: Bool[Tensor, "batch seq"]
     seq_lens: Int[Tensor, "packed"]
     padding_len: int
+    mm_kwargs: dict[str, Tensor] | None
+    mm_token_type_ids: Int[Tensor, "batch seq"] | None
 
 
 class StatefulIterableDataset(Stateful, IterableDataset):
@@ -106,10 +111,25 @@ class FakeDataset(StatefulIterableDataset):
                 "loss_mask": loss_mask,
                 "seq_lens": [seq_len],
                 "padding_len": 0,
+                "mm_kwargs": None,
+                "mm_token_type_ids": None,
             }
             self.num_samples["fake"] += 1
             self.num_tokens["fake"] += len(input_ids)
             yield fake_sample
+
+
+def _flatten_mm_items(mm_items: dict[str, list[dict[str, Any]]]) -> dict[str, Tensor]:
+    """Fold per-item renderer outputs into model-forward tensors."""
+    out: dict[str, Tensor] = {}
+    for items in mm_items.values():
+        for item in items:
+            for key, value in item.items():
+                if not isinstance(value, (np.ndarray, Tensor)):
+                    continue
+                tensor = torch.as_tensor(value)
+                out[key] = torch.cat([out[key], tensor], dim=0) if key in out else tensor
+    return out
 
 
 def _drop_null_fields(value: Any, path: tuple[str, ...] = ()) -> Any:
@@ -130,6 +150,34 @@ def _drop_null_fields(value: Any, path: tuple[str, ...] = ()) -> Any:
     if isinstance(value, list):
         return [_drop_null_fields(v, path) for v in value]
     return value
+
+
+def _find_image_safe_cut(budget: int, mm: MultiModalData | None) -> int:
+    """Return the largest cut at most ``budget`` outside placeholder runs."""
+    if mm is None or not mm.mm_placeholders:
+        return budget
+    cut = budget
+    for ranges in mm.mm_placeholders.values():
+        for placeholder in ranges:
+            if placeholder.offset < cut < placeholder.offset + placeholder.length:
+                cut = placeholder.offset
+    return cut
+
+
+def _truncate_mm_data(mm: MultiModalData, cut: int) -> MultiModalData:
+    """Drop multimodal items whose placeholder ranges extend past ``cut``."""
+    new_placeholders: dict[str, list[PlaceholderRange]] = {}
+    new_items: dict[str, list[dict[str, Any]]] = {}
+    new_hashes: dict[str, list[str]] = {}
+    for content_type, ranges in mm.mm_placeholders.items():
+        keep = [index for index, placeholder in enumerate(ranges) if placeholder.offset + placeholder.length <= cut]
+        if not keep:
+            continue
+        new_placeholders[content_type] = [ranges[index] for index in keep]
+        new_items[content_type] = [mm.mm_items[content_type][index] for index in keep]
+        if content_type in mm.mm_hashes:
+            new_hashes[content_type] = [mm.mm_hashes[content_type][index] for index in keep]
+    return MultiModalData(mm_hashes=new_hashes, mm_placeholders=new_placeholders, mm_items=new_items)
 
 
 class SFTDataset(StatefulIterableDataset):
@@ -257,11 +305,35 @@ class SFTDataset(StatefulIterableDataset):
         )
         input_ids = list(sample.token_ids)
         loss_mask = list(sample.loss_mask)
+        mm = sample.multi_modal_data
+        mm_token_type_ids = list(sample.mm_token_type_ids) if sample.mm_token_type_ids is not None else None
+
+        was_mm_truncated = False
+        if mm is not None:
+            budget = self.seq_len + 1
+            if len(input_ids) > budget:
+                was_mm_truncated = True
+                cut = _find_image_safe_cut(budget, mm)
+                self.logger.debug(
+                    f"Truncating example {example.get('__index', '')} from "
+                    f"{len(input_ids)} → {cut} tokens (budget={budget})"
+                )
+                input_ids = input_ids[:cut]
+                loss_mask = loss_mask[:cut]
+                if mm_token_type_ids is not None:
+                    mm_token_type_ids = mm_token_type_ids[:cut]
+                if mm.mm_items:
+                    mm = _truncate_mm_data(mm, cut)
+
+        if was_mm_truncated and not set(self.renderer.get_stop_token_ids()) & set(input_ids):
+            return None
 
         # Causal shift: model predicts next token from current.
         target_ids = input_ids.copy()[1:]
         loss_mask = loss_mask[1:]
         input_ids = input_ids[:-1]
+        if mm_token_type_ids is not None:
+            mm_token_type_ids = mm_token_type_ids[:-1]
 
         if sum(loss_mask[: self.seq_len]) == 0:
             self.logger.warning(
@@ -277,6 +349,14 @@ class SFTDataset(StatefulIterableDataset):
             "A renderer stop token must be present in target_ids"
         )
 
+        mm_kwargs: dict[str, Tensor] | None = None
+        if mm is not None and mm.mm_items:
+            mm_kwargs = _flatten_mm_items(mm.mm_items)
+            if any("video" in key for key in mm_kwargs):
+                raise ValueError("Video SFT is not supported; sample contains video inputs")
+        if mm_token_type_ids is not None:
+            assert len(mm_token_type_ids) == len(input_ids)
+
         return {
             "input_ids": input_ids,
             "target_ids": target_ids,
@@ -284,6 +364,8 @@ class SFTDataset(StatefulIterableDataset):
             "position_ids": list(range(len(input_ids))),
             "seq_lens": [len(input_ids)],
             "padding_len": 0,
+            "mm_kwargs": mm_kwargs,
+            "mm_token_type_ids": mm_token_type_ids,
         }
 
     def __iter__(self):
@@ -331,7 +413,7 @@ class SFTDataset(StatefulIterableDataset):
 
 
 class CatDataset(StatefulIterableDataset):
-    """A dataset that concatenates samples into a single sequence with a fixed length."""
+    """Concatenate text and multimodal samples into one fixed-length row."""
 
     def __init__(self, dataset: StatefulIterableDataset, seq_len: int):
         self.logger = get_logger()
@@ -351,6 +433,8 @@ class CatDataset(StatefulIterableDataset):
 
     def __iter__(self):
         packed_samples = defaultdict(list)
+        packed_samples["mm_kwargs"] = None
+        packed_samples["mm_token_type_ids"] = None
         seq_len = 0
 
         pending_sample = self.pending_sample
@@ -369,18 +453,50 @@ class CatDataset(StatefulIterableDataset):
                 yield self._finalize_pack(packed_samples, self.seq_len)
                 self.pending_sample = None
                 packed_samples = defaultdict(list)
+                packed_samples["mm_kwargs"] = None
+                packed_samples["mm_token_type_ids"] = None
                 seq_len = 0
 
+            existing_len = len(packed_samples["input_ids"])
             for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
                 value = sample[key]
                 assert isinstance(value, list)
                 packed_samples[key].extend(value)
             packed_samples["seq_lens"].append(sample_len)
+
+            sample_mm_kwargs = sample.get("mm_kwargs")
+            sample_mm_type_ids = sample.get("mm_token_type_ids")
+            if sample_mm_kwargs is None:
+                if packed_samples["mm_token_type_ids"] is not None:
+                    packed_samples["mm_token_type_ids"].extend([0] * sample_len)
+            else:
+                if sample_mm_type_ids is not None and len(sample_mm_type_ids) != sample_len:
+                    raise ValueError("mm_token_type_ids length must match input_ids length")
+                if packed_samples["mm_kwargs"] is not None and (
+                    (packed_samples["mm_token_type_ids"] is None) != (sample_mm_type_ids is None)
+                ):
+                    raise ValueError("Cannot pack multimodal samples with mixed mm_token_type_ids")
+
+                if packed_samples["mm_kwargs"] is None:
+                    packed_samples["mm_kwargs"] = dict(sample_mm_kwargs)
+                else:
+                    if packed_samples["mm_kwargs"].keys() != sample_mm_kwargs.keys():
+                        raise ValueError("Cannot pack multimodal samples with different mm_kwargs keys")
+                    for key, value in sample_mm_kwargs.items():
+                        packed_samples["mm_kwargs"][key] = torch.cat([packed_samples["mm_kwargs"][key], value], dim=0)
+
+                if packed_samples["mm_token_type_ids"] is None and sample_mm_type_ids is not None:
+                    packed_samples["mm_token_type_ids"] = [0] * existing_len
+                if packed_samples["mm_token_type_ids"] is not None:
+                    packed_samples["mm_token_type_ids"].extend(sample_mm_type_ids or [0] * sample_len)
+
             seq_len += sample_len
 
             if seq_len >= self.seq_len:
                 yield self._finalize_pack(packed_samples, self.seq_len)
                 packed_samples = defaultdict(list)
+                packed_samples["mm_kwargs"] = None
+                packed_samples["mm_token_type_ids"] = None
                 seq_len = 0
 
         if seq_len > 0:
@@ -408,12 +524,19 @@ class CatDataset(StatefulIterableDataset):
             result["target_ids"].extend([0] * pad_len)
             result["seq_lens"][-1] += pad_len
             result["padding_len"] = pad_len
+        result["mm_kwargs"] = packed["mm_kwargs"]
+        if packed["mm_token_type_ids"] is not None:
+            result["mm_token_type_ids"] = packed["mm_token_type_ids"][:seq_len] + [0] * pad_len
+        else:
+            result["mm_token_type_ids"] = None
         return result
 
 
 def cat_collate(samples: list[Sample]) -> Batch:
     if len(samples) != 1:
         raise ValueError(f"CatDataset collate expects exactly one packed row, got {len(samples)}")
+    sample = samples[0]
+    mm_token_type_ids = sample.get("mm_token_type_ids")
     return {
         "input_ids": torch.stack([torch.tensor(sample["input_ids"]) for sample in samples], dim=0).long().to("cuda"),
         "position_ids": torch.stack([torch.tensor(sample["position_ids"]) for sample in samples], dim=0)
@@ -421,9 +544,21 @@ def cat_collate(samples: list[Sample]) -> Batch:
         .to("cuda"),
         "loss_mask": torch.stack([torch.tensor(sample["loss_mask"]) for sample in samples], dim=0).bool().to("cuda"),
         "target_ids": torch.stack([torch.tensor(sample["target_ids"]) for sample in samples], dim=0).long().to("cuda"),
-        "seq_lens": torch.tensor(samples[0]["seq_lens"], dtype=torch.long, device="cuda"),
-        "padding_len": samples[0]["padding_len"],
+        "seq_lens": torch.tensor(sample["seq_lens"], dtype=torch.long, device="cuda"),
+        "padding_len": sample["padding_len"],
+        "mm_kwargs": _move_mm_kwargs_to_cuda(sample.get("mm_kwargs")),
+        "mm_token_type_ids": (
+            torch.tensor(mm_token_type_ids, dtype=torch.long, device="cuda").unsqueeze(0)
+            if mm_token_type_ids is not None
+            else None
+        ),
     }
+
+
+def _move_mm_kwargs_to_cuda(mm_kwargs: dict[str, Tensor] | None) -> dict[str, Tensor] | None:
+    if mm_kwargs is None:
+        return None
+    return {key: value.to("cuda") for key, value in mm_kwargs.items()}
 
 
 def setup_and_interleave_datasets(
@@ -502,6 +637,7 @@ def setup_dataset(
     max_epochs: int | None = None,
     raw_dataset: Dataset | None = None,
     renderer: Renderer | None = None,
+    multimodal: bool = False,
 ) -> StatefulIterableDataset:
     if config.type == "fake":
         return FakeDataset(

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -335,24 +335,37 @@ class CatDataset(StatefulIterableDataset):
         self.logger = get_logger()
         self.dataset = dataset
         self.seq_len = seq_len
+        self.pending_sample: Sample | None = None
 
     def state_dict(self) -> dict:
-        # Known limitation: the overflow sample pending at a yield boundary is
-        # not persisted, so a checkpoint resume drops at most one sample per
-        # dataloader worker.
-        return {"dataset": self.dataset.state_dict()}
+        return {
+            "dataset": self.dataset.state_dict(),
+            "pending_sample": self.pending_sample,
+        }
 
     def load_state_dict(self, state_dict: dict):
         self.dataset.load_state_dict(state_dict["dataset"])
+        self.pending_sample = state_dict.get("pending_sample")
 
     def __iter__(self):
         packed_samples = defaultdict(list)
         seq_len = 0
-        for sample in self.dataset:
+
+        pending_sample = self.pending_sample
+        self.pending_sample = None
+
+        def samples():
+            if pending_sample is not None:
+                yield pending_sample
+            yield from self.dataset
+
+        for sample in samples():
             sample_len = len(sample["input_ids"])
             would_overflow = seq_len + sample_len > self.seq_len
             if seq_len > 0 and would_overflow:
+                self.pending_sample = sample
                 yield self._finalize_pack(packed_samples, self.seq_len)
+                self.pending_sample = None
                 packed_samples = defaultdict(list)
                 seq_len = 0
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -26,6 +26,7 @@ class Sample(TypedDict):
     position_ids: list[int]
     loss_mask: list[bool]
     target_ids: list[int]
+    seq_lens: list[int]
 
 
 class Batch(TypedDict):
@@ -33,6 +34,7 @@ class Batch(TypedDict):
     position_ids: Int[Tensor, "batch seq"]
     target_ids: Int[Tensor, "batch seq"]
     loss_mask: Bool[Tensor, "batch seq"]
+    seq_lens: Int[Tensor, "packed"] | None
 
 
 class StatefulIterableDataset(Stateful, IterableDataset):
@@ -102,10 +104,31 @@ class FakeDataset(StatefulIterableDataset):
                 "target_ids": input_ids[1:],
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
+                "seq_lens": [seq_len],
             }
             self.num_samples["fake"] += 1
             self.num_tokens["fake"] += len(input_ids)
             yield fake_sample
+
+
+def _new_pack() -> dict[str, Any]:
+    return {
+        "input_ids": [],
+        "position_ids": [],
+        "loss_mask": [],
+        "target_ids": [],
+        "seq_lens": [],
+    }
+
+
+def _append_sample_to_pack(pack: dict[str, Any], sample: dict[str, Any]) -> None:
+    sample_len = len(sample["input_ids"])
+
+    for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
+        value = sample[key]
+        assert isinstance(value, list)
+        pack[key].extend(value)
+    pack["seq_lens"].append(sample_len)
 
 
 def _drop_null_fields(value: Any, path: tuple[str, ...] = ()) -> Any:
@@ -278,6 +301,7 @@ class SFTDataset(StatefulIterableDataset):
             "target_ids": target_ids,
             "loss_mask": loss_mask,
             "position_ids": list(range(len(input_ids))),
+            "seq_lens": [len(input_ids)],
         }
 
     def __iter__(self):
@@ -333,29 +357,57 @@ class CatDataset(StatefulIterableDataset):
         self.seq_len = seq_len
 
     def state_dict(self) -> dict:
+        # Known limitation: the overflow sample pending at a yield boundary is
+        # not persisted, so a checkpoint resume drops at most one sample per
+        # dataloader worker.
         return {"dataset": self.dataset.state_dict()}
 
     def load_state_dict(self, state_dict: dict):
         self.dataset.load_state_dict(state_dict["dataset"])
 
     def __iter__(self):
-        packed_samples, seq_len = defaultdict(list), 0
+        packed_samples = _new_pack()
+        seq_len = 0
         for sample in self.dataset:
-            # Add sample to packed samples
-            for key, value in sample.items():
-                assert isinstance(value, list), f"Value for key {key} must be a list"
-                packed_samples[key].extend(value)
+            sample_len = len(sample["input_ids"])
+            would_overflow = seq_len + sample_len > self.seq_len
+            if seq_len > 0 and would_overflow:
+                yield self._finalize_pack(packed_samples, self.seq_len)
+                packed_samples = _new_pack()
+                seq_len = 0
 
-            # Update sequence length
-            seq_len += len(sample["input_ids"])
+            _append_sample_to_pack(packed_samples, sample)
+            seq_len += sample_len
 
-            # If batch is full, truncate and yield it
             if seq_len >= self.seq_len:
-                for key, value in packed_samples.items():
-                    assert isinstance(value, list), f"Value for key {key} must be a list"
-                    packed_samples[key] = value[: self.seq_len]
-                yield packed_samples
-                packed_samples, seq_len = defaultdict(list), 0
+                yield self._finalize_pack(packed_samples, self.seq_len)
+                packed_samples = _new_pack()
+                seq_len = 0
+
+        if seq_len > 0:
+            yield self._finalize_pack(packed_samples, self.seq_len)
+
+    def _finalize_pack(self, packed: dict[str, Any], seq_len: int) -> dict:
+        result: dict[str, Any] = {
+            k: packed[k][:seq_len] for k in ("input_ids", "position_ids", "loss_mask", "target_ids")
+        }
+        result["seq_lens"] = []
+        remaining = len(result["input_ids"])
+        for sample_len in packed["seq_lens"]:
+            if remaining <= 0:
+                break
+            kept = min(sample_len, remaining)
+            if kept > 0:
+                result["seq_lens"].append(kept)
+            remaining -= kept
+        pad_len = seq_len - len(result["input_ids"])
+        if pad_len > 0:
+            result["input_ids"].extend([0] * pad_len)
+            result["position_ids"].extend(range(pad_len))
+            result["loss_mask"].extend([False] * pad_len)
+            result["target_ids"].extend([0] * pad_len)
+            result["seq_lens"].append(pad_len)
+        return result
 
 
 class StackDataset(StatefulIterableDataset):
@@ -395,9 +447,10 @@ class StackDataset(StatefulIterableDataset):
             # Truncate sample if it's longer than max area
             len_sample = len(sample["input_ids"])
             if len_sample > self.max_area:
-                for key, value in sample.items():
+                for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
+                    value = sample[key]
                     assert isinstance(value, list)
-                    sample[key] = sample[key][: self.max_area]
+                    sample[key] = value[: self.max_area]
                 len_sample = self.max_area
 
             # Add sample to bucket
@@ -437,15 +490,17 @@ class StackDataset(StatefulIterableDataset):
 
                     while self.bucket_sizes[bucket_idx] * len(self.buckets[bucket_idx]) < self.max_area:
                         dummy_sample = {}
-                        for key, value in sample.items():
+                        for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
                             dummy_sample[key] = [0]
+                        dummy_sample["seq_lens"] = [1]
                         self.buckets[bucket_idx].append(dummy_sample)
 
                 packed_samples = defaultdict(list)
                 num_samples, num_tokens, num_trainable_tokens, num_pad_tokens = 0, 0, 0, 0
                 for bucket_item in self.buckets[bucket_idx]:
                     num_samples += 1
-                    for key, value in bucket_item.items():
+                    for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
+                        value = bucket_item[key]
                         pad_tokens = [0] * (self.bucket_sizes[bucket_idx] - len(value))
                         if key == "loss_mask":
                             num_tokens += len(value)
@@ -458,6 +513,7 @@ class StackDataset(StatefulIterableDataset):
                 self.logger.debug(
                     f"Yield bucket {bucket_idx} because {reason} with {num_samples=}, {num_tokens=}, {num_trainable_tokens=}, {num_pad_tokens=}"
                 )
+                packed_samples["seq_lens"] = None
                 yield packed_samples
                 self.step += 1
                 self.buckets[bucket_idx] = []
@@ -473,6 +529,7 @@ def stack_collate(samples: list[Sample]) -> Batch:
         "position_ids": torch.tensor(samples[0]["position_ids"], dtype=torch.long, device="cuda"),
         "loss_mask": torch.tensor(samples[0]["loss_mask"], dtype=torch.bool, device="cuda"),
         "target_ids": torch.tensor(samples[0]["target_ids"], dtype=torch.long, device="cuda"),
+        "seq_lens": None,
     }
 
 
@@ -484,6 +541,10 @@ def cat_collate(samples: list[Sample]) -> Batch:
         .to("cuda"),
         "loss_mask": torch.stack([torch.tensor(sample["loss_mask"]) for sample in samples], dim=0).bool().to("cuda"),
         "target_ids": torch.stack([torch.tensor(sample["target_ids"]) for sample in samples], dim=0).long().to("cuda"),
+        # CatDataset emits exactly one packed sample per dataloader item.
+        "seq_lens": torch.tensor(samples[0]["seq_lens"], dtype=torch.long, device="cuda")
+        if len(samples) == 1
+        else None,
     }
 
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -338,10 +338,10 @@ class CatDataset(StatefulIterableDataset):
         self.pending_sample: Sample | None = None
 
     def state_dict(self) -> dict:
-        return {
-            "dataset": self.dataset.state_dict(),
-            "pending_sample": self.pending_sample,
-        }
+        state = {"dataset": self.dataset.state_dict()}
+        if self.pending_sample is not None:
+            state["pending_sample"] = self.pending_sample
+        return state
 
     def load_state_dict(self, state_dict: dict):
         self.dataset.load_state_dict(state_dict["dataset"])

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -18,8 +18,6 @@ from prime_rl.trainer.world import get_world
 from prime_rl.utils.chat_template import deserialize_tool_calls, normalize_messages
 from prime_rl.utils.logger import get_logger
 
-STACKING_DATASET_BUCKET_TIMEOUT = 10
-
 
 class Sample(TypedDict):
     input_ids: list[int]
@@ -27,6 +25,7 @@ class Sample(TypedDict):
     loss_mask: list[bool]
     target_ids: list[int]
     seq_lens: list[int]
+    padding_len: int
 
 
 class Batch(TypedDict):
@@ -34,7 +33,8 @@ class Batch(TypedDict):
     position_ids: Int[Tensor, "batch seq"]
     target_ids: Int[Tensor, "batch seq"]
     loss_mask: Bool[Tensor, "batch seq"]
-    seq_lens: Int[Tensor, "packed"] | None
+    seq_lens: Int[Tensor, "packed"]
+    padding_len: int
 
 
 class StatefulIterableDataset(Stateful, IterableDataset):
@@ -105,6 +105,7 @@ class FakeDataset(StatefulIterableDataset):
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
                 "seq_lens": [seq_len],
+                "padding_len": 0,
             }
             self.num_samples["fake"] += 1
             self.num_tokens["fake"] += len(input_ids)
@@ -282,6 +283,7 @@ class SFTDataset(StatefulIterableDataset):
             "loss_mask": loss_mask,
             "position_ids": list(range(len(input_ids))),
             "seq_lens": [len(input_ids)],
+            "padding_len": 0,
         }
 
     def __iter__(self):
@@ -389,6 +391,7 @@ class CatDataset(StatefulIterableDataset):
             k: packed[k][:seq_len] for k in ("input_ids", "position_ids", "loss_mask", "target_ids")
         }
         result["seq_lens"] = []
+        result["padding_len"] = 0
         remaining = len(result["input_ids"])
         for sample_len in packed["seq_lens"]:
             if remaining <= 0:
@@ -404,133 +407,13 @@ class CatDataset(StatefulIterableDataset):
             result["loss_mask"].extend([False] * pad_len)
             result["target_ids"].extend([0] * pad_len)
             result["seq_lens"].append(pad_len)
+            result["padding_len"] = pad_len
         return result
 
 
-class StackDataset(StatefulIterableDataset):
-    """A dataset that stacks samples into batch with a fixed area"""
-
-    def __init__(self, dataset: StatefulIterableDataset, max_area: int):
-        self.logger = get_logger()
-        self.dataset = dataset
-        self.max_area = max_area
-        assert self.max_area % 256 == 0
-        self.bucket_sizes = []
-        while max_area % 256 == 0:
-            self.bucket_sizes.insert(0, max_area)
-            max_area //= 2
-        self.logger.debug(f"Initialized {len(self.bucket_sizes)} buckets (bucket_sizes={self.bucket_sizes})")
-        # Checkpoint state
-        self.step = 0
-        self.buckets = [[] for _ in range(len(self.bucket_sizes))]
-        self.bucket_timers: list[int | None] = [None] * len(self.buckets)
-
-    def state_dict(self) -> dict:
-        return {
-            "dataset": self.dataset.state_dict(),
-            "step": self.step,
-            "buckets": self.buckets,
-            "bucket_timers": self.bucket_timers,
-        }
-
-    def load_state_dict(self, state_dict: dict):
-        self.dataset.load_state_dict(state_dict["dataset"])
-        self.step = state_dict["step"]
-        self.buckets = state_dict["buckets"]
-        self.bucket_timers = state_dict["bucket_timers"]
-
-    def __iter__(self):
-        for sample in self.dataset:
-            # Truncate sample if it's longer than max area
-            len_sample = len(sample["input_ids"])
-            if len_sample > self.max_area:
-                for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
-                    value = sample[key]
-                    assert isinstance(value, list)
-                    sample[key] = value[: self.max_area]
-                len_sample = self.max_area
-
-            # Add sample to bucket
-            def find_bucket_idx(len_sample: int) -> int:
-                bucket_idx = 0
-                while bucket_idx < len(self.bucket_sizes) - 1 and len_sample > self.bucket_sizes[bucket_idx]:
-                    bucket_idx += 1
-                return bucket_idx
-
-            bucket_idx = find_bucket_idx(len_sample)
-            self.buckets[bucket_idx].append(sample)
-
-            # Check if bucket has timed out
-            bucket_timer = self.bucket_timers[bucket_idx]
-            if bucket_timer is not None:
-                hit_timeout = bucket_timer + STACKING_DATASET_BUCKET_TIMEOUT < self.step
-            else:
-                hit_timeout = False
-
-            # Check if bucket is full
-            is_full = self.bucket_sizes[bucket_idx] * len(self.buckets[bucket_idx]) >= self.max_area
-
-            if is_full or hit_timeout:
-                if hit_timeout:
-                    while bucket_idx < len(self.buckets) - 1:
-                        if (
-                            self.bucket_sizes[bucket_idx + 1]
-                            * (len(self.buckets[bucket_idx]) + len(self.buckets[bucket_idx + 1]))
-                            < self.max_area
-                        ):
-                            self.buckets[bucket_idx + 1].extend(self.buckets[bucket_idx])
-                            self.buckets[bucket_idx] = []
-                            self.bucket_timers[bucket_idx] = None
-                            bucket_idx += 1
-                        else:
-                            break
-
-                    while self.bucket_sizes[bucket_idx] * len(self.buckets[bucket_idx]) < self.max_area:
-                        dummy_sample = {}
-                        for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
-                            dummy_sample[key] = [0]
-                        dummy_sample["seq_lens"] = [1]
-                        self.buckets[bucket_idx].append(dummy_sample)
-
-                packed_samples = defaultdict(list)
-                num_samples, num_tokens, num_trainable_tokens, num_pad_tokens = 0, 0, 0, 0
-                for bucket_item in self.buckets[bucket_idx]:
-                    num_samples += 1
-                    for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
-                        value = bucket_item[key]
-                        pad_tokens = [0] * (self.bucket_sizes[bucket_idx] - len(value))
-                        if key == "loss_mask":
-                            num_tokens += len(value)
-                            num_trainable_tokens += sum(value)
-                            num_pad_tokens += len(pad_tokens)
-                        packed_samples[key].append(value + pad_tokens)
-                reason = "bucket is full" if is_full else "because bucket timed out"
-                reason += " and " if is_full and hit_timeout else ""
-                reason += "bucket timed out" if hit_timeout else ""
-                self.logger.debug(
-                    f"Yield bucket {bucket_idx} because {reason} with {num_samples=}, {num_tokens=}, {num_trainable_tokens=}, {num_pad_tokens=}"
-                )
-                packed_samples["seq_lens"] = None
-                yield packed_samples
-                self.step += 1
-                self.buckets[bucket_idx] = []
-                self.bucket_timers[bucket_idx] = None
-            else:
-                if self.bucket_timers[bucket_idx] is None:
-                    self.bucket_timers[bucket_idx] = self.step
-
-
-def stack_collate(samples: list[Sample]) -> Batch:
-    return {
-        "input_ids": torch.tensor(samples[0]["input_ids"], dtype=torch.long, device="cuda"),
-        "position_ids": torch.tensor(samples[0]["position_ids"], dtype=torch.long, device="cuda"),
-        "loss_mask": torch.tensor(samples[0]["loss_mask"], dtype=torch.bool, device="cuda"),
-        "target_ids": torch.tensor(samples[0]["target_ids"], dtype=torch.long, device="cuda"),
-        "seq_lens": None,
-    }
-
-
 def cat_collate(samples: list[Sample]) -> Batch:
+    if len(samples) != 1:
+        raise ValueError(f"CatDataset collate expects exactly one packed row, got {len(samples)}")
     return {
         "input_ids": torch.stack([torch.tensor(sample["input_ids"]) for sample in samples], dim=0).long().to("cuda"),
         "position_ids": torch.stack([torch.tensor(sample["position_ids"]) for sample in samples], dim=0)
@@ -538,10 +421,8 @@ def cat_collate(samples: list[Sample]) -> Batch:
         .to("cuda"),
         "loss_mask": torch.stack([torch.tensor(sample["loss_mask"]) for sample in samples], dim=0).bool().to("cuda"),
         "target_ids": torch.stack([torch.tensor(sample["target_ids"]) for sample in samples], dim=0).long().to("cuda"),
-        # CatDataset emits exactly one packed sample per dataloader item.
-        "seq_lens": torch.tensor(samples[0]["seq_lens"], dtype=torch.long, device="cuda")
-        if len(samples) == 1
-        else None,
+        "seq_lens": torch.tensor(samples[0]["seq_lens"], dtype=torch.long, device="cuda"),
+        "padding_len": samples[0]["padding_len"],
     }
 
 
@@ -649,11 +530,5 @@ def setup_dataset(
 
 
 def setup_dataloader(dataset: StatefulIterableDataset, config: DataConfig) -> StatefulDataLoader:
-    if config.pack_function == "stack":
-        stacking_dataset = StackDataset(dataset, config.seq_len * config.micro_batch_size)
-        return StatefulDataLoader(stacking_dataset, batch_size=1, collate_fn=stack_collate)
-    elif config.pack_function == "cat":
-        packing_dataset = CatDataset(dataset, config.seq_len * config.micro_batch_size)
-        return StatefulDataLoader(packing_dataset, batch_size=1, collate_fn=cat_collate)
-    else:
-        raise ValueError(f"Invalid pack function: {config.pack_function}")
+    packing_dataset = CatDataset(dataset, config.seq_len * config.micro_batch_size)
+    return StatefulDataLoader(packing_dataset, batch_size=1, collate_fn=cat_collate)

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -477,8 +477,6 @@ class CatDataset(StatefulIterableDataset):
                 if packed_samples["mm_token_type_ids"] is not None:
                     packed_samples["mm_token_type_ids"].extend([0] * sample_len)
             else:
-                if sample_mm_type_ids is not None and len(sample_mm_type_ids) != sample_len:
-                    raise ValueError("mm_token_type_ids length must match input_ids length")
                 if packed_samples["mm_kwargs"] is not None and (
                     (packed_samples["mm_token_type_ids"] is None) != (sample_mm_type_ids is None)
                 ):

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -406,7 +406,7 @@ class CatDataset(StatefulIterableDataset):
             result["position_ids"].extend(range(pad_len))
             result["loss_mask"].extend([False] * pad_len)
             result["target_ids"].extend([0] * pad_len)
-            result["seq_lens"].append(pad_len)
+            result["seq_lens"][-1] += pad_len
             result["padding_len"] = pad_len
         return result
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -176,10 +176,7 @@ def train(config: SFTConfig):
         renderer = create_renderer(tokenizer, config.renderer)
         if processor is not None and hasattr(renderer, "_processor"):
             renderer._processor = processor
-        logger.info(
-            f"Initialized {type(renderer).__name__} for {config.tokenizer.name} "
-            f"(multimodal_processor={processor is not None})"
-        )
+        logger.info(f"Initialized {type(renderer).__name__} for {config.tokenizer.name}")
 
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -28,6 +28,7 @@ from prime_rl.trainer.model import (
     forward,
     get_load_balance_stats,
     is_tt_moe_model,
+    setup_processor,
     setup_tokenizer,
     setup_model,
 )
@@ -161,6 +162,11 @@ def train(config: SFTConfig):
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)
+    processor = setup_processor(config.tokenizer)
+    if config.model.vlm is not None and processor is None:
+        raise ValueError(
+            f"[model.vlm] is set but no multimodal processor could be loaded for {config.tokenizer.name!r}"
+        )
 
     # Fake data never renders messages, so a model without a hand-coded renderer
     # can still be used to benchmark step time / memory. Validation data is
@@ -168,7 +174,12 @@ def train(config: SFTConfig):
     renderer = None
     if config.data.type != "fake" or config.val is not None:
         renderer = create_renderer(tokenizer, config.renderer)
-        logger.info(f"Initialized {type(renderer).__name__} for {config.tokenizer.name}")
+        if processor is not None and hasattr(renderer, "_processor"):
+            renderer._processor = processor
+        logger.info(
+            f"Initialized {type(renderer).__name__} for {config.tokenizer.name} "
+            f"(multimodal_processor={processor is not None})"
+        )
 
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")
@@ -188,7 +199,8 @@ def train(config: SFTConfig):
 
     # Set up the dataset and dataloader
     logger.info(f"Initializing data ({config.data})")
-    dataset = setup_dataset(tokenizer, config.data, config.model.cp, renderer=renderer)
+    multimodal = config.model.vlm is not None
+    dataset = setup_dataset(tokenizer, config.data, config.model.cp, renderer=renderer, multimodal=multimodal)
     dataloader = setup_dataloader(dataset, config.data)
     dataiter = iter(dataloader)
 
@@ -244,6 +256,8 @@ def train(config: SFTConfig):
         target_ids = micro_batch["target_ids"].to("cuda")
         loss_mask = micro_batch["loss_mask"].to("cuda")
         seq_lens = micro_batch["seq_lens"].to("cuda")
+        mm_kwargs = micro_batch.get("mm_kwargs")
+        mm_type_ids = micro_batch.get("mm_token_type_ids")
 
         if cp_enabled:
             total_tokens = input_ids.shape[1]
@@ -275,10 +289,19 @@ def train(config: SFTConfig):
                     position_ids,
                     seq_lens=seq_lens,
                     labels=masked_target_ids,
+                    mm_kwargs=mm_kwargs,
+                    mm_token_type_ids=mm_type_ids,
                 )
                 loss_sum = out["loss"] * token_count
             else:
-                out = forward(model, input_ids, position_ids, seq_lens=seq_lens)
+                out = forward(
+                    model,
+                    input_ids,
+                    position_ids,
+                    mm_kwargs=mm_kwargs,
+                    mm_token_type_ids=mm_type_ids,
+                    seq_lens=seq_lens,
+                )
                 logits = out["logits"]
                 B, L, V = logits.shape
                 token_loss = ce_loss(logits.view(-1, V), target_ids.view(-1)).view(B, L)
@@ -331,6 +354,7 @@ def train(config: SFTConfig):
             max_epochs=1,
             raw_dataset=val_raw_dataset,
             renderer=renderer,
+            multimodal=multimodal,
         )
         val_dataloader = setup_dataloader(val_dataset, config.val.data)
 
@@ -487,7 +511,7 @@ def train(config: SFTConfig):
             if weight_ckpt_manager is not None:
                 logger.info(f"Saving weight checkpoint at step {progress.step}")
                 save_ckpt_start_time = time.perf_counter()
-                weight_ckpt_manager.save(progress.step, model, tokenizer)
+                weight_ckpt_manager.save(progress.step, model, tokenizer, processor)
                 save_ckpt_time += time.perf_counter() - save_ckpt_start_time
                 weight_ckpt_manager.maybe_clean()
         else:
@@ -623,7 +647,7 @@ def train(config: SFTConfig):
     # Write final weight checkpoint
     if weight_ckpt_manager is not None:
         logger.info("Writing final weight checkpoint")
-        weight_ckpt_manager.save(progress.step, model, tokenizer)
+        weight_ckpt_manager.save(progress.step, model, tokenizer, processor)
         weight_ckpt_manager.maybe_clean()
 
     logger.info(f"Peak memory: {max(to_col_format(monitor.history)['perf/peak_memory']):.1f} GiB")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -242,7 +242,8 @@ def train(config: SFTConfig):
         position_ids = micro_batch["position_ids"].to("cuda")
         target_ids = micro_batch["target_ids"].to("cuda")
         loss_mask = micro_batch["loss_mask"].to("cuda")
-        seq_lens = micro_batch.get("seq_lens")
+        seq_lens = micro_batch["seq_lens"].to("cuda")
+        padding_len = micro_batch["padding_len"]
 
         if cp_enabled:
             # seq_lens spans the pre-shard pack; CP consumption needs global
@@ -263,10 +264,17 @@ def train(config: SFTConfig):
             if config.loss_impl in ("liger_fused", "quack_fused"):
                 masked_target_ids = target_ids.clone()
                 masked_target_ids[~loss_mask] = FUSED_CE_IGNORE_INDEX
-                out = forward(model, input_ids, position_ids, labels=masked_target_ids, seq_lens=seq_lens)
+                out = forward(
+                    model,
+                    input_ids,
+                    position_ids,
+                    seq_lens=seq_lens,
+                    padding_len=padding_len,
+                    labels=masked_target_ids,
+                )
                 loss_sum = out["loss"] * token_count
             else:
-                out = forward(model, input_ids, position_ids, seq_lens=seq_lens)
+                out = forward(model, input_ids, position_ids, seq_lens=seq_lens, padding_len=padding_len)
                 logits = out["logits"]
                 B, L, V = logits.shape
                 token_loss = ce_loss(logits.view(-1, V), target_ids.view(-1)).view(B, L)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -242,8 +242,12 @@ def train(config: SFTConfig):
         position_ids = micro_batch["position_ids"].to("cuda")
         target_ids = micro_batch["target_ids"].to("cuda")
         loss_mask = micro_batch["loss_mask"].to("cuda")
+        seq_lens = micro_batch.get("seq_lens")
 
         if cp_enabled:
+            # seq_lens spans the pre-shard pack; CP consumption needs global
+            # boundary semantics the models don't have yet.
+            seq_lens = None
             input_ids, position_ids = setup_cp_params(
                 input_ids, position_ids, cp_rank, cp_size, cp_group, cp_style=config.model.cp_style
             )
@@ -259,10 +263,10 @@ def train(config: SFTConfig):
             if config.loss_impl in ("liger_fused", "quack_fused"):
                 masked_target_ids = target_ids.clone()
                 masked_target_ids[~loss_mask] = FUSED_CE_IGNORE_INDEX
-                out = forward(model, input_ids, position_ids, labels=masked_target_ids)
+                out = forward(model, input_ids, position_ids, labels=masked_target_ids, seq_lens=seq_lens)
                 loss_sum = out["loss"] * token_count
             else:
-                out = forward(model, input_ids, position_ids)
+                out = forward(model, input_ids, position_ids, seq_lens=seq_lens)
                 logits = out["logits"]
                 B, L, V = logits.shape
                 token_loss = ce_loss(logits.view(-1, V), target_ids.view(-1)).view(B, L)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -49,6 +49,7 @@ from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.config import cli
 from prime_rl.utils.process import set_proc_title
+from prime_rl.utils.sequence import get_cp_local_seq_lens
 from prime_rl.utils.utils import clean_exit, to_col_format
 import torch.distributed as dist
 from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss
@@ -243,15 +244,19 @@ def train(config: SFTConfig):
         target_ids = micro_batch["target_ids"].to("cuda")
         loss_mask = micro_batch["loss_mask"].to("cuda")
         seq_lens = micro_batch["seq_lens"].to("cuda")
-        padding_len = micro_batch["padding_len"]
 
         if cp_enabled:
-            # seq_lens spans the pre-shard pack; CP consumption needs global
-            # boundary semantics the models don't have yet.
-            seq_lens = None
+            total_tokens = input_ids.shape[1]
             input_ids, position_ids = setup_cp_params(
-                input_ids, position_ids, cp_rank, cp_size, cp_group, cp_style=config.model.cp_style
+                input_ids,
+                position_ids,
+                cp_rank,
+                cp_size,
+                cp_group,
+                seq_lens=seq_lens,
+                cp_style=config.model.cp_style,
             )
+            seq_lens = get_cp_local_seq_lens(seq_lens, total_tokens, cp_rank, cp_size)
             target_ids = shard_for_cp(target_ids, cp_rank=cp_rank, cp_world_size=cp_size)
             loss_mask = shard_for_cp(loss_mask, cp_rank=cp_rank, cp_world_size=cp_size)
 
@@ -269,12 +274,11 @@ def train(config: SFTConfig):
                     input_ids,
                     position_ids,
                     seq_lens=seq_lens,
-                    padding_len=padding_len,
                     labels=masked_target_ids,
                 )
                 loss_sum = out["loss"] * token_count
             else:
-                out = forward(model, input_ids, position_ids, seq_lens=seq_lens, padding_len=padding_len)
+                out = forward(model, input_ids, position_ids, seq_lens=seq_lens)
                 logits = out["logits"]
                 B, L, V = logits.shape
                 token_loss = ce_loss(logits.view(-1, V), target_ids.view(-1)).view(B, L)

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -89,6 +89,8 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     sequence_lengths: list[int]
     temperatures: list[float]  # Per-token temperatures used during generation
     env_names: list[str]
+    seq_lens: list[int]
+    padding_len: int
     ref_logprobs: list[float] | None = None
     lora_num_tokens: list[int] | None = None
     routed_experts: RoutedExperts | None = None
@@ -108,6 +110,3 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     # Packer-derived metadata used for run-local token exports.
     run_id: str | None = None
     run_step: int | None = None
-
-    # Packed sample boundaries. Sum equals len(input_ids) when present.
-    seq_lens: list[int] | None = None

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -108,3 +108,6 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     # Packer-derived metadata used for run-local token exports.
     run_id: str | None = None
     run_step: int | None = None
+
+    # Packed sample boundaries. Sum equals len(input_ids) when present.
+    seq_lens: list[int] | None = None

--- a/src/prime_rl/utils/cp.py
+++ b/src/prime_rl/utils/cp.py
@@ -11,7 +11,7 @@ import torch.distributed.nn as dist_nn
 import torch.nn as nn
 from ring_flash_attn import update_ring_flash_attn_params
 
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 CPStyle = Literal["ring", "ulysses"]
 
@@ -161,20 +161,25 @@ def setup_cp_params(
     cp_rank: int,
     cp_world_size: int,
     cp_group: dist.ProcessGroup,
+    *,
+    seq_lens: torch.Tensor,
     cp_style: CPStyle = "ring",
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Prepare the input for context parallelism and set required attention params.
 
-    Both ring and ulysses styles need cu_seqlens computed from the *full*
-    (un-sharded) position_ids, then publish them to the patched attention layer:
+    Both ring and ulysses styles need cu_seqlens computed from the full,
+    unsharded sequence lengths, then publish them to the patched attention layer:
       - ring: via ring_flash_attn's DATA_PARAMS (with local_k_slice).
       - ulysses: via ULYSSES_PARAMS (just the full cu_seqlens / max_seqlen).
 
     Returns the sequence-sharded input_ids and position_ids — the rest of the
     model still runs sequence-sharded; only attention sees the full sequence.
     """
-    cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+    cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+        seq_lens.to(device=position_ids.device),
+        total_tokens=position_ids.shape[-1],
+    )
 
     if cp_style == "ring":
         update_ring_flash_attn_params(cu_seqlens, cp_group)

--- a/src/prime_rl/utils/sequence.py
+++ b/src/prime_rl/utils/sequence.py
@@ -50,3 +50,24 @@ def get_cu_seqlens_from_seq_lens(seq_lens: torch.Tensor, total_tokens: int | Non
     cu_seqlens[0] = 0
     cu_seqlens[1:] = seq_lens.cumsum(dim=0, dtype=torch.int32)
     return cu_seqlens, int(seq_lens.max().item())
+
+
+def get_cp_local_seq_lens(
+    seq_lens: torch.Tensor,
+    total_tokens: int,
+    cp_rank: int,
+    cp_world_size: int,
+) -> torch.Tensor:
+    """Intersect global sequence boundaries with one contiguous CP shard."""
+    if total_tokens % cp_world_size != 0:
+        raise ValueError(f"Sequence length {total_tokens} must be divisible by CP size {cp_world_size}")
+    if not 0 <= cp_rank < cp_world_size:
+        raise ValueError(f"CP rank {cp_rank} must be in [0, {cp_world_size})")
+
+    shard_size = total_tokens // cp_world_size
+    shard_start = seq_lens.new_tensor(cp_rank * shard_size)
+    shard_end = shard_start + shard_size
+    seq_ends = seq_lens.cumsum(dim=0)
+    seq_starts = torch.cat([seq_lens.new_zeros(1), seq_ends[:-1]])
+    overlaps = torch.minimum(seq_ends, shard_end) - torch.maximum(seq_starts, shard_start)
+    return overlaps[overlaps > 0]

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -178,6 +178,7 @@ def test_pad_micro_batch_preserves_explicit_sequence_lengths():
     assert len(padded.input_ids) == 6
     assert padded.sequence_lengths == [4, 2]
     assert padded.seq_lens == [4, 2]
+    assert padded.padding_len == 2
     assert sum(padded.sequence_lengths) == len(padded.input_ids)
     assert padded.loss_mask[-2:] == [False, False]
 

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -161,6 +161,7 @@ def test_randomized_packing_invariants():
         for batch in flat_batches:
             assert len(batch.input_ids) <= seq_len
             assert sum(batch.sequence_lengths) == len(batch.input_ids)
+            assert batch.seq_lens == batch.sequence_lengths
             assert sum(batch.lora_num_tokens) == len(batch.input_ids)
             assert len(batch.env_names) == len(batch.input_ids)
 
@@ -176,6 +177,7 @@ def test_pad_micro_batch_preserves_explicit_sequence_lengths():
 
     assert len(padded.input_ids) == 6
     assert padded.sequence_lengths == [4, 2]
+    assert padded.seq_lens == [4, 2]
     assert sum(padded.sequence_lengths) == len(padded.input_ids)
     assert padded.loss_mask[-2:] == [False, False]
 
@@ -271,6 +273,7 @@ def test_prepare_batch_packs_different_temperatures(make_training_example):
     # Second sample (4 tokens): all get temp 1.1
     assert flat_batches[0].temperatures[4:8] == [1.1, 1.1, 1.1, 1.1]
     assert flat_batches[0].env_names == ["env-a"] * 4 + ["env-b"] * 4
+    assert flat_batches[0].seq_lens == [4, 4]
 
 
 def test_prepare_sample_propagates_weight_streams(make_training_example):

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -176,8 +176,8 @@ def test_pad_micro_batch_preserves_explicit_sequence_lengths():
     padded = pad_micro_batch(micro_batch, pad_to_multiple_of=6)
 
     assert len(padded.input_ids) == 6
-    assert padded.sequence_lengths == [4, 2]
-    assert padded.seq_lens == [4, 2]
+    assert padded.sequence_lengths == [6]
+    assert padded.seq_lens == [6]
     assert padded.padding_len == 2
     assert sum(padded.sequence_lengths) == len(padded.input_ids)
     assert padded.loss_mask[-2:] == [False, False]

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -567,6 +567,11 @@ def test_sft_allows_unused_default_renderer_for_fake_data():
     assert config.renderer.name == "default"
 
 
+def test_sft_rejects_removed_pack_function():
+    with pytest.raises(ValidationError, match="pack_function"):
+        SFTConfig.model_validate({"data": {"pack_function": "stack"}})
+
+
 def test_orchestrator_explicit_renderer_skips_unmapped_check():
     """Explicit renderer.name bypasses the auto-resolution check — user opted in."""
     config = OrchestratorConfig.model_validate(

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -567,11 +567,6 @@ def test_sft_allows_unused_default_renderer_for_fake_data():
     assert config.renderer.name == "default"
 
 
-def test_sft_rejects_removed_pack_function():
-    with pytest.raises(ValidationError, match="pack_function"):
-        SFTConfig.model_validate({"data": {"pack_function": "stack"}})
-
-
 def test_orchestrator_explicit_renderer_skips_unmapped_check():
     """Explicit renderer.name bypasses the auto-resolution check — user opted in."""
     config = OrchestratorConfig.model_validate(

--- a/tests/unit/train/models/test_afmoe.py
+++ b/tests/unit/train/models/test_afmoe.py
@@ -87,7 +87,11 @@ def test_afmoe_attn_only() -> None:
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(
+        input_ids,
+        position_ids=position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"),
+    )
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -120,7 +124,11 @@ def test_afmoe_mlp_only() -> None:
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(
+        input_ids,
+        position_ids=position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"),
+    )
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -140,7 +148,11 @@ def test_afmoe() -> None:
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(
+        input_ids,
+        position_ids=position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"),
+    )
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 

--- a/tests/unit/train/models/test_glm4_moe.py
+++ b/tests/unit/train/models/test_glm4_moe.py
@@ -64,7 +64,7 @@ def test_glm4_moe_attn_only() -> None:
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -92,7 +92,7 @@ def test_glm4_moe_mlp_only() -> None:
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -112,7 +112,7 @@ def test_glm4_moe() -> None:
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 

--- a/tests/unit/train/models/test_llama.py
+++ b/tests/unit/train/models/test_llama.py
@@ -52,7 +52,7 @@ def test_llama_attn_only():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -80,7 +80,7 @@ def test_llama_mlp_only():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -100,7 +100,7 @@ def test_llama():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 

--- a/tests/unit/train/models/test_nemotron_h.py
+++ b/tests/unit/train/models/test_nemotron_h.py
@@ -44,6 +44,10 @@ _BASE = dict(
 )
 
 
+def _seq_lens(input_ids: torch.Tensor) -> torch.Tensor:
+    return torch.tensor([input_ids.shape[1]], device=input_ids.device)
+
+
 def get_model_pairs():
     """Create an HF model and a PrimeRL model with shared weights."""
     hf_config = HFNemotronHConfig(**_BASE, hybrid_override_pattern="ME*E")
@@ -90,7 +94,7 @@ def test_nemotron_h_mamba_moe_only():
         position_ids = torch.arange(0, 32).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(input_ids, position_ids=position_ids, seq_lens=_seq_lens(input_ids))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -144,7 +148,7 @@ def test_nemotron_h_reverse():
         position_ids = torch.arange(0, 32).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(input_ids, position_ids=position_ids, seq_lens=_seq_lens(input_ids))
 
     logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=1e-2), (
@@ -161,7 +165,7 @@ def test_nemotron_h():
         position_ids = torch.arange(0, 32).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(input_ids, position_ids=position_ids, seq_lens=_seq_lens(input_ids))
     # Slightly larger tolerance due to different SDPA attention implementations
     logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=5e-2), (
@@ -180,7 +184,7 @@ def test_nemotron_h_backward():
     inject_prime_lm_head(model)
 
     input_ids = torch.randint(0, 256, (2, 16), device="cuda")
-    output = model(input_ids)
+    output = model(input_ids, seq_lens=_seq_lens(input_ids))
     output["logits"].sum().backward()
 
     zero_grads = []
@@ -231,7 +235,7 @@ def test_nemotron_h_no_latent_projection():
     inject_prime_lm_head(model)
 
     input_ids = torch.randint(0, 256, (2, 16), device="cuda")
-    output = model(input_ids)
+    output = model(input_ids, seq_lens=_seq_lens(input_ids))
     assert output["logits"].shape == (2, 16, 256)
 
     output["logits"].sum().backward()

--- a/tests/unit/train/models/test_nemotron_h_kl.py
+++ b/tests/unit/train/models/test_nemotron_h_kl.py
@@ -62,10 +62,14 @@ def _make_model(device="cuda"):
     return model
 
 
+def _seq_lens(input_ids: torch.Tensor) -> torch.Tensor:
+    return torch.tensor([input_ids.shape[1]], device=input_ids.device)
+
+
 def _get_logprobs_vanilla(model, input_ids):
     """Get logprobs using VanillaOutputLinear (returns logits, we compute logprobs)."""
     with torch.no_grad():
-        out = model(input_ids)
+        out = model(input_ids, seq_lens=_seq_lens(input_ids))
     logits = out["logits"]
     labels = torch.cat(
         [input_ids[:, 1:], torch.zeros(input_ids.shape[0], 1, dtype=torch.long, device=input_ids.device)], dim=1
@@ -197,7 +201,7 @@ def test_kl_with_fused_lm_head():
     labels = torch.cat([input_ids[:, 1:], torch.zeros(1, 1, dtype=torch.long, device="cuda")], dim=1)
 
     with torch.no_grad():
-        vanilla_out = model(input_ids)
+        vanilla_out = model(input_ids, seq_lens=_seq_lens(input_ids))
     vanilla_logits = vanilla_out["logits"]
     temperature = torch.ones(1, 16, device="cuda")
     vanilla_logprobs = selective_log_softmax(vanilla_logits / temperature.unsqueeze(-1), labels)
@@ -205,7 +209,7 @@ def test_kl_with_fused_lm_head():
     # Now switch to fused head and compare
     inject_prime_lm_head(model, chunk_size=16)
     with torch.no_grad():
-        fused_out = model(input_ids, labels=labels, temperature=temperature)
+        fused_out = model(input_ids, labels=labels, temperature=temperature, seq_lens=_seq_lens(input_ids))
     fused_logprobs = fused_out["logprobs"]
 
     diff = (vanilla_logprobs - fused_logprobs).abs().max()
@@ -220,7 +224,7 @@ def test_kl_logprob_alignment():
 
     # Simulate what the training loop does
     with torch.no_grad():
-        out = model(input_ids)
+        out = model(input_ids, seq_lens=_seq_lens(input_ids))
     logits = out["logits"]
 
     # Labels = shifted input_ids (predict next token)
@@ -257,14 +261,14 @@ def test_kl_backward_through_policy():
 
     # Reference logprobs (detached)
     with torch.no_grad():
-        ref_out = ref_model(input_ids)
+        ref_out = ref_model(input_ids, seq_lens=_seq_lens(input_ids))
     ref_logprobs = selective_log_softmax(ref_out["logits"], labels)
     ref_logprobs = shift_tensor_right(
         ref_logprobs, pad_value=torch.log(torch.tensor(1.0 / ref_model.config.vocab_size)).item()
     ).detach()
 
     # Policy logprobs (with grad)
-    policy_out = policy_model(input_ids)
+    policy_out = policy_model(input_ids, seq_lens=_seq_lens(input_ids))
     policy_logprobs = selective_log_softmax(policy_out["logits"], labels)
     policy_logprobs = shift_tensor_right(
         policy_logprobs, pad_value=torch.log(torch.tensor(1.0 / policy_model.config.vocab_size)).item()

--- a/tests/unit/train/models/test_qwen3_5_moe.py
+++ b/tests/unit/train/models/test_qwen3_5_moe.py
@@ -53,7 +53,11 @@ def test_qwen3_5_moe():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(
+        input_ids,
+        position_ids=position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"),
+    )
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -98,14 +102,20 @@ def test_qwen3_5_moe_router_replay():
         input_ids = torch.randint(0, prime_model.config.vocab_size, (1, 100))
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
-    out_normal = prime_model(input_ids, position_ids=position_ids)
+    seq_lens = torch.tensor([input_ids.shape[1]], device="cuda")
+    out_normal = prime_model(input_ids, position_ids=position_ids, seq_lens=seq_lens)
 
     num_layers = prime_model.config.num_hidden_layers
     topk = prime_model.config.num_experts_per_tok
     routed_experts = torch.randint(0, prime_model.config.num_experts, (1, 100, num_layers, topk), device="cuda")
 
     prime_model.zero_grad()
-    out_replay = prime_model(input_ids, position_ids=position_ids, routed_experts=routed_experts)
+    out_replay = prime_model(
+        input_ids,
+        position_ids=position_ids,
+        routed_experts=routed_experts,
+        seq_lens=seq_lens,
+    )
 
     assert out_replay["logits"].shape == out_normal["logits"].shape
 

--- a/tests/unit/train/models/test_qwen3_5_moe_mrope.py
+++ b/tests/unit/train/models/test_qwen3_5_moe_mrope.py
@@ -36,6 +36,7 @@ def test_qwen35_mrope_text_only_positions():
         mm_token_type_ids=mm_token_type_ids,
         image_grid_thw=None,
         spatial_merge_size=2,
+        seq_lens=torch.tensor([input_ids.shape[1]]),
     )
 
     expected = torch.arange(4).view(1, 1, -1).expand(3, 1, -1)
@@ -52,6 +53,7 @@ def test_qwen35_mrope_single_image_with_surrounding_text():
         mm_token_type_ids=mm_token_type_ids,
         image_grid_thw=image_grid_thw,
         spatial_merge_size=2,
+        seq_lens=torch.tensor([input_ids.shape[1]]),
     )
 
     expected = torch.tensor(
@@ -74,6 +76,7 @@ def test_qwen35_mrope_adjacent_images_consume_multiple_grids():
         mm_token_type_ids=mm_token_type_ids,
         image_grid_thw=image_grid_thw,
         spatial_merge_size=2,
+        seq_lens=torch.tensor([input_ids.shape[1]]),
     )
 
     expected = torch.tensor(
@@ -121,6 +124,7 @@ def test_qwen35_mrope_packed_matches_standalone_segments():
         mm_token_type_ids=segment_token_types,
         image_grid_thw=image_grid_thw,
         spatial_merge_size=2,
+        seq_lens=torch.tensor([segment_input_ids.shape[1]]),
     )
     packed = build_qwen3_5_mrope_position_ids(
         input_ids=torch.cat([segment_input_ids, segment_input_ids], dim=1),
@@ -145,6 +149,7 @@ def test_qwen35_mrope_rejects_image_length_grid_mismatch():
             mm_token_type_ids=mm_token_type_ids,
             image_grid_thw=image_grid_thw,
             spatial_merge_size=2,
+            seq_lens=torch.tensor([input_ids.shape[1]]),
         )
 
 
@@ -158,6 +163,7 @@ def test_qwen35_mrope_rejects_video_tokens():
             mm_token_type_ids=mm_token_type_ids,
             image_grid_thw=None,
             spatial_merge_size=2,
+            seq_lens=torch.tensor([input_ids.shape[1]]),
         )
 
 

--- a/tests/unit/train/models/test_qwen3_5_moe_vlm.py
+++ b/tests/unit/train/models/test_qwen3_5_moe_vlm.py
@@ -69,6 +69,10 @@ def _make_mm_token_type_ids(input_ids, image_token_id):
     return mm_token_type_ids
 
 
+def _seq_lens(input_ids: torch.Tensor) -> torch.Tensor:
+    return torch.tensor([input_ids.shape[1]], device=input_ids.device)
+
+
 def test_vlm_forward():
     """Custom VLM produces logits for both text-only and multimodal inputs."""
     config = _tiny_vlm_config()
@@ -81,7 +85,7 @@ def test_vlm_forward():
     # Text-only (avoid special token range 250-253)
     input_ids = torch.randint(0, 200, (1, 20), device="cuda")
     position_ids = torch.arange(1, 21, device="cuda").unsqueeze(0)
-    out_text = model(input_ids=input_ids, position_ids=position_ids)
+    out_text = model(input_ids=input_ids, position_ids=position_ids, seq_lens=_seq_lens(input_ids))
     assert out_text["logits"].shape == (1, 20, vocab)
 
     # Multimodal
@@ -96,6 +100,7 @@ def test_vlm_forward():
         pixel_values=pixel_values,
         image_grid_thw=image_grid_thw,
         mm_token_type_ids=mm_token_type_ids,
+        seq_lens=_seq_lens(input_ids_mm),
     )
     assert out_mm["logits"].shape == (1, input_ids_mm.shape[1], vocab)
 
@@ -118,6 +123,7 @@ def test_vlm_backward():
         pixel_values=pixel_values,
         image_grid_thw=image_grid_thw,
         mm_token_type_ids=mm_token_type_ids,
+        seq_lens=_seq_lens(input_ids),
     )
     out["logits"].sum().backward()
 
@@ -151,7 +157,7 @@ def test_vlm_weight_load_from_hf():
     # Verify model produces output after weight loading
     input_ids = torch.randint(0, 200, (1, 20), device="cuda")
     position_ids = torch.arange(1, 21, device="cuda").unsqueeze(0)
-    out = prime_model(input_ids=input_ids, position_ids=position_ids)
+    out = prime_model(input_ids=input_ids, position_ids=position_ids, seq_lens=_seq_lens(input_ids))
     assert out["logits"].shape[2] == config.text_config.vocab_size
     assert not torch.isnan(out["logits"]).any()
 
@@ -200,7 +206,12 @@ def test_vlm_forward_requires_mm_token_type_ids():
     input_ids = torch.full((1, n_img_tokens), config.image_token_id, device="cuda")
 
     with pytest.raises(ValueError, match="mm_token_type_ids"):
-        model(input_ids=input_ids, pixel_values=pixel_values, image_grid_thw=image_grid_thw)
+        model(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+            seq_lens=_seq_lens(input_ids),
+        )
 
 
 def test_vlm_forward_rejects_2d_positions_with_images():
@@ -222,6 +233,7 @@ def test_vlm_forward_rejects_2d_positions_with_images():
             pixel_values=pixel_values,
             image_grid_thw=image_grid_thw,
             mm_token_type_ids=mm_token_type_ids,
+            seq_lens=_seq_lens(input_ids),
         )
 
 
@@ -250,6 +262,7 @@ def test_vlm_router_replay():
         image_grid_thw=image_grid_thw,
         mm_token_type_ids=mm_token_type_ids,
         routed_experts=routed_experts,
+        seq_lens=_seq_lens(input_ids),
     )
     assert out["logits"].shape == (1, seq_len, vocab)
 

--- a/tests/unit/train/models/test_qwen3_moe.py
+++ b/tests/unit/train/models/test_qwen3_moe.py
@@ -63,7 +63,7 @@ def test_qwen3_moe_attn_only():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -91,7 +91,7 @@ def test_qwen3_moe_mlp_only():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -111,7 +111,7 @@ def test_qwen3_moe():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -132,7 +132,8 @@ def test_qwen3_moe_router_replay():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     # Forward without router replay
-    out_normal = prime_model(input_ids, position_ids)
+    seq_lens = torch.tensor([input_ids.shape[1]], device="cuda")
+    out_normal = prime_model(input_ids, position_ids, seq_lens=seq_lens)
 
     # Construct routed_experts with fixed expert indices
     # Shape: [batch=1, seq_len=100, num_hidden_layers=3, num_experts_per_tok=4]
@@ -142,7 +143,7 @@ def test_qwen3_moe_router_replay():
 
     # Forward with router replay
     prime_model.zero_grad()
-    out_replay = prime_model(input_ids, position_ids, routed_experts=routed_experts)
+    out_replay = prime_model(input_ids, position_ids, routed_experts=routed_experts, seq_lens=seq_lens)
 
     # Outputs should differ because routing is forced to different experts
     assert out_replay["logits"].shape == out_normal["logits"].shape

--- a/tests/unit/train/rl/test_fused_lm_head.py
+++ b/tests/unit/train/rl/test_fused_lm_head.py
@@ -208,11 +208,12 @@ def test_full_model_fused_vs_vanilla():
             labels = torch.randint(0, config.vocab_size, (batch_size, seq_len))
             position_ids = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
             temperature = torch.full((batch_size, seq_len), temp_value, dtype=torch.float32, device="cuda")
+            seq_lens = torch.tensor([seq_len])
 
         # Vanilla forward (returns logits, compute logprobs/entropy using RL train functions)
         optimizer_vanilla.zero_grad()
         out_vanilla = cast_float_and_contiguous(
-            model_vanilla(labels, position_ids, labels=labels, temperature=temperature)
+            model_vanilla(labels, position_ids, labels=labels, temperature=temperature, seq_lens=seq_lens)
         )
         if out_vanilla.get("logprobs") is None:
             assert out_vanilla.get("logits") is not None
@@ -225,7 +226,9 @@ def test_full_model_fused_vs_vanilla():
 
         # Fused forward (returns logprobs and entropy directly)
         optimizer_fused.zero_grad()
-        out_fused = cast_float_and_contiguous(model_fused(labels, position_ids, labels=labels, temperature=temperature))
+        out_fused = cast_float_and_contiguous(
+            model_fused(labels, position_ids, labels=labels, temperature=temperature, seq_lens=seq_lens)
+        )
         if out_fused.get("logprobs") is None:
             assert out_fused.get("logits") is not None
             logits = out_fused["logits"] / temp_value

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -132,8 +132,9 @@ def test_fake_dataset_single_rank_state_with_packing():
     resumed_dataset = setup_dataset(tokenizer, config)
     resumed_dataloader = setup_dataloader(resumed_dataset, config)
     resumed_dataloader.load_state_dict(state_dict)
+    resumed_dataiter = iter(resumed_dataloader)
     torch.random.set_rng_state(rng_state)
-    resumed_batch = next(iter(resumed_dataloader))
+    resumed_batch = next(resumed_dataiter)
 
     for key in ("input_ids", "position_ids", "target_ids", "loss_mask", "seq_lens"):
         torch.testing.assert_close(resumed_batch[key], expected_batch[key])

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -120,7 +120,7 @@ def test_fake_dataset_single_rank_state_with_packing():
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["seq_lens"].sum() == micro_batch["input_ids"].shape[1]
         if micro_batch["padding_len"]:
-            assert micro_batch["seq_lens"][-1] == micro_batch["padding_len"]
+            assert micro_batch["seq_lens"][-1] > micro_batch["padding_len"]
         dataset_state = dataloader.state_dict()["dataset_state"]
         pending_sample = dataset_state.get("pending_sample")
         expected_dataset_step = step + (pending_sample is not None)

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -118,6 +118,9 @@ def test_fake_dataset_single_rank_state_with_packing():
         num_packed_examples = len(micro_batch["input_ids"][micro_batch["loss_mask"]].unique())
         step += num_packed_examples
         assert micro_batch["input_ids"].shape == (1, 128)
+        assert micro_batch["seq_lens"].sum() == micro_batch["input_ids"].shape[1]
+        if micro_batch["padding_len"]:
+            assert micro_batch["seq_lens"][-1] == micro_batch["padding_len"]
         dataset_state = dataloader.state_dict()["dataset_state"]
         pending_sample = dataset_state.get("pending_sample")
         expected_dataset_step = step + (pending_sample is not None)
@@ -138,3 +141,4 @@ def test_fake_dataset_single_rank_state_with_packing():
 
     for key in ("input_ids", "position_ids", "target_ids", "loss_mask", "seq_lens"):
         torch.testing.assert_close(resumed_batch[key], expected_batch[key])
+    assert resumed_batch["padding_len"] == expected_batch["padding_len"]

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import torch
 from transformers import AutoTokenizer
 
 from prime_rl.configs.sft import FakeDataConfig
@@ -114,7 +115,23 @@ def test_fake_dataset_single_rank_state_with_packing():
     step = 0
     for _ in range(8):
         micro_batch = next(dataiter)
-        num_packed_examples = len(micro_batch["input_ids"].unique())
+        num_packed_examples = len(micro_batch["input_ids"][micro_batch["loss_mask"]].unique())
         step += num_packed_examples
         assert micro_batch["input_ids"].shape == (1, 128)
-        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step, "epoch": 0}}
+        dataset_state = dataloader.state_dict()["dataset_state"]
+        pending_sample = dataset_state["pending_sample"]
+        expected_dataset_step = step + (pending_sample is not None)
+        assert dataset_state["dataset"] == {"step": expected_dataset_step, "epoch": 0}
+        if pending_sample is not None:
+            assert pending_sample["input_ids"][0] == step
+
+    state_dict = dataloader.state_dict()
+    expected_batch = next(dataiter)
+
+    resumed_dataset = setup_dataset(tokenizer, config)
+    resumed_dataloader = setup_dataloader(resumed_dataset, config)
+    resumed_dataloader.load_state_dict(state_dict)
+    resumed_batch = next(iter(resumed_dataloader))
+
+    for key in ("input_ids", "position_ids", "target_ids", "loss_mask", "seq_lens"):
+        torch.testing.assert_close(resumed_batch[key], expected_batch[key])

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -119,18 +119,20 @@ def test_fake_dataset_single_rank_state_with_packing():
         step += num_packed_examples
         assert micro_batch["input_ids"].shape == (1, 128)
         dataset_state = dataloader.state_dict()["dataset_state"]
-        pending_sample = dataset_state["pending_sample"]
+        pending_sample = dataset_state.get("pending_sample")
         expected_dataset_step = step + (pending_sample is not None)
         assert dataset_state["dataset"] == {"step": expected_dataset_step, "epoch": 0}
         if pending_sample is not None:
             assert pending_sample["input_ids"][0] == step
 
     state_dict = dataloader.state_dict()
+    rng_state = torch.random.get_rng_state()
     expected_batch = next(dataiter)
 
     resumed_dataset = setup_dataset(tokenizer, config)
     resumed_dataloader = setup_dataloader(resumed_dataset, config)
     resumed_dataloader.load_state_dict(state_dict)
+    torch.random.set_rng_state(rng_state)
     resumed_batch = next(iter(resumed_dataloader))
 
     for key in ("input_ids", "position_ids", "target_ids", "loss_mask", "seq_lens"):

--- a/tests/unit/train/sft/test_sft_dataset.py
+++ b/tests/unit/train/sft/test_sft_dataset.py
@@ -418,7 +418,7 @@ def test_vlm_truncation_does_not_append_trainable_eos(monkeypatch):
         )
 
     monkeypatch.setattr(sft_data, "build_training_sample", fake_build_training_sample)
-    dataset = SFTDataset(Dataset.from_list([]), _DummyRenderer(), seq_len=2)
+    dataset = SFTDataset(Dataset.from_list([]), _DummyRenderer(), seq_len=2, multimodal=True)
 
     assert dataset._process({"messages": [{"role": "assistant", "content": "ignored"}]}) is None
 

--- a/tests/unit/train/sft/test_sft_dataset.py
+++ b/tests/unit/train/sft/test_sft_dataset.py
@@ -1,12 +1,14 @@
 from collections import Counter
 
 import pytest
+import torch
 from datasets import Dataset, interleave_datasets
 from renderers import create_renderer
-from renderers.base import RenderedTokens
+from renderers.base import MultiModalData, PlaceholderRange, RenderedTokens, RenderedTrainingSample
 from transformers import AutoTokenizer
 
-from prime_rl.trainer.sft.data import SFTDataset, _drop_null_fields
+import prime_rl.trainer.sft.data as sft_data
+from prime_rl.trainer.sft.data import CatDataset, SFTDataset, _drop_null_fields
 from prime_rl.trainer.utils import print_sample
 
 _BOS_TOKEN_ID = 0
@@ -399,3 +401,107 @@ def test_null_messages_falls_back_to_prompt_and_completion():
     )
 
     assert next(iter(mixed_row_dataset)) == next(iter(expected_dataset))
+
+
+def test_vlm_truncation_does_not_append_trainable_eos(monkeypatch):
+    mm = MultiModalData(
+        mm_placeholders={"image": [PlaceholderRange(offset=1, length=1)]},
+        mm_items={"image": [{"pixel_values": torch.ones(1, 1), "image_grid_thw": torch.tensor([[1, 1, 1]])}]},
+    )
+
+    def fake_build_training_sample(*args, **kwargs):
+        return RenderedTrainingSample(
+            token_ids=[10, 11, 12, _STOP_TOKEN_ID],
+            loss_mask=[False, False, False, True],
+            multi_modal_data=mm,
+            mm_token_type_ids=[0, 1, 0, 0],
+        )
+
+    monkeypatch.setattr(sft_data, "build_training_sample", fake_build_training_sample)
+    dataset = SFTDataset(Dataset.from_list([]), _DummyRenderer(), seq_len=2)
+
+    assert dataset._process({"messages": [{"role": "assistant", "content": "ignored"}]}) is None
+
+
+def _sft_sample(
+    input_ids: list[int],
+    *,
+    mm_kwargs: dict[str, torch.Tensor] | None = None,
+    mm_token_type_ids: list[int] | None = None,
+) -> dict:
+    return {
+        "input_ids": input_ids,
+        "position_ids": list(range(len(input_ids))),
+        "loss_mask": [True] * len(input_ids),
+        "target_ids": [x + 1 for x in input_ids],
+        "seq_lens": [len(input_ids)],
+        "padding_len": 0,
+        "mm_kwargs": mm_kwargs,
+        "mm_token_type_ids": mm_token_type_ids,
+    }
+
+
+def test_cat_dataset_packs_multimodal_samples():
+    dataset = CatDataset(
+        [
+            _sft_sample(
+                [1, 2],
+                mm_kwargs={
+                    "pixel_values": torch.ones(2, 3),
+                    "image_grid_thw": torch.tensor([[1, 1, 2]]),
+                },
+                mm_token_type_ids=[0, 1],
+            ),
+            _sft_sample(
+                [3, 4, 5],
+                mm_kwargs={
+                    "pixel_values": 2 * torch.ones(3, 3),
+                    "image_grid_thw": torch.tensor([[1, 1, 3]]),
+                },
+                mm_token_type_ids=[0, 1, 1],
+            ),
+        ],
+        seq_len=5,
+    )
+
+    packed = next(iter(dataset))
+
+    assert packed["input_ids"] == [1, 2, 3, 4, 5]
+    assert packed["seq_lens"] == [2, 3]
+    assert packed["mm_token_type_ids"] == [0, 1, 0, 1, 1]
+    assert packed["mm_kwargs"]["pixel_values"].shape == (5, 3)
+    assert packed["mm_kwargs"]["image_grid_thw"].tolist() == [[1, 1, 2], [1, 1, 3]]
+
+
+def test_cat_dataset_packs_text_and_multimodal_samples_together():
+    dataset = CatDataset(
+        [
+            _sft_sample([1]),
+            _sft_sample(
+                [2, 3],
+                mm_kwargs={
+                    "pixel_values": torch.ones(2, 3),
+                    "image_grid_thw": torch.tensor([[1, 1, 2]]),
+                },
+                mm_token_type_ids=[0, 1],
+            ),
+            _sft_sample([4]),
+            _sft_sample([5, 6]),
+        ],
+        seq_len=5,
+    )
+
+    dataiter = iter(dataset)
+    packed = next(dataiter)
+    text_pack = next(dataiter)
+
+    assert packed["input_ids"] == [1, 2, 3, 4, 0]
+    assert packed["loss_mask"] == [True, True, True, True, False]
+    assert packed["seq_lens"] == [1, 2, 1, 1]
+    assert packed["mm_kwargs"] is not None
+    assert packed["mm_token_type_ids"] == [0, 0, 1, 0, 0]
+    assert text_pack["input_ids"] == [5, 6, 0, 0, 0]
+    assert text_pack["loss_mask"] == [True, True, False, False, False]
+    assert text_pack["seq_lens"] == [2, 3]
+    assert text_pack["mm_kwargs"] is None
+    assert text_pack["mm_token_type_ids"] is None

--- a/tests/unit/train/test_model.py
+++ b/tests/unit/train/test_model.py
@@ -47,7 +47,7 @@ def test_model_forward(model):
     model = model.to("cuda")
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
-        outputs = model(input_ids=inputs_ids)
+        outputs = model(input_ids=inputs_ids, seq_lens=torch.tensor([SEQ_LEN], device="cuda"))
         logits = outputs["logits"]
 
         assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)
@@ -59,7 +59,11 @@ def test_model_with_position_ids(model):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
         position_ids = torch.arange(SEQ_LEN).unsqueeze(0).repeat(BS, 1).to("cuda")
 
-        outputs = model(input_ids=inputs_ids, position_ids=position_ids)
+        outputs = model(
+            input_ids=inputs_ids,
+            position_ids=position_ids,
+            seq_lens=torch.tensor([SEQ_LEN], device="cuda"),
+        )
         logits = outputs["logits"]
 
         assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)
@@ -84,7 +88,7 @@ def test_model_with_sequence_packing(model, correct_position_ids):
 
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.Tensor(inputs).repeat(1, 1).int().to("cuda")
-        outputs = model(input_ids=inputs_ids)
+        outputs = model(input_ids=inputs_ids, seq_lens=torch.tensor([len(inputs)], device="cuda"))
         output_base = outputs["logits"]
 
         assert output_base.shape == (1, len(inputs), model.config.vocab_size)
@@ -97,7 +101,11 @@ def test_model_with_sequence_packing(model, correct_position_ids):
         else:
             position_ids = torch.Tensor([0, 1, 2, 3, 4, 5, 6, 7]).repeat(1, 1).int().to("cuda")
             # should fail
-        outputs = model(input_ids=inputs_ids, position_ids=position_ids)
+        outputs = model(
+            input_ids=inputs_ids,
+            position_ids=position_ids,
+            seq_lens=torch.tensor([len(inputs), len(inputs)], device="cuda"),
+        )
         outputs_packed = outputs["logits"]
 
         assert outputs_packed.shape == (1, 2 * len(inputs), model.config.vocab_size)
@@ -124,7 +132,7 @@ def test_moe_custom_impl():
     inject_prime_lm_head(model, chunk_size=None)
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
-        outputs = model(input_ids=inputs_ids)
+        outputs = model(input_ids=inputs_ids, seq_lens=torch.tensor([SEQ_LEN], device="cuda"))
         logits = outputs["logits"]
 
         assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)
@@ -140,7 +148,7 @@ def test_model_forward_custom_impl(model_name):
     model = model.to("cuda")
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
-        outputs = model(input_ids=inputs_ids)
+        outputs = model(input_ids=inputs_ids, seq_lens=torch.tensor([SEQ_LEN], device="cuda"))
         logits = outputs["logits"]
 
         assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)

--- a/tests/unit/train/test_model_forward.py
+++ b/tests/unit/train/test_model_forward.py
@@ -48,6 +48,8 @@ def test_forward_passes_renderer_mm_token_type_ids_through():
         model,
         input_ids,
         position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]]),
+        padding_len=0,
         mm_kwargs={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw},
         mm_token_type_ids=mm_token_type_ids,
     )
@@ -72,6 +74,8 @@ def test_forward_omits_mm_token_type_ids_when_renderer_does_not_supply():
         model,
         input_ids,
         position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]]),
+        padding_len=0,
         mm_kwargs={"pixel_values": torch.ones(2, 3), "image_grid_thw": torch.tensor([[1, 1, 2]])},
     )
 
@@ -91,6 +95,8 @@ def test_forward_keeps_position_ids_for_non_mrope_vlm():
         model,
         input_ids,
         position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]]),
+        padding_len=0,
         mm_kwargs={"pixel_values": torch.ones(2, 3)},
     )
 
@@ -104,7 +110,7 @@ def test_forward_does_not_leak_seq_lens_to_generic_text_models():
     position_ids = torch.arange(input_ids.shape[1]).unsqueeze(0)
     seq_lens = torch.tensor([2, 2])
 
-    forward(model, input_ids, position_ids, seq_lens=seq_lens)
+    forward(model, input_ids, position_ids, seq_lens=seq_lens, padding_len=0)
 
     assert model.kwargs is not None
     assert "seq_lens" not in model.kwargs
@@ -116,7 +122,18 @@ def test_forward_passes_typed_seq_lens_to_custom_models():
     position_ids = torch.arange(input_ids.shape[1]).unsqueeze(0)
     seq_lens = torch.tensor([2, 2])
 
-    forward(model, input_ids, position_ids, seq_lens=seq_lens)
+    forward(model, input_ids, position_ids, seq_lens=seq_lens, padding_len=0)
 
     assert model.kwargs is not None
     torch.testing.assert_close(model.kwargs["seq_lens"], seq_lens)
+
+
+def test_forward_merges_padding_into_final_document_for_custom_models():
+    model = _PrimeCaptureModel()
+    input_ids = torch.tensor([[1, 2, 3, 0]])
+    position_ids = torch.arange(input_ids.shape[1]).unsqueeze(0)
+
+    forward(model, input_ids, position_ids, seq_lens=torch.tensor([3, 1]), padding_len=1)
+
+    assert model.kwargs is not None
+    torch.testing.assert_close(model.kwargs["seq_lens"], torch.tensor([4]))

--- a/tests/unit/train/test_model_forward.py
+++ b/tests/unit/train/test_model_forward.py
@@ -3,7 +3,10 @@ from types import SimpleNamespace
 import torch
 import torch.nn as nn
 
-from prime_rl.trainer.model import forward
+from prime_rl.configs.shared import VLMConfig
+from prime_rl.configs.trainer import LoRAConfig, ModelConfig
+from prime_rl.trainer.model import configure_trainable_parameters, forward
+from prime_rl.trainer.models.layers.lora import MultiLoRALinear
 
 
 class _CaptureModel(nn.Module):
@@ -19,6 +22,35 @@ class _CaptureModel(nn.Module):
         else:
             shape = kwargs["inputs_embeds"].shape[:2]
         return {"logits": torch.zeros(*shape, 4)}
+
+
+class _ToyVLM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.visual = nn.Module()
+        self.visual.gate_proj = nn.Linear(4, 4)
+        self.language_model = nn.Module()
+        self.language_model.gate_proj = nn.Linear(4, 4)
+
+
+def test_frozen_vision_encoder_is_excluded_from_lora():
+    model = _ToyVLM()
+    config = ModelConfig(
+        vlm=VLMConfig(vision_encoder_attr="visual", language_model_attr="language_model"),
+        lora=LoRAConfig(target_modules=["gate_proj"]),
+    )
+
+    configure_trainable_parameters(model, config, SimpleNamespace(ep_enabled=False))
+
+    assert isinstance(model.visual.gate_proj, nn.Linear)
+    assert not isinstance(model.visual.gate_proj, MultiLoRALinear)
+    assert all(not parameter.requires_grad for parameter in model.visual.parameters())
+    assert isinstance(model.language_model.gate_proj, MultiLoRALinear)
+    lora_parameters = [
+        parameter for name, parameter in model.language_model.gate_proj.named_parameters() if "lora_" in name
+    ]
+    assert lora_parameters
+    assert all(parameter.requires_grad for parameter in lora_parameters)
 
 
 def test_forward_passes_renderer_mm_token_type_ids_through():

--- a/tests/unit/train/test_model_forward.py
+++ b/tests/unit/train/test_model_forward.py
@@ -2,10 +2,8 @@ from types import SimpleNamespace
 
 import torch
 import torch.nn as nn
-from transformers import PretrainedConfig
 
 from prime_rl.trainer.model import forward
-from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 
 
 class _CaptureModel(nn.Module):
@@ -16,19 +14,6 @@ class _CaptureModel(nn.Module):
 
     def forward(self, **kwargs):
         self.kwargs = kwargs
-        input_ids = kwargs["input_ids"]
-        return {"logits": torch.zeros(*input_ids.shape, 4)}
-
-
-class _PrimeCaptureModel(PreTrainedModelPrimeRL):
-    config_class = PretrainedConfig
-
-    def __init__(self):
-        super().__init__(PretrainedConfig())
-        self.kwargs = None
-
-    def forward(self, seq_lens: torch.Tensor | None = None, **kwargs):
-        self.kwargs = {**kwargs, "seq_lens": seq_lens}
         input_ids = kwargs["input_ids"]
         return {"logits": torch.zeros(*input_ids.shape, 4)}
 
@@ -49,7 +34,6 @@ def test_forward_passes_renderer_mm_token_type_ids_through():
         input_ids,
         position_ids,
         seq_lens=torch.tensor([input_ids.shape[1]]),
-        padding_len=0,
         mm_kwargs={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw},
         mm_token_type_ids=mm_token_type_ids,
     )
@@ -75,7 +59,6 @@ def test_forward_omits_mm_token_type_ids_when_renderer_does_not_supply():
         input_ids,
         position_ids,
         seq_lens=torch.tensor([input_ids.shape[1]]),
-        padding_len=0,
         mm_kwargs={"pixel_values": torch.ones(2, 3), "image_grid_thw": torch.tensor([[1, 1, 2]])},
     )
 
@@ -96,44 +79,8 @@ def test_forward_keeps_position_ids_for_non_mrope_vlm():
         input_ids,
         position_ids,
         seq_lens=torch.tensor([input_ids.shape[1]]),
-        padding_len=0,
         mm_kwargs={"pixel_values": torch.ones(2, 3)},
     )
 
     assert model.kwargs is not None
     torch.testing.assert_close(model.kwargs["position_ids"], position_ids)
-
-
-def test_forward_does_not_leak_seq_lens_to_generic_text_models():
-    model = _CaptureModel(SimpleNamespace(model_type="qwen3"))
-    input_ids = torch.tensor([[1, 2, 3, 4]])
-    position_ids = torch.arange(input_ids.shape[1]).unsqueeze(0)
-    seq_lens = torch.tensor([2, 2])
-
-    forward(model, input_ids, position_ids, seq_lens=seq_lens, padding_len=0)
-
-    assert model.kwargs is not None
-    assert "seq_lens" not in model.kwargs
-
-
-def test_forward_passes_typed_seq_lens_to_custom_models():
-    model = _PrimeCaptureModel()
-    input_ids = torch.tensor([[1, 2, 3, 4]])
-    position_ids = torch.arange(input_ids.shape[1]).unsqueeze(0)
-    seq_lens = torch.tensor([2, 2])
-
-    forward(model, input_ids, position_ids, seq_lens=seq_lens, padding_len=0)
-
-    assert model.kwargs is not None
-    torch.testing.assert_close(model.kwargs["seq_lens"], seq_lens)
-
-
-def test_forward_merges_padding_into_final_document_for_custom_models():
-    model = _PrimeCaptureModel()
-    input_ids = torch.tensor([[1, 2, 3, 0]])
-    position_ids = torch.arange(input_ids.shape[1]).unsqueeze(0)
-
-    forward(model, input_ids, position_ids, seq_lens=torch.tensor([3, 1]), padding_len=1)
-
-    assert model.kwargs is not None
-    torch.testing.assert_close(model.kwargs["seq_lens"], torch.tensor([4]))

--- a/tests/unit/train/test_model_forward.py
+++ b/tests/unit/train/test_model_forward.py
@@ -33,11 +33,16 @@ class _ToyVLM(nn.Module):
         self.language_model.gate_proj = nn.Linear(4, 4)
 
 
-def test_frozen_vision_encoder_is_excluded_from_lora():
+def test_frozen_vision_encoder_is_excluded_from_lora(monkeypatch):
+    runs = SimpleNamespace(max_runs=1, register_module=lambda *args: None)
+    monkeypatch.setattr("prime_rl.trainer.lora.get_multi_run_manager", lambda: runs)
+    monkeypatch.setattr("prime_rl.trainer.models.layers.lora.base.LORA_NUM_TOKENS", torch.zeros(1, dtype=torch.int32))
+    monkeypatch.setattr("prime_rl.trainer.models.layers.lora.base.SCALING_FACTORS", torch.ones(1, dtype=torch.bfloat16))
     model = _ToyVLM()
     config = ModelConfig(
         vlm=VLMConfig(vision_encoder_attr="visual", language_model_attr="language_model"),
         lora=LoRAConfig(target_modules=["gate_proj"]),
+        moe_router_dtype="bfloat16",
     )
 
     configure_trainable_parameters(model, config, SimpleNamespace(ep_enabled=False))

--- a/tests/unit/train/test_model_forward.py
+++ b/tests/unit/train/test_model_forward.py
@@ -2,8 +2,10 @@ from types import SimpleNamespace
 
 import torch
 import torch.nn as nn
+from transformers import PretrainedConfig
 
 from prime_rl.trainer.model import forward
+from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 
 
 class _CaptureModel(nn.Module):
@@ -14,6 +16,19 @@ class _CaptureModel(nn.Module):
 
     def forward(self, **kwargs):
         self.kwargs = kwargs
+        input_ids = kwargs["input_ids"]
+        return {"logits": torch.zeros(*input_ids.shape, 4)}
+
+
+class _PrimeCaptureModel(PreTrainedModelPrimeRL):
+    config_class = PretrainedConfig
+
+    def __init__(self):
+        super().__init__(PretrainedConfig())
+        self.kwargs = None
+
+    def forward(self, seq_lens: torch.Tensor | None = None, **kwargs):
+        self.kwargs = {**kwargs, "seq_lens": seq_lens}
         input_ids = kwargs["input_ids"]
         return {"logits": torch.zeros(*input_ids.shape, 4)}
 
@@ -81,3 +96,27 @@ def test_forward_keeps_position_ids_for_non_mrope_vlm():
 
     assert model.kwargs is not None
     torch.testing.assert_close(model.kwargs["position_ids"], position_ids)
+
+
+def test_forward_does_not_leak_seq_lens_to_generic_text_models():
+    model = _CaptureModel(SimpleNamespace(model_type="qwen3"))
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+    position_ids = torch.arange(input_ids.shape[1]).unsqueeze(0)
+    seq_lens = torch.tensor([2, 2])
+
+    forward(model, input_ids, position_ids, seq_lens=seq_lens)
+
+    assert model.kwargs is not None
+    assert "seq_lens" not in model.kwargs
+
+
+def test_forward_passes_typed_seq_lens_to_custom_models():
+    model = _PrimeCaptureModel()
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+    position_ids = torch.arange(input_ids.shape[1]).unsqueeze(0)
+    seq_lens = torch.tensor([2, 2])
+
+    forward(model, input_ids, position_ids, seq_lens=seq_lens)
+
+    assert model.kwargs is not None
+    torch.testing.assert_close(model.kwargs["seq_lens"], seq_lens)

--- a/tests/unit/train/test_model_forward.py
+++ b/tests/unit/train/test_model_forward.py
@@ -14,8 +14,11 @@ class _CaptureModel(nn.Module):
 
     def forward(self, **kwargs):
         self.kwargs = kwargs
-        input_ids = kwargs["input_ids"]
-        return {"logits": torch.zeros(*input_ids.shape, 4)}
+        if "input_ids" in kwargs:
+            shape = kwargs["input_ids"].shape
+        else:
+            shape = kwargs["inputs_embeds"].shape[:2]
+        return {"logits": torch.zeros(*shape, 4)}
 
 
 def test_forward_passes_renderer_mm_token_type_ids_through():
@@ -84,3 +87,23 @@ def test_forward_keeps_position_ids_for_non_mrope_vlm():
 
     assert model.kwargs is not None
     torch.testing.assert_close(model.kwargs["position_ids"], position_ids)
+
+
+def test_forward_strips_position_ids_without_leaking_seq_lens_for_mrope_vlm():
+    """Generic VLMs do not receive PrimeRL-only packed-boundary kwargs."""
+    model = _CaptureModel(SimpleNamespace(model_type="qwen3_5_moe"))
+    input_ids = torch.tensor([[1, 10, 10, 2, 20, 20]])
+    position_ids = torch.tensor([[0, 1, 2, 0, 1, 2]])
+    seq_lens = torch.tensor([3, 3])
+
+    forward(
+        model,
+        input_ids,
+        position_ids,
+        mm_kwargs={"pixel_values": torch.ones(4, 3), "image_grid_thw": torch.tensor([[1, 1, 2], [1, 1, 2]])},
+        seq_lens=seq_lens,
+    )
+
+    assert model.kwargs is not None
+    assert "position_ids" not in model.kwargs
+    assert "seq_lens" not in model.kwargs

--- a/tests/unit/train/test_model_forward.py
+++ b/tests/unit/train/test_model_forward.py
@@ -121,8 +121,7 @@ def test_forward_keeps_position_ids_for_non_mrope_vlm():
     torch.testing.assert_close(model.kwargs["position_ids"], position_ids)
 
 
-def test_forward_strips_position_ids_without_leaking_seq_lens_for_mrope_vlm():
-    """Generic VLMs do not receive PrimeRL-only packed-boundary kwargs."""
+def test_forward_omits_prime_only_kwargs_for_hf_mrope_vlm():
     model = _CaptureModel(SimpleNamespace(model_type="qwen3_5_moe"))
     input_ids = torch.tensor([[1, 10, 10, 2, 20, 20]])
     position_ids = torch.tensor([[0, 1, 2, 0, 1, 2]])

--- a/tests/unit/utils/test_sequence.py
+++ b/tests/unit/utils/test_sequence.py
@@ -1,7 +1,11 @@
 import pytest
 import torch
 
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
+from prime_rl.utils.sequence import (
+    get_cp_local_seq_lens,
+    get_cu_seqlens_from_position_ids,
+    get_cu_seqlens_from_seq_lens,
+)
 
 
 @pytest.mark.parametrize(
@@ -36,3 +40,10 @@ def test_get_cu_seqlens_from_seq_lens():
 def test_get_cu_seqlens_from_seq_lens_rejects_wrong_total():
     with pytest.raises(ValueError, match="sum must equal"):
         get_cu_seqlens_from_seq_lens(torch.tensor([4, 3]), total_tokens=9)
+
+
+@pytest.mark.parametrize(("cp_rank", "expected"), [(0, [3, 1]), (1, [4])])
+def test_get_cp_local_seq_lens(cp_rank: int, expected: list[int]):
+    local_seq_lens = get_cp_local_seq_lens(torch.tensor([3, 5]), 8, cp_rank, 2)
+
+    assert local_seq_lens.tolist() == expected


### PR DESCRIPTION
## Summary

Part 4/7 of the split of #2485. **Based on #3032 (`feat/seq-lens-packing`)** — needs the seq_lens boundary contract (MRoPE packs can't encode boundaries in position_ids) and the dense Qwen3.5 model from #2943.

Renderer-produced multimodal samples flow end to end through SFT (no CP yet):

- **Data**: `SFTDataset` keeps the renderer's `MultiModalData` — image-safe truncation (never cuts inside a placeholder run, drops truncated-out images, skips samples whose EOS was truncated away), `mm_token_type_ids` kept aligned through EOS append and causal shift, video inputs rejected explicitly. `_flatten_mm_items` folds per-image processor outputs into model-forward kwargs. Cat packing concatenates `mm_kwargs` across samples in a pack (text spans become zeros in `mm_token_type_ids`). Local `data_files` normalization wraps string content into typed content blocks under a multimodal flag so Arrow unifies text and image rows.
- **Trainer**: `setup_processor` loads the `AutoProcessor` and attaches it to the renderer; VLM SFT fails fast without one; weight checkpoints save the processor alongside the tokenizer.
- **Models**: dense Qwen3.5 gains the composite VLM body (HF vision encoder + custom text model) with MRoPE positions from `mm_token_type_ids`, registered in `_CUSTOM_VLM_MAPPING`. **VLM training now requires a custom PrimeRL implementation — in both trainers.** This is a deliberate policy change: custom models are the only KL-validated, packable, CP-able path, and maintaining a second (hf) numerics regime for MM training isn't worth it. Consequently the RL MM configs (`configs/debug/multimodal.toml`, `configs/ci/nightly/multimodal_color_codeword.toml`) migrate from `Qwen/Qwen3-VL-4B-Instruct` (hf-only) to a Qwen3.5 checkpoint; text-only training of VLM checkpoints (no `[model.vlm]`) loads the custom VLM class too (auto dispatch) with the vision encoder frozen — the dummy vision pass gives vision params zero (not None) grads, and unfrozen they would silently shrink under AdamW weight decay. Both dense and MoE VLM bodies always run the vision encoder (dummy input on text-only microbatches, kept in the backward graph with zero contribution) for FSDP/EP collective symmetry.
- **Config**: VLM SFT requires bfloat16 optimization/reduction and `micro_batch_size=1`; unfreezing the vision encoder is incompatible with LoRA; the renderer-vs-VLM rejection is gone (renderers own multimodal tokenization now). Example configs for dense (`examples/vlm_sft`) and MoE (`examples/vlm_sft_moe`) VLM SFT.

**Review fixes**: the rebased series saves the processor before the tokenizer, freezes the vision encoder for text-only VLM checkpoints, rejects multimodal renderer output without `[model.vlm]`, enforces the VLM dtype contract, centralizes trainability policy, and preserves the explicit `seq_lens`/padding contract from #3032. Stack packing is no longer supported.

## KL mismatch table (multimodal)

20 steps, color-codeword, batch 64, group 8, 1 train + 1 infer H100 (text-protocol knobs on the MM env). Control on `main` with the hf Qwen3-VL path (what the MM nightly ran until now) for calibration:

| run | impl / model | mean mismatch KL | step 0 (on-policy = pure numerics) | steady state |
|---|---|---|---|---|
| text reference (#2943) | custom Qwen3.5-0.8B, hendrycks-math | 0.0003 | 0.0003 | 0.0003 |
| **this PR, MM** ([stack-pr4-rl-kl-mm](https://wandb.ai/primeintellect/pr2485/runs/11cf49aa353d456fb5892a1944b30260)) | custom Qwen3.5-0.8B VLM, color-codeword | **0.0138** | **0.0025** | 0.003–0.006 |
| main control, MM ([main-rl-kl-mm-hf](https://wandb.ai/primeintellect/pr2485/runs/4902c84180644e8ba8d5416bbab5a3c3)) | hf Qwen3-VL-4B, color-codeword | 0.1145 | 0.0004 | 0.02–0.42 |

Mean is under the 0.015 bar; step-0 (pure trainer-vs-vLLM numerics) is 0.0025 — the ~8× gap vs text is the vision-conditioned forward (vision encoder + MRoPE). The hf control shows the mean-based bar doesn't transfer to MM runs that actually learn (policy movement at lr 3e-6 dominates numerics: 0.1145 mean on the established nightly path); step-0 KL is the impl-quality stat. Follow-up: recheck step-0 KL at larger Qwen3.5 scale.

**Multi-replica serving note**: the engine deaths seen with 4 inference replicas on the validation node were root-caused (verified with a `/dev/shm` sampler: usage hits 65,008K of 65,536K in the second the engine cores die) as **64MB `/dev/shm` exhaustion** — vLLM's DP engine shared-memory queues with multimodal payloads overflow the K8s-default tmpfs and the cores die natively (no traceback). Text-only serving of the same checkpoint on 4 replicas is unaffected. Not a code/config issue — this is the exact failure #2339 already fixed for nightly CI (`--shm-size=16g` in `nightly_tests.yaml`, with a comment describing the same SIGBUS): dp>1 routes API-server↔engine IPC through shm-backed MessageQueues (~160MB virtual each), and tmpfs pages commit lazily, so text payloads never touch them while MM pixel tensors fill them. The validation node's K8s pod lacks that provisioning; the nightly's multi-GPU MM config is fine on CI.

## E2E

- [ ] MM SFT on real multimodal traces: dense VLM + MoE VLM, cp=1 — W&B links TBD
- [ ] Text regression rerun — W&B link TBD
- [ ] RL MM smoke with the migrated `multimodal_color_codeword` config (custom Qwen3.5, unpacked, cp=1 — what the nightly runs once this merges) — W&B link TBD

- [x] Integration suite (subset) at this tip: 3/5 — same marginal `loss_goes_down` flip as #2944 and a `test_reverse_text_moe` env error that reproduces on unmodified `main` on this node

- [x] SFT dataset unit tests after rebase: 22 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model loading policy, distributed VLM forwards, and SFT packing/truncation for images—mistakes could break training or silently corrupt multimodal batches; scope is large but guarded by new validators and unit tests.
> 
> **Overview**
> Adds **end-to-end multimodal SFT**: renderer outputs (`pixel_values`, `image_grid_thw`, `mm_token_type_ids`) flow through packing/truncation into `forward()`, with new dense **Qwen3.5 VLM** support in the custom stack and tighter VLM training policy.
> 
> **Data & trainer:** `SFTDataset`/`CatDataset` carry multimodal kwargs through image-safe truncation and packing; SFT loads an `AutoProcessor`, wires it to the renderer, and saves it in HF weight checkpoints. VLM SFT is validated for **bfloat16**, **`micro_batch_size=1`**, no CP, and LoRA vs unfrozen vision encoder.
> 
> **Models & policy:** Dense `Qwen3_5ForCausalLM` gains a composite VLM body (HF vision + custom text, MRoPE from renderer tokens); MoE VLM refactors embed prep and always runs the vision encoder (dummy pass on text-only batches) for distributed collective symmetry. **`[model.vlm]` now requires a registered custom PrimeRL VLM** — HF-only VLMs fail at load. LoRA skips frozen vision subtrees; trainability is centralized in `configure_trainable_parameters`.
> 
> **Configs/docs:** Removes the old “renderer SFT can’t do VLMs” gate; RL/debug MM configs switch from Qwen3-VL to **Qwen3.5**; docs mark VLM **CP as unsupported**; adds `examples/vlm_sft` and `vlm_sft_moe`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2d2e8c788509a244b8f75f8bbe41c3a9daaa17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->