### PR TITLE
fix(orchestrator): allow final nccl batch through dispatch gate

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -814,9 +814,18 @@ class Orchestrator:
         are 1-indexed while policy versions stay 0-indexed, so the shipped-batch
         count is ``progress.step - 1``."""
         lead = (self.progress.step - 1) - self.policy.version
+        # The trainer skips the final NCCL weight broadcast (inference group is
+        # torn down), so policy.version never reaches the last step. Without this
+        # the gate deadlocks waiting for a version that will never be published.
+        # The last batch uses the penultimate policy anyway, so let it through.
+        building_final_batch_nccl = (
+            self.config.weight_broadcast.type == "nccl"
+            and self.config.max_steps is not None
+            and self.progress.step >= self.config.max_steps - 1
+        )
         gate = self.dispatcher.dispatch_allowed
         was_set = gate.is_set()
-        if lead > TARGET_LAG:
+        if lead > TARGET_LAG and not building_final_batch_nccl:
             if was_set:
                 get_logger().info(
                     "Pausing dispatcher to prevent orchestrator from racing from trainer. Waiting for new policy..."


### PR DESCRIPTION
## Summary

The trainer skips the final NCCL weight broadcast (`nccl_broadcast_unused` in `train.py`: `step >= max_steps - 1`) because the inference NCCL group is torn down before that broadcast lands. As a result, `policy.version` never reaches the final step.

The orchestrator's dispatch gate (`update_dispatch_gate`) was unaware of this: it pauses dispatch when `lead > TARGET_LAG`, waiting for a policy version the trainer will never publish. Once the rollout buffer can't cover the last batch on its own, the run **deadlocks**.

This PR mirrors the trainer's `nccl_broadcast_unused` condition in the gate: when building the final batch under NCCL, let it through regardless of lead. The last batch is meant to build on the penultimate policy anyway, so this is safe.

## Changes

- **`src/prime_rl/orchestrator/orchestrator.py`** — `update_dispatch_gate`: add a `building_final_batch_nccl` guard that mirrors the trainer's `nccl_broadcast_unused` condition (`weight_broadcast.type == "nccl" and max_steps is not None and step >= max_steps - 1`). When this is true, the gate is not clamped even if `lead > TARGET_LAG`.

## Why this is safe

- The condition **exactly matches** the trainer's existing skip logic in `train.py` (L565–569), so both sides stay in sync.
- The gate is only bypassed for the **last batch** under NCCL — all other batches are unaffected.
- The last batch is designed to use the penultimate policy (1-step async barrier), which was already broadcast.

## Notes

- Consider extracting the shared 3-line condition into a small helper (e.g. `is_final_nccl_step`) to prevent the two copies from drifting in the future.
- Edge case: when `max_steps = 1`, the condition is always true, effectively disabling the gate for the entire single-step run — which is correct (there's only one batch).
- A regression test simulating the dispatch gate at `step >= max_steps - 1` with NCCL broadcast would protect against reintroduction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async pipeline backpressure at training shutdown under NCCL; behavior is narrowly scoped to the last batch and mirrors existing trainer logic, but a mismatch between the two copies could reintroduce deadlock or loosen lag control.
> 
> **Overview**
> Fixes a **deadlock at the end of NCCL runs** when the orchestrator dispatch gate pauses because `policy.version` lags behind shipped batches.
> 
> `update_dispatch_gate` now skips pausing when **`building_final_batch_nccl`** is true—the same condition the trainer uses to skip the last NCCL weight broadcast (`nccl` + `max_steps` + `progress.step >= max_steps - 1`). The final batch can still dispatch even though that policy version will never be published; it is expected to use the penultimate policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4865c99ca903e2fb6dd601739bcd296c4a4d36fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->