### PR TITLE
feat(trainer): Add softmax_scale support to ring attention

### DIFF
--- a/src/prime_rl/trainer/models/layers/attn.py
+++ b/src/prime_rl/trainer/models/layers/attn.py
@@ -326,6 +326,7 @@ def substitute_ring_attn(
             window_size=window_size,
             group=process_group,
             heads_k_stride=heads_k_stride,
+            softmax_scale=self.scaling,
         )
         if isinstance(out, tuple):
             out = out[0]

--- a/src/prime_rl/trainer/models/layers/ring_attn.py
+++ b/src/prime_rl/trainer/models/layers/ring_attn.py
@@ -120,6 +120,7 @@ class _RingFA3Varlen(torch.autograd.Function):
         group_name: str,
         window_size_left: int = -1,
         window_size_right: int = -1,
+        softmax_scale: float | None = None,
     ) -> torch.Tensor:
         group = dist.group.WORLD
         for pg in dist.distributed_c10d._world.pg_map:
@@ -129,7 +130,8 @@ class _RingFA3Varlen(torch.autograd.Function):
 
         local_k_slice = slice(local_k_slice_start, local_k_slice_stop)
         window_size = (window_size_left, window_size_right)
-        softmax_scale = q.shape[-1] ** (-0.5)
+        if softmax_scale is None:
+            softmax_scale = q.shape[-1] ** (-0.5)
         out_list = []
         lse_list = []
 
@@ -275,8 +277,8 @@ class _RingFA3Varlen(torch.autograd.Function):
 
         # Grads for: q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
         #            local_k_slice_start, local_k_slice_stop, heads_k_stride, causal, group_name,
-        #            window_size_left, window_size_right
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None
+        #            window_size_left, window_size_right, softmax_scale
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 def ring_fa3_varlen_func(
@@ -292,6 +294,7 @@ def ring_fa3_varlen_func(
     heads_k_stride: int,
     group: dist.ProcessGroup,
     window_size: tuple[int, int] = (-1, -1),
+    softmax_scale: float | None = None,
 ) -> torch.Tensor:
     return _RingFA3Varlen.apply(
         q,
@@ -308,6 +311,7 @@ def ring_fa3_varlen_func(
         group.group_name,
         window_size[0],
         window_size[1],
+        softmax_scale,
     )
 
 
@@ -415,6 +419,7 @@ class _RingFA4Varlen(torch.autograd.Function):
         group_name: str,
         window_size_left: int = -1,
         window_size_right: int = -1,
+        softmax_scale: float | None = None,
     ) -> torch.Tensor:
         group = dist.group.WORLD
         for pg in dist.distributed_c10d._world.pg_map:
@@ -424,7 +429,8 @@ class _RingFA4Varlen(torch.autograd.Function):
 
         local_k_slice = slice(local_k_slice_start, local_k_slice_stop)
         window_size = (window_size_left, window_size_right)
-        softmax_scale = q.shape[-1] ** (-0.5)
+        if softmax_scale is None:
+            softmax_scale = q.shape[-1] ** (-0.5)
         out_list = []
         lse_list = []
 
@@ -570,8 +576,8 @@ class _RingFA4Varlen(torch.autograd.Function):
 
         # Grads for: q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
         #            local_k_slice_start, local_k_slice_stop, heads_k_stride, causal, group_name,
-        #            window_size_left, window_size_right
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None
+        #            window_size_left, window_size_right, softmax_scale
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 def ring_fa4_varlen_func(
@@ -587,6 +593,7 @@ def ring_fa4_varlen_func(
     heads_k_stride: int,
     group: dist.ProcessGroup,
     window_size: tuple[int, int] = (-1, -1),
+    softmax_scale: float | None = None,
 ) -> torch.Tensor:
     return _RingFA4Varlen.apply(
         q,
@@ -603,4 +610,5 @@ def ring_fa4_varlen_func(
         group.group_name,
         window_size[0],
         window_size[1],
+        softmax_scale,
     )


### PR DESCRIPTION
Fixes #2588

`_RingFA3Varlen` and `_RingFA4Varlen` (the FA3/FA4 ring-attention autograd `Function`s in `ring_attn.py`) hardcoded `softmax_scale = head_dim ** -0.5` internally, ignoring any custom scale configured on the attention module. This meant `cp_style="ring"` silently used the default scale even when a model set a non-default `self.scaling`.

- `_RingFA3Varlen` / `_RingFA4Varlen`: accept `softmax_scale: float | None = None`, threaded into the low-level FA3/FA4 forward+backward calls; falls back to the old `head_dim ** -0.5` default when unset.
- `ring_fa3_varlen_func` / `ring_fa4_varlen_func`: expose the same `softmax_scale` param.
- `attn.py`'s `_ring_compute_attention`: now passes `softmax_scale=self.scaling` to whichever ring kernel is active. Covers all three CP wrappers — FA2 (`llama3_flash_attn_varlen_func`, from `ring_flash_attn`, which already accepted this kwarg upstream — it just wasn't being passed), FA3, and FA4.

**Testing:**
- `uv run pre-commit run` — passes (ruff check + format).
- `uv run pytest tests/unit -v -m "not gpu"` — 447 passed, 1 skipped, 29 pre-existing failures unrelated to this change (confirmed by reverting to the base commit and reproducing the identical failure list). `test_qwen3_5_ring_patches_dense_flash_attention`, which exercises `substitute_ring_attn`, passes.
- CPU-only mock test confirming `softmax_scale` reaches the low-level FA3/FA4 forward and backward calls with the correct value, `None` preserves prior default behavior, and the autograd arg-count change doesn't break `backward()`.
- Not verified: real numerical correctness on GPU (ring-attention output/gradients vs. plain flash-attention with the same custom scale). Blocked by this dev host's hardware (Thor, `sm_110`) not being supported by the repo's pinned stable PyTorch build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed training attention numerics and autograd signatures on a hot path; behavior is unchanged when scale is unset but wrong wiring would affect forward/backward correctness.
> 
> **Overview**
> Ring attention for **FA3** and **FA4** no longer forces `head_dim ** -0.5` inside `_RingFA3Varlen` / `_RingFA4Varlen`. Both autograd paths take optional `softmax_scale`, use it in the low-level forward/backward kernels, and still default to the old formula when it is omitted.
> 
> `ring_fa3_varlen_func` and `ring_fa4_varlen_func` expose the same parameter. **`substitute_ring_attn`**’s `_ring_compute_attention` now passes **`softmax_scale=self.scaling`** into whichever ring kernel is active (FA2 via `llama3_flash_attn_varlen_func`, FA3, or FA4), so `cp_style="ring"` respects the attention module’s configured scale instead of silently ignoring it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc1b137cd24b8a1ec81bda700a0269bfb0523fe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->