### PR TITLE
fix(trainer): skip unneeded gradients in fused LM-head backward

### DIFF
--- a/src/prime_rl/trainer/models/layers/lm_head.py
+++ b/src/prime_rl/trainer/models/layers/lm_head.py
@@ -238,8 +238,9 @@ class _SequenceChunkedLogProbEntropyFn(torch.autograd.Function):
         vocab = weight.shape[0]
         vocab_chunk_size = min(vocab, 8192)
 
-        grad_hidden = torch.zeros_like(hidden)
-        grad_weight = torch.zeros_like(weight)
+        needs_hidden, needs_weight = ctx.needs_input_grad[0], ctx.needs_input_grad[1]
+        grad_hidden = torch.zeros_like(hidden) if needs_hidden else None
+        grad_weight = torch.zeros_like(weight) if needs_weight else None
 
         for start in range(0, n, chunk_size):
             end = min(start + chunk_size, n)
@@ -263,8 +264,10 @@ class _SequenceChunkedLogProbEntropyFn(torch.autograd.Function):
                     grad_logits[mask, idx] += grad_chunk[mask]
                 grad_logits = grad_logits * inv_t_chunk
 
-                grad_hidden[start:end].add_(grad_logits.to(hidden.dtype) @ weight_chunk)
-                grad_weight[vocab_start:vocab_end].add_(grad_logits.to(weight.dtype).t() @ hidden_chunk)
+                if needs_hidden:
+                    grad_hidden[start:end].add_(grad_logits.to(hidden.dtype) @ weight_chunk)
+                if needs_weight:
+                    grad_weight[vocab_start:vocab_end].add_(grad_logits.to(weight.dtype).t() @ hidden_chunk)
 
         return grad_hidden, grad_weight, None, None, None
 

--- a/tests/unit/train/rl/test_fused_lm_head.py
+++ b/tests/unit/train/rl/test_fused_lm_head.py
@@ -61,6 +61,34 @@ def test_fused_lm_head_matches_full_logits_forward_and_backward_cpu():
     torch.testing.assert_close(grad_weight1, grad_weight0, rtol=0, atol=1e-5)
 
 
+def test_fused_lm_head_frozen_weight_backward_cpu():
+    """Frozen LM-head weight: hidden gradient matches baseline, no weight gradient is produced."""
+    torch.manual_seed(0)
+    b, s, h, v = 2, 4, 8, 37
+    temperature = torch.full((b, s), 1.7, dtype=torch.float32)
+    chunk_size = 3
+
+    hidden0 = torch.randn(b, s, h, dtype=torch.float32, requires_grad=True)
+    labels = torch.randint(0, v, (b, s), dtype=torch.long)
+    weight0 = torch.randn(v, h, dtype=torch.float32)
+
+    # Baseline (weight frozen)
+    logp0, _ = _baseline_logprobs_and_entropy(hidden0, weight0, labels, temperature=temperature)
+    logp0.sum().backward()
+    grad_hidden0 = hidden0.grad.detach().clone()
+
+    # Fused (weight frozen)
+    hidden1 = hidden0.detach().clone().requires_grad_(True)
+    lm = FusedOutputLinear(in_features=h, out_features=v, chunk_size=chunk_size)
+    lm.weight = torch.nn.Parameter(weight0.clone(), requires_grad=False)
+
+    out = lm(hidden1, labels, temperature=temperature)
+    out["logprobs"].sum().backward()
+
+    torch.testing.assert_close(hidden1.grad, grad_hidden0, rtol=0, atol=1e-5)
+    assert lm.weight.grad is None
+
+
 def test_fused_lm_head_requires_labels():
     """Test that FusedOutputLinear raises assertion error when labels is None."""
     torch.manual_seed(0)


### PR DESCRIPTION
## Problem

`_SequenceChunkedLogProbEntropyFn.backward` (fused LM-head log-prob/entropy) unconditionally allocates `grad_hidden = torch.zeros_like(hidden)` **and** `grad_weight = torch.zeros_like(weight)` and accumulates both matmuls per chunk, without consulting `ctx.needs_input_grad`. When the output-head weight is frozen (e.g. LoRA runs that don't adapt the head), the full `[vocab, hidden]` gradient buffer is allocated and the `grad_logits.t() @ hidden_chunk` matmuls are computed for a result autograd then discards — wasted memory and compute at vocab-size scale.

## Fix

Read `needs_hidden, needs_weight = ctx.needs_input_grad[0], ctx.needs_input_grad[1]`, allocate each gradient only when required (else `None`), guard the two accumulation matmuls accordingly, and return `None` for unneeded gradients. Chunking structure, `grad_logits` computation, masking, and temperature scaling are untouched; when both gradients are needed (the common case) behavior is identical to before.

## Test

Added `test_fused_lm_head_frozen_weight_backward_cpu` to the existing fused-LM-head suite: mirrors the CPU parity test with `weight.requires_grad=False`, asserting the hidden gradient matches the full-logits baseline and no weight gradient materializes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-only optimization gated on autograd flags; full dual-gradient behavior is unchanged and covered by existing parity tests.
> 
> **Overview**
> **Fused LM-head backward** (`_SequenceChunkedLogProbEntropyFn`) now respects `ctx.needs_input_grad` instead of always building full `grad_hidden` and `grad_weight` buffers and running both accumulation matmuls every vocab chunk.
> 
> When the output head weight is frozen (e.g. LoRA without adapting the head), it skips the `[vocab, hidden]` weight-gradient allocation and the `grad_logits.t() @ hidden_chunk` work; hidden gradients are unchanged when only hidden needs grad. Forward path and `grad_logits` math are untouched.
> 
> Adds **`test_fused_lm_head_frozen_weight_backward_cpu`**: frozen `lm.weight`, checks hidden grad matches the full-logits baseline and `weight.grad` stays `None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcec7fadd56a17001a37cdca53916c6d8bcefa23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->