### PR TITLE
fix(orchestrator): train shared sampled nodes exactly once across branches

### DIFF
--- a/src/prime_rl/orchestrator/algo/echo.py
+++ b/src/prime_rl/orchestrator/algo/echo.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable
 
 from prime_rl.configs.algorithm import EchoAlgoConfig
 from prime_rl.orchestrator.algo.grpo import GRPOAlgorithm
+from prime_rl.orchestrator.trajectories import iter_trainable_branches
 from prime_rl.utils.utils import import_object
 
 if TYPE_CHECKING:
@@ -55,7 +56,9 @@ class EchoAlgorithm(GRPOAlgorithm):
         (role tags, separators, tool-response wraps) is excluded. Nodes without
         attribution (the default renderer, or relay turns with no token ids)
         fall back to weighting the whole non-sampled span."""
-        trainable_branches = [branch for branch in rollout.branches if any(branch.sampled_mask)]
+        # Same branch selection as ``trace_to_samples``, so the zip with ``rollout.samples``
+        # stays aligned when fork dedup drops a branch.
+        trainable_branches = [branch for branch, _ in iter_trainable_branches(rollout)]
         filter_masks = self._filter_masks(rollout, trainable_branches) if self.filter_fn is not None else None
         for sample_idx, (sample, branch) in enumerate(zip(rollout.samples, trainable_branches)):
             weights = [0.0] * len(sample.token_ids)

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -82,8 +82,18 @@ def trace_to_samples(
     yield nothing.
     """
     samples: list[TrainingSample] = []
+    trained_nodes: set[int] = set()
     for branch in trace.branches:
-        mask = branch.sampled_mask
+        # A sampled node shared by several branches (a mid-trajectory fork) is trainable only
+        # in the first branch containing it; later branches carry its tokens as context.
+        mask: list[bool] = []
+        for node in branch.nodes:
+            if node.sampled and any(node.mask) and id(node) in trained_nodes:
+                mask.extend([False] * len(node.mask))
+            else:
+                if node.sampled and any(node.mask):
+                    trained_nodes.add(id(node))
+                mask.extend(node.mask)
         if not any(mask):
             continue
         token_ids = branch.token_ids

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -15,6 +15,8 @@ the images it introduced (`branch.multi_modal_data`), rebuilt here into the flat
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import numpy as np
 import verifiers.v1 as vf
 
@@ -64,6 +66,29 @@ def _encode_routed_experts(arr: np.ndarray | None, num_tokens: int) -> RoutedExp
     return RoutedExperts(data=arr.tobytes(), shape=list(arr.shape), dtype=str(arr.dtype))
 
 
