### PR TITLE
chore: bump research-environments and verifiers to 0.2.0

### DIFF
--- a/packages/prime-rl-configs/pyproject.toml
+++ b/packages/prime-rl-configs/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "renderers>=0.1.8.dev28",
     "tomli>=2.2.1",
     "tomli-w>=1.2.0",
-    "verifiers>=0.1.15.dev390",
+    "verifiers>=0.2.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "setproctitle>=1.3.0",
     "uvloop>=0.21.0",
     "torchtitan",
-    "verifiers[harbor]>=0.1.15.dev411",
+    "verifiers[harbor]>=0.2.0",
     "renderers",
     "dion",
     "tilelang>=0.1.8",

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -91,7 +91,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -106,7 +106,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -282,7 +282,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -306,7 +306,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -423,7 +423,7 @@ dependencies = [
 requires-dist = [
     { name = "httpx" },
     { name = "openai" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -929,7 +929,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "openai" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -1357,7 +1357,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -1413,7 +1413,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic" },
-    { name = "verifiers", extras = ["harbor"], specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", extras = ["harbor"], specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -1531,7 +1531,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "openai" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -1546,7 +1546,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -1799,7 +1799,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "orjson" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -1814,7 +1814,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -1863,7 +1863,7 @@ requires-dist = [
     { name = "setuptools", specifier = "<78" },
     { name = "spacy" },
     { name = "syllapy" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -1884,7 +1884,7 @@ requires-dist = [
     { name = "immutabledict" },
     { name = "langdetect" },
     { name = "nltk" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -2276,7 +2276,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets", specifier = ">=2.0.0" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -2341,7 +2341,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "huggingface-hub" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -2435,7 +2435,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "longcot", git = "https://github.com/LongHorizonReasoning/longcot.git?rev=6a569ab" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -2452,7 +2452,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "longcot", git = "https://github.com/LongHorizonReasoning/longcot.git?rev=6a569ab" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -2467,7 +2467,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets", specifier = ">=3.0" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -2552,7 +2552,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -2596,7 +2596,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -2739,7 +2739,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -2813,7 +2813,7 @@ dependencies = [
 requires-dist = [
     { name = "filelock" },
     { name = "httpx" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -3326,7 +3326,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "huggingface-hub" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -3343,7 +3343,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "openai" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -3362,7 +3362,7 @@ requires-dist = [
     { name = "datasets" },
     { name = "openai" },
     { name = "python-dateutil" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -3444,7 +3444,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -3581,7 +3581,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "verifiers", specifier = ">=0.1.15.dev443" }]
+requires-dist = [{ name = "verifiers", specifier = ">=0.2.0" }]
 
 [[package]]
 name = "orderly-set"
@@ -3662,7 +3662,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "openai" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -3704,7 +3704,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "nltk", specifier = ">=3.8" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -4214,7 +4214,7 @@ requires-dist = [
     { name = "renderers", specifier = ">=0.1.8.dev28" },
     { name = "tomli", specifier = ">=2.2.1" },
     { name = "tomli-w", specifier = ">=1.2.0" },
-    { name = "verifiers", specifier = ">=0.1.15.dev390" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -4257,7 +4257,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "verifiers", specifier = ">=0.1.15.dev443" }]
+requires-dist = [{ name = "verifiers", specifier = ">=0.2.0" }]
 
 [[package]]
 name = "prometheus-client"
@@ -4715,7 +4715,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -4766,7 +4766,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -4969,7 +4969,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "huggingface-hub" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -4996,7 +4996,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -5134,7 +5134,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "openai" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -5151,7 +5151,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "openai" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -5386,7 +5386,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "verifiers", specifier = ">=0.1.15.dev443" }]
+requires-dist = [{ name = "verifiers", specifier = ">=0.2.0" }]
 
 [[package]]
 name = "swebench-verified-v1"
@@ -5397,7 +5397,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "verifiers", specifier = ">=0.1.15.dev443" }]
+requires-dist = [{ name = "verifiers", specifier = ">=0.2.0" }]
 
 [[package]]
 name = "swelego-v1"
@@ -5411,7 +5411,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -5490,7 +5490,7 @@ dependencies = [
 requires-dist = [
     { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
     { name = "tau2", git = "https://github.com/sierra-research/tau2-bench.git?rev=337326e" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -5540,7 +5540,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "verifiers", specifier = ">=0.1.15.dev443" }]
+requires-dist = [{ name = "verifiers", specifier = ">=0.2.0" }]
 
 [[package]]
 name = "textarena"
@@ -5686,7 +5686,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "verifiers", extras = ["harbor"], specifier = ">=0.1.15.dev443" }]
+requires-dist = [{ name = "verifiers", extras = ["harbor"], specifier = ">=0.2.0" }]
 
 [[package]]
 name = "tokenizers"
@@ -6009,7 +6009,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -6030,7 +6030,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "verifiers", specifier = ">=0.1.15.dev443" }]
+requires-dist = [{ name = "verifiers", specifier = ">=0.2.0" }]
 
 [[package]]
 name = "uvicorn"
@@ -6079,7 +6079,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "faker", specifier = ">=20.0.0" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -6779,7 +6779,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "openai" },
-    { name = "verifiers", specifier = ">=0.1.15.dev443" },
+    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -6836,7 +6836,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "verifiers", specifier = ">=0.1.15.dev443" }]
+requires-dist = [{ name = "verifiers", specifier = ">=0.2.0" }]
 
 [[package]]
 name = "wordle"


### PR DESCRIPTION
## Summary

- Bump the `verifiers` floor to the freshly-released **0.2.0** tag in both `pyproject.toml` (`verifiers[harbor]>=0.2.0`) and `packages/prime-rl-configs/pyproject.toml` (`verifiers>=0.2.0`).
- Advance the `deps/research-environments` submodule to the 0.2.0 companion commit (`Update Verifiers requirements for V1 environments`, #652), which pins every v1 environment at `verifiers>=0.2.0`.
- Relock (`uv.lock`): all v1 environment specifiers move from `>=0.1.15.dev443` to `>=0.2.0`.

The `deps/verifiers` submodule pointer is unchanged — it already sits on the exact commit the `v0.2.0` tag points at, so with the tag now published, hatch-vcs derives `0.2.0` for the editable install.

## Verification

- `uv lock --check` — up to date, resolves cleanly (462 packages).
- Editable rebuild reports the expected version:
  ```
  verifiers==0.1.15.dev443  ->  verifiers==0.2.0
  ```
- Remaining `verifiers>=0.1.15.dev443` floors belong only to the v0 `logic-env` / `math-env` (upstream #652 bumped v1 envs only); `0.2.0` satisfies them, so they still resolve to the local editable verifiers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> A semver minor floor on `verifiers` affects RL training/eval environment resolution across many packages; breakage would show up at install or runtime API mismatches, not in application logic in this diff.
> 
> **Overview**
> Raises the minimum **`verifiers`** version from pre-0.2 dev pins to **`>=0.2.0`** across the repo’s declared dependencies and lockfile.
> 
> The root **`pyproject.toml`** now requires **`verifiers[harbor]>=0.2.0`**, and **`packages/prime-rl-configs/pyproject.toml`** requires **`verifiers>=0.2.0`**. **`uv.lock`** is updated so editable v1 research environments and **`prime-rl-configs`** metadata specifiers that previously used **`>=0.1.15.dev443`** (or similar dev floors) align on **`>=0.2.0`**, keeping resolution consistent with the published **0.2.0** release while the local editable **`deps/verifiers`** install still satisfies those floors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77f9e017c78324ce536a3728b34e14843eb6b522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->