### PR TITLE
feat: save all rollouts, not just the effective ones

### DIFF
--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -133,8 +133,8 @@ curl -s http://localhost:8000/metrics | grep -E "num_requests|gpu_cache_usage"
 ### Traces
 
 ```
-{output_dir}/traces/{train,eval}/all/traces.jsonl           # flat stream, appended per rollout
-{output_dir}/traces/{train,eval}/effective/step_N/traces.jsonl   # written per finalized batch / eval epoch
+{output_dir}/traces/step_N/{train,eval}/all/traces.jsonl        # appended per rollout as it completes
+{output_dir}/traces/step_N/{train,eval}/effective/traces.jsonl  # written per finalized batch / eval epoch
 ```
 
 JSONL files of `vf.Trace` records (training tensors excluded). `all` gets every completed
@@ -145,9 +145,9 @@ the non-errored epoch cohort; multiple eval envs share the step file). Each reco
 provisioned resource id, e.g. the sandbox id).
 
 ```bash
-wc -l {output_dir}/traces/train/all/traces.jsonl
-jq '.rewards' {output_dir}/traces/train/effective/step_42/traces.jsonl
-jq 'select(.errors != []) | {id, env_name, runtime}' {output_dir}/traces/train/all/traces.jsonl
+wc -l {output_dir}/traces/step_42/train/{all,effective}/traces.jsonl
+jq '.rewards' {output_dir}/traces/step_42/train/effective/traces.jsonl
+jq 'select(.errors != []) | {id, env_name, runtime}' {output_dir}/traces/step_*/train/all/traces.jsonl
 ```
 
 The binary batches consumed by the trainer still live at `{output_dir}/rollouts/step_N/train_rollouts.bin`.

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -58,7 +58,7 @@ After a restart, verify all processes are back up and progress resumed before th
 - `scripts/tmux.sh` launches the run with a `Launcher` window in the named tmux session. The Claude window receives the output dir and session name in its appended prompt — if either is missing, **ask** rather than guess.
 - `{output_dir}/configs/` — resolved TOMLs (`rl.toml` has the full picture).
 - `{output_dir}/logs/` — see below.
-- `{output_dir}/traces/` — saved rollout traces (see Traces below).
+- `{output_dir}/rollouts/{train,eval}/` — saved rollout traces (see Traces below).
 
 ### Logs
 
@@ -133,8 +133,8 @@ curl -s http://localhost:8000/metrics | grep -E "num_requests|gpu_cache_usage"
 ### Traces
 
 ```
-{output_dir}/traces/step_N/{train,eval}/all/traces.jsonl        # appended per rollout as it completes
-{output_dir}/traces/step_N/{train,eval}/effective/traces.jsonl  # written per finalized batch / eval epoch
+{output_dir}/rollouts/{train,eval}/step_N/all/traces.jsonl        # appended per rollout as it completes
+{output_dir}/rollouts/{train,eval}/step_N/effective/traces.jsonl  # written per finalized batch / eval epoch
 ```
 
 JSONL files of `vf.Trace` records (training tensors excluded). `all` gets every completed
@@ -145,9 +145,9 @@ the non-errored epoch cohort; multiple eval envs share the step file). Each reco
 provisioned resource id, e.g. the sandbox id).
 
 ```bash
-wc -l {output_dir}/traces/step_42/train/{all,effective}/traces.jsonl
-jq '.rewards' {output_dir}/traces/step_42/train/effective/traces.jsonl
-jq 'select(.errors != []) | {id, env_name, runtime}' {output_dir}/traces/step_*/train/all/traces.jsonl
+wc -l {output_dir}/rollouts/train/step_42/{all,effective}/traces.jsonl
+jq '.rewards' {output_dir}/rollouts/train/step_42/effective/traces.jsonl
+jq 'select(.errors != []) | {id, env_name, runtime}' {output_dir}/rollouts/train/step_*/all/traces.jsonl
 ```
 
 The binary batches consumed by the trainer still live at `{output_dir}/rollouts/step_N/train_rollouts.bin`.

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -58,7 +58,7 @@ After a restart, verify all processes are back up and progress resumed before th
 - `scripts/tmux.sh` launches the run with a `Launcher` window in the named tmux session. The Claude window receives the output dir and session name in its appended prompt — if either is missing, **ask** rather than guess.
 - `{output_dir}/configs/` — resolved TOMLs (`rl.toml` has the full picture).
 - `{output_dir}/logs/` — see below.
