### PR TITLE
fix: respect packed document boundaries in Qwen3.5 DeltaNet CP

### DIFF
--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -24,6 +24,7 @@ from prime_rl.trainer.models.layers.attn import (
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.moe import FeedForward, MoE, MoEArgs
 from prime_rl.trainer.models.layers.rotary_emb import apply_rotary_pos_emb
+from prime_rl.trainer.models.layers.ulysses_attn import ULYSSES_PARAMS
 from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
 
 from .configuration_qwen3_5_moe import Qwen3_5MoeConfig
@@ -43,6 +44,7 @@ except ImportError:
 
 try:
     from fla.modules import FusedRMSNormGated
+    from fla.modules.conv import causal_conv1d as fla_causal_conv1d
     from fla.ops.cp import FLACPContext, build_cp_context
     from fla.ops.gated_delta_rule import chunk_gated_delta_rule
 except ImportError:
@@ -50,6 +52,7 @@ except ImportError:
     FusedRMSNormGated = None  # type: ignore
     FLACPContext = None  # type: ignore
     build_cp_context = None  # type: ignore
+    fla_causal_conv1d = None  # type: ignore
 
 logger = logging.get_logger(__name__)
 
@@ -233,16 +236,16 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         self._causal_conv1d_fn = causal_conv1d_fn
         self._chunk_gated_delta_rule = chunk_gated_delta_rule or torch_chunk_gated_delta_rule
 
-    def _build_cp_context(self, local_seq_len: int, device: torch.device) -> "FLACPContext | None":
-        """Build fla CP context from the local (sharded) sequence length."""
+    def _build_cp_context(self) -> "FLACPContext | None":
+        """Build fla CP context from the full pre-shard document boundaries."""
         cp_group = getattr(self, "cp_group", None)
         if cp_group is None or build_cp_context is None:
             return None
-        # Reconstruct global cu_seqlens: single contiguous sequence across all CP ranks
-        global_seq_len = local_seq_len * self.cp_world_size
-        global_cu_seqlens = torch.tensor([0, global_seq_len], dtype=torch.int32, device=device)
+        # Local cu_seqlens cannot describe documents straddling shard boundaries;
+        # use the full (un-sharded) cu_seqlens published by setup_cp_params. fla
+        # derives per-rank boundaries and document-aware state passing from them.
         return build_cp_context(
-            cu_seqlens=global_cu_seqlens,
+            cu_seqlens=ULYSSES_PARAMS["cu_seqlens"],
             group=cp_group,
             conv1d_kernel_size=self.conv_kernel_size,
         )
@@ -259,9 +262,23 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         b = self.in_proj_b(hidden_states)
         a = self.in_proj_a(hidden_states)
 
+        cp_context = self._build_cp_context()
+
         # Causal conv1d — must reset at sequence boundaries for packed batches,
         # otherwise the kernel-1 left pad leaks state across sequences.
-        if self._causal_conv1d_fn is not None:
+        if cp_context is not None:
+            # fla's CP conv resets at the true document boundaries and exchanges
+            # tail tokens with the previous rank for documents straddling the
+            # shard boundary; the local cu_seqlens can express neither.
+            conv_out, _ = fla_causal_conv1d(
+                x=mixed_qkv.transpose(1, 2),
+                weight=self.conv1d.weight.squeeze(1),
+                bias=self.conv1d.bias,
+                activation=self.activation,
+                cp_context=cp_context,
+            )
+            mixed_qkv = conv_out.transpose(1, 2)
+        elif self._causal_conv1d_fn is not None:
             seq_idx = None
             if cu_seqlens is not None:
                 seg_lens = cu_seqlens[1:] - cu_seqlens[:-1]
@@ -303,7 +320,6 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 
         # Use fla's native CP when available, otherwise fall back to PyTorch kernel
-        cp_context = self._build_cp_context(seq_len, hidden_states.device)
         if cp_context is not None:
             cu_seqlens = cp_context.cu_seqlens
             core_attn_out, _ = self._chunk_gated_delta_rule(


### PR DESCRIPTION
Fixes #3002.

Under Ulysses CP the DeltaNet layer built its fla CP context from a fabricated single-sequence `cu_seqlens` (`[0, global_seq_len]`), so the gated delta rule carried recurrent state across packed documents. Independently, the causal convolution derived its `seq_idx` from shard-local `cu_seqlens`, resetting mid-document at every CP shard boundary — wrong even for unpacked rows.

The fix hands fla the information it already knows how to use:

- `_build_cp_context` now uses the full pre-shard `cu_seqlens` published by `setup_cp_params` (same source as the Nemotron-H fix in #3001). fla derives per-rank boundaries, document-aware state passing, and conv halo sizes from them.
- Under CP the convolution runs through fla's CP conv (`fla.modules.conv.causal_conv1d` with `cp_context`), which resets at true document boundaries and exchanges tail tokens with the previous rank for documents straddling the shard boundary, in both forward and backward.

The non-CP paths are untouched.

## Validation

2-GPU (CP=2, bf16, real fla kernels, layer wired exactly as the trainer wires it), packed row `[37, 51, 40]` with doc 2 straddling the shard boundary, vs the trusted non-CP varlen path:

| check | before | after |
|---|---|---|
| doc 2 max\|CP − ref\| (packed) | 4.6e-01 | 7.8e-03 (bf16 noise) |
| single unpacked doc, shard-boundary tokens | 4.6e-01 | 2.0e-03 (1 ulp) |
| doc 3 response to doc-2 tail perturbation, slow decay (must be 0) | 7.8e-01 | 0.0 |

`tests/unit/train/models/test_qwen3_5_moe.py` passes (4 passed); ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed training correctness for linear-attention layers under CP and packed sequences; wrong boundaries would silently corrupt activations, but scope is limited to the CP+fla code path in one model file.
> 
> **Overview**
> Fixes incorrect **GatedDeltaNet** behavior under **Ulysses context parallelism** when batches pack multiple documents or a document spans a shard boundary.
> 
> **`Qwen3_5MoeGatedDeltaNet._build_cp_context`** no longer synthesizes a single global sequence (`[0, global_seq_len]`). It passes the full pre-shard **`cu_seqlens`** from **`ULYSSES_PARAMS`** (same pattern as flash attention / Nemotron-H) into fla's **`build_cp_context`**, so the gated delta rule resets recurrent state at real document boundaries instead of leaking across packed docs.
> 
> When CP is active, the depthwise **causal conv** path switches from **`causal_conv1d_fn`** with shard-local **`seq_idx`** to fla's **`fla_causal_conv1d`** with **`cp_context`**, so conv state resets at true doc boundaries and halo tokens are exchanged across ranks for docs split at shard edges. **`cp_context`** is built once at the start of **`forward`** and reused for both conv and **`chunk_gated_delta_rule`**.
> 
> Non-CP conv and attention fallbacks are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6178c1656cdbf16e503314bb9b5b1218054edb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->