+def iter_trainable_branches(trace: vf.Trace) -> Iterator[tuple[vf.Branch, list[bool]]]:
+    """Yield each branch that yields a training sample, with its trainable-token mask.
+
+    The mask is `branch.sampled_mask` except that a sampled node shared by several branches
+    (a mid-trajectory fork) is trainable only in the first branch containing it; later
+    branches carry its tokens as context (mask False). Branches left with no trainable
+    tokens are skipped, so consumers pairing branches with `trace_to_samples` output
+    (e.g. echo's observation weighting) must filter through here to stay aligned.
+    """
+    trained_nodes: set[int] = set()
+    for branch in trace.branches:
+        mask: list[bool] = []
+        for node in branch.nodes:
+            if node.sampled and any(node.mask) and id(node) in trained_nodes:
+                mask.extend([False] * len(node.mask))
+            else:
+                if node.sampled and any(node.mask):
+                    trained_nodes.add(id(node))
+                mask.extend(node.mask)
+        if any(mask):
+            yield branch, mask
+
+
 def trace_to_samples(
     trace: vf.Trace,
     *,
@@ -82,20 +107,7 @@ def trace_to_samples(
     yield nothing.
     """
     samples: list[TrainingSample] = []
-    trained_nodes: set[int] = set()
-    for branch in trace.branches:
-        # A sampled node shared by several branches (a mid-trajectory fork) is trainable only
-        # in the first branch containing it; later branches carry its tokens as context.
-        mask: list[bool] = []
-        for node in branch.nodes:
-            if node.sampled and any(node.mask) and id(node) in trained_nodes:
-                mask.extend([False] * len(node.mask))
-            else:
-                if node.sampled and any(node.mask):
-                    trained_nodes.add(id(node))
-                mask.extend(node.mask)
-        if not any(mask):
-            continue
+    for branch, mask in iter_trainable_branches(trace):
         token_ids = branch.token_ids
         mm_kwargs: dict[str, EncodedTensor] | None = None
         mm_token_type_ids: list[int] | None = None


### PR DESCRIPTION
## Bug

`trace_to_samples` builds one training sample per `trace.branches` entry, using `branch.sampled_mask` as the trainable-token mask. Branches are root→leaf *paths* over the trace's message graph, so a node shared by several branches appears in several samples. For **input** nodes that's correct — they are context (mask `False`) everywhere. But for **sampled** nodes it means a completion token lying on N branches is mask-`True` in N samples. The trainer normalizes the loss by global token counts and has no cross-sample dedup, so those tokens get **N× the gradient weight**; advantages are stamped per sample, so the same completion contributes N advantage-weighted policy-gradient terms.

Today this is mostly latent: in-tree harnesses produce branches that share only input nodes (linear rollouts; compaction rebuilds the prompt as `[system, user(summary)]`). The one existing path that can trigger it is a renderer-level token-drift fork (`graph._commit_turn`'s token-identity tightening), which forks *at* the divergence — the shared prefix's sampled nodes then land in both branches' samples. Any future harness with genuine mid-trajectory forks (subagents off a shared sampled prefix, tree-search / best-of-n on one trace) makes it acute: k forks off a leaf give the shared completion tokens ~k× weight.

## Fix

A sampled node is trainable exactly once across the trace. Walk branches in their stable order (`trace.branches` follows node-creation order); the first branch containing a sampled node keeps that node's mask, every later branch carries its tokens as pure context (mask `False`).

- No behavior change for traces whose branches share only input nodes — the computed mask equals `branch.sampled_mask` exactly (existing `trace_to_samples` coverage passes unchanged).
- Every sampled token still receives gradient exactly once, in the branch where it first appears; later branches still *see* the shared completion as context, so their own tokens train against the correct conditioning.
- `id(node)` is a safe dedup key: branches are views over the same `trace.nodes` list, so a shared node is the same object in every branch.

Fixing elsewhere was considered and rejected: `Branch.sampled_mask`'s per-branch semantics ("was this token model-sampled?") are correct and other consumers (`num_output_tokens`) rely on them; the trainer is too late (samples are packed/split across micro batches, node identity is gone). The sample builder is the single point that flattens the graph, so it owns the invariant.

## Verification

- `tests/unit/orchestrator/test_advantage.py` + `test_algorithms.py` (35 tests exercising `trace_to_samples`) pass unchanged.
- Manual repro: a trace with two branches forking off a shared sampled node yields the shared tokens mask-`True` in exactly one of the two samples, with each branch's own tail still trainable; a linear trace's mask equals `branch.sampled_mask` exactly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how trainable masks are built for all RL samples; incorrect logic would skew gradients, but behavior is unchanged for typical linear rollouts and only affects forked traces.
> 
> **Overview**
> Fixes **double-counting of model-sampled tokens** when multiple trace branches share the same completion node (mid-trajectory forks). Previously each branch used `branch.sampled_mask` independently, so shared sampled tokens could be mask-`True` in every sample and receive multiplied policy-gradient weight.
> 
> Introduces **`iter_trainable_branches`**, which walks branches in order and marks a shared sampled node trainable only in the **first** branch that contains it; later branches keep those tokens as context (mask `False`). Branches with no trainable tokens are skipped. **`trace_to_samples`** now builds samples from this helper instead of raw per-branch masks.
> 
> **Echo** observation weighting switches to the same branch list so its zip with `rollout.samples` stays aligned when dedup drops empty branches. Linear traces where branches only share input nodes are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8200ae0274d897d0faadab493f7c4585280b14fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->