### PR TITLE
feat(inference): HiSparse vLLM wheel for GLM-5.x PD decode instances

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -234,7 +234,17 @@ num_bytes = 128_000_000_000
 path = "/scratch/kv"
 ```
 
-For `native`, `cpu.num_bytes` is the aggregate CPU KV pool for the instance (vLLM shards it across workers). For `mooncake`, `cpu.num_bytes` is the DRAM each node contributes to the shared pool (so the total pool ≈ `num_bytes × #inference-nodes`); the store uses RDMA, so it requires an RDMA-capable fabric. Enabling offload automatically enables prefix caching.
+For `native`, `cpu.num_bytes` is the aggregate CPU KV pool for the instance (vLLM shards it across workers). For `mooncake`, `cpu.num_bytes` is the DRAM each node contributes to the shared pool (so the total pool ≈ `num_bytes × #contributing-nodes`); the store uses RDMA, so it requires an RDMA-capable fabric. Enabling offload automatically enables prefix caching.
+
+For disaggregated deployments, `roles` scopes the offload to a subset of instance roles. Nodes outside the scope skip the store client (contributing no DRAM segment) and their vLLM config drops the offload connector. This frees decode-node RAM — e.g. for HiSparse host pools, which need `ranks × host_pool_gib` on each decode node:
+
+```toml
+[inference.kv_cache_offload]
+type = "mooncake"
+roles = ["prefill"]   # decode nodes keep their RAM; prefill nodes share prefixes
+[inference.kv_cache_offload.cpu]
+num_bytes = 128_000_000_000
+```
 
 
 ### Optimized P/D disaggregation deployment

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -551,9 +551,7 @@ class InferenceConfig(BaseConfig):
             self.api_server_count = 1  # LoRA requires only one API server
         return self
 
