### PR TITLE
fix(orchestrator): use atomic writes for checkpoint saves

### DIFF
--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import contextlib
+import os
+import tempfile
 import time
 from dataclasses import asdict
 from pathlib import Path
@@ -27,8 +30,17 @@ class CheckpointManager:
         ckpt_path = self.get_ckpt_path(step)
         ckpt_path.mkdir(parents=True, exist_ok=True)
         start = time.perf_counter()
-        with open(ckpt_path / "progress.pt", "wb") as f:
-            torch.save({"progress": progress}, f)
+        # Save to a temporary file and do an atomic rename, to avoid corrupting the last
+        # file if the process gets killed while writing
+        fd, tmp_name = tempfile.mkstemp(dir=ckpt_path, prefix="progress.pt.", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                torch.save({"progress": progress}, f)
+            os.replace(tmp_name, ckpt_path / "progress.pt")
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name)
+            raise
         get_logger().debug(
             f"Orchestrator checkpoint saved to {ckpt_path} in {format_time(time.perf_counter() - start)}"
         )


### PR DESCRIPTION
## Summary

The orchestrator checkpoint manager writes `progress.pt` by directly opening the file and calling `torch.save()`. If the process is killed mid-write (OOM, preemption, node failure, manual kill), the file is left partially written and corrupt. On restart, `torch.load()` fails on the truncated file and the last good checkpoint is lost.

This PR writes to a temporary file first, then atomically renames it into place using `os.replace()` (atomic on POSIX). Readers either see the old file or the complete new file — never a partial write.

## Changes

- **`src/prime_rl/orchestrator/ckpt.py`** — `CheckpointManager.save()`: use `tempfile.mkstemp()` to create a temp file in the same directory, write via `torch.save()`, then `os.replace()` to atomically swap it into place. On any exception (including `KeyboardInterrupt`), the temp file is cleaned up and the error re-raised.

## Why this is safe

- Temp file is created in the same directory as the target (same filesystem → `os.replace` is atomic)
- `BaseException` catch handles signals and `KeyboardInterrupt`, not just `Exception`
- `contextlib.suppress(OSError)` on cleanup avoids masking the original error
- The temp file is cleaned up on failure; the existing `progress.pt` (if any) is untouched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path write semantics change in orchestrator checkpointing only; load behavior is unchanged and the pattern reduces corruption risk on failure.
> 
> **Overview**
> **Orchestrator `progress.pt` saves are now atomic** so a kill mid-write cannot leave a truncated checkpoint that breaks `torch.load()` on restart.
> 
> `CheckpointManager.save()` writes via `tempfile.mkstemp()` in the checkpoint directory, runs `torch.save()` on the temp file, then **`os.replace()`** into `progress.pt`. On any failure (including `KeyboardInterrupt`), it removes the temp file and re-raises, leaving any existing `progress.pt` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc7cd27f8b096d6142edb829c5d2ad9add4b4f83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->