### PR TITLE
refactor: share trace_to_sample with verifiers in the prime monitor

### DIFF
--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -16,6 +16,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from prime_cli.core.config import Config as PrimeConfig
 from transformers.tokenization_utils import PreTrainedTokenizer
+from verifiers.v1.samples import trace_to_sample
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.configs.shared import PrimeMonitorConfig
@@ -325,35 +326,28 @@ class PrimeMonitor(Monitor):
         )
 
     def _rollouts_to_parquet_bytes(self, rollouts: list[Rollout], step: int) -> bytes | None:
-        """Convert rollouts to Parquet bytes for upload. One row per rollout, built from the
-        message graph: the conversation is the unit (no prompt/completion split — meaningless in
-        a multi-turn branch), so `completion` carries the main (last) branch's full message list
-        and `trajectory` carries one message list per branch (`trace.branches`)."""
+        """Convert rollouts to Parquet bytes for upload. One row per rollout. The conversation
+        is the unit (no prompt/completion split — meaningless mid-branch): `completion` is the
+        last branch's messages and `trajectory` is one message list per branch. Shares
+        `verifiers.v1.samples.trace_to_sample` with verifiers' eval `--push`, so a training-run
+        sample and an eval sample land on the platform identically; the RFT-only columns
+        (run/step/advantage/problem_id/env_name) are layered on here."""
         now = datetime.now(timezone.utc)
         rows = []
 
         for sample_id, rollout in enumerate(rollouts):
-            branches = rollout.branches
-            if not branches:
+            sample = trace_to_sample(rollout, rollout_number=sample_id + 1)
+            trajectory = sample["trajectory"]
+            if not trajectory:  # no branches (e.g. a rollout that errored before any message)
                 continue
-            main_messages = [m.model_dump(mode="json") for m in branches[-1].messages]
+            advantage = rollout.scalar_advantage()
+            trajectory = [{**branch, "advantage": advantage} for branch in trajectory]
 
-            task_idx = rollout.task.idx
+            example_id = sample["example_id"]
             try:
-                problem_id = int(task_idx) if task_idx is not None else sample_id
+                problem_id = int(example_id) if example_id is not None else sample_id
             except (TypeError, ValueError):
                 problem_id = sample_id
-
-            trajectory_data = [
-                {
-                    "messages": [m.model_dump(mode="json") for m in branch.messages],
-                    "reward": rollout.reward,
-                    "advantage": rollout.scalar_advantage(),
-                    "num_input_tokens": branch.num_input_tokens,
-                    "num_output_tokens": branch.num_output_tokens,
-                }
-                for branch in branches
-            ]
 
             rows.append(
                 {
@@ -363,18 +357,18 @@ class PrimeMonitor(Monitor):
                     "problem_id": problem_id,
                     "sample_id": sample_id,
                     "prompt": "",
-                    "completion": json.dumps(main_messages),
-                    "trajectory": json.dumps(trajectory_data),
+                    "completion": json.dumps(sample["completion"]),
+                    "trajectory": json.dumps(trajectory),
                     "answer": "",
                     "env_name": rollout.env_name,
-                    "task": rollout.task.model_dump_json(),
+                    "task": json.dumps(sample["task"]),
                     "info": json.dumps(rollout.info),
-                    "reward": rollout.reward,
-                    "advantage": rollout.scalar_advantage(),
-                    "metrics": json.dumps(rollout.metrics),
-                    "timing": rollout.timing.model_dump_json(),
-                    "num_input_tokens": branches[-1].num_input_tokens,
-                    "num_output_tokens": branches[-1].num_output_tokens,
+                    "reward": sample["reward"],
+                    "advantage": advantage,
+                    "metrics": json.dumps(sample["metrics"]),
+                    "timing": json.dumps(sample["timing"]),
+                    "num_input_tokens": trajectory[-1]["num_input_tokens"],
+                    "num_output_tokens": trajectory[-1]["num_output_tokens"],
                     "created_at": now,
                 }
             )

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -16,7 +16,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from prime_cli.core.config import Config as PrimeConfig
 from transformers.tokenization_utils import PreTrainedTokenizer
-from verifiers.v1.samples import trace_to_sample
+from verifiers.v1.push import trace_to_sample
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.configs.shared import PrimeMonitorConfig
@@ -329,7 +329,7 @@ class PrimeMonitor(Monitor):
         """Convert rollouts to Parquet bytes for upload. One row per rollout. The conversation
         is the unit (no prompt/completion split — meaningless mid-branch): `completion` is the
         last branch's messages and `trajectory` is one message list per branch. Shares
-        `verifiers.v1.samples.trace_to_sample` with verifiers' eval `--push`, so a training-run
+        `verifiers.v1.push.trace_to_sample` with verifiers' eval `--push`, so a training-run
         sample and an eval sample land on the platform identically; the RFT-only columns
         (run/step/advantage/problem_id/env_name) are layered on here."""
         now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary

- Replace the prime monitor's hand-rolled v1-trace → sample conversion in `_rollouts_to_parquet_bytes` with `verifiers.v1.push.trace_to_sample` — the single canonical "old format" converter, now shared with verifiers' eval `uv run eval --push`.
- Both producers (a training-run sample push here, and an eval `--push` / `prime eval push` in verifiers) now emit one identically-shaped sample record, so the platform renders them consistently and the conversion logic can't drift between the two repos.
- The RFT-only parquet columns (`run_id`/`step`/`advantage`/`problem_id`/`env_name`) are layered on here; the shared function owns the conversation/branch/trajectory extraction.
- Bumps the `deps/verifiers` submodule to the companion verifiers PR that adds `trace_to_sample`.

## Behavior

Behavior-preserving: the `_SAMPLE_SCHEMA` and every column value are unchanged. The existing `tests/unit/utils/test_prime_monitor.py` asserts (problem_id/sample_id/completion/trajectory) still hold; I verified the refactored mapping produces identical `num_input_tokens`/`num_output_tokens` (still `branches[-1]`) and completion/trajectory content against those cases. The only nuance: messages now serialize with `exclude_none=True` (drops null fields like `tool_calls: null`) — smaller strings, same content.

## Companion PR

Companion to the verifiers PR that introduced `verifiers.v1.push.trace_to_sample` (merged):
PrimeIntellect-ai/verifiers#1947

The `deps/verifiers` submodule is pinned to that PR's squash-merge commit on verifiers `main` (`9c6b155e`). Validated end-to-end with a 20-step `reverse_text` RL run on this branch (reward 0.78 at step 20, 0 errors).



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of monitor upload serialization with intended behavior parity; tests cover key columns; only minor JSON null-field omission differs.
> 
> **Overview**
> **Prime monitor sample uploads** now build each parquet row from `verifiers.v1.push.trace_to_sample` instead of inline branch/message serialization, aligning training-run pushes with verifiers eval `--push`.
> 
> `_rollouts_to_parquet_bytes` still owns `_SAMPLE_SCHEMA` and RFT-only fields (`run_id`, `step`, `advantage`, `problem_id`, `env_name`, etc.). It maps `example_id` → `problem_id`, injects **advantage** on every trajectory branch, and reads token counts from the last branch. Empty trajectories are still skipped.
> 
> `completion`, `task`, `reward`, `metrics`, and `timing` come from the shared sample dict (JSON-encoded where before). Message JSON may omit null fields via `exclude_none=True` in verifiers—slightly smaller payloads, same semantics per PR notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 130bd1dd838f81d4d5ac737bbfbb7e1f19ae2219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->