### PR TITLE
exp(glm45air): rubric monitoring/shaping configs (rlm + swe judges, research/glm-5.2)

### DIFF
--- a/configs/glm45air/swe_rubric_monitor.toml
+++ b/configs/glm45air/swe_rubric_monitor.toml
@@ -101,14 +101,14 @@ use_prime_registry = true
 id = "rubric"
 name = "rlm"
 path = "deps/research-environments/rubrics/rlm.toml"
-model = "zai-org/GLM-5.2"
+model = "research/glm-5.2"
 weight = 0.0
 
 [[orchestrator.train.env.taskset.judges]]
 id = "rubric"
 name = "swe"
 path = "deps/research-environments/rubrics/swe.toml"
-model = "zai-org/GLM-5.2"
+model = "research/glm-5.2"
 weight = 0.0
 
 [orchestrator.prime_monitor]
@@ -120,9 +120,27 @@ interval = 20
 
 [[orchestrator.eval.env]]
 name = "swebench-verified"
-taskset = { id = "swebench-verified-v1", use_prime_registry = true }
 harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe-rubric-monitor"] } }
 timeout = { rollout = 3600 }
+
+[orchestrator.eval.env.taskset]
+id = "swebench-verified-v1"
+use_prime_registry = true
+
+# rlm + swe rubric judges as metric-only monitors (weight 0) on eval too, judged by GLM-5.2.
+[[orchestrator.eval.env.taskset.judges]]
+id = "rubric"
+name = "rlm"
+path = "deps/research-environments/rubrics/rlm.toml"
+model = "research/glm-5.2"
+weight = 0.0
+
+[[orchestrator.eval.env.taskset.judges]]
+id = "rubric"
+name = "swe"
+path = "deps/research-environments/rubrics/swe.toml"
+model = "research/glm-5.2"
+weight = 0.0
 
 # --- Inference ---
 

--- a/configs/glm45air/swe_rubric_monitor.toml
+++ b/configs/glm45air/swe_rubric_monitor.toml
@@ -1,0 +1,141 @@
+# Rubric ablation (based on configs/glm45air/swe.toml): GLM-4.5-Air on scaleswe with the
+# rlm (harness-mechanics) + swe (code-usage) rubric judges attached to the TRAIN env as
+# PURE MONITORS (weight = 0) — they emit `rlm/*` and `swe/*` metrics but don't shape reward.
+# Judge model: zai-org/GLM-5.2 on the default Prime inference endpoint. Everything else matches swe.toml.
+
+max_steps = 1000
+seq_len = 131072
+
+# Redirect compile/JIT caches to node-local /tmp (per user + job) to avoid
+# slow/contended shared-FS caches and FS lock deadlocks.
+[env_vars]
+TRITON_CACHE_DIR = "/tmp/.triton-cache"
+
+[slurm]
+job_name = "glm45air-swe-rubric-monitor"
+partition = "all"
+# Clean up this run's orphaned prime sandboxes before launch (hardcoded label, matches the harness labels below).
+pre_run_command = 'timeout 120 prime sandbox delete --label "glm45air-swe-rubric-monitor" -y || true'
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 2
+num_infer_nodes = 1
+num_infer_replicas = 4
+
+[wandb]
+project = "rubric-ablations"
+name = "glm45air-swe-rubric-monitor"
+
+[weight_broadcast]
+type = "nccl"
+timeout = 3600
+
+[ckpt]
+interval = 50
+keep_last = 1
+resume_step = -1
+
+[model]
+name = "zai-org/GLM-4.5-Air"
+
+# --- Trainer ---
+
+[trainer]
+dist_timeout_seconds = 3600
+enable_router_replay = true
+
+[trainer.model]
+impl = "custom"
+attn = "flash_attention_3"
+cp = 8
+cp_style = "ulysses"
+fused_lm_head_token_chunk_size = 1024
+optim_cpu_offload = true
+
+[trainer.model.ac]
+
+[trainer.model.ac_offloading]
+max_inflight_activations = 1
+
+[trainer.model.compile]
+
+[trainer.ckpt]
+skip_gather_master_weights = true
+skip_optimizer = true
+
+[trainer.optim]
+type = "muon"
+
+# --- Orchestrator ---
+
+[orchestrator]
+batch_size = 256
+group_size = 16
+max_off_policy_steps = 32
+max_inflight_rollouts = 512
+
+[orchestrator.algo]
+type = "grpo"
+
+[orchestrator.algo.length_penalty]
+type = "linear"
+num_output_tokens_weight = 0.0
+num_input_tokens_weight = 0.1
+num_turns_weight = 0.1
+
+[orchestrator.renderer]
+name = "glm-4.5"
+thinking_retention = "all"
+
+[[orchestrator.train.env]]
+name = "scaleswe"
+harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe-rubric-monitor"] } }
+
+[orchestrator.train.env.taskset]
+id = "scaleswe-v1"
+use_prime_registry = true
+
+# rlm + swe rubric judges as metric-only monitors (weight 0), judged by GLM-5.2.
+[[orchestrator.train.env.taskset.judges]]
+id = "rubric"
+name = "rlm"
+path = "deps/research-environments/rubrics/rlm.toml"
+model = "zai-org/GLM-5.2"
+weight = 0.0
+
+[[orchestrator.train.env.taskset.judges]]
+id = "rubric"
+name = "swe"
+path = "deps/research-environments/rubrics/swe.toml"
+model = "zai-org/GLM-5.2"
+weight = 0.0
+
+[orchestrator.prime_monitor]
+
+# --- Eval: SWE-Bench Verified at step 0 + every 20 steps, rlm harness on prime ---
+
+[orchestrator.eval]
+interval = 20
+
+[[orchestrator.eval.env]]
+name = "swebench-verified"
+taskset = { id = "swebench-verified-v1", use_prime_registry = true }
+harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe-rubric-monitor"] } }
+timeout = { rollout = 3600 }
+
+# --- Inference ---
+
+[inference]
+enable_return_routed_experts = true
+
+# vLLM + FlashInfer caches on node-local /tmp (see [env_vars]).
+[inference.env_vars]
+VLLM_CACHE_ROOT = "/tmp/.vllm-cache"
+FLASHINFER_WORKSPACE_BASE = "/tmp/.flashinfer-cache"
+
+[inference.model]
+max_model_len = 131072
+
+[inference.parallel]
+tp = 8