-- `{output_dir}/rollouts/{train,eval}/` — saved rollout traces (see Traces below).
+- `{output_dir}/rollouts/step_N/{train,eval}/` — saved rollout traces (see Traces below).
 
 ### Logs
 
@@ -133,8 +133,8 @@ curl -s http://localhost:8000/metrics | grep -E "num_requests|gpu_cache_usage"
 ### Traces
 
 ```
-{output_dir}/rollouts/{train,eval}/step_N/all/traces.jsonl        # appended per rollout as it completes
-{output_dir}/rollouts/{train,eval}/step_N/effective/traces.jsonl  # written per finalized batch / eval epoch
+{output_dir}/rollouts/step_N/{train,eval}/all/traces.jsonl        # appended per rollout as it completes
+{output_dir}/rollouts/step_N/{train,eval}/effective/traces.jsonl  # written per finalized batch / eval epoch
 ```
 
 JSONL files of `vf.Trace` records (training tensors excluded). `all` gets every completed
@@ -145,12 +145,12 @@ the non-errored epoch cohort; multiple eval envs share the step file). Each reco
 provisioned resource id, e.g. the sandbox id).
 
 ```bash
-wc -l {output_dir}/rollouts/train/step_42/{all,effective}/traces.jsonl
-jq '.rewards' {output_dir}/rollouts/train/step_42/effective/traces.jsonl
-jq 'select(.errors != []) | {id, env_name, runtime}' {output_dir}/rollouts/train/step_*/all/traces.jsonl
+wc -l {output_dir}/rollouts/step_42/train/{all,effective}/traces.jsonl
+jq '.rewards' {output_dir}/rollouts/step_42/train/effective/traces.jsonl
+jq 'select(.errors != []) | {id, env_name, runtime}' {output_dir}/rollouts/step_*/train/all/traces.jsonl
 ```
 
-The binary batches consumed by the trainer still live at `{output_dir}/rollouts/step_N/train_rollouts.bin`.
+The binary batches consumed by the trainer still live at `{output_dir}/rollouts/step_N/train_rollouts.bin`, next to the trace subtrees.
 
 ### Common failure modes
 

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -58,7 +58,7 @@ After a restart, verify all processes are back up and progress resumed before th
 - `scripts/tmux.sh` launches the run with a `Launcher` window in the named tmux session. The Claude window receives the output dir and session name in its appended prompt — if either is missing, **ask** rather than guess.
 - `{output_dir}/configs/` — resolved TOMLs (`rl.toml` has the full picture).
 - `{output_dir}/logs/` — see below.
-- `{output_dir}/rollouts/step_N/` — saved rollouts.
+- `{output_dir}/traces/` — saved rollout traces (see Traces below).
 
 ### Logs
 
@@ -130,20 +130,27 @@ curl -s http://localhost:8000/metrics | grep -E "num_requests|gpu_cache_usage"
 # vllm:num_requests_running, vllm:num_requests_waiting, vllm:gpu_cache_usage_perc (→1.0 = KV cache saturated)
 ```
 
-### Rollouts
+### Traces
 
 ```
