### PR TITLE
chore: release v0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prime-rl"
-version = "0.6.0"
+version = "0.7.0"
 description = "Async RL Training at Scale"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/uv.lock
+++ b/uv.lock
@@ -4812,7 +4812,7 @@ dev = [
 
 [[package]]
 name = "prime-rl"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Bumps version to 0.7.0. Draft release: https://github.com/PrimeIntellect-ai/prime-rl/releases/tag/v0.7.0

On merge, `tag-and-release.yaml` tags the commit and promotes the draft release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-metadata-only change with no runtime or dependency updates.
> 
> **Overview**
> **Release v0.7.0** — bumps the package version from `0.6.0` to `0.7.0` in `pyproject.toml` and syncs the `prime-rl` entry in `uv.lock`.
> 
> No application or dependency changes beyond the version string. On merge, `tag-and-release.yaml` is expected to tag the commit and publish the existing draft GitHub release for `v0.7.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be0a33bd56563d82d7b6798cd298a5034b103ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->