-    def build_kv_transfer_config(
-        self, role: Literal["prefill", "decode"] | None = None
-    ) -> dict[str, Any] | None:
+    def build_kv_transfer_config(self, role: Literal["prefill", "decode"] | None = None) -> dict[str, Any] | None:
         """Build the single vLLM ``kv_transfer_config`` from the transfer + offload connectors.
 
         Disaggregated P/D always uses NIXL for prefill→decode transfer. KV cache offload (if

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -103,6 +103,14 @@ class BaseKVCacheOffloadConfig(BaseConfig):
     disk: DiskOffloadTier | None = None
     """Optional disk tier, layered behind the CPU tier (GPU → DRAM → disk)."""
 
+    roles: list[Literal["prefill", "decode"]] = ["prefill", "decode"]
+    """Which disaggregated instance roles attach the offload connector (and, for
+    ``mooncake``, run the per-node store client). Scoping to ``["prefill"]`` keeps
+    cross-node prefix reuse for prefill while freeing decode-node RAM (e.g. for
+    HiSparse host pools). Narrowing only takes effect for disaggregated
+    deployments (no hard validation: per-rank launches re-parse the config
+    without the deployment section)."""
+
     @model_validator(mode="after")
     def valid_tiers(self):
         # Both backends support only two shapes: cpu-only or cpu+disk. Native disk
@@ -110,6 +118,8 @@ class BaseKVCacheOffloadConfig(BaseConfig):
         # staging tier. Disk-only is rejected for both.
         if self.cpu is None:
             raise ValueError("inference.kv_cache_offload requires a cpu tier (disk-only offload is not supported).")
+        if not self.roles:
+            raise ValueError("inference.kv_cache_offload.roles must not be empty (omit it to apply to all roles).")
         return self
 
 
@@ -541,11 +551,14 @@ class InferenceConfig(BaseConfig):
             self.api_server_count = 1  # LoRA requires only one API server
         return self
 
-    def build_kv_transfer_config(self) -> dict[str, Any] | None:
+    def build_kv_transfer_config(
+        self, role: Literal["prefill", "decode"] | None = None
+    ) -> dict[str, Any] | None:
         """Build the single vLLM ``kv_transfer_config`` from the transfer + offload connectors.
 
         Disaggregated P/D always uses NIXL for prefill→decode transfer. KV cache offload (if
-        configured) contributes its own connector. When both are present they are composed via
+        configured) contributes its own connector for the roles it is scoped to (``role=None``
+        means unscoped: include it). When both are present they are composed via
         ``MultiConnector``. Returns None when neither applies.
         """
         connectors: list[dict[str, Any]] = []
@@ -557,7 +570,7 @@ class InferenceConfig(BaseConfig):
                     "kv_connector_extra_config": {"num_threads": 1},
                 }
             )
-        if self.kv_cache_offload is not None:
+        if self.kv_cache_offload is not None and (role is None or role in self.kv_cache_offload.roles):
             connectors.append(self.kv_cache_offload.to_connector_dict())
 
         if not connectors:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,17 @@ vllm-router = [
     { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
 ]
 vllm = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl", marker = "platform_machine == 'x86_64'" },
+    # HiSparse fork wheel (faresobeid/vllm feat/hisparse-mla-decode @ c6f2044,
+    # sm90a, cp312). Host-resident sparse-MLA decode hot-buffering for
+    # GLM-5.x PD decode instances (vllm-project/vllm#46326). c6f2044 adds the
+    # mixed-batch row-split (decode rows no longer staged during local
+    # prefill), the DP-pad backup clamp, deterministic pinned-pool teardown
+    # (cudaHostRegister/Unregister, ~12-15s per 256 GiB rank in-process — no
+    # more "Kill task failed" drains on graceful cancels), top-k tie-overflow
+    # padding, and NIXL/mooncake shutdown hardening.
+    # Setting attention_config.hisparse_config (with a required host_pool_gib)
+    # is what enables HiSparse. Mooncake-store offload via MultiConnector.
+    { url = "https://github.com/faresobeid/vllm/releases/download/hisparse-c6f2044/vllm-0.24.1.dev0+hisparse.c6f204424.cu129-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" },
     { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
 ]
 deep-ep = [

--- a/scripts/install_nixl_from_source.sh
+++ b/scripts/install_nixl_from_source.sh
@@ -41,6 +41,15 @@ fi
 cd "$UCX_SRC"
 git checkout v1.19.x
 
+# Neutralize the single-mode cross-thread ownership assert (ucp_worker.h):
+# nixl's shared UCX worker is legitimately touched from vLLM's NIXL handshake
+# listener thread while the progress thread runs; with the assert compiled in,
+# a handshake racing a transfer aborts the worker process (observed killing a
+# whole decode DP group mid-run). Assert-free release semantics are what this
+# stack effectively runs on everywhere else.
+sed -i 's|ucs_assert(ucs_async_check_owner_thread(&(_worker)->async)); \\|(void)(_worker); \\|' \
+    src/ucp/core/ucp_worker.h
+
 if [ ! -f "$UCX_INSTALL/lib/libucs.so" ]; then
     ./autogen.sh
     ./configure \
@@ -52,6 +61,8 @@ if [ ! -f "$UCX_INSTALL/lib/libucs.so" ]; then
         --enable-cma \
         --enable-devel-headers \
         --enable-mt \
+        --disable-assertions \
+        --disable-params-check \
         --with-verbs \
         --with-rdmacm \
         --with-cuda="$CUDA_PATH" \

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -49,6 +49,24 @@ tmux send-keys -t "$SESSION:Launcher" 'your command here' Enter
 
 After a restart, verify all processes are back up and progress resumed before the next check-in.
 
+### Cancelling a HiSparse inference job
+
+HiSparse decode ranks hold multi-hundred-GiB pinned host pools per rank. A
+plain `scancel` gives them only SLURM's KillWait before SIGKILL; if the unpin
+doesn't finish, the node drains with "Kill task failed" and needs an admin
+resume. Use the two-step cancel:
+
+```bash
+scancel --batch --signal=TERM <jobid>   # batch shell forwards TERM; ranks drain + unpin in-process
+# wait for the job to exit on its own (decode logs print
+# "HiSparse: unpinned N GiB of host pool in-process in S s"); give it up to ~10 min
+scancel <jobid>                          # only if it is still there
+```
+
+Cancel during boot or idle is safe either way. A job whose decode engines are
+already dead/wedged (CUDA fault, DeepEP interlock) cannot run its teardown —
+expect possible drains there regardless; cancel it anyway and note the nodes.
+
 ---
 
 ## Reference

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -79,17 +79,29 @@ curl http://localhost:8000/v1/chat/completions \
 - Entrypoint: `src/prime_rl/entrypoints/inference.py`
 - SLURM: single-node, multi-node, and disaggregated deployments
 
-## Summary
+### Multi-node SLURM bring-up gotchas
 
-| Command | Purpose | Typical use |
-|---------|---------|-------------|
-| `rl` | Full RL pipeline | Production RL training |
-| `sft` | Supervised fine-tuning | SFT and hard-distill |
-| `inference` | vLLM server | Standalone serving / debugging |
-
-## Key paths
-
-- `src/prime_rl/entrypoints/` — `rl`, `sft`, `inference` (+ `trainer`, `orchestrator` for direct launches)
-- `packages/prime-rl-configs/src/prime_rl/configs/` — all config classes
-- `configs/debug/` — minimal debug configs
-- `examples/` — full example configs (e.g. `reverse_text/`)
+- **Cache paths must be user-scoped.** On shared clusters `/tmp/.cache/*` may be
+  owned by another user; set `TRITON_CACHE_DIR` / `VLLM_CACHE_ROOT` /
+  `DG_JIT_CACHE_DIR` under a per-user path (e.g. `/tmp/<user>-cache/...`) in
+  `[env_vars]`. Triton JIT failures from EACCES are fatal mid-run.
+- **Node starts must be near-simultaneous for DP groups.** vLLM's DP
+  coordinator handshake has a hard 5-minute deadline
+  (`HANDSHAKE_TIMEOUT_MINS`, not env-tunable): if setup staggers nodes by more
+  than ~5 min, the early nodes' engines die waiting for the last node's
+  front-end. The sbatch template syncs the venv once at the batch level and
+  launches all nodes with a single srun for this reason.
+- **Don't let ranks re-sync uv concurrently.** Per-rank `uv run` without
+  `--no-sync` re-resolves the project; on a shared checkout the ranks race on
+  `~/.cache/uv` ("Text file busy" → exit 2 kills the job) and add ~30-60 s of
+  stagger per rank. The launch helper uses `uv run --no-sync`.
+- **Per-role vLLM overrides accept nested dicts.** `decode_vllm_overrides` /
+  `prefill_vllm_overrides` are JSON-serialized into the per-rank engine args
+  and applied after the base config (last key wins), so e.g.
+  `decode_vllm_overrides = { gpu_memory_utilization = 0.9, attention_config = { hisparse_config = { host_pool_gib = 256 } } }`
+  works as-is.
+- **HiSparse + llm-d routing**: `non_cached_tokens` works at any positive
+  value (128 = prod default; short-suffix turns then run decode-local via the
+  row-split mixed-batch path, validated under an hour of adversarial traffic).
+  Never set it to 0 — that disables P/D splitting entirely (EPP pd-decider
+  semantics).

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -28,6 +28,22 @@ def vllm_overrides_fragment(overrides: dict[str, Any]) -> str:
     return ", " + json.dumps(overrides)[1:-1].replace('"', '\\"')
 
 
+def role_kv_overrides_for(config):
+    """Per-role ``kv_transfer_config`` override when the KV offload is scoped by role.
+
+    Roles outside ``kv_cache_offload.roles`` get a kv_transfer_config without the
+    offload connector (overriding the unscoped one from ``to_vllm()``).
+    """
+
+    def overrides(role: str) -> dict[str, Any]:
+        offload = config.kv_cache_offload
+        if offload is None or role in offload.roles:
+            return {}
+        return {"kv_transfer_config": config.build_kv_transfer_config(role=role)}
+
+    return overrides
+
+
 def write_config(config: InferenceConfig, output_dir: Path, exclude: set[str] | None = None) -> Path:
     """Write resolved config to disk."""
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -49,9 +65,11 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
 
     is_disaggregated = config.deployment.type == "disaggregated"
     dp_per_node = config.deployment.gpus_per_node // config.parallel.tp
+    role_kv_overrides = role_kv_overrides_for(config)
 
     offload = config.kv_cache_offload
     is_mooncake = offload is not None and offload.type == "mooncake"
+    offload_roles = list(offload.roles) if offload is not None else []
 
     template_vars = dict(
         **config.slurm.template_vars,
@@ -67,6 +85,12 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
         kv_offload_cpu_bytes=int(offload.cpu.num_bytes) if is_mooncake else 0,
         kv_offload_disk_path=str(offload.disk.path) if (is_mooncake and offload.disk is not None) else "",
         kv_offload_device_name=offload.device_name if is_mooncake else "",
+        kv_offload_roles=" ".join(offload_roles),
+        kv_offload_head_index=(
+            config.deployment.num_prefill_nodes
+            if (is_mooncake and is_disaggregated and "prefill" not in offload_roles)
+            else 0
+        ),
         inference_env_vars={**DEFAULT_COMMON_ENV_VARS, **DEFAULT_INFERENCE_ENV_VARS, **config.env_vars},
     )
 
@@ -87,8 +111,12 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
             use_deep_gemm=config.use_deep_gemm,
             prefill_env_vars=config.deployment.prefill_env_vars,
             decode_env_vars=config.deployment.decode_env_vars,
-            prefill_vllm_extra_json=vllm_overrides_fragment(config.deployment.prefill_vllm_overrides),
-            decode_vllm_extra_json=vllm_overrides_fragment(config.deployment.decode_vllm_overrides),
+            prefill_vllm_extra_json=vllm_overrides_fragment(
+                {**role_kv_overrides("prefill"), **config.deployment.prefill_vllm_overrides}
+            ),
+            decode_vllm_extra_json=vllm_overrides_fragment(
+                {**role_kv_overrides("decode"), **config.deployment.decode_vllm_overrides}
+            ),
         )
     elif is_multi_node:
         template_vars.update(

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -15,7 +15,7 @@ import tomli_w
 from prime_rl.configs.algorithm import FrozenModelConfig
 from prime_rl.configs.inference import VllmRouterConfig
 from prime_rl.configs.rl import RLConfig
-from prime_rl.entrypoints.inference import vllm_overrides_fragment
+from prime_rl.entrypoints.inference import role_kv_overrides_for, vllm_overrides_fragment
 from prime_rl.utils.config import cli, to_toml_dict
 from prime_rl.utils.logger import get_logger, setup_logger
 from prime_rl.utils.pathing import (
@@ -364,12 +364,20 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
 
     offload = config.inference.kv_cache_offload if config.inference is not None else None
     is_mooncake = offload is not None and offload.type == "mooncake"
+    offload_roles = list(offload.roles) if offload is not None else []
+    is_disaggregated_inference = config.inference is not None and config.inference.deployment.type == "disaggregated"
     mooncake_vars = dict(
         kv_offload=offload is not None,
         kv_offload_mooncake=is_mooncake,
         kv_offload_cpu_bytes=int(offload.cpu.num_bytes) if is_mooncake else 0,
         kv_offload_disk_path=str(offload.disk.path) if (is_mooncake and offload.disk is not None) else "",
         kv_offload_device_name=offload.device_name if is_mooncake else "",
+        kv_offload_roles=" ".join(offload_roles),
+        kv_offload_head_index=(
+            config.inference.deployment.num_prefill_nodes
+            if (is_mooncake and is_disaggregated_inference and "prefill" not in offload_roles)
+            else 0
+        ),
     )
 
     # Per-component env vars: launcher defaults (shared + multi-node-specific) with the
@@ -396,6 +404,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
         )
     elif config.inference is not None and config.inference.deployment.type == "disaggregated":
         infer_deploy = config.inference.deployment
+        role_kv_overrides = role_kv_overrides_for(config.inference)
 
         script = template.render(
             **config.slurm.template_vars,
@@ -425,8 +434,12 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             trainer_env_vars=trainer_env_vars,
             orchestrator_env_vars=orchestrator_env_vars,
             inference_env_vars=inference_env_vars,
-            prefill_vllm_extra_json=vllm_overrides_fragment(infer_deploy.prefill_vllm_overrides),
-            decode_vllm_extra_json=vllm_overrides_fragment(infer_deploy.decode_vllm_overrides),
+            prefill_vllm_extra_json=vllm_overrides_fragment(
+                {**role_kv_overrides("prefill"), **infer_deploy.prefill_vllm_overrides}
+            ),
+            decode_vllm_extra_json=vllm_overrides_fragment(
+                {**role_kv_overrides("decode"), **infer_deploy.decode_vllm_overrides}
+            ),
             dp_per_node=config.deployment.gpus_per_node // config.inference.parallel.tp,
             **mooncake_vars,
             use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",

--- a/src/prime_rl/templates/_launch_rank.sh.j2
+++ b/src/prime_rl/templates/_launch_rank.sh.j2
@@ -21,7 +21,9 @@ launch_inference_rank() {
     # rank on the node. Node-local /tmp also avoids inheriting an absent submit-node TMPDIR.
     local rpcbase="/tmp/vllm-rpc-$USER-$SLURM_JOB_ID-$port"
     mkdir -p "$rpcbase"
-    local -a cmd=(uv run inference @ "$CONFIG_PATH"
+    # --no-sync: the env was synced once during node setup; per-rank re-syncs
+    # race on the shared uv cache (Text file busy) and stagger rank starts.
+    local -a cmd=(uv run --no-sync inference @ "$CONFIG_PATH"
         --server.host 0.0.0.0 --server.port "$port"
         --parallel.dp "$dp" --data-parallel-size-local 1 --api-server-count 1)
     [ -n "$rpc" ] && cmd+=(--data-parallel-rpc-port "$rpc")

--- a/src/prime_rl/templates/_launch_router.sh.j2
+++ b/src/prime_rl/templates/_launch_router.sh.j2
@@ -52,7 +52,10 @@ LLMD_EOF
         --grpc-port 9002 --grpc-health-port 9013 --metrics-port 9090 \
         --secure-serving=false --metrics-endpoint-auth=false --tracing=false \
         >> "$log" 2>&1 &
-    envoy -c "$LLMD_DIR/envoy.yaml" >> "$log" 2>&1 &
+    # Dynamic base-id: with the default base-id 0, envoy SIGABRTs at startup if
+    # /dev/shm/envoy_shared_memory_0 was left behind by another user on a shared
+    # node (0600 + sticky /dev/shm makes it unremovable by us).
+    envoy -c "$LLMD_DIR/envoy.yaml" --use-dynamic-base-id >> "$log" 2>&1 &
 {%- else %}
     local tag="vllm-router"; [ "$mode" = pd ] && tag="vllm-router (PD)"
     echo "Starting $tag on $LOCAL_IP:$port${replica:+ for replica $replica}" | tee "$log"

--- a/src/prime_rl/templates/_mooncake_store.sh.j2
+++ b/src/prime_rl/templates/_mooncake_store.sh.j2
@@ -6,16 +6,29 @@
     Requires shell vars: LOCAL_IP, INFER_NODE_RANK, OUTPUT_DIR (and SLURM env).
     Requires jinja vars: kv_offload_cpu_bytes, kv_offload_disk_path, kv_offload_device_name.
     Exports PYTHONHASHSEED + MOONCAKE_CONFIG_PATH for the vLLM process. (VLLM_RPC_BASE_PATH,
-    used by the mooncake-store lookup ipc socket, is set per-rank in _launch_rank.sh.j2.) -#}
+    used by the mooncake-store lookup ipc socket, is set per-rank in _launch_rank.sh.j2.)
+
+    Process management: the pip mooncake_client / mooncake_master entrypoints are python
+    shims (mooncake/cli_client.py) that run the native binary as a subprocess child, so the
+    $! captured here is the shim, not the server. Killing that PID orphans a live native
+    server that keeps port 50052 and the abstract IPC socket @mooncake_client_50052.sock,
+    and any relaunched client then dies on the bind collision and takes the job down via
+    wait -n (r11/463). So: never kill the shim by PID, never supervise/retry. setsid gives
+    shim + binary their own process group and the EXIT trap kills the whole group at
+    teardown. The native client never forks or daemonizes (real_client_main.cpp runs a
+    foreground coro_rpc server), so the shim exits iff the client dies: boot failures trip
+    the fail-loud port wait below, post-boot deaths reach the wait -n of the node script. -#}
     # ---- Mooncake distributed store (shared pool across inference nodes) ----
     MC_DIR="$OUTPUT_DIR/mooncake/node_${INFER_NODE_RANK}"
     mkdir -p "$MC_DIR"
     export PYTHONHASHSEED=0
     export MOONCAKE_CONFIG_PATH="$MC_DIR/config.json"
-    # The head inference node (first in the nodelist) hosts the one master + metadata server.
-    MC_HEAD=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -1)
+    # The master + metadata server run on the first inference node whose role is
+    # included in the offload scope (index 0 unless the store is decode-only).
+    MC_HEAD=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | sed -n "{{ (kv_offload_head_index | default(0, true)) + 1 }}p")
     MC_MASTER="$MC_HEAD:50051"
     MC_METADATA="http://$MC_HEAD:8080/metadata"
+    MC_PGIDS=""
 {%- if kv_offload_disk_path %}
     mkdir -p "{{ kv_offload_disk_path }}"
     export MOONCAKE_OFFLOAD_FSDIR="{{ kv_offload_disk_path }}"
@@ -24,18 +37,40 @@
 {%- endif %}
     if [ "$SLURMD_NODENAME" = "$MC_HEAD" ]; then
 {%- if kv_offload_disk_path %}
-        mooncake_master -rpc_port=50051 -enable_http_metadata_server -http_metadata_server_host=0.0.0.0 -http_metadata_server_port=8080 -default_kv_lease_ttl=3600000 -enable_offload=true -root_fs_dir={{ kv_offload_disk_path }} > "$MC_DIR/master.log" 2>&1 &
+        setsid mooncake_master -rpc_port=50051 -enable_http_metadata_server -http_metadata_server_host=0.0.0.0 -http_metadata_server_port=8080 -default_kv_lease_ttl=3600000 -enable_offload=true -root_fs_dir={{ kv_offload_disk_path }} > "$MC_DIR/master.log" 2>&1 &
 {%- else %}
         # default_kv_lease_ttl raised from 5s: KV blocks were expiring before the decode side
         # reused them ("invalid KV blocks ... may have expired"), the real non-NIC config issue.
-        mooncake_master -rpc_port=50051 -enable_http_metadata_server -http_metadata_server_host=0.0.0.0 -http_metadata_server_port=8080 -default_kv_lease_ttl=3600000 > "$MC_DIR/master.log" 2>&1 &
+        setsid mooncake_master -rpc_port=50051 -enable_http_metadata_server -http_metadata_server_host=0.0.0.0 -http_metadata_server_port=8080 -default_kv_lease_ttl=3600000 > "$MC_DIR/master.log" 2>&1 &
 {%- endif %}
+        MC_PGIDS="$MC_PGIDS -$!"
     fi
     # Every node waits for the shared master + metadata, then contributes its segment.
+    # (Remote connect probes; if the master never serves, the client below fails its
+    # mount RPC and exits, which trips the fail-loud check on port 50052.)
     for _ in $(seq 1 120); do timeout 1 bash -c "echo > /dev/tcp/$MC_HEAD/50051" 2>/dev/null && break; sleep 1; done
     for _ in $(seq 1 120); do timeout 1 bash -c "echo > /dev/tcp/$MC_HEAD/8080" 2>/dev/null && break; sleep 1; done
-    mooncake_client -host=$LOCAL_IP -port=50052 -master_server_address=$MC_MASTER -metadata_server=$MC_METADATA -protocol=rdma -global_segment_size={{ kv_offload_cpu_bytes }}{% if kv_offload_device_name %} -device_names={{ kv_offload_device_name }}{% endif %}{% if kv_offload_disk_path %} -enable_offload=true{% endif %} > "$MC_DIR/client.log" 2>&1 &
-    for _ in $(seq 1 60); do timeout 1 bash -c "echo > /dev/tcp/$LOCAL_IP/50052" 2>/dev/null && break; sleep 1; done
+    setsid mooncake_client -host=$LOCAL_IP -port=50052 -master_server_address=$MC_MASTER -metadata_server=$MC_METADATA -protocol=rdma -global_segment_size={{ kv_offload_cpu_bytes }}{% if kv_offload_device_name %} -device_names={{ kv_offload_device_name }}{% endif %}{% if kv_offload_disk_path %} -enable_offload=true{% endif %} > "$MC_DIR/client.log" 2>&1 &
+    MC_CLIENT_PID=$!
+    MC_PGIDS="$MC_PGIDS -$MC_CLIENT_PID"
+    # Group-kill shim + native binary (and the master group on the head node) when the
+    # node script exits: the per-PID TERM loop after wait -n only reaches the shims.
+    trap "kill -9 -- $MC_PGIDS 2>/dev/null" EXIT
+    # Wait until the client actually serves: registering the pinned DRAM segment opens
+    # port 50052 only at the end and takes ~70s per TB (measured on H200), hence the
+    # 600s budget. Probe the kernel listen table (state 0A = LISTEN), not /dev/tcp:
+    # 50052 sits inside ip_local_port_range, so a connect probe can succeed against
+    # itself (TCP self-connect) and misreport a dead client as serving.
+    MC_PORT_HEX=$(printf "%04X" 50052)
+    for _ in $(seq 1 600); do
+        grep " 0A " /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -q ":$MC_PORT_HEX " && break
+        kill -0 $MC_CLIENT_PID 2>/dev/null || break
+        sleep 1
+    done
+    if ! kill -0 $MC_CLIENT_PID 2>/dev/null || ! grep " 0A " /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -q ":$MC_PORT_HEX "; then
+        echo "[mooncake] node ${INFER_NODE_RANK} ($SLURMD_NODENAME) mooncake_client is not serving on port 50052 - see $MC_DIR/client.log" >&2
+        exit 1
+    fi
     cat > "$MOONCAKE_CONFIG_PATH" <<MOONCAKE_JSON
 {"mode":"standalone-store","global_segment_size":0,"local_buffer_size":4294967296,"protocol":"rdma","device_name":"{{ kv_offload_device_name }}","master_server_address":"$MC_MASTER","metadata_server":"$MC_METADATA","enable_offload":{% if kv_offload_disk_path %}true{% else %}false{% endif %}}
 MOONCAKE_JSON

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -70,6 +70,9 @@ source .venv/bin/activate
 srun --ntasks-per-node=1 bash -c 'cd $PROJECT_DIR && { [ -f .env ] && source .env || true; } && uv sync --all-extras --all-packages'
 {% else %}
 # Shared (NFS) venv: one sync on the batch node populates it for all nodes.
+# Per-rank launches use `uv run --no-sync`, so node starts are not staggered
+# by serialized re-syncs on the shared venv (vLLM's DP coordinator handshake
+# has a hard 5-minute deadline).
 uv sync --all-extras --all-packages
 {% endif %}
 
@@ -163,6 +166,12 @@ CLEANUP_SH
 # --kill-on-bad-exit=1 propagates a non-zero exit on any node to all other
 # tasks so a crashed router/engine terminates the SLURM job instead of leaving
 # the surviving ranks holding nodes.
+# Backgrounded with a TERM trap: `scancel --batch --signal=TERM` reaches only
+# this batch shell, and a foreground child would defer the trap until it
+# exits. Forwarding to srun (which propagates the signal to every task) opens
+# the graceful window in which vLLM drains its engines and HiSparse decode
+# ranks unpin their host pools in-process instead of in uninterruptible
+# kernel exit after SIGKILL.
 srun --kill-on-bad-exit=1 bash -c '
     # pipefail ensures `cmd | tee log` propagates `cmd` failures, and the
     # wait/cleanup block at the end of this script surfaces background
@@ -190,7 +199,17 @@ srun --kill-on-bad-exit=1 bash -c '
     ulimit -l unlimited
 {%- endif %}
 {%- if kv_offload_mooncake %}
+{%- if is_disaggregated and kv_offload_roles and kv_offload_roles != "prefill decode" %}
+    # KV offload scoped to role(s): {{ kv_offload_roles }} — other roles skip the
+    # store client (no DRAM segment, no MOONCAKE_CONFIG_PATH; their vLLM config
+    # drops the store connector via the per-role kv_transfer_config override).
+    if [ $((INFER_NODE_RANK % NODES_PER_REPLICA)) -lt $NUM_PREFILL_NODES ]; then _MC_ROLE=prefill; else _MC_ROLE=decode; fi
+    if [[ " {{ kv_offload_roles }} " == *" $_MC_ROLE "* ]]; then
 {% include "_mooncake_store.sh.j2" %}
+    fi
+{%- else %}
+{% include "_mooncake_store.sh.j2" %}
+{%- endif %}
 {%- endif %}
 
 {% if is_disaggregated -%}
@@ -255,7 +274,9 @@ srun --kill-on-bad-exit=1 bash -c '
         ROLE_EXTRA="\"all2all_backend\": \"deepep_high_throughput\"{{ prefill_vllm_extra_json }}"
     else
         # ── Decode node ──
-        export UCX_NET_DEVICES=mlx5_0:1
+        # Decode inherits the auto-detected multi-rail UCX_NET_DEVICES from
+        # above, like prefill. Operators can still pin via decode_env_vars
+        # (exported below, so it overrides).
         ROLE="decode"
         RANK_IN_DECODE=$((RANK_IN_REPLICA - NUM_PREFILL_NODES))
         SUB_REPLICA=$((RANK_IN_DECODE / NODES_PER_DECODE_REPLICA))
@@ -347,12 +368,59 @@ srun --kill-on-bad-exit=1 bash -c '
 # Wait for the first background job to exit and propagate its exit code. This
 # turns background process crashes (router) into task failures that
 # --kill-on-bad-exit=1 can broadcast to the other nodes so the whole job tears
-# down instead of leaving zombies holding the allocation.
+# down instead of leaving zombies holding the allocation. A trapped TERM
+# (plain scancel, or the batch shell forwarding scancel --batch --signal=TERM)
+# interrupts wait -n and lands in the same epilogue; TERMED distinguishes a
+# job-level cancel from a component crash.
+TERMED=0
+trap "TERMED=1; kill -TERM \$(jobs -p) 2>/dev/null || true" TERM
 wait -n
 EXIT_CODE=$?
 echo "[$(hostname)] component exited with code $EXIT_CODE - terminating remaining processes"
-for pid in $(jobs -p); do
-    kill -TERM $pid 2>/dev/null || true
+if [ "$TERMED" = "0" ]; then
+    # A component exiting without a job-level cancel is always a failure —
+    # including exit 0: an engine death makes the vLLM API server exit
+    # cleanly, which would otherwise never trip --kill-on-bad-exit and leave
+    # a silent job-wide wedge. Escalate to a job-level TERM so every node
+    # (including this one) runs the graceful drain instead of being
+    # SIGKILLed mid-unpin by the broadcast. The escalation makes every node
+    # exit 0 (job reads COMPLETED), so leave a crash marker for ops.
+    echo "component exit code $EXIT_CODE at $(date -u +%FT%TZ)" > "$OUTPUT_DIR/logs/CRASH_$(hostname)" 2>/dev/null || true
+    scancel --signal=TERM $SLURM_JOB_ID 2>/dev/null || true
+    for pid in $(jobs -p); do
+        kill -TERM $pid 2>/dev/null || true
+    done
+fi
+# Graceful drain window: vLLM frontends must stop their engines and HiSparse
+# decode ranks unpin multi-hundred-GiB host pools in-process. Exiting now
+# (letting slurmstepd SIGKILL the survivors) pushes that unpin into
+# uninterruptible kernel exit and drains the node ("Kill task failed"). On a
+# plain scancel SLURM caps this wait at KillWait; the two-step cancel
+# (scancel --batch --signal=TERM, wait, scancel) grants the full window.
+for _ in $(seq 1 900); do
+    [ -z "$(jobs -pr)" ] && break
+    sleep 1
 done
+# On a job-level cancel every node exits 0 after draining: prefill nodes (no
+# pinned pool) finish in seconds and a non-zero exit would make
+# --kill-on-bad-exit SIGKILL the decode nodes mid-unpin. Component crashes
+# keep their non-zero code so the broadcast teardown stays fail-loud.
+if [ "$TERMED" = "1" ]; then
+    EXIT_CODE=0
+fi
 exit $EXIT_CODE
-'
+' &
+SRUN_PID=$!
+trap "kill -TERM $SRUN_PID 2>/dev/null || true" TERM
+# `|| SRUN_EXIT=$?` keeps errexit (set -e) from killing the batch script when
+# the trapped TERM interrupts wait with status 143 — that would end the job
+# while the steps are still draining, collapsing the graceful window to
+# SLURM's KillWait.
+SRUN_EXIT=0
+wait $SRUN_PID || SRUN_EXIT=$?
+if [ $SRUN_EXIT -gt 128 ]; then
+    # wait was interrupted by the trapped TERM; wait again for the real code.
+    SRUN_EXIT=0
+    wait $SRUN_PID || SRUN_EXIT=$?
+fi
+exit $SRUN_EXIT

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -231,7 +231,17 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     ulimit -l unlimited
 {%- endif %}
 {%- if kv_offload_mooncake %}
+{%- if is_disaggregated and kv_offload_roles and kv_offload_roles != "prefill decode" %}
+    # KV offload scoped to role(s): {{ kv_offload_roles }} — other roles skip the
+    # store client (no DRAM segment, no MOONCAKE_CONFIG_PATH; their vLLM config
+    # drops the store connector via the per-role kv_transfer_config override).
+    if [ $((INFER_NODE_RANK % NODES_PER_INFER_REPLICA)) -lt $NUM_PREFILL_NODES ]; then _MC_ROLE=prefill; else _MC_ROLE=decode; fi
+    if [[ " {{ kv_offload_roles }} " == *" $_MC_ROLE "* ]]; then
 {% include "_mooncake_store.sh.j2" %}
+    fi
+{%- else %}
+{% include "_mooncake_store.sh.j2" %}
+{%- endif %}
 {%- endif %}
 
     REPLICA_IDX=$((INFER_NODE_RANK / NODES_PER_INFER_REPLICA))
@@ -292,7 +302,12 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
 {% endfor %}
         ROLE_EXTRA="\"all2all_backend\": \"deepep_high_throughput\"{{ prefill_vllm_extra_json }}"
     else
-        export UCX_NET_DEVICES=mlx5_0:1
+        # Decode inherits the auto-detected multi-rail UCX_NET_DEVICES (same
+        # as prefill): pinning every rank onto one HCA (the same device that
+        # leads NVSHMEM_HCA_LIST for DeepEP IBGDA) is the top suspect for
+        # one-node NIC-plane freezes under HiSparse host-pool RDMA. Operators
+        # can still pin via decode_env_vars (exported below). No apostrophes
+        # here: this text lives inside a single-quoted bash -c body.
         ROLE="decode"
         RANK_IN_DECODE=$((RANK_IN_REPLICA - NUM_PREFILL_NODES))
         SUB_REPLICA=$((RANK_IN_DECODE / NODES_PER_DECODE_REPLICA))

--- a/src/prime_rl/utils/process.py
+++ b/src/prime_rl/utils/process.py
@@ -30,6 +30,11 @@ DEFAULT_INFERENCE_ENV_VARS: dict[str, str] = {
     "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:False",
     "VLLM_ENGINE_READY_TIMEOUT_S": "4200",
     "UCX_TLS": "all",
+    # Grace before vLLM SIGKILLs engine/worker procs at shutdown (read by
+    # both the MPClient engine manager and the multiproc executor). The 5s
+    # default truncates HiSparse decode ranks mid host-pool unpin, pushing
+    # the remainder into uninterruptible kernel exit (node drain).
+    "VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS": "600",
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -5109,7 +5109,7 @@ dependencies = [
     { name = "uvloop" },
     { name = "verifiers", extra = ["harbor"] },
     { name = "vllm", version = "0.24.0+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64'" },
-    { name = "vllm", version = "0.24.0+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
+    { name = "vllm", version = "0.24.1.dev0+hisparse.c6f204424.cu129", source = { url = "https://github.com/faresobeid/vllm/releases/download/hisparse-c6f2044/vllm-0.24.1.dev0+hisparse.c6f204424.cu129-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
     { name = "wandb" },
     { name = "wandb-workspaces" },
 ]
@@ -5230,7 +5230,7 @@ requires-dist = [
     { name = "verifiers", extras = ["harbor"], editable = "deps/verifiers" },
     { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'", specifier = ">=0.24.0" },
     { name = "vllm", marker = "platform_machine == 'aarch64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" },
-    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" },
+    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/faresobeid/vllm/releases/download/hisparse-c6f2044/vllm-0.24.1.dev0+hisparse.c6f204424.cu129-cp312-cp312-linux_x86_64.whl" },
     { name = "vllm-router", marker = "platform_machine == 'aarch64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl" },
     { name = "vllm-router", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'disagg'" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl" },
@@ -8039,8 +8039,8 @@ provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttens
 
 [[package]]
 name = "vllm"
-version = "0.24.0+cu129"
-source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" }
+version = "0.24.1.dev0+hisparse.c6f204424.cu129"
+source = { url = "https://github.com/faresobeid/vllm/releases/download/hisparse-c6f2044/vllm-0.24.1.dev0+hisparse.c6f204424.cu129-cp312-cp312-linux_x86_64.whl" }
 resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
@@ -8119,7 +8119,7 @@ dependencies = [
     { name = "xgrammar" },
 ]
 wheels = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:597949743f2a00c0539d9e2ff0f67b32c608a378e973f99e7529fd6fa9445f70" },
+    { url = "https://github.com/faresobeid/vllm/releases/download/hisparse-c6f2044/vllm-0.24.1.dev0+hisparse.c6f204424.cu129-cp312-cp312-linux_x86_64.whl", hash = "sha256:978fc4f95e5b31e5b45b32136c7b8e36bf9f46736da05849d2a11325dd5d25da" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
Enables HiSparse host-resident sparse-MLA decode ([vllm-project/vllm#46326](https://github.com/vllm-project/vllm/pull/46326)) for GLM-5.2 deployments. Three commits:

1. **Wheel pin**: x86_64 vLLM moves to the fork wheel ([hisparse-c6f2044](https://github.com/faresobeid/vllm/releases/tag/hisparse-c6f2044), v0.24.0 release base). aarch64 stays upstream; runtime patches/plugin apply unchanged.
2. **`kv_cache_offload.roles`**: scopes the Mooncake store to a subset of P/D roles. Out-of-scope nodes skip the store client and get a NIXL-only transfer config — decode-node RAM goes to HiSparse pinned pools (`ranks × host_pool_gib`) instead of a store segment.
3. **Graceful teardown + hardening** in the sbatch templates: TERM traps with a bounded drain window (decode ranks unpin multi-hundred-GiB pinned pools in-process; a SIGKILLed unpin runs in uninterruptible kernel context, outlives SLURM's KillWait, and drains the node), `VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS=600`, component-crash escalation (`scancel --signal=TERM` + `CRASH_<host>` marker — an engine death can no longer leave a silently wedged deployment), envoy `--use-dynamic-base-id` (a stale `/dev/shm/envoy_shared_memory_0` from another user's crashed run SIGABRTs the default base-id; reproduced and fix-validated on a poisoned node), orphan-proof mooncake store launcher, per-rank `uv run --no-sync`, decode on auto-detected multi-rail `UCX_NET_DEVICES`.

## Why

A GLM-5.2 wide-EP decode rank has O(10 GiB) of GPU KV after weights and sparse-stack workspaces — a handful of long-context requests per engine. HiSparse keeps the full sparse-MLA KV in pinned host memory and serves decode from per-request GPU hot buffers of the indexer top-k.

## Measured (GLM-5.2-FP8, this branch's wheel)

**16-node stack** (8 prefill + 8 decode DP64, llm-d, NIXL, mooncake), A/B vs plain GPU-KV decode — identical topology, traffic, and 50-min saturated window:

| decode side | GPU-KV | HiSparse |
|---|---|---|
| generation throughput | 10,653 tok/s | **12,951 tok/s** (+22%) |
| requests completed | 84,026 | **101,653** (+21%) |
| preemptions | 5,174 | **0** |
| TTFT p99 | 99.9 s | **2.5 s** |
| KV usage peak — GPU KV vs host pool | 100.0% (pinned) | **57.5%** |

Pushed to seat saturation (c=6500): **26,056 decode tok/s sustained**, 99% peak seat occupancy, zero preemptions — 3.3× the c=1000 operating point; the binding constraint is `max_num_seqs`, not memory.

**Agentic RL workload** (r2e-gym through the router, c=1000, 4P+2D): baseline pinned at 99.9% KV with 1,533 preemptions, **5 of 155** rollouts solved; HiSparse: zero preemptions, **585 solved**, +124% steady-state decode throughput.

## Deployment notes

- Enable via decode overrides: `attention_config = { hisparse_config = { host_pool_gib = <N> } }` per rank; budget node RAM for `ranks × pool` (+ any co-tenants — hence `roles = ["prefill"]` on the store).
- **Cap decode `max_num_seqs`** (e.g. 96): hot buffers are eager (~370 MB/request across GLM-5.2's 78 sparse layers) and the seat count is the admission control — size it to sustained decode compute at your context lengths, or rely on orchestrator inflight caps.
- Decode `gpu_memory_utilization` can go to 0.9 (the GPU KV budget mostly idles under HiSparse).
- Cancel HiSparse jobs with the two-step TERM-then-scancel flow (documented in the monitor-run skill) so pools unpin in-process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
