### PR TITLE
fix: preserve explicit None config overrides across config write/re-parse

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/utils/config.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/config.py
@@ -1,8 +1,43 @@
 from pathlib import Path
 from typing import Any
 
+from pydantic import BaseModel
 from pydantic_config import BaseConfig as BaseConfig  # noqa: F401
 from pydantic_config import cli  # noqa: F401
+
+
+def to_toml_dict(config: BaseModel, exclude: set[str] | None = None) -> dict:
+    """Dump a config to a TOML-serializable dict.
+
+    TOML cannot represent null, so None fields left at their default are dropped
+    (they re-resolve identically on re-parse) while explicitly-set None fields
+    are encoded as the string ``"None"``, which ``BaseConfig`` converts back to
+    ``None``. Dropping those too would silently revert explicit None overrides
+    (e.g. ``--trainer.model.compile None``) to their non-None defaults when the
+    written config is re-parsed.
+    """
+    return _encode_model(config, config.model_dump(exclude=exclude, mode="json"))
+
+
+def _encode_model(model: BaseModel, dumped: dict) -> dict:
+    encoded = {}
+    for name, value in dumped.items():
+        if value is None:
+            if name in model.model_fields_set:
+                encoded[name] = "None"
+            continue
+        encoded[name] = _encode_value(getattr(model, name), value)
+    return encoded
+
+
+def _encode_value(attr: Any, value: Any) -> Any:
+    if isinstance(attr, BaseModel) and isinstance(value, dict):
+        return _encode_model(attr, value)
+    if isinstance(value, list) and isinstance(attr, (list, tuple)):
+        return [_encode_value(a, v) for a, v in zip(attr, value)]
+    if isinstance(value, dict) and isinstance(attr, dict):
+        return {k: _encode_value(a, v) for (k, v), a in zip(value.items(), attr.values())}
+    return "None" if value is None else value
 
 
 def find_package_resource(subdir: str) -> Path | None:

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -8,7 +8,7 @@ from typing import Any
 import tomli_w
 
 from prime_rl.configs.inference import InferenceConfig
-from prime_rl.utils.config import cli
+from prime_rl.utils.config import cli, to_toml_dict
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir
 from prime_rl.utils.process import DEFAULT_COMMON_ENV_VARS, DEFAULT_INFERENCE_ENV_VARS, set_proc_title
