### PR TITLE
feat: PRL_* env-var config overrides

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,16 +18,18 @@ Every `prime-rl` entrypoint uses [`pydantic-config`](https://github.com/PrimeInt
   - [None](#none)
   - [Discriminated Unions](#discriminated-unions)
   - [Environments](#environments-orchestratortrainenv)
+  - [PRL Environment Variable Overrides](#prl-environment-variable-overrides)
   - [Environment Variables](#environment-variables)
 - [Examples](#examples)
 
 ## Sources and Precedence
 
-Field values come from three sources — Pydantic defaults, TOML files (passed with `@`), and CLI flags. They're layered in this order, with later sources winning:
+Field values come from four sources — Pydantic defaults, `PRL_*` environment variables, TOML files (passed with `@`), and CLI flags. They're layered in this order, with later sources winning:
 
 1. **Defaults** declared on the Pydantic model.
-2. **TOML files** passed with `@`, left to right — later files override earlier ones.
-3. **CLI flags** in dotted, kebab-case form (`--model.name`).
+2. **`PRL_*` environment variables** — see [PRL Environment Variable Overrides](#prl-environment-variable-overrides).
+3. **TOML files** passed with `@`, left to right — later files override earlier ones.
+4. **CLI flags** in dotted, kebab-case form (`--model.name`).
 
 ## TOML Composition
 
@@ -168,6 +170,21 @@ args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }
 `args` is forwarded verbatim to the environment's `load_environment(**args)`.
 
 The same `id` can appear multiple times across train and eval (or with different `args`) — useful for evaluating on a held-out split of the env you're training on, or comparing two configurations of the same env side by side. When `id` is reused, set a distinct `name` on each entry; `name` defaults to `id` and must be unique across all envs in the same group.
+
+### PRL Environment Variable Overrides
+
+Every config field can be set from the environment under the `PRL_` prefix. Nesting levels are joined with a **double underscore** (field names keep their own single underscores):
+
+```bash
+export PRL_MAX_STEPS=50                      # --max-steps 50
+export PRL_TRAINER__OPTIM__LR=1e-5           # --trainer.optim.lr 1e-5
+export PRL_WANDB=None                        # disable an optional sub-config (true enables with defaults)
+export PRL_CHECKPOINT_STEPS='[100,200]'      # list/dict fields take a JSON literal
+```
+
+Env vars sit below TOML and CLI in [precedence](#sources-and-precedence) — they set defaults, and any TOML or CLI value for the same field wins. Only variables matching a real config field are read; unrelated `PRL_*` variables are ignored. A value that fails validation is reported against the variable name (`PRL_TRAINER__OPTIM__LR (from env)`).
+
+> Not to be confused with [`[env_vars]`](#environment-variables) below, which *exports* OS environment variables into launched processes; `PRL_*` variables are *read* by the entrypoint to fill config fields.
 
 ### Environment Variables
 

--- a/packages/prime-rl-configs/src/prime_rl/utils/config.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/config.py
@@ -1,8 +1,16 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 from pydantic_config import BaseConfig as BaseConfig  # noqa: F401
-from pydantic_config import cli  # noqa: F401
+from pydantic_config import cli as _cli
+
+T = TypeVar("T", bound=BaseConfig)
+
+
+def cli(cls: type[T], **kwargs: Any) -> T:
+    """`pydantic_config.cli` with `PRL_*` env-var overrides enabled (see docs/configuration.md)."""
+    kwargs.setdefault("env_prefix", "PRL")
+    return _cli(cls, **kwargs)
 
 
 def find_package_resource(subdir: str) -> Path | None:

--- a/packages/prime-rl-configs/src/prime_rl/utils/config.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/config.py
@@ -1,16 +1,8 @@
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any
 
 from pydantic_config import BaseConfig as BaseConfig  # noqa: F401
-from pydantic_config import cli as _cli
-
-T = TypeVar("T", bound=BaseConfig)
-
-
-def cli(cls: type[T], **kwargs: Any) -> T:
-    """`pydantic_config.cli` with `PRL_*` env-var overrides enabled (see docs/configuration.md)."""
-    kwargs.setdefault("env_prefix", "PRL")
-    return _cli(cls, **kwargs)
+from pydantic_config import cli  # noqa: F401
 
 
 def find_package_resource(subdir: str) -> Path | None:

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -17,9 +17,11 @@ uv run rl --model @ model.toml --data @ data.toml                          # nes
 uv run rl @ base.toml --trainer @ trainer.toml --trainer.lr 1e-3           # mixed
 ```
 
-Resolution order: CLI > config files (left-to-right) > class defaults. Merging is deep — unset fields in an overlay are preserved from the base.
+Resolution order: CLI > config files (left-to-right) > `PRL_*` env vars > class defaults. Merging is deep — unset fields in an overlay are preserved from the base.
 
 Naming: CLI uses kebab-case (`--model.max-model-len`); TOML uses snake_case (`max_model_len`).
+
+Env var overrides: any field is settable as `PRL_<PATH>` with nesting levels joined by a double underscore — `PRL_TRAINER__OPTIM__LR=1e-5` ≙ `--trainer.optim.lr 1e-5`. TOML/CLI values for the same field win; unrelated `PRL_*` vars are ignored; list/dict fields take JSON literals; `PRL_WANDB=None` disables an optional sub-config. (Distinct from `[env_vars]` TOML tables, which export OS env vars into launched processes.)
 
 ## Inspect & validate
 

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -176,7 +176,7 @@ def inference(config: InferenceConfig):
 
 def main():
     set_proc_title("Inference")
-    inference(cli(InferenceConfig))
+    inference(cli(InferenceConfig, env_prefix="PRL"))
 
 
 if __name__ == "__main__":

--- a/src/prime_rl/entrypoints/orchestrator.py
+++ b/src/prime_rl/entrypoints/orchestrator.py
@@ -18,7 +18,7 @@ from prime_rl.utils.process import set_proc_title
 
 def main():
     set_proc_title("Orchestrator")
-    config = cli(OrchestratorConfig)
+    config = cli(OrchestratorConfig, env_prefix="PRL")
     from prime_rl.orchestrator.orchestrator import run_orchestrator
 
     asyncio.run(run_orchestrator(config))

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -567,7 +567,7 @@ def rl(config: RLConfig):
 
 def main():
     set_proc_title("Launcher")
-    rl(cli(RLConfig))
+    rl(cli(RLConfig, env_prefix="PRL"))
 
 
 if __name__ == "__main__":

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -225,7 +225,7 @@ def sft(config: SFTConfig):
 
 def main():
     set_proc_title("SFT")
-    sft(cli(SFTConfig))
+    sft(cli(SFTConfig, env_prefix="PRL"))
 
 
 if __name__ == "__main__":

--- a/src/prime_rl/entrypoints/trainer.py
+++ b/src/prime_rl/entrypoints/trainer.py
@@ -16,7 +16,7 @@ from prime_rl.utils.process import set_proc_title
 
 def main():
     set_proc_title("Trainer")
-    config = cli(TrainerConfig)
+    config = cli(TrainerConfig, env_prefix="PRL")
     from prime_rl.trainer.rl.train import train
 
     train(config)

--- a/src/prime_rl/orchestrator/env_server/env_server.py
+++ b/src/prime_rl/orchestrator/env_server/env_server.py
@@ -35,7 +35,7 @@ def run_server(config: EnvServerConfig):
 def main():
     """Main entry-point for env-server. Run using `uv run env-server`"""
     set_proc_title("EnvServer")
-    run_server(cli(EnvServerConfig))
+    run_server(cli(EnvServerConfig, env_prefix="PRL"))
 
 
 if __name__ == "__main__":

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -888,7 +888,7 @@ def main() -> None:
     import uvloop
 
     uvloop.install()
-    asyncio.run(run_orchestrator(cli(OrchestratorConfig)))
+    asyncio.run(run_orchestrator(cli(OrchestratorConfig, env_prefix="PRL")))
 
 
 if __name__ == "__main__":

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -785,7 +785,7 @@ def train(config: TrainerConfig):
 def main():
     """Main entry-point for RL trainer. Run using `uv run trainer`"""
     set_proc_title("Trainer")
-    train(cli(TrainerConfig))
+    train(cli(TrainerConfig, env_prefix="PRL"))
 
 
 if __name__ == "__main__":

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -630,7 +630,7 @@ def train(config: SFTConfig):
 
 def main():
     set_proc_title("SFTTrainer")
-    train(cli(SFTConfig))
+    train(cli(SFTConfig, env_prefix="PRL"))
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,11 @@ def setup_logging():
 def setup_env():
     """Auto-fixture to reset environment variables between tests"""
     original_env = dict(os.environ)
+    # Strip config-override vars from the outer shell so they can't leak into
+    # config parsing; tests set their own via monkeypatch.
+    for key in list(os.environ):
+        if key.startswith("PRL_"):
+            del os.environ[key]
     yield
     os.environ.clear()
     os.environ.update(original_env)

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -162,6 +162,31 @@ def test_cli_overrides_toml(tmp_path):
     assert config.nested.weight_decay == 0.01
 
 
+def test_env_var_overrides_defaults(monkeypatch):
+    """PRL_* env vars override defaults (nesting levels join with a double underscore)."""
+    monkeypatch.setenv("PRL_SEED", "7")
+    monkeypatch.setenv("PRL_NESTED__LR", "3e-4")
+    config = cli(DummyConfig, args=[])
+    assert config.seed == 7
+    assert config.nested.lr == 3e-4
+    assert config.nested.weight_decay == 0.01
+
+
+def test_toml_overrides_env_var(tmp_path, monkeypatch):
+    """TOML overrides PRL_* env vars."""
+    monkeypatch.setenv("PRL_SEED", "7")
+    write_toml(tmp_path / "cfg.toml", {"seed": 1})
+    config = cli(DummyConfig, args=["@", str(tmp_path / "cfg.toml")])
+    assert config.seed == 1
+
+
+def test_cli_overrides_env_var(monkeypatch):
+    """CLI args override PRL_* env vars."""
+    monkeypatch.setenv("PRL_SEED", "7")
+    config = cli(DummyConfig, args=["--seed", "99"])
+    assert config.seed == 99
+
+
 def test_removed_fused_lm_head_chunk_size_field_is_rejected():
     with pytest.raises(ValidationError, match="fused_lm_head_chunk_size"):
         TrainerModelConfig.model_validate({"fused_lm_head_chunk_size": "auto"})

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -166,7 +166,7 @@ def test_env_var_overrides_defaults(monkeypatch):
     """PRL_* env vars override defaults (nesting levels join with a double underscore)."""
     monkeypatch.setenv("PRL_SEED", "7")
     monkeypatch.setenv("PRL_NESTED__LR", "3e-4")
-    config = cli(DummyConfig, args=[])
+    config = cli(DummyConfig, args=[], env_prefix="PRL")
     assert config.seed == 7
     assert config.nested.lr == 3e-4
     assert config.nested.weight_decay == 0.01
@@ -176,14 +176,14 @@ def test_toml_overrides_env_var(tmp_path, monkeypatch):
     """TOML overrides PRL_* env vars."""
     monkeypatch.setenv("PRL_SEED", "7")
     write_toml(tmp_path / "cfg.toml", {"seed": 1})
-    config = cli(DummyConfig, args=["@", str(tmp_path / "cfg.toml")])
+    config = cli(DummyConfig, args=["@", str(tmp_path / "cfg.toml")], env_prefix="PRL")
     assert config.seed == 1
 
 
 def test_cli_overrides_env_var(monkeypatch):
     """CLI args override PRL_* env vars."""
     monkeypatch.setenv("PRL_SEED", "7")
-    config = cli(DummyConfig, args=["--seed", "99"])
+    config = cli(DummyConfig, args=["--seed", "99"], env_prefix="PRL")
     assert config.seed == 99
 
 


### PR DESCRIPTION
## Summary

- Enables `PRL_*` environment-variable config overrides across all entrypoints: any config field is settable as `PRL_<PATH>`, with nesting levels joined by a double underscore — `PRL_TRAINER__OPTIM__LR=1e-5` ≙ `--trainer.optim.lr 1e-5`.
- Precedence: **CLI > TOML > `PRL_*` env var > class default**. Only variables matching a real config field are read; unrelated `PRL_*` vars are ignored. Bad values are reported against the variable name (`PRL_TRAINER__OPTIM__LR (from env)`).
- Implemented by bumping `deps/pydantic-config` to the new `env_prefix` feature (PrimeIntellect-ai/pydantic-config#17) and passing `env_prefix="PRL"` explicitly at each of the 9 entrypoint `cli(...)` call sites.
- Docs: new "PRL Environment Variable Overrides" section in `docs/configuration.md` (disambiguated from the existing `[env_vars]` section, which *exports* vars into launched processes) + `skills/configs/SKILL.md` resolution order.
- Tests: env-applies / TOML-wins / CLI-wins cases in `tests/unit/test_configs.py`; the autouse `setup_env` fixture now strips stray `PRL_*` shell exports so they can't leak into config-parsing tests.

Depends on PrimeIntellect-ai/pydantic-config#17 — the submodule currently points at the feature branch head; re-bump to the merge commit once it lands.

## Verification

- `uv run pytest tests/unit/test_configs.py` — 40 passed (the 15 `test_load_configs` failures are pre-existing on this box: missing optional env packages, identical on `main`).
- E2E dry-run on the real entrypoint: `PRL_TRAINER__OPTIM__WEIGHT_DECAY=0.456 uv run rl @ examples/reverse_text/rl.toml --dry-run` → resolved `trainer.toml` has `weight_decay = 0.456`; with the TOML setting `lr = 3e-6`, `PRL_TRAINER__OPTIM__LR=9e-9` correctly loses to TOML, and `--trainer.optim.lr 3e-3` beats both; `PRL_TRAINER__MODEL__COMPILE=true` enables the optional compile sub-config with defaults.

## Related PRs

- Feature: https://github.com/PrimeIntellect-ai/pydantic-config/pull/17
- verifiers `VF` integration: https://github.com/PrimeIntellect-ai/verifiers/pull/1954

🤖 Generated with [Claude Code](https://claude.com/claude-code)

