### PR TITLE
fix(orchestrator): unify off-policy lag across sink queue

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -529,7 +529,10 @@ class OrchestratorConfig(BaseConfig):
     """Maximum training steps. If None, runs indefinitely."""
 
     max_off_policy_steps: int = Field(8, ge=0)
-    """Maximum policies allowed to generate a single rollout. Rollouts generated more than ``max_off_policy_steps`` ahead of training are discarded. Higher values yield better throughput at the cost of off-policy noise."""
+    """Maximum trainer–policy lag allowed per rollout before it is discarded.
+
+    Lag is measured as ``(trainer_step - 1) - policy_version_at_generation``,
+    covering both in-flight rollouts and rollouts waiting in the train sink."""
 
     bench: bool = False
     """Benchmark mode. Sets ``max_steps`` to 5 and disables W&B."""

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -12,8 +12,9 @@
   source's emptiness), so in-flight rollouts of the opposite kind drain
   naturally on either side of an eval boundary.
 - ``on_version_pending`` (called by the watcher before the engines pause for
-  the weight update) bumps ``off_policy_steps`` on in-flight train rollouts and
-  drops groups past ``max_off_policy_steps``.
+  the weight update) recomputes off-policy lag as
+  ``(trainer_step - 1) - policy_version_at_start`` on in-flight train rollouts
+  and drops groups past ``max_off_policy_steps``.
   Eval rollouts are measurements for the policy version they started with,
   so they are allowed to finish even if training advances. Train rollouts
   sampled from a frozen model never age — their sampler doesn't change
@@ -47,6 +48,11 @@ from prime_rl.orchestrator.types import (
 from prime_rl.utils.async_utils import safe_cancel, safe_cancel_all
 from prime_rl.utils.client import InferencePool, client_identity
 from prime_rl.utils.logger import get_logger
+
+
+def off_policy_lag(trainer_step: int, policy_version_at_start: int) -> int:
+    """Trainer-aligned lag: batches shipped ahead of the rollout's policy version."""
+    return max(0, (trainer_step - 1) - policy_version_at_start)
 
 
 class DispatcherMode(Enum):
@@ -285,8 +291,9 @@ class RolloutDispatcher:
             # change with policy updates.
             if not self.train_envs.get(meta.env_name).sampler.samples_from_live_policy:
                 continue
-            meta.off_policy_steps += 1
-            if meta.off_policy_steps > self.max_off_policy_steps:
+            lag = off_policy_lag(step, meta.policy_version)
+            meta.off_policy_steps = lag
+            if lag > self.max_off_policy_steps:
                 stale_groups.add(meta.group_id)
 
         for gid in stale_groups:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -367,7 +367,7 @@ class Orchestrator:
             config,
             policy=self.policy,
             inference=self.policy_inference,
-            observers=[self.dispatcher, self],
+            observers=[self.dispatcher, self.train_sink, self],
             lora_name=self.lora_name,
             ckpt_step=self.policy.version,
         )

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -304,17 +304,14 @@ class TrainSink:
         self.pending_batch = kept_batch
 
         for group_id, group in list(self.pending_groups.items()):
-            survivors = []
-            for rollout in group:
-                if is_stale(rollout):
-                    dropped += 1
-                else:
-                    rollout.off_policy_steps = off_policy_lag(trainer_step, rollout.policy_version)
-                    survivors.append(rollout)
-            if survivors:
-                self.pending_groups[group_id] = survivors
-            else:
+            if any(is_stale(rollout) for rollout in group):
+                # Drop the whole partial group — removing only stale members would
+                # strand survivors below group_size with no Cancelled siblings.
+                dropped += len(group)
                 self.pending_groups.pop(group_id, None)