--- a/configs/glm45air/swe_rubric_shaped.toml
+++ b/configs/glm45air/swe_rubric_shaped.toml
@@ -1,0 +1,142 @@
+# Rubric ablation (based on configs/glm45air/swe.toml): GLM-4.5-Air on scaleswe with the
+# rlm (harness-mechanics) + swe (code-usage) rubric judges attached to the TRAIN env with
+# weight = 0.1 — they SHAPE the reward (each contributes 0.1 alongside the task reward) while
+# also emitting `rlm/*` and `swe/*` metrics. Judge model: zai-org/GLM-5.2 on default Prime
+# inference. Companion to swe_rubric_monitor.toml (identical except judge weight 0.1 vs 0).
+
+max_steps = 1000
+seq_len = 131072
+
+# Redirect compile/JIT caches to node-local /tmp (per user + job) to avoid
+# slow/contended shared-FS caches and FS lock deadlocks.
+[env_vars]
+TRITON_CACHE_DIR = "/tmp/.triton-cache"
+
+[slurm]
+job_name = "glm45air-swe-rubric-shaped"
+partition = "all"
+# Clean up this run's orphaned prime sandboxes before launch (hardcoded label, matches the harness labels below).
+pre_run_command = 'timeout 120 prime sandbox delete --label "glm45air-swe-rubric-shaped" -y || true'
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 2
+num_infer_nodes = 1
+num_infer_replicas = 4
+
+[wandb]
+project = "rubric-ablations"
+name = "glm45air-swe-rubric-shaped"
+
+[weight_broadcast]
+type = "nccl"
+timeout = 3600
+
+[ckpt]
+interval = 50
+keep_last = 1
+resume_step = -1
+
+[model]
+name = "zai-org/GLM-4.5-Air"
+
+# --- Trainer ---
+
+[trainer]
+dist_timeout_seconds = 3600
+enable_router_replay = true
+
+[trainer.model]
+impl = "custom"
+attn = "flash_attention_3"
+cp = 8
+cp_style = "ulysses"
+fused_lm_head_token_chunk_size = 1024
+optim_cpu_offload = true
+
+[trainer.model.ac]
+
+[trainer.model.ac_offloading]
+max_inflight_activations = 1
+
+[trainer.model.compile]
+
+[trainer.ckpt]
+skip_gather_master_weights = true
+skip_optimizer = true
+
+[trainer.optim]
+type = "muon"
+
+# --- Orchestrator ---
+
+[orchestrator]
+batch_size = 256
+group_size = 16
+max_off_policy_steps = 32
+max_inflight_rollouts = 512
+
+[orchestrator.algo]
+type = "grpo"
+
+[orchestrator.algo.length_penalty]
+type = "linear"
+num_output_tokens_weight = 0.0
+num_input_tokens_weight = 0.1
+num_turns_weight = 0.1
+
+[orchestrator.renderer]
+name = "glm-4.5"
+thinking_retention = "all"
+
+[[orchestrator.train.env]]
+name = "scaleswe"
+harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe-rubric-shaped"] } }
+
+[orchestrator.train.env.taskset]
+id = "scaleswe-v1"
+use_prime_registry = true
+
+# rlm + swe rubric judges shaping the reward (weight 0.1 each), judged by GLM-5.2.
+[[orchestrator.train.env.taskset.judges]]
+id = "rubric"
+name = "rlm"
+path = "deps/research-environments/rubrics/rlm.toml"
+model = "zai-org/GLM-5.2"
+weight = 0.1
+
+[[orchestrator.train.env.taskset.judges]]
+id = "rubric"
+name = "swe"
+path = "deps/research-environments/rubrics/swe.toml"
+model = "zai-org/GLM-5.2"
+weight = 0.1
+
+[orchestrator.prime_monitor]
+
+# --- Eval: SWE-Bench Verified at step 0 + every 20 steps, rlm harness on prime ---
+
+[orchestrator.eval]
+interval = 20
+
+[[orchestrator.eval.env]]
+name = "swebench-verified"
+taskset = { id = "swebench-verified-v1", use_prime_registry = true }
+harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe-rubric-shaped"] } }
+timeout = { rollout = 3600 }
+
+# --- Inference ---
+
+[inference]
+enable_return_routed_experts = true
+
+# vLLM + FlashInfer caches on node-local /tmp (see [env_vars]).
+[inference.env_vars]
+VLLM_CACHE_ROOT = "/tmp/.vllm-cache"
+FLASHINFER_WORKSPACE_BASE = "/tmp/.flashinfer-cache"
+
+[inference.model]
+max_model_len = 131072
+
+[inference.parallel]
+tp = 8