-{output_dir}/rollouts/step_N/
-├── train_rollouts.jsonl   # all train rollouts (vf.RolloutOutput, trajectory excluded)
-├── eval_rollouts.jsonl    # only present when eval ran
-└── train_rollouts.bin     # binary batch consumed by the trainer
+{output_dir}/traces/{train,eval}/all/traces.jsonl           # flat stream, appended per rollout
+{output_dir}/traces/{train,eval}/effective/step_N/traces.jsonl   # written per finalized batch / eval epoch
 ```
+
+JSONL files of `vf.Trace` records (training tensors excluded). `all` gets every completed
+rollout the moment it arrives — errored, filtered, and never-batched ones included — so it's
+crash-durable; `effective` gets the clean subset that went into the step's train batch (eval:
+the non-errored epoch cohort; multiple eval envs share the step file). Each record carries
+`kind`, `env_name`, `group_id`, `policy_version`, and `eval_step`, plus `runtime` (config +
+provisioned resource id, e.g. the sandbox id).
 
 ```bash
-wc -l {output_dir}/rollouts/step_42/train_rollouts.jsonl
-head -1 {output_dir}/rollouts/step_42/train_rollouts.jsonl | python -m json.tool
-jq '.reward' {output_dir}/rollouts/step_42/train_rollouts.jsonl
+wc -l {output_dir}/traces/train/all/traces.jsonl
+jq '.rewards' {output_dir}/traces/train/effective/step_42/traces.jsonl
+jq 'select(.errors != []) | {id, env_name, runtime}' {output_dir}/traces/train/all/traces.jsonl
 ```
+
+The binary batches consumed by the trainer still live at `{output_dir}/rollouts/step_N/train_rollouts.bin`.
 
 ### Common failure modes
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -466,11 +466,15 @@ class Orchestrator:
                 continue
 
             # Every completed rollout — errored, filtered, or never batched — lands in the
-            # ``all`` trace stream the moment it arrives, so it survives crashes and drains.
+            # ``all`` trace file the moment it arrives, so it survives crashes and drains.
+            # Train rollouts belong to the batch window currently collecting (``progress.step``),
+            # eval rollouts to the step whose eval triggered them.
+            step = rollout.eval_step if rollout.kind == "eval" else self.progress.step
+            assert step is not None
             await asyncio.to_thread(
                 save_rollouts,
                 [rollout.to_record()],
-                get_trace_path(self.config.output_dir, rollout.kind, "all"),
+                get_trace_path(self.config.output_dir, step, rollout.kind, "all"),
             )
 
             if rollout.kind == "eval":
@@ -538,7 +542,7 @@ class Orchestrator:
         # record, and can't round-trip json (raw numpy bytes).
         effective = batch.rollouts.effective
         records = [r.to_record() for r in effective]
-        await asyncio.to_thread(save_rollouts, records, get_trace_path(config.output_dir, "train", "effective", step))
+        await asyncio.to_thread(save_rollouts, records, get_trace_path(config.output_dir, step, "train", "effective"))
 
         await self.sender.send(TrainingBatch(examples=batch.samples, step=step))
         self.progress.step += 1
@@ -754,7 +758,7 @@ class Orchestrator:
         # streamed into ``all`` on arrival.
         records = [r.to_record() for r in batch.rollouts.effective]
         await asyncio.to_thread(
-            save_rollouts, records, get_trace_path(self.config.output_dir, "eval", "effective", batch.step)
+            save_rollouts, records, get_trace_path(self.config.output_dir, batch.step, "eval", "effective")
         )
         self.monitor.log_eval_samples(batch.rollouts, env_name=batch.env_name, step=batch.step)
         policy_versions = {r.policy_version for r in batch.rollouts}

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -75,7 +75,7 @@ from prime_rl.utils.client import init_nccl_broadcast
 from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.logger import format_time, get_logger, setup_logger
 from prime_rl.utils.monitor import setup_monitor
-from prime_rl.utils.pathing import get_log_dir, get_rollout_dir, get_step_path
+from prime_rl.utils.pathing import get_log_dir, get_trace_path
 from prime_rl.utils.usage_reporter import UsageReporter
 from prime_rl.utils.utils import (
     clean_exit,
@@ -465,6 +465,14 @@ class Orchestrator:
             except asyncio.TimeoutError:
                 continue
 
+            # Every completed rollout — errored, filtered, or never batched — lands in the
+            # ``all`` trace stream the moment it arrives, so it survives crashes and drains.
+            await asyncio.to_thread(
+                save_rollouts,
+                [rollout.to_record()],
+                get_trace_path(self.config.output_dir, rollout.kind, "all"),
+            )
+
             if rollout.kind == "eval":
                 assert self.eval_sink is not None  # eval rollouts only emitted when eval is configured
                 eval_batch = self.eval_sink.add(rollout)
@@ -524,12 +532,13 @@ class Orchestrator:
                 f"({n_trainable / len(batch.rollouts):.1%}) — consider reviewing task difficulty / filter config"
             )
 
-        # Serialize the typed Trace at the I/O boundary (disk + wandb sample tables); to_record
-        # drops the per-node training tensors — they're for training, not the rollout record, and
-        # can't round-trip json (raw numpy bytes).
-        rollout_dicts = [r.to_record() for r in batch.rollouts]
-        step_path = get_step_path(get_rollout_dir(config.output_dir), step)
-        await asyncio.to_thread(save_rollouts, rollout_dicts, step_path / "train_rollouts.jsonl")
+        # The effective (clean, trained-on) subset lands in the per-step ``effective`` trace file
+        # at ship time; the full arrival window already streamed into ``all`` on arrival.
+        # to_record drops the per-node training tensors — they're for training, not the rollout
+        # record, and can't round-trip json (raw numpy bytes).
+        effective = batch.rollouts.effective
+        records = [r.to_record() for r in effective]
+        await asyncio.to_thread(save_rollouts, records, get_trace_path(config.output_dir, "train", "effective", step))
 
         await self.sender.send(TrainingBatch(examples=batch.samples, step=step))
         self.progress.step += 1
@@ -540,7 +549,6 @@ class Orchestrator:
 
         # Rollout metrics over the {agg,<env>} × {all,effective} matrix. ``batch.rollouts`` is the
         # full arrival window (errored + filtered included); ``.effective`` is the clean subset.
-        effective = batch.rollouts.effective
         metrics: dict[str, float] = {}
         for subset, pool in (("all", batch.rollouts), ("effective", effective)):
             metrics |= pool.metrics.to_wandb(prefix="train/agg", subset=subset)
@@ -740,12 +748,13 @@ class Orchestrator:
             get_logger().warning(f"Eval @ step={batch.step} env={batch.env_name}: no rollouts returned, skipping log")
             return
 
-        rollout_dicts = [r.to_record() for r in batch.rollouts]
-        step_path = get_step_path(get_rollout_dir(self.config.output_dir), batch.step)
+        # The non-errored subset lands in the per-step ``effective`` trace file on epoch
+        # completion (multiple eval envs share the step file — each epoch appends its cohort
+        # once, and every record carries ``env_name``); the full returned cohort already
+        # streamed into ``all`` on arrival.
+        records = [r.to_record() for r in batch.rollouts.effective]
         await asyncio.to_thread(
-            save_rollouts,
-            rollout_dicts,
-            step_path / f"eval_rollouts_{batch.env_name}.jsonl",
+            save_rollouts, records, get_trace_path(self.config.output_dir, "eval", "effective", batch.step)
         )
         self.monitor.log_eval_samples(batch.rollouts, env_name=batch.env_name, step=batch.step)
         policy_versions = {r.policy_version for r in batch.rollouts}

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -73,8 +73,8 @@ class Rollout(vf.Trace[TaskT], Generic[TaskT]):
     """A completed rollout: the env's typed ``vf.Trace`` *is* the rollout — prime-rl's
     orchestration metadata lives on it directly (set by the dispatcher once the rollout
     returns), so there's no wrapper. Train vs eval is the ``kind`` discriminator. All metadata
-    fields are ``exclude=True``, so dumping a Rollout yields a plain trace — the on-disk
-    ``results.jsonl`` is unchanged.
+    fields are ``exclude=True``, so dumping a Rollout yields a plain trace on the wire;
+    :meth:`to_record` adds the small metadata fields back for the on-disk trace files.
 
     It is also the single currency the scoring hooks receive: a hook reads the trace
     directly (``rollout.reward``, ``rollout.nodes``, ``rollout.num_turns``) and writes
@@ -97,6 +97,19 @@ class Rollout(vf.Trace[TaskT], Generic[TaskT]):
     is_filtered: bool = Field(default=False, exclude=True)
     filter_results: dict[str, bool] = Field(default_factory=dict, exclude=True)
     eval_step: int | None = Field(default=None, exclude=True)
+
+    def to_record(self) -> dict:
+        """The plain trace record plus the orchestration metadata (excluded from the pydantic
+        dump) needed to place a record without relying on its file path — the flat ``all``
+        streams span every step and env. ``eval_step`` is the eval trigger step (None for train
+        rollouts, whose batch step isn't known until their batch finalizes)."""
+        return super().to_record() | {
+            "kind": self.kind,
+            "env_name": self.env_name,
+            "group_id": str(self.group_id),
+            "policy_version": self.policy_version,
+            "eval_step": self.eval_step,
+        }
 
     def assign_advantages(self, values: float | list[float]) -> None:
         """Write the rl advantage stream: a scalar broadcast over the

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -100,9 +100,9 @@ class Rollout(vf.Trace[TaskT], Generic[TaskT]):
 
     def to_record(self) -> dict:
         """The plain trace record plus the orchestration metadata (excluded from the pydantic
-        dump) needed to place a record without relying on its file path — the flat ``all``
-        streams span every step and env. ``eval_step`` is the eval trigger step (None for train
-        rollouts, whose batch step isn't known until their batch finalizes)."""
+        dump), so a record stays fully placeable — kind, env, policy — even when trace files
+        are merged or read away from their paths. ``eval_step`` is the eval trigger step (None
+        for train rollouts)."""
         return super().to_record() | {
             "kind": self.kind,
             "env_name": self.env_name,

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -51,10 +51,12 @@ async def setup_policy_inference_pool(*, config: OrchestratorConfig, tokenizer):
 
 
 def save_rollouts(rollouts: list[dict], path: Path) -> None:
-    """Save rollouts (Trace dicts, already JSON-serializable) to a JSONL file."""
+    """Append rollouts (Trace record dicts, already JSON-serializable) to a JSONL file.
+    The trace streams are append-only: ``all`` grows one rollout at a time as they
+    complete, ``effective`` one batch at a time on finalize."""
     path.parent.mkdir(parents=True, exist_ok=True)
     opts = orjson.OPT_APPEND_NEWLINE | orjson.OPT_SERIALIZE_NUMPY
-    with open(path, "wb") as f:
+    with open(path, "ab") as f:
         for rollout in rollouts:
             f.write(orjson.dumps(rollout, default=str, option=opts))
 

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -74,10 +74,10 @@ def get_rollout_dir(output_dir: Path) -> Path:
 
 
 def get_trace_path(output_dir: Path, step: int, kind: str, subset: str) -> Path:
-    """Where one trace file lives: ``rollouts/{train,eval}/step_{n}/{all,effective}/traces.jsonl``.
+    """Where one trace file lives: ``rollouts/step_{n}/{train,eval}/{all,effective}/traces.jsonl``.
     ``all`` is appended per rollout the moment it completes; ``effective`` is written at once
     per finalized train batch / eval epoch."""
-    return get_step_path(get_rollout_dir(output_dir) / kind, step) / subset / "traces.jsonl"
+    return get_step_path(get_rollout_dir(output_dir), step) / kind / subset / "traces.jsonl"
 
 
 def get_eval_dir(output_dir: Path) -> Path:
@@ -167,11 +167,6 @@ def clean_future_steps(output_dir: Path, resume_step: int) -> None:
         get_rollout_dir(run_default),
         get_broadcast_dir(run_default),
     ]
-    # Trace files nest per-kind under the rollout dir (``rollouts/{train,eval}/step_N/…``),
-    # so their step directories rewind the same way.
-    for base in (output_dir, run_default):
-        for kind in ("train", "eval"):
-            dirs.append(get_rollout_dir(base) / kind)
 
     for directory in dirs:
         steps_to_delete = [step for step in get_all_ckpt_steps(directory) if step > resume_step]

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -73,15 +73,11 @@ def get_rollout_dir(output_dir: Path) -> Path:
     return output_dir / "rollouts"
 
 
-def get_trace_dir(output_dir: Path) -> Path:
-    return output_dir / "traces"
-
-
 def get_trace_path(output_dir: Path, step: int, kind: str, subset: str) -> Path:
-    """Where one trace file lives: ``traces/step_{n}/{train,eval}/{all,effective}/traces.jsonl``.
+    """Where one trace file lives: ``rollouts/{train,eval}/step_{n}/{all,effective}/traces.jsonl``.
     ``all`` is appended per rollout the moment it completes; ``effective`` is written at once
     per finalized train batch / eval epoch."""
-    return get_step_path(get_trace_dir(output_dir), step) / kind / subset / "traces.jsonl"
+    return get_step_path(get_rollout_dir(output_dir) / kind, step) / subset / "traces.jsonl"
 
 
 def get_eval_dir(output_dir: Path) -> Path:
@@ -170,9 +166,12 @@ def clean_future_steps(output_dir: Path, resume_step: int) -> None:
         get_rollout_dir(output_dir),
         get_rollout_dir(run_default),
         get_broadcast_dir(run_default),
-        get_trace_dir(output_dir),
-        get_trace_dir(run_default),
     ]
+    # Trace files nest per-kind under the rollout dir (``rollouts/{train,eval}/step_N/…``),
+    # so their step directories rewind the same way.
+    for base in (output_dir, run_default):
+        for kind in ("train", "eval"):
+            dirs.append(get_rollout_dir(base) / kind)
 
     for directory in dirs:
         steps_to_delete = [step for step in get_all_ckpt_steps(directory) if step > resume_step]

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -73,6 +73,20 @@ def get_rollout_dir(output_dir: Path) -> Path:
     return output_dir / "rollouts"
 
 
+def get_trace_dir(output_dir: Path) -> Path:
+    return output_dir / "traces"
+
+
+def get_trace_path(output_dir: Path, kind: str, subset: str, step: int | None = None) -> Path:
+    """Where one trace file lives: ``traces/{train,eval}/{all,effective}/[step_{n}/]traces.jsonl``.
+    ``all`` is one flat stream appended per rollout as it completes (a rollout's batch step isn't
+    known when it lands); ``effective`` is written per finalized batch under its step."""
+    trace_dir = get_trace_dir(output_dir) / kind / subset
+    if step is not None:
+        trace_dir = get_step_path(trace_dir, step)
+    return trace_dir / "traces.jsonl"
+
+
 def get_eval_dir(output_dir: Path) -> Path:
     return output_dir / "evals"
 
@@ -155,11 +169,24 @@ def clean_future_steps(output_dir: Path, resume_step: int) -> None:
     Pass ``resume_step=-1`` to wipe every step directory (fresh runs).
     """
     run_default = output_dir / "run_default"
+
+    # The ``all`` trace streams are flat run-level JSONL (no per-step layout), so they can't
+    # be rewound to ``resume_step`` — wipe them only when starting from scratch.
+    if resume_step == -1:
+        for trace_dir in (get_trace_dir(output_dir), get_trace_dir(run_default)):
+            if trace_dir.exists():
+                get_logger().info(f"Deleting stale trace directory {trace_dir}")
+                shutil.rmtree(trace_dir)
+
     dirs = [
         get_rollout_dir(output_dir),
         get_rollout_dir(run_default),
         get_broadcast_dir(run_default),
     ]
+    # The ``effective`` trace streams are per-step, so they rewind like rollouts do.
+    for base in (output_dir, run_default):
+        for kind in ("train", "eval"):
+            dirs.append(get_trace_dir(base) / kind / "effective")
 
     for directory in dirs:
         steps_to_delete = [step for step in get_all_ckpt_steps(directory) if step > resume_step]

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -77,14 +77,11 @@ def get_trace_dir(output_dir: Path) -> Path:
     return output_dir / "traces"
 
 
-def get_trace_path(output_dir: Path, kind: str, subset: str, step: int | None = None) -> Path:
-    """Where one trace file lives: ``traces/{train,eval}/{all,effective}/[step_{n}/]traces.jsonl``.
-    ``all`` is one flat stream appended per rollout as it completes (a rollout's batch step isn't
-    known when it lands); ``effective`` is written per finalized batch under its step."""
-    trace_dir = get_trace_dir(output_dir) / kind / subset
-    if step is not None:
-        trace_dir = get_step_path(trace_dir, step)
-    return trace_dir / "traces.jsonl"
+def get_trace_path(output_dir: Path, step: int, kind: str, subset: str) -> Path:
+    """Where one trace file lives: ``traces/step_{n}/{train,eval}/{all,effective}/traces.jsonl``.
+    ``all`` is appended per rollout the moment it completes; ``effective`` is written at once
+    per finalized train batch / eval epoch."""
+    return get_step_path(get_trace_dir(output_dir), step) / kind / subset / "traces.jsonl"
 
 
 def get_eval_dir(output_dir: Path) -> Path:
@@ -164,29 +161,18 @@ def validate_output_dir(output_dir: Path, *, resuming: bool, clean: bool, ckpt_o
 
 
 def clean_future_steps(output_dir: Path, resume_step: int) -> None:
-    """Remove stale rollouts and broadcasts past ``resume_step``.
+    """Remove stale rollouts, broadcasts, and traces past ``resume_step``.
 
     Pass ``resume_step=-1`` to wipe every step directory (fresh runs).
     """
     run_default = output_dir / "run_default"
-
-    # The ``all`` trace streams are flat run-level JSONL (no per-step layout), so they can't
-    # be rewound to ``resume_step`` — wipe them only when starting from scratch.
-    if resume_step == -1:
-        for trace_dir in (get_trace_dir(output_dir), get_trace_dir(run_default)):
-            if trace_dir.exists():
-                get_logger().info(f"Deleting stale trace directory {trace_dir}")
-                shutil.rmtree(trace_dir)
-
     dirs = [
         get_rollout_dir(output_dir),
         get_rollout_dir(run_default),
         get_broadcast_dir(run_default),
+        get_trace_dir(output_dir),
+        get_trace_dir(run_default),
     ]
-    # The ``effective`` trace streams are per-step, so they rewind like rollouts do.
-    for base in (output_dir, run_default):
-        for kind in ("train", "eval"):
-            dirs.append(get_trace_dir(base) / kind / "effective")
 
     for directory in dirs:
         steps_to_delete = [step for step in get_all_ckpt_steps(directory) if step > resume_step]


### PR DESCRIPTION
## Summary

- Save **all** rollouts, not just the ones that land in a batch. Rollout traces move from `rollouts/step_N/{train,eval}_rollouts*.jsonl` to `rollouts/step_N/{train,eval}/{all,effective}/traces.jsonl`, next to the step's trainer-bound `train_rollouts.bin` (untouched):
  - `all/traces.jsonl` is appended one rollout at a time the moment it completes — errored, filtered, and never-batched rollouts included — so it is durable across crashes and drains. Train arrivals attribute to the batch window currently collecting (`progress.step`), eval arrivals to their eval trigger step.
  - `effective/traces.jsonl` is written at once on batch finalize as before, but now holds only the clean subset that shipped to the trainer (eval: the non-errored epoch cohort; multiple eval envs share the step file, each record carries `env_name`).
- `Rollout.to_record()` now includes the orchestration metadata (`kind`, `env_name`, `group_id`, `policy_version`, `eval_step`), so records stay fully placeable when trace files are merged or read away from their paths.
- Bump `deps/verifiers` to `fab50d51` to pick up [verifiers#1959](https://github.com/PrimeIntellect-ai/verifiers/pull/1959) — every trace now records its runtime info (full runtime config + provisioned resource id), so sandbox failures can be correlated with a sandbox id straight from the `all` stream.
- The trace subtrees live inside the existing per-step rollout directories, so resume rewinds them via the existing `clean_future_steps` step-glob — no new cleanup paths.
- Updated the `monitor-run` skill for the new layout.

Worst case (nothing errored or filtered) `all` duplicates `effective` on disk. Deduplicating would mean making `effective` a manifest of trace ids into `all`, at the cost of it no longer being self-contained — not worth it for now.

## Breaking

- On-disk rollout dumps moved: `rollouts/step_N/train_rollouts.jsonl` and `rollouts/step_N/eval_rollouts_{env}.jsonl` are gone; read `rollouts/step_N/{train,eval}/{all,effective}/traces.jsonl` instead. Records gain the metadata keys listed above; eval records for all envs of a step share one file (filter by `env_name`).

## Verification

Ran a 2-GPU GSM8K smoke run with eval (`configs/debug/v1/gsm8k.toml`, 3 steps, batch 64, group 8, eval every step with 16 examples) and validated the trace files:

- `rollouts/step_{1,2,3}/train/all` hold exactly the arrival windows the step logs report (95/43/69 rollouts); `rollouts/step_4/train/all` captures the 67 drain-window rollouts that never shipped — previously these were lost.
- `rollouts/step_N/train/effective` (55/35/44) match the `.effective` view (the zero-advantage post-batch filter is enforcing by default); every effective id is present in `all`, and no `all` file has duplicate ids.
- `rollouts/step_{1..4}/eval/{all,effective}` hold the full 16-rollout epochs (0% errors, so all == effective).
- Every record carries `kind`, `env_name`, `group_id`, `policy_version`, `eval_step`, and `runtime` with the provisioned resource id, e.g. `{"type": "subprocess", "id": "/tmp/ccc5421f5c..."}`.
- The trace subtrees sit next to `train_rollouts.bin` inside each step directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk rollout artifact layout (breaking for downstream readers) and grows I/O on every completion, but training payloads and resume cleanup via `clean_future_steps` stay aligned with existing step directories.
> 
> **Overview**
> Rollout persistence is split into **append-only trace streams** under `rollouts/step_N/{train,eval}/{all,effective}/traces.jsonl`, replacing the old per-step `train_rollouts.jsonl` and per-env `eval_rollouts_*.jsonl` dumps. **`all/traces.jsonl`** gets each completed rollout as soon as it arrives (including errored, filtered, and never-batched train rollouts and full eval cohorts), keyed to the collecting train step or eval trigger step. **`effective/traces.jsonl`** still captures only the subset that ships to training or the non-errored eval epoch, with eval envs sharing one file per step.
> 
> `Rollout.to_record()` now merges orchestration fields (`kind`, `env_name`, `group_id`, `policy_version`, `eval_step`) into on-disk records, `save_rollouts` opens files in append mode, and `get_trace_path` centralizes layout. The **monitor-run** skill documents the new paths and `jq` examples; `train_rollouts.bin` is unchanged beside the trace subtrees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f848b9589a12c23740d6355c7e3e0e84fc9acb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->