### PR TITLE
fix(orchestrator): scope the train batch observation window to finalized groups

### DIFF
--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -57,10 +57,13 @@ class TrainSink:
         self.pre_filters = pre_filters
         self.post_filters = post_filters
 
+        # Observation window for the next shipped batch: rollouts of groups
+        # finalized since the last ship (errored + filtered + survivors).
+        # In-progress groups stay out until they finalize.
+        self.pending_rollouts: TrainRollouts = TrainRollouts()
         # Keyed by the dispatcher's group UUID. ``(env_name, task_idx)``
         # isn't unique — the same task can be re-sampled while an
         # earlier group is still in flight
-        self.pending_rollouts: TrainRollouts = TrainRollouts()
         self.pending_groups: dict[uuid.UUID, list[Rollout]] = defaultdict(list)
         self.pending_batch: list[Rollout] = []
         # Running token total of ``pending_batch`` (token-batched runs), kept in
@@ -117,13 +120,18 @@ class TrainSink:
 
     async def add(self, rollout: Rollout) -> TrainBatch | None:
         """Process one arrival; finalize the group on the ``group_size``-th
-        arrival; return a ``TrainBatch`` if the batch threshold is met."""
+        arrival; return a ``TrainBatch`` if the finalization pushed (or left)
+        the batch over its threshold. Arrivals into still-incomplete groups
+        never ship a batch."""
         await self.process_rollout(rollout)
         env_name = rollout.env_name
-        self.pending_rollouts.append(rollout)
         self.pending_groups[rollout.group_id].append(rollout)
-        if len(self.pending_groups[rollout.group_id]) >= self.group_size_for(env_name):
-            await self.process_group(rollout.group_id)
+        if len(self.pending_groups[rollout.group_id]) < self.group_size_for(env_name):
+            return None
+        await self.process_group(rollout.group_id)
+        # ``pending_batch`` only grows on group finalization, so readiness is
+        # only re-checked here — the window of a shipped batch then always
+        # contains at least the group that finalized it.
         ready = (
             len(self.pending_batch) >= self.batch_size
             if self.batch_size is not None
@@ -159,6 +167,12 @@ class TrainSink:
         group = self.pending_groups.pop(group_id, [])
         if not group:
             return
+        # Window membership follows group finalization, not arrival: a rollout
+        # only becomes observable (metrics / persistence) once its whole group
+        # is finalized, so a batch's window never claims rollouts of a group
+        # that ships later. Dropped groups still land here — they were observed.
+        for r in group:
+            self.pending_rollouts.append(r)
         env_name = group[0].env_name
         task_idx = group[0].task.data.idx
         survivors = [r for r in group if not r.has_error]
@@ -253,11 +267,12 @@ class TrainSink:
         # advantage stream and loss routing on each sample. Filtered rollouts don't ship.
         samples: list[TrainingSample] = [sample for r in cohort if not r.is_filtered for sample in r.samples]
 
-        # ``rollouts`` is the whole arrival window (errored + filtered + survivors); ``samples`` is
-        # the shipped cohort's trainable payload. ``rollouts.effective`` / ``rollouts.metrics`` derive
-        # the clean subset + metric views on demand. Reset the window only when the batch actually
-        # ships (non-empty samples) — an empty batch is dropped unlogged by the orchestrator, so keep
-        # accumulating its arrivals (and any overflow) into the next shipped batch's window.
+        # ``rollouts`` is the observation window — every rollout of every group finalized since the
+        # last ship (errored + filtered + survivors) — while ``samples`` is the shipped cohort's
+        # trainable payload. ``rollouts.effective`` / ``rollouts.metrics`` derive the clean subset +
+        # metric views on demand. Reset the window only when the batch actually ships (non-empty
+        # samples) — an empty batch is dropped unlogged by the orchestrator, so keep accumulating its
+        # finalized groups (and any overflow) into the next shipped batch's window.
         rollouts = self.pending_rollouts
         if samples:
             self.pending_rollouts = TrainRollouts()

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -147,11 +147,12 @@ class Rollout(vf.Trace[DataT], Generic[DataT]):
 
 @dataclass
 class TrainBatch:
-    """``rollouts`` is the full arrival window since the last ship (errored + filtered included; its
-    ``.effective`` / ``.metrics`` views drive logging). ``samples`` is the trainer-bound payload (the
-    shipped cohort's post-filter survivors) — an empty list means nothing ships, which would stall the
-    trainer. Trainable counts derive from ``rollouts`` (``r.is_trainable``) and token totals from
-    ``samples``, so neither is carried as a field."""
+    """``rollouts`` is the observation window since the last ship — every rollout of every group
+    finalized in that span (errored + filtered included; rollouts of still-incomplete groups wait
+    for a later window). Its ``.effective`` / ``.metrics`` views drive logging. ``samples`` is the
+    trainer-bound payload (the shipped cohort's post-filter survivors) — an empty list means nothing
+    ships, which would stall the trainer. Trainable counts derive from ``rollouts``
+    (``r.is_trainable``) and token totals from ``samples``, so neither is carried as a field."""
 
     rollouts: TrainRollouts
     samples: list[TrainingSample]


### PR DESCRIPTION
> [!NOTE]
> Draft for team discussion — this tightens the meaning of `TrainBatch.rollouts`, which affects metrics denominators and per-step trace persistence.

## Problem

`TrainSink` maintains an observation window (`TrainBatch.rollouts`) used for wandb metrics and the per-step `all`/`effective` trace files. The window was filled **on arrival**: every rollout was appended the moment it arrived, even if its group was still incomplete.

Failure sequence:

1. Group A finalizes with enough survivors for more than one batch; one A batch ships, A overflow stays ready.
2. The **first** rollout of a new, incomplete group B arrives; the arrival triggers the readiness check.
3. The A-overflow batch ships with B's rollout in its window; the window resets.
4. When B's group later completes and ships, B's first rollout is missing from its own batch's window.

Trainer payload (`samples`) is unaffected — this is an ownership/observability bug: per-step reward metrics, error rates, and persisted rollout traces can describe rollouts belonging to a different batch, precisely in runs with group overflow.

## Fix

Window membership follows **group finalization**, not arrival:

- Arrivals accumulate privately in `pending_groups`; an arrival into a still-incomplete group returns early and can no longer trigger a ship.
- `process_group` moves **all** of a finalized group's rollouts (errored + filtered + survivors) into the window before any drop path — dropped groups were still observed.
- Readiness is only checked after finalization, which is the only event that grows `pending_batch`/`pending_tokens`, so no ship opportunities are lost — a ready overflow ships on the next group finalization instead of on the next arbitrary arrival.

Invariant after the fix: every rollout appears in exactly one batch's window, and a window never claims rollouts of a group still in flight. The empty-batch carry semantics (window not reset when nothing ships) are preserved.

## Known nuance

If group C's finalization triggers shipping group A's overflow, C's rollouts are observed in that batch's window while C's survivors may only ship as samples in the next batch — window ≠ exact sample cohort for overflow steps. Each rollout is still reported exactly once; exact cohort ownership was explicitly deferred by the review note.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch-shipping timing and what rollouts appear in logged/persisted windows, which can shift wandb metrics and trace files in overflow scenarios without altering training payloads.
> 
> **Overview**
> **`TrainSink`** no longer adds rollouts to `TrainBatch.rollouts` on arrival. The observation window now only gains rollouts when a GRPO group **finalizes** in `process_group` (including errored/filtered members of dropped groups).
> 
> **`add()`** returns without shipping when a group is still incomplete, and batch readiness is checked only after finalization—the event that grows `pending_batch`. That stops a stray first rollout of a new in-flight group from triggering a ship and pulling overflow into a window that mixes groups.
> 
> **`TrainBatch`** docs are updated to describe the window as finalized groups since the last ship, not all arrivals. Trainer **`samples`** behavior is unchanged; this fixes metrics, error rates, and per-step trace persistence ownership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7ea318aa806521ebab83b46a85c3fda3a41ec72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->