### PR TITLE
fix(configs): validate max_cpu_loras >= max_loras when LoRA is enabled

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -501,6 +501,20 @@ class InferenceConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def validate_lora_cpu_capacity(self):
+        """Validate that CPU LoRA capacity can hold all GPU-resident LoRAs.
+
+        vLLM's LoRAConfig requires max_cpu_loras >= max_loras; a smaller value
+        would otherwise only fail at inference server startup.
+        """
+        if self.enable_lora and self.max_cpu_loras < self.max_loras:
+            raise ValueError(
+                f"max_cpu_loras ({self.max_cpu_loras}) must be >= max_loras ({self.max_loras}) "
+                "when LoRA is enabled (vLLM LoRAConfig requirement)"
+            )
+        return self
+
+    @model_validator(mode="after")
     def auto_setup_api_server_count(self):
         """
         Ensures that we have at least as many API servers as data parallel


### PR DESCRIPTION
## Problem

`InferenceConfig` can express `max_cpu_loras < max_loras` with LoRA enabled. vLLM 0.24.0 (the pinned version) rejects this unconditionally — `LoRAConfig._validate_lora_config` raises `"max_cpu_loras must be >= max_loras"` whenever a `LoRAConfig` is constructed — and prime-rl always forwards an explicit `max_cpu_loras` via `to_vllm`, so the invariant applies unconditionally here. An invalid combination previously surfaced only at inference server startup.

## Fix

Add a `validate_lora_cpu_capacity` model validator on `InferenceConfig` that raises at config-parse time when `enable_lora` is true and `max_cpu_loras < max_loras`, citing the vLLM contract. Non-LoRA configs stay unconstrained (vLLM never constructs a `LoRAConfig` then).

Checked existing repo configs: the only one touching these fields (`configs/ci/integration/reverse_text_multi_run/inference.toml`: `max_loras = 4`, default `max_cpu_loras = 100`) passes the validator.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a narrow config validation guard with no runtime or security behavior changes beyond earlier error reporting.
> 
> **Overview**
> Adds **`validate_lora_cpu_capacity`** on `InferenceConfig` so invalid LoRA sizing fails when the config is parsed, not when vLLM starts.
> 
> When **`enable_lora`** is true and **`max_cpu_loras < max_loras`**, validation raises a clear `ValueError` matching vLLM’s `LoRAConfig` rule. Configs with LoRA off are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf413eca9ed0d08e3c6de9b873d3950de51a18a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->