### PR TITLE
fix(trainer): reduce filesystem churn in nccl weight broadcast

### DIFF
--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Callable, Generator, cast
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from torch import Tensor
 from torch.distributed.tensor import DTensor
@@ -200,7 +201,7 @@ class NCCLWeightBroadcast(WeightBroadcast):
         # `_compute_notified_runs` is a pure function of SPMD-replicated state on
         # multi_run_manager, so every trainer rank derives the same list. Only
         # the master touches the filesystem to notify the orchestrator, but all
-        # ranks must wait on NCCL_READY before entering the broadcast path:
+        # ranks must wait for the inference pool before entering the broadcast path:
         # the broadcast preparation (DTensor resolution, quantization) enqueues
         # collectives on non-master ranks, and if those ranks start prep before
         # the orchestrator has paused inference, the collectives sit unmatched
@@ -208,7 +209,9 @@ class NCCLWeightBroadcast(WeightBroadcast):
         notified_runs = self._compute_notified_runs()
         if self.world.is_master:
             self._notify_orchestrator(notified_runs)
-        self._wait_for_nccl_ready(notified_runs)
+            self._wait_for_nccl_ready(notified_runs)
+        if self.world.world_size > 1:
+            dist.barrier()
         self.nccl_broadcast_sender.broadcast_weights(model, step)
         self.logger.debug(f"Weights broadcasted in {time.perf_counter() - start_time:.2f}s")
 


### PR DESCRIPTION
## Summary

When broadcasting weights via NCCL, every trainer rank independently polled the filesystem for `NCCL_READY` marker files via `_wait_for_nccl_ready()`. On multi-node setups this causes N ranks to redundantly poll the same shared filesystem.

This PR makes only the **master rank** poll for `NCCL_READY` markers. Once the master confirms the inference pool is ready, all ranks synchronize via `dist.barrier()` before entering the broadcast path. Non-master ranks never touch the filesystem.

## Changes

- **`src/prime_rl/trainer/rl/broadcast/nccl.py`** — moved `_wait_for_nccl_ready` inside the `if self.world.is_master:` block, and added a `dist.barrier()` (guarded by `world_size > 1`) to sync all ranks before `broadcast_weights`.

## Why this is safe

- Only the master needs to observe `NCCL_READY`; the barrier propagates readiness to all other ranks.
- The barrier is a no-op when `world_size == 1` (single-rank training).
- The broadcast preparation (DTensor resolution, quantization) still cannot start before inference is paused — the guarantee is preserved, just enforced via barrier instead of redundant file polling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes synchronization on the distributed NCCL weight broadcast path; a mis-timed barrier could deadlock or let ranks start prep early, though the scope is small and matches existing `dist.barrier()` usage elsewhere.
> 
> **Overview**
> NCCL weight broadcast no longer has every trainer rank poll shared storage for `NCCL_READY` markers. **Only the master** runs `_notify_orchestrator` and `_wait_for_nccl_ready`; non-master ranks skip filesystem waits entirely.
> 
> After the master confirms inference is ready, **multi-rank jobs** (`world_size > 1`) call **`dist.barrier()`** so all ranks enter `nccl_broadcast_sender.broadcast_weights` together. That keeps the same guarantee that DTensor/quantization prep cannot run before inference is paused, without redundant polling on multi-node setups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba1bab545c4097a4a3febfb3826097fd32bd2e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->