### PR TITLE
fix(orchestrator): propagate dispatcher and watcher failures

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -62,6 +62,7 @@ from prime_rl.orchestrator.types import (
 from prime_rl.orchestrator.utils import (
     get_weight_dir,
     intercept_vf_logging,
+    raise_for_failed_component_tasks,
     save_rollouts,
     set_default_executor,
     setup_policy_inference_pool,
@@ -455,6 +456,7 @@ class Orchestrator:
         to the train / eval sink. Both sinks return a finalized batch (or
         ``None``) from ``add()``; we just dispatch on the result."""
         while not self.stopped.is_set():
+            raise_for_failed_component_tasks(self.component_tasks)
             if self.draining and self.dispatcher.is_idle:
                 get_logger().info("Pipeline drained, exiting main loop")
                 self.stopped.set()

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -19,6 +19,16 @@ from prime_rl.utils.utils import (
 )
 
 
+def raise_for_failed_component_tasks(tasks: list[asyncio.Task]) -> None:
+    """Raise a named error for any failed long-lived orchestrator task."""
+    for task in tasks:
+        if not task.done() or task.cancelled():
+            continue
+        exception = task.exception()
+        if exception is not None:
+            raise RuntimeError(f"Orchestrator component task {task.get_name()!r} failed") from exception
+
+
 async def setup_policy_inference_pool(*, config: OrchestratorConfig, tokenizer):
     """Build the live policy inference pool + matching renderer. Returns
     ``(renderer, inference_pool)``.

--- a/tests/unit/orchestrator/test_orchestrator_setup.py
+++ b/tests/unit/orchestrator/test_orchestrator_setup.py
@@ -2,9 +2,26 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from renderers import Qwen3VLRendererConfig
 
-from prime_rl.orchestrator.utils import setup_policy_inference_pool
+from prime_rl.orchestrator.utils import raise_for_failed_component_tasks, setup_policy_inference_pool
+
+
+def test_raise_for_failed_component_tasks_preserves_cause():
+    async def run() -> None:
+        async def fail_weight_update() -> None:
+            raise ConnectionError("weight update failed")
+
+        task = asyncio.create_task(fail_weight_update(), name="watcher")
+        await asyncio.sleep(0)
+
+        with pytest.raises(RuntimeError, match="component task 'watcher' failed") as exc_info:
+            raise_for_failed_component_tasks([task])
+
+        assert isinstance(exc_info.value.__cause__, ConnectionError)
+
+    asyncio.run(run())
 
 
 def test_setup_policy_inference_pool_uses_renderer_when_enabled():


### PR DESCRIPTION
## Summary

The orchestrator runs its dispatcher and weight watcher as background tasks. If
either task raises, the exception remains stored on the task while the main loop
continues waiting for rollouts.

Inspect these component tasks from the main loop and propagate failures with the
component name and original exception preserved.

## Failure mode

The weight watcher has a reachable uncaught failure path:

1. `WeightWatcher.apply_policy_update()` awaits
   `InferencePool.update_weights()`.
2. If the weight update raises, `WeightWatcher.start()` terminates because it
   only handles cancellation.
3. The orchestrator never awaits or inspects the failed task.
4. Once the training lead exceeds `TARGET_LAG`, `dispatch_allowed` is cleared.
   Without another policy update, the gate cannot reopen.

If the dispatcher task raises, no loop remains to collect completed rollout
tasks and put them on `out_q`. The main loop instead continues retrying its
queue timeout.

Individual rollout-task failures are handled separately by converting them into
errored rollouts. That behavior is unchanged.

## Fix

- Inspect the dispatcher and watcher tasks on each main-loop iteration.
- Raise a named `RuntimeError` when either task contains an exception.
- Preserve the component exception as the error cause.
- Skip pending and cancelled tasks.

When the rollout queue is idle, failures are detected within its existing
0.5-second polling interval.

## Verification

- Added `test_raise_for_failed_component_tasks_preserves_cause`.
- The test models a watcher failure with a named asyncio task and verifies that
  its `ConnectionError` is preserved as the cause of the orchestrator error.
- `tests/unit/orchestrator/test_orchestrator_setup.py`: 3 passed.
- `ruff check` passed.
- `ruff format --check` passed.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestrator liveness by failing fast when core pipeline tasks die, which is desirable but alters long-running run behavior on weight-update or dispatch errors.
> 
> **Overview**
> Background **dispatcher** and **weight watcher** tasks could exit with an exception while the orchestrator **main loop** kept polling the rollout queue, leading to silent stalls (e.g. dispatch gate closed after a failed weight update with no recovery).
> 
> Each main-loop iteration now calls **`raise_for_failed_component_tasks`** on `component_tasks`, which raises a **`RuntimeError`** naming the failed task and chains the original exception as **`__cause__`**. Pending and cancelled tasks are ignored.
> 
> A unit test verifies the named error and preserved cause for a failed `"watcher"` task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2f58c8f886c98ad428ab90695c2d17e3cd395cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->