@@ -33,7 +33,7 @@ def write_config(config: InferenceConfig, output_dir: Path, exclude: set[str] | 
     output_dir.mkdir(parents=True, exist_ok=True)
     config_path = output_dir / INFERENCE_TOML
     with open(config_path, "wb") as f:
-        tomli_w.dump(config.model_dump(exclude=exclude, exclude_none=True, mode="json"), f)
+        tomli_w.dump(to_toml_dict(config, exclude=exclude), f)
     return config_path
 
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -16,7 +16,7 @@ from prime_rl.configs.algorithm import FrozenModelConfig
 from prime_rl.configs.inference import VllmRouterConfig
 from prime_rl.configs.rl import RLConfig
 from prime_rl.entrypoints.inference import vllm_overrides_fragment
-from prime_rl.utils.config import cli
+from prime_rl.utils.config import cli, to_toml_dict
 from prime_rl.utils.logger import get_logger, setup_logger
 from prime_rl.utils.pathing import (
     clean_future_steps,
@@ -56,9 +56,8 @@ def get_physical_gpu_ids() -> list[int]:
 def write_config(config: RLConfig, output_dir: Path, exclude: set[str] | None = None) -> None:
     """Write resolved config to disk, excluding launcher-only fields."""
     output_dir.mkdir(parents=True, exist_ok=True)
-    config_dict = config.model_dump(exclude=exclude, exclude_none=True, mode="json")
     with open(output_dir / RL_TOML, "wb") as f:
-        tomli_w.dump(config_dict, f)
+        tomli_w.dump(to_toml_dict(config, exclude=exclude), f)
 
 
 def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
@@ -66,16 +65,16 @@ def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     with open(output_dir / TRAINER_TOML, "wb") as f:
-        tomli_w.dump(config.trainer.model_dump(exclude_none=True, mode="json"), f)
+        tomli_w.dump(to_toml_dict(config.trainer), f)
 
     with open(output_dir / ORCHESTRATOR_TOML, "wb") as f:
-        tomli_w.dump(config.orchestrator.model_dump(exclude_none=True, mode="json"), f)
+        tomli_w.dump(to_toml_dict(config.orchestrator), f)
 
     if config.inference is not None:
         # Exclude launcher-only fields that are not needed by the vLLM server
         exclude_inference = {"deployment", "slurm", "output_dir", "dry_run"}
         with open(output_dir / INFERENCE_TOML, "wb") as f:
-            tomli_w.dump(config.inference.model_dump(exclude=exclude_inference, exclude_none=True, mode="json"), f)
+            tomli_w.dump(to_toml_dict(config.inference, exclude=exclude_inference), f)
 
 
 def rl_local(config: RLConfig):

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -9,7 +9,7 @@ from threading import Event, Thread
 import tomli_w
 
 from prime_rl.configs.sft import SFTConfig
-from prime_rl.utils.config import cli
+from prime_rl.utils.config import cli, to_toml_dict
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir, validate_output_dir
 from prime_rl.utils.process import (
@@ -28,9 +28,8 @@ SFT_SBATCH = "sft.sbatch"
 def write_config(config: SFTConfig, config_path: Path, exclude: set[str] | None = None) -> None:
     """Write resolved config to disk, excluding launcher-only fields."""
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_dict = config.model_dump(exclude=exclude, exclude_none=True, mode="json")
     with open(config_path, "wb") as f:
-        tomli_w.dump(config_dict, f)
+        tomli_w.dump(to_toml_dict(config, exclude=exclude), f)
 
 
 def write_slurm_script(config: SFTConfig, config_path: Path, script_path: Path) -> None:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -72,6 +72,7 @@ from prime_rl.trainer.model import setup_tokenizer
 from prime_rl.transport import TrainingBatch, setup_training_batch_sender
 from prime_rl.utils.async_utils import EventLoopLagMonitor, EventLoopLagStats, safe_cancel
 from prime_rl.utils.client import init_nccl_broadcast
+from prime_rl.utils.config import to_toml_dict
 from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.logger import format_time, get_logger, setup_logger
 from prime_rl.utils.monitor import setup_monitor
@@ -195,7 +196,7 @@ class Orchestrator:
         config_dir = config.output_dir / "control"
         config_dir.mkdir(parents=True, exist_ok=True)
         with open(config_dir / "orch.toml", "wb") as f:
-            tomli_w.dump(config.model_dump(exclude_none=True, mode="json"), f)
+            tomli_w.dump(to_toml_dict(config), f)
 
         get_logger().info(f"Initializing tokenizer ({config.tokenizer})")
         self.tokenizer = setup_tokenizer(config.tokenizer)

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -13,7 +13,7 @@ from prime_rl.configs.rl import RLConfig
 from prime_rl.configs.sft import SFTConfig
 from prime_rl.configs.trainer import ModelConfig as TrainerModelConfig
 from prime_rl.configs.trainer import TrainerConfig
-from prime_rl.utils.config import BaseConfig, cli
+from prime_rl.utils.config import BaseConfig, cli, to_toml_dict
 
 # All config config classes
 CONFIG_CLASSES = [
@@ -165,6 +165,22 @@ def test_cli_overrides_toml(tmp_path):
 def test_removed_fused_lm_head_chunk_size_field_is_rejected():
     with pytest.raises(ValidationError, match="fused_lm_head_chunk_size"):
         TrainerModelConfig.model_validate({"fused_lm_head_chunk_size": "auto"})
+
+
+def test_to_toml_dict_roundtrips_explicit_none(tmp_path):
+    """An explicit None override survives the write/re-parse round-trip used by SLURM launches."""
+    config = cli(TrainerConfig, args=["--model.compile", "None", "--optim.max_norm", "None"])
+    assert config.model.compile is None
+    assert config.optim.max_norm is None
+
+    write_toml(tmp_path / "cfg.toml", to_toml_dict(config))
+    reloaded = cli(TrainerConfig, args=["@", str(tmp_path / "cfg.toml")])
+    assert reloaded.model.compile is None
+    assert reloaded.optim.max_norm is None
+    assert reloaded == config
+
+    # Unset None fields stay dropped, so defaults still resolve on re-parse
+    assert "max_steps" not in to_toml_dict(cli(TrainerConfig, args=[]))
 
 
 def test_env_algo_overrides_top_level():


### PR DESCRIPTION
## Summary

- Explicit `None` overrides (e.g. `--trainer.model.compile None`) were silently ignored on SLURM launches: the launcher writes the resolved config to TOML with `model_dump(exclude_none=True)`, so the field was dropped and reverted to its non-None default when the sbatch job re-parsed the file. Any Optional field with a non-None default was affected (`trainer.model.compile`, `trainer.model.ac`, `trainer.optim.max_norm`, `trainer.gc`, `inference.model.reasoning_parser`, ...).
- Added `to_toml_dict()` (in `prime_rl.utils.config`, next to `BaseConfig`): unset `None` fields are still dropped (they re-resolve identically on re-parse), but explicitly-set `None` fields are encoded as the string `"None"` — the config system's existing TOML convention for null, converted back to `None` by `BaseConfig` on load.
- Switched all config dump sites to it: `rl` (`rl.toml` + multi-node subconfigs), `sft`, standalone `inference`, and the orchestrator's `control/orch.toml` (re-parsed by the trainer's multi-run manager).
- Serializing *all* `None` fields as `"None"` would instead trip `RLConfig`'s shared-vs-subconfig conflict validator (shared defaults like `log.level = None` disagree with sub-config defaults like `"info"`), hence the `model_fields_set` distinction.
- Added a round-trip regression test.

## Verification

Repro before the fix:

```
uv run rl @ configs/gsm8k/rl.toml --slurm --dry-run --trainer.model.compile None --output-dir <tmp>
```

- Before: written `rl.toml` has no `compile` key; re-parsing it (as the sbatch job does) yields `trainer.model.compile = CompileConfig(fullgraph=False)` — the override is lost.
- After: written `rl.toml` contains `compile = "None"` and re-parses to `None`. Both SLURM paths (single-node `rl.toml` and multi-node trainer/orchestrator/inference subconfigs) now round-trip the resolved config exactly (`reloaded == config`).
- `tests/unit` passes (the 4 `test_load_configs` env-config failures pre-exist on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all persisted run configs are serialized; incorrect encoding could affect SLURM/multi-node launches, but behavior is narrow (explicit None only) and covered by a round-trip test.
> 
> **Overview**
> Fixes SLURM and local launches losing CLI/TOML **explicit `None`** overrides (e.g. `--trainer.model.compile None`) when the launcher writes resolved config to disk and jobs re-parse it.
> 
> Adds **`to_toml_dict()`** in `prime_rl.utils.config`: unset `None` defaults are still omitted from TOML, but fields in **`model_fields_set`** with value `None` are written as **`"None"`** so `BaseConfig` can restore them on load—replacing **`model_dump(..., exclude_none=True)`** everywhere configs are persisted.
> 
> **RL**, **SFT**, **inference**, and orchestrator **`control/orch.toml`** writers now use this helper; a unit test asserts write → re-parse round-trip equality for explicit `None` fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182614803e023440354f4bd09737b94b6e297483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->