### PR TITLE
chore: release v0.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prime-rl"
-version = "0.6.0"
+version = "0.6.1"
 description = "Async RL Training at Scale"
 readme = "README.md"
 requires-python = "~=3.12.0"
@@ -34,7 +34,7 @@ dependencies = [
     "setproctitle>=1.3.0",
     "uvloop>=0.21.0",
     "torchtitan",
-    "verifiers[harbor]>=0.1.15.dev411",
+    "verifiers[harbor]>=0.2.0",
     "renderers",
     "dion",
     "tilelang>=0.1.8",

--- a/uv.lock
+++ b/uv.lock
@@ -26,12 +26,10 @@ flash-attn-3 = false
 prime-tunnel = false
 deep-gemm = false
 prime-evals = false
-tasksets = "2099-12-31T23:00:00Z"
 tokenspeed-mla = false
 deep-ep = false
 prime-sandboxes = false
 renderers = false
-harnesses = "2099-12-31T23:00:00Z"
 prime = false
 
 [manifest]

--- a/uv.lock
+++ b/uv.lock
@@ -26,10 +26,12 @@ flash-attn-3 = false
 prime-tunnel = false
 deep-gemm = false
 prime-evals = false
+tasksets = "2099-12-31T23:00:00Z"
 tokenspeed-mla = false
 deep-ep = false
 prime-sandboxes = false
 renderers = false
+harnesses = "2099-12-31T23:00:00Z"
 prime = false
 
 [manifest]
@@ -3894,7 +3896,7 @@ dev = [
 
 [[package]]
 name = "prime-rl"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Bumps the prime-rl version to 0.6.1 and requires `verifiers[harbor]>=0.2.0`.

`uv.lock` changes only the root `prime-rl` version to 0.6.1; no locked dependency versions or unrelated lock options change.

Draft release: https://github.com/PrimeIntellect-ai/prime-rl/releases/tag/v0.6.1

On merge, the tag-and-release workflow tags this commit and promotes the v0.6.1 draft release.

## Validation

- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and minimum dependency bump only; no application code changes.
> 
> **Overview**
> **Release v0.6.1** bumps the package version from `0.6.0` to `0.6.1` in `pyproject.toml` and syncs the `prime-rl` entry in `uv.lock`.
> 
> The only dependency constraint change is raising **`verifiers[harbor]`** from `>=0.1.15.dev411` to **`>=0.2.0`**, aligning the published release with the Verifiers 0.2 line. The lockfile was refreshed for that resolution; per the PR description, no other locked dependency versions change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 981932577b78669451d5619e5fa83931c442419a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->