--- a/configs/glm45air/swe_rubric_shaped.toml
+++ b/configs/glm45air/swe_rubric_shaped.toml
@@ -102,14 +102,14 @@ use_prime_registry = true
 id = "rubric"
 name = "rlm"
 path = "deps/research-environments/rubrics/rlm.toml"
-model = "zai-org/GLM-5.2"
+model = "research/glm-5.2"
 weight = 0.1
 
 [[orchestrator.train.env.taskset.judges]]
 id = "rubric"
 name = "swe"
 path = "deps/research-environments/rubrics/swe.toml"
-model = "zai-org/GLM-5.2"
+model = "research/glm-5.2"
 weight = 0.1
 
 [orchestrator.prime_monitor]
@@ -121,9 +121,27 @@ interval = 20
 
 [[orchestrator.eval.env]]
 name = "swebench-verified"
-taskset = { id = "swebench-verified-v1", use_prime_registry = true }
 harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe-rubric-shaped"] } }
 timeout = { rollout = 3600 }
+
+[orchestrator.eval.env.taskset]
+id = "swebench-verified-v1"
+use_prime_registry = true
+
+# rlm + swe rubric judges as metric-only monitors (weight 0) on eval; only train shapes reward.
+[[orchestrator.eval.env.taskset.judges]]
+id = "rubric"
+name = "rlm"
+path = "deps/research-environments/rubrics/rlm.toml"
+model = "research/glm-5.2"
+weight = 0.0
+
+[[orchestrator.eval.env.taskset.judges]]
+id = "rubric"
+name = "swe"
+path = "deps/research-environments/rubrics/swe.toml"
+model = "research/glm-5.2"
+weight = 0.0
 
 # --- Inference ---
 


### PR DESCRIPTION
Rubric-judge ablations on `configs/glm45air/swe.toml` (GLM-4.5-Air on scaleswe, eval on SWE-Bench-Verified), attaching the `rlm` (harness-mechanics) + `swe` (code-usage) rubric judges from `research-environments`, judged by `research/glm-5.2`.

| config | train judges | eval judges | effect |
|---|---|---|---|
| `configs/glm45air/swe_rubric_monitor.toml` | rlm + swe, **weight 0** | rlm + swe, weight 0 | pure monitoring — emits `rlm/*` + `swe/*` metrics, no reward effect |
| `configs/glm45air/swe_rubric_shaped.toml` | rlm + swe, **weight 0.1** | rlm + swe, weight 0 | shapes the train reward (each rubric +0.1) + same metrics |

Identical except the **train** judge weight (0 vs 0.1). Eval judges are weight-0 in both (eval isn't trained).

⚠️ **Judge model not reachable yet:** `research/glm-5.2` returns HTTP 404 on the default Prime inference endpoint (as do all GLM-5.2 id variants; `/models` is 403). These configs won't run until that model is accessible (access grant, or a base_url/api-key override for the research server).
