### PR TITLE
ci: use filesystem weight broadcast for RL integration tests (temp NCCL workaround)

### DIFF
--- a/configs/ci/integration/alphabet_sort.toml
+++ b/configs/ci/integration/alphabet_sort.toml
@@ -1,6 +1,12 @@
 max_steps = 10
 seq_len = 2048
 
+[weight_broadcast]
+# TEMP: NCCL weight broadcast currently crashes the trainer on CI GPU runners
+# (trainer exits during NCCL init). Use filesystem transport until the NCCL
+# path is fixed. See CI RL integration test failures on main.
+type = "filesystem"
+
 [ckpt]
 
 [model]

--- a/configs/ci/integration/reverse_text/resume.toml
+++ b/configs/ci/integration/reverse_text/resume.toml
@@ -1,6 +1,12 @@
 max_steps = 20
 seq_len = 2048
 
+[weight_broadcast]
+# TEMP: NCCL weight broadcast currently crashes the trainer on CI GPU runners
+# (trainer exits during NCCL init). Use filesystem transport until the NCCL
+# path is fixed. See CI RL integration test failures on main.
+type = "filesystem"
+
 [ckpt]
 resume_step = 15
 

--- a/configs/ci/integration/reverse_text/start.toml
+++ b/configs/ci/integration/reverse_text/start.toml
@@ -1,6 +1,12 @@
 max_steps = 15
 seq_len = 2048
 
+[weight_broadcast]
+# TEMP: NCCL weight broadcast currently crashes the trainer on CI GPU runners
+# (trainer exits during NCCL init). Use filesystem transport until the NCCL
+# path is fixed. See CI RL integration test failures on main.
+type = "filesystem"
+
 [ckpt]
 
 [model]

--- a/configs/ci/integration/reverse_text_moe/start.toml
+++ b/configs/ci/integration/reverse_text_moe/start.toml
@@ -1,6 +1,12 @@
 max_steps = 20
 seq_len = 2048
 
+[weight_broadcast]
+# TEMP: NCCL weight broadcast currently crashes the trainer on CI GPU runners
+# (trainer exits during NCCL init). Use filesystem transport until the NCCL
+# path is fixed. See CI RL integration test failures on main.
+type = "filesystem"
+
 [ckpt]
 
 [model]

--- a/configs/ci/integration/reverse_text_rl_opd/start.toml
+++ b/configs/ci/integration/reverse_text_rl_opd/start.toml
@@ -7,6 +7,12 @@
 max_steps = 15
 seq_len = 2048
 
+[weight_broadcast]
+# TEMP: NCCL weight broadcast currently crashes the trainer on CI GPU runners
+# (trainer exits during NCCL init). Use filesystem transport until the NCCL
+# path is fixed. See CI RL integration test failures on main.
+type = "filesystem"
+
 [model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 

--- a/configs/ci/integration/reverse_text_rl_sft/start.toml
+++ b/configs/ci/integration/reverse_text_rl_sft/start.toml
@@ -7,6 +7,12 @@
 max_steps = 15
 seq_len = 2048
 
+[weight_broadcast]
+# TEMP: NCCL weight broadcast currently crashes the trainer on CI GPU runners
+# (trainer exits during NCCL init). Use filesystem transport until the NCCL
+# path is fixed. See CI RL integration test failures on main.
+type = "filesystem"
+
 [model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 


### PR DESCRIPTION
## What

Temporary CI fix: switch the RL integration test configs to the **filesystem** weight-broadcast transport instead of **NCCL**.

## Why

The RL integration tests are failing on `main` (GPU CI). All of them die the same way:

- Orchestrator + vLLM inference come up fine, then the **trainer subprocess exits with code 1 right at NCCL weight-broadcast init**:
  ```
  INFO Initializing NCCL broadcast: 1 servers, inference_world_size=1, gpus_per_server=1
  ERROR Error: Trainer failed with exit code 1        # ~5s later
  ```
- Only the **RL** tests fail (`reverse_text`, `alphabet_sort`, `reverse_text_moe`, `reverse_text_rl_opd`, `reverse_text_rl_sft`) because they use the trainer↔inference NCCL weight transfer. SFT-only and unit tests pass since they don't.
- The fast (~5s) crash means an exception in communicator setup, not the 1200s NCCL watchdog timeout. The real trainer traceback isn't visible because `tests/utils.py::check_no_error` only dumps `inference.log` / `orchestrator.log`, not `trainer.log`.

This PR is a **stopgap to get main CI green**. It does not fix NCCL — that will be done separately.

## Change

Add a top-level `[weight_broadcast]` block with `type = "filesystem"` to the affected unified RL configs under `configs/ci/integration/`. This is the same transport that `reverse_text_multi_run` already uses (and which passes).

## Follow-ups (not in this PR)
- Root-cause + fix the NCCL weight-broadcast crash (suspects: vLLM 0.23→0.24 bump, torch cu128 wheels in a cuda13 container).
- Make `check_no_error` also dump `trainer.log` so trainer failures are debuggable from CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only CI workaround with no production or application code changes; slightly different weight-sync path in tests only.
> 
> **Overview**
> Adds a top-level **`[weight_broadcast]`** block with **`type = "filesystem"`** to six unified RL CI configs under `configs/ci/integration/` (`alphabet_sort`, `reverse_text` start/resume, `reverse_text_moe`, `reverse_text_rl_opd`, `reverse_text_rl_sft`). Comments document this as a **temporary** workaround because **NCCL** weight broadcast makes the trainer exit during init on GPU CI runners.
> 
> Training behavior in CI should match the already-passing **`reverse_text_multi_run`** setup, which already uses filesystem transport, until NCCL is fixed separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99b1f682c420ee172c34653f9a657a9f60eb85d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->