### PR TITLE
fix(orchestrator): count token batches by shipped sample payload

### DIFF
--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -30,6 +30,19 @@ from prime_rl.transport import TrainingSample
 from prime_rl.utils.logger import get_logger
 
 
+def payload_tokens(rollout: Rollout) -> int:
+    """Token cost of the rollout's trainer-bound payload — the samples built by
+    ``process_rollout``. This is what actually ships: forked traces can drop
+    branches with no trainable tokens, so ``Trace.num_total_tokens`` (which sums
+    over all branches) may overcount. For linear traces the two agree.
+
+    Zero-payload rollouts (no trainable samples at all) fall back to the trace
+    total so they still advance token batching — a degenerate all-zero-payload
+    stream then ships empty batches and trips the orchestrator's
+    consecutive-empty-batch abort instead of stalling the readiness check."""
+    return sum(len(sample.token_ids) for sample in rollout.samples) or rollout.num_total_tokens
+
+
 class TrainSink:
     """Three-level train sink. Constructed once, fed via ``add(rollout)``."""
 
@@ -63,9 +76,9 @@ class TrainSink:
         self.pending_rollouts: TrainRollouts = TrainRollouts()
         self.pending_groups: dict[uuid.UUID, list[Rollout]] = defaultdict(list)
         self.pending_batch: list[Rollout] = []
-        # Running token total of ``pending_batch`` (token-batched runs), kept in
-        # sync on append/pop so the readiness check never re-walks the uncached
-        # ``Trace.num_total_tokens`` graph property per arrival.
+        # Running payload-token total of ``pending_batch`` (token-batched
+        # runs), kept in sync on append/pop so the readiness check never
+        # re-sums per arrival.
         self.pending_tokens: int = 0
 
         # Reset by the orchestrator after each ship via ``reset_pre_filter_stats``
@@ -211,7 +224,7 @@ class TrainSink:
             r.is_filtered = False
             self.pending_batch.append(r)
             if self.token_batch_size is not None:
-                self.pending_tokens += r.num_total_tokens
+                self.pending_tokens += payload_tokens(r)
 
         # Per-group summary. One line per finalized group; per-filter
         # detection breakdown lives at debug level in ``apply_filters``
@@ -238,7 +251,7 @@ class TrainSink:
             cut = 0
             running = 0
             for i, r in enumerate(self.pending_batch):
-                running += r.num_total_tokens
+                running += payload_tokens(r)
                 cut = i + 1
                 if running >= self.token_batch_size:
                     break


### PR DESCRIPTION
## Problem

Token-batched `TrainSink` accounting counts `Trace.num_total_tokens`, which sums token lengths over **all** branches of the trace graph. The shipped payload, however, is built by `trace_to_samples`, which (since #2975) skips branches left with no trainable tokens after fork dedup. For forked traces (subagents, tree search, best-of-N, …) the counted total can therefore exceed the actual trainer payload, making `token_batch_size` misrepresent batch cost.

## Fix

Count the trainer-bound payload directly: a module-level `payload_tokens(rollout)` helper returning `sum(len(sample.token_ids) for sample in rollout.samples)`, used at both accounting sites:

- `process_group` — `pending_tokens` accumulation
- `process_batch` — the batch-cut loop

Using the same measure at both sites keeps the `pending_tokens -= running` bookkeeping exactly consistent. `rollout.samples` is always populated by `process_rollout` before `process_group` runs, and errored rollouts are excluded from survivors before accounting.

**Zero-payload survivors** (non-errored rollouts whose trace yields no trainable samples — `trace_to_samples` returns `[]` and warns) fall back to `rollout.num_total_tokens` so they still advance the readiness check. This preserves the pre-change behavior for the degenerate case: an all-zero-payload stream ships (empty) batches and trips the orchestrator's `MAX_CONSECUTIVE_EMPTY_BATCHES` abort, instead of accumulating 0 tokens forever and silently stalling batching.

For linear traces with trainable samples this is byte-identical to the previous behavior.

## Scope

`token_batch_size` now means **wire payload tokens** (full sample context, including loss-masked context tokens). Broader design questions from the review note (trainable-loss vs model-forward tokens, multimodal cost, post-filter underfill backfill) are intentionally left open.

Found during the TTT review triage (deferred issue: train-sink token-batching payload accounting).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized bookkeeping change in TrainSink token batching; behavior is unchanged for linear traces and preserves the zero-payload stall guard via fallback.
> 
> **Overview**
> **Token-batched `TrainSink` now sizes batches from the tokens that actually ship to the trainer**, not from `Trace.num_total_tokens` across every trace branch.
> 
> A new `payload_tokens(rollout)` helper sums `len(sample.token_ids)` over `rollout.samples` (built in `process_rollout`). **`process_group`** uses it when updating `pending_tokens`; **`process_batch`** uses the same helper in the cut loop so `pending_tokens -= running` stays consistent with readiness checks.
> 
> Forked traces (subagents, tree search, etc.) can drop branches with no trainable tokens, so the old trace total could **overcount** and make `token_batch_size` misrepresent batch cost. Linear traces with trainable samples behave the same as before.
> 
> Rollouts with **no trainable samples** still fall back to `num_total_tokens` so token batching advances and the orchestrator can hit the consecutive-empty-batch abort instead of stalling at zero counted tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3bc0e86aa85bb6d2e590fb1f924fbcbabc690ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->