### PR TITLE
feat(sft): pass local data_files through to load_dataset

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -176,6 +176,7 @@ Multi-GPU and multi-node use torchrun under the hood (the `sft` entrypoint manag
 | Knob | What it controls |
 |---|---|
 | `data.name` | HF dataset name or local path |
+| `data.data_files` | Local data files passed to `load_dataset` (use with a loader-style `data.name` such as `"json"`); supports globs and compressed files |
 | `data.batch_size` | Tokens per trainer step (packed) |
 | `data.seq_len` | Per-sample sequence length |
 | `loss_mask.*` | Which roles contribute to loss (system / user / assistant / tool). |

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -84,6 +84,10 @@ class SFTDataConfig(BaseDataConfig):
     name: str = "PrimeIntellect/Reverse-Text-SFT"
     """HF dataset name or path."""
 
+    data_files: list[str] | None = None
+    """Local data files passed through to ``load_dataset``. Requires a loader-style
+    ``name`` (e.g. ``"json"``). Supports glob patterns and compressed files natively."""
+
     subsets: list[str] | None = None
     """Subsets to load from the HF dataset."""
 
@@ -108,6 +112,8 @@ class SFTDataConfig(BaseDataConfig):
 
     @model_validator(mode="after")
     def validate_subsets_and_splits(self):
+        if self.data_files is not None and (self.subsets is not None or self.splits is not None):
+            raise ValueError("data_files cannot be combined with subsets/splits")
         if self.subsets is not None or self.splits is not None:
             if self.subsets is not None and self.splits is not None:
                 if len(self.subsets) != len(self.splits):

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -505,12 +505,13 @@ def setup_and_interleave_datasets(
     probabilities: list[float] | None,
     stopping_strategy: Literal["first_exhausted", "all_exhausted"],
     seed: int = 0,
+    data_files: list[str] | None = None,
 ) -> Dataset:
     logger = get_logger()
     datasets = []
     for subset, split in subsets_and_splits:
-        logger.debug(f"Loading dataset {dataset_name} with {subset=} and {split=}")
-        dataset = cast(Dataset, load_dataset(dataset_name, subset, split=split))
+        logger.debug(f"Loading dataset {dataset_name} with {subset=}, {split=}, {data_files=}")
+        dataset = cast(Dataset, load_dataset(dataset_name, subset, split=split, data_files=data_files))
         num_examples = len(dataset)
         dataset = dataset.add_column("__subset", [subset] * num_examples, new_fingerprint=str(uuid.uuid4()))
         dataset = dataset.add_column("__split", [split] * num_examples, new_fingerprint=str(uuid.uuid4()))
@@ -539,6 +540,7 @@ def load_sft_dataset(config: SFTDataConfig) -> Dataset:
             subsets_and_splits=[(None, "train")],
             probabilities=config.probabilities,
             stopping_strategy=config.stopping_strategy,
+            data_files=config.data_files,
         )
     elif config.subsets is not None and config.splits is None:
         logger.debug(f"Loading datasets for subsets {config.subsets} with default split 'train'")
@@ -547,6 +549,7 @@ def load_sft_dataset(config: SFTDataConfig) -> Dataset:
             subsets_and_splits=[(subset, "train") for subset in config.subsets],
             probabilities=config.probabilities,
             stopping_strategy=config.stopping_strategy,
+            data_files=config.data_files,
         )
     elif config.subsets is None and config.splits is not None:
         logger.debug(f"Loading datasets for splits {config.splits} with default subset 'None'")
@@ -555,6 +558,7 @@ def load_sft_dataset(config: SFTDataConfig) -> Dataset:
             subsets_and_splits=[(None, split) for split in config.splits],
             probabilities=config.probabilities,
             stopping_strategy=config.stopping_strategy,
+            data_files=config.data_files,
         )
     else:
         assert config.subsets is not None and config.splits is not None
@@ -564,6 +568,7 @@ def load_sft_dataset(config: SFTDataConfig) -> Dataset:
             subsets_and_splits=list(zip(config.subsets, config.splits)),
             probabilities=config.probabilities,
             stopping_strategy=config.stopping_strategy,
+            data_files=config.data_files,
         )
 
 


### PR DESCRIPTION
## Summary

Stacked on #2968. Replaces the custom local-file ingestion from #2942 with a plain passthrough: `data.data_files` is forwarded verbatim to HF `load_dataset` alongside a loader-style `data.name` (e.g. `"json"`).

- **`data.data_files`** (`list[str] | None`): local files handed straight to `load_dataset(name, data_files=...)`. HF expands globs and decompresses compressed files natively, so none of #2942's normalization machinery (`_normalize_oai_record` / `_normalize_jsonl` / `_resolve_local_data_files` — zstd subprocess decompression, per-node temp caching, distributed barriers) is needed.
- `data_files` cannot be combined with `subsets`/`splits` (config validator).
- Datasets with heterogeneous `tool_calls`/`tools` shapes should pre-stringify those columns; the existing `deserialize_tool_calls` read path already reverses that.

Usage:

```toml
[data]
name = "json"
data_files = ["path/to/*.jsonl"]
```

## Tests

- All 18 tests in `tests/unit/train/sft/test_sft_dataset.py` pass.
- Smoke-tested `load_sft_dataset` end-to-end with a local JSONL file, a glob pattern, and the `subsets`/`splits` validator rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow data-loading change with config validation; no auth, security, or training-algorithm impact.
> 
> **Overview**
> Adds **`data.data_files`** on SFT so local JSON/JSONL (and similar) can be loaded via HuggingFace **`load_dataset`** with a loader-style **`data.name`** (e.g. `"json"`), instead of custom local-file ingestion. Paths support globs and HF’s native compressed-file handling.
> 
> **`setup_and_interleave_datasets`** / **`load_sft_dataset`** forward **`data_files`** into **`load_dataset(..., data_files=...)`** on every load path. Config validation rejects combining **`data_files`** with **`subsets`** or **`splits`**. Training docs list the new knob and example usage (`name = "json"`, `data_files = ["path/to/*.jsonl"]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb24181c8fb1b4b22f0f600da42a0f8a106f1d09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->