+                continue
+            for rollout in group:
+                rollout.off_policy_steps = off_policy_lag(trainer_step, rollout.policy_version)
 
         if dropped:
             self.pending_rollouts = TrainRollouts(

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -21,6 +21,7 @@ import uuid
 from collections import defaultdict
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
+from prime_rl.orchestrator.dispatcher import off_policy_lag
 from prime_rl.orchestrator.envs import TrainEnvs
 from prime_rl.orchestrator.filters import RolloutFilter, apply_filters
 from prime_rl.orchestrator.metrics import TrainRollouts
@@ -267,3 +268,56 @@ class TrainSink:
         self.pre_filter_seen = 0
         self.pre_filter_dropped = 0
         self.pre_filter_dropped_by_name.clear()
+
+    async def on_version_pending(self, trainer_step: int) -> None:
+        """Drop completed rollouts waiting in sink queues once policy lag exceeds the cap."""
+        dropped = self.drop_stale_rollouts(trainer_step, self.config.max_off_policy_steps)
+        if dropped:
+            get_logger().warning(
+                f"Dropped {dropped} queued train rollouts past max_off_policy_steps="
+                f"{self.config.max_off_policy_steps} (sink queue lag)."
+            )
+
+    async def on_new_version(self, step: int) -> None:
+        return
+
+    def drop_stale_rollouts(self, trainer_step: int, max_off_policy_steps: int) -> int:
+        dropped = 0
+
+        def is_stale(rollout: Rollout) -> bool:
+            if rollout.kind != "train":
+                return False
+            env = self.train_envs.get(rollout.env_name)
+            if not env.sampler.samples_from_live_policy:
+                return False
+            return off_policy_lag(trainer_step, rollout.policy_version) > max_off_policy_steps
+
+        kept_batch: list[Rollout] = []
+        for rollout in self.pending_batch:
+            if is_stale(rollout):
+                dropped += 1
+                if self.token_batch_size is not None:
+                    self.pending_tokens -= rollout.num_total_tokens
+            else:
+                rollout.off_policy_steps = off_policy_lag(trainer_step, rollout.policy_version)
+                kept_batch.append(rollout)
+        self.pending_batch = kept_batch
+
+        for group_id, group in list(self.pending_groups.items()):
+            survivors = []
+            for rollout in group:
+                if is_stale(rollout):
+                    dropped += 1
+                else:
+                    rollout.off_policy_steps = off_policy_lag(trainer_step, rollout.policy_version)
+                    survivors.append(rollout)
+            if survivors:
+                self.pending_groups[group_id] = survivors
+            else:
+                self.pending_groups.pop(group_id, None)
+
+        if dropped:
+            self.pending_rollouts = TrainRollouts(
+                [r for r in self.pending_rollouts if not is_stale(r)]
+            )
+        return dropped

--- a/tests/unit/orchestrator/test_off_policy_lag.py
+++ b/tests/unit/orchestrator/test_off_policy_lag.py
@@ -1,0 +1,15 @@
+"""Tests for unified off-policy lag (#2674)."""
+
+from prime_rl.orchestrator.dispatcher import off_policy_lag
+
+
+def test_off_policy_lag_inflight_during_version_bumps():
+    assert off_policy_lag(8, 5) == 2
+
+
+def test_off_policy_lag_sink_queue():
+    assert off_policy_lag(10, 5) == 4
+
+
+def test_off_policy_lag_never_negative():
+    assert off_policy_lag(3, 5) == 0


### PR DESCRIPTION
## Summary
`off_policy_steps` only incremented during in-flight version bumps, missing rollouts that finished quickly but sat in `TrainSink` waiting for `batch_size` (#2674).

- Compute lag as `(trainer_step - 1) - policy_version_at_start` in dispatcher
- Register `TrainSink` as `VersionObserver` to drop stale queued rollouts
- Update `max_off_policy_steps` config docstring to match unified definition

## Verify
```bash
uv run pytest tests/unit/orchestrator/test_off_policy_lag.py -v
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which training rollouts are discarded before shipment, which can shift batch composition and off-policy noise; logic is localized to orchestrator with a explicit formula and unit tests.
> 
> **Overview**
> Fixes a gap where **off-policy staleness only applied to in-flight rollouts**, so fast-finished train rollouts could sit in `TrainSink` until `batch_size`/`token_batch_size` while training moved on (#2674).
> 
> **Lag is now one shared definition:** `(trainer_step - 1) - policy_version_at_generation`, clamped at zero, via new `off_policy_lag()`. The dispatcher **recomputes** lag on `on_version_pending` instead of bumping a per-version counter.
> 
> **`TrainSink` is a `WeightWatcher` observer** and drops stale rollouts from `pending_batch`, partial `pending_groups` (whole group), and the metrics window when lag exceeds `max_off_policy_steps`. Frozen / non–live-policy envs are unchanged.
> 
> Config docstring for `max_off_policy_steps` matches this behavior. Small unit tests cover the lag helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73fc774507174fbe6dee7e8b218b8c93c64dcc0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->