### PR TITLE
fix(trainer): re-broadcast checkpoint weights on NCCL resume

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -247,6 +247,21 @@ def train(config: TrainerConfig):
 
     token_exporter = setup_token_exporter(config, parallel_dims, world, logger)
 
+    # NCCL weight broadcast streams weights live from the trainer, so on resume the
+    # inference servers still hold base weights and the orchestrator immediately asks
+    # them to adopt the checkpoint version — a request only the trainer can serve.
+    # Re-broadcast the resumed weights once before the first step; without this the
+    # inference pool pauses waiting for a broadcast that never arrives and the run
+    # deadlocks until the distributed timeout.
+    if checkpoint_step is not None and weight_broadcast is not None and config.weight_broadcast.type == "nccl":
+        logger.info(f"Re-broadcasting resumed checkpoint weights (policy v{checkpoint_step}) to inference")
+        if world.is_master:
+            multi_run_manager.discover_runs()
+        multi_run_manager.synchronize_state()
+        for idx in multi_run_manager.used_idxs:
+            multi_run_manager.ready_to_update[idx] = True
+        weight_broadcast.broadcast_weights(model, step=checkpoint_step)
+
     gc_handler = GarbageCollection(config.gc.interval) if config.gc else None
 
     logger.info(f"Starting training loop (max_steps={config.max_steps or 'infinite'})")


### PR DESCRIPTION
With `weight_broadcast.type = "nccl"` (the default since #2982), resuming from a checkpoint deadlocks the whole deployment:

1. The orchestrator resumes, sees the checkpoint's broadcast marker (`broadcasts/step_{ckpt}/STABLE`), and calls `/update_weights` so inference adopts policy v{ckpt}.
2. The inference servers pause generation and wait to receive the NCCL broadcast.
3. The trainer never sends one — it only broadcasts after completing a step, which needs a batch, which needs the (paused) inference servers.
4. Everything stalls until `dist_timeout_seconds`/httpx timeouts kill the run (observed: orchestrator `httpx.ReadTimeout` after ~34 min, trainer dist-timeout at 1h).

Fix: after loading the checkpoint, the trainer force-broadcasts the resumed weights once before entering the training loop (running run discovery + state sync first so the broadcast dir resolves to `step_{ckpt}`, and setting `ready_to_update` so `_compute_notified_runs` includes the run).

Hit on every checkpoint resume in our GLM-4.5-Air training campaign; verified across ~10 resumes since (the ~11h auth-token expiry makes scheduled resumes routine for us, so this path gets exercised a lot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
