### PR TITLE
fix: support DeepGEMM FP8 training on SM100

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ flash-attn-cute = [
 ]
 disagg = [
     "deep-ep ; platform_machine == 'x86_64'",
-    "deep-gemm ; platform_machine == 'x86_64'",
+    "deep-gemm",
     "nixl",
     "nixl-cu12 ; platform_machine == 'x86_64'",
     "vllm-router ; platform_machine == 'x86_64'",
@@ -201,7 +201,10 @@ vllm = [
     { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
 ]
 deep-ep = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.2.1+29d31c0-cp312-cp312-linux_x86_64.whl" }
-deep-gemm = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl" }
+deep-gemm = [
+    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" },
+    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_aarch64.whl", marker = "platform_machine == 'aarch64'" },
+]
 nixl-cu12 = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }
 flash-linear-attention = { git = "https://github.com/fla-org/flash-linear-attention" }
 flash_attn_3 = { index = "pytorch-cu128-test" }

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -46,8 +46,10 @@ Requires `nvcc`. Without `mamba-ssm`, NemotronH falls back to HF's pure-PyTorch 
 ### FP8 inference (GLM-5-FP8, etc.)
 
 ```bash
-uv sync --group fp8-inference   # installs the prebuilt deep-gemm wheel
+uv sync --extra disagg
 ```
+
+This installs the prebuilt DeepGEMM wheel selected by `uv` for Linux x86_64 or aarch64.
 
 ### Trainer DeepEP backend
 

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -43,14 +43,6 @@ CUDA_HOME=/usr/local/cuda uv pip install mamba-ssm
 
 Requires `nvcc`. Without `mamba-ssm`, NemotronH falls back to HF's pure-PyTorch SSD path, which computes softplus in bf16 and yields ~0.4 KL divergence vs vLLM. Do **not** install `causal-conv1d` unless your GPU arch matches the prebuilt kernels — the code falls back to `nn.Conv1d` when it's absent.
 
-### FP8 inference (GLM-5-FP8, etc.)
-
-```bash
-uv sync --extra disagg
-```
-
-This installs the prebuilt DeepGEMM wheel selected by `uv` for Linux x86_64 or aarch64.
-
 ### Trainer DeepEP backend
 
 `scripts/install_ep_kernels.sh` auto-detects the CUDA toolkit matching torch and the GPU arch, builds NVSHMEM + DeepEP from source, and skips if `deep_ep` already imports.

--- a/src/prime_rl/trainer/models/kernels/fp8_utils.py
+++ b/src/prime_rl/trainer/models/kernels/fp8_utils.py
@@ -249,7 +249,7 @@ def _grouped_per_token_fp8_kernel(
 
 
 @triton.jit
-def _grouped_per_channel_fp8_sm90_kmajor_kernel(
+def _grouped_per_channel_fp8_kernel(
     x_ptr,
     block_to_group_ptr,
     starts_ptr,
@@ -264,6 +264,7 @@ def _grouped_per_channel_fp8_sm90_kmajor_kernel(
     stride_sf0,
     stride_sf1,
     USE_UE8M0: tl.constexpr,
+    K_MAJOR: tl.constexpr,
     BLOCK_K: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
@@ -293,8 +294,20 @@ def _grouped_per_channel_fp8_sm90_kmajor_kernel(
         scale = tl.exp2(tl.ceil(tl.log2(scale)))
     y = x / scale[None, :]
     flat_base = block_start.to(tl.int64) * BLOCK_K * cols
-    out_ptrs = out_ptr + flat_base + col_offsets_i64[:, None] * aligned_m + row_offsets_i64[None, :]
-    tl.store(out_ptrs, tl.trans(y).to(tl.float8e4nv), mask=valid_cols[:, None] & (row_offsets[None, :] < aligned_m))
+    if K_MAJOR:
+        out_ptrs = out_ptr + flat_base + col_offsets_i64[:, None] * aligned_m + row_offsets_i64[None, :]
+        tl.store(
+            out_ptrs,
+            tl.trans(y).to(tl.float8e4nv),
+            mask=valid_cols[:, None] & (row_offsets[None, :] < aligned_m),
+        )
+    else:
+        out_ptrs = out_ptr + flat_base + row_offsets_i64[:, None] * cols + col_offsets_i64[None, :]
+        tl.store(
+            out_ptrs,
+            y.to(tl.float8e4nv),
+            mask=(row_offsets[:, None] < aligned_m) & valid_cols[None, :],
+        )
     tl.store(
         sf_ptr + pid_blk * stride_sf0 + col_offsets_i64 * stride_sf1,
         scale,
@@ -477,7 +490,7 @@ def grouped_per_channel_cast_to_fp8_sm90_kmajor_triton(
     if block_to_group.numel() == 0:
         return out, sf.T
     grid = (block_to_group.numel(), ceil_div(x.size(1), 128))
-    _grouped_per_channel_fp8_sm90_kmajor_kernel[grid](
+    _grouped_per_channel_fp8_kernel[grid](
         x,
         block_to_group,
         starts_tensor,
@@ -492,11 +505,54 @@ def grouped_per_channel_cast_to_fp8_sm90_kmajor_triton(
         sf.stride(0),
         sf.stride(1),
         USE_UE8M0=use_ue8m0,
+        K_MAJOR=True,
         BLOCK_K=gran_k,
         BLOCK_N=128,
         num_warps=4,
     )
     return out, sf.T
+
+
+def grouped_per_channel_cast_to_fp8_rowmajor_triton(
+    x: torch.Tensor,
+    padded_total_m: int,
+    block_to_group: torch.Tensor,
+    starts_tensor: torch.Tensor,
+    actual_ms_tensor: torch.Tensor,
+    ks_tensor: torch.Tensor,
+    block_starts_tensor: torch.Tensor,
+    use_ue8m0: bool,
+    gran_k: int = GROUP_ALIGNMENT,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert x.dim() == 2
+    assert gran_k == GROUP_ALIGNMENT
+    out = torch.empty((padded_total_m, x.size(1)), device=x.device, dtype=torch.float8_e4m3fn)
+    total_blocks = padded_total_m // gran_k
+    sf = torch.empty((total_blocks, x.size(1)), device=x.device, dtype=torch.float32)
+    if block_to_group.numel() == 0:
+        return out, sf
+    grid = (block_to_group.numel(), ceil_div(x.size(1), 128))
+    _grouped_per_channel_fp8_kernel[grid](
+        x,
+        block_to_group,
+        starts_tensor,
+        actual_ms_tensor,
+        ks_tensor,
+        block_starts_tensor,
+        out,
+        sf,
+        x.size(1),
+        x.stride(0),
+        x.stride(1),
+        sf.stride(0),
+        sf.stride(1),
+        USE_UE8M0=use_ue8m0,
+        K_MAJOR=False,
+        BLOCK_K=gran_k,
+        BLOCK_N=128,
+        num_warps=4,
+    )
+    return out, sf
 
 
 def grouped_per_block_cast_to_fp8_triton(

--- a/src/prime_rl/trainer/models/layers/fp8_grouped_gemm.py
+++ b/src/prime_rl/trainer/models/layers/fp8_grouped_gemm.py
@@ -1,21 +1,25 @@
 from __future__ import annotations
 
+import torch
+
 try:
     import deep_gemm
 except ImportError:
     deep_gemm = None  # CPU-only environments don't ship deep_gemm; FP8 paths
     # are GPU-only at runtime, so leaving the symbol None is safe — only the
     # autograd Function bodies below actually call into it.
-import torch
 
 from prime_rl.trainer.models.kernels.fp8_utils import (
     GROUP_ALIGNMENT,
     build_grouped_layout,
     grouped_per_block_cast_to_fp8_triton,
+    grouped_per_channel_cast_to_fp8_rowmajor_triton,
     grouped_per_channel_cast_to_fp8_sm90_kmajor_triton,
     grouped_per_token_cast_to_fp8_triton,
     unpack_rows_triton,
 )
+
+USE_POWER_OF_TWO_SCALES = True
 
 
 def _compute_grad_weight(
@@ -30,32 +34,60 @@ def _compute_grad_weight(
     block_starts_tensor: torch.Tensor,
     aligned_ms: list[int],
 ) -> torch.Tensor:
-    x_k_major = grouped_per_channel_cast_to_fp8_sm90_kmajor_triton(
-        x,
-        padded_total_m,
-        block_to_group,
-        starts_tensor,
-        actual_ms_tensor,
-        ks_tensor,
-        block_starts_tensor,
-        False,
-        GROUP_ALIGNMENT,
-    )
-    dy_k_major = grouped_per_channel_cast_to_fp8_sm90_kmajor_triton(
-        grad_output,
-        padded_total_m,
-        block_to_group,
-        starts_tensor,
-        actual_ms_tensor,
-        ks_tensor,
-        block_starts_tensor,
-        False,
-        GROUP_ALIGNMENT,
-    )
+    is_sm100 = torch.cuda.get_device_capability(x.device)[0] >= 10
+    if is_sm100:
+        x_fp8 = grouped_per_channel_cast_to_fp8_rowmajor_triton(
+            x,
+            padded_total_m,
+            block_to_group,
+            starts_tensor,
+            actual_ms_tensor,
+            ks_tensor,
+            block_starts_tensor,
+            USE_POWER_OF_TWO_SCALES,
+            GROUP_ALIGNMENT,
+        )
+        dy_fp8 = grouped_per_channel_cast_to_fp8_rowmajor_triton(
+            grad_output,
+            padded_total_m,
+            block_to_group,
+            starts_tensor,
+            actual_ms_tensor,
+            ks_tensor,
+            block_starts_tensor,
+            USE_POWER_OF_TWO_SCALES,
+            GROUP_ALIGNMENT,
+        )
+        grouped_weight_grad = deep_gemm.k_grouped_fp8_gemm_tn_contiguous
+    else:
+        x_fp8 = grouped_per_channel_cast_to_fp8_sm90_kmajor_triton(
+            x,
+            padded_total_m,
+            block_to_group,
+            starts_tensor,
+            actual_ms_tensor,
+            ks_tensor,
+            block_starts_tensor,
+            USE_POWER_OF_TWO_SCALES,
+            GROUP_ALIGNMENT,
+        )
+        dy_fp8 = grouped_per_channel_cast_to_fp8_sm90_kmajor_triton(
+            grad_output,
+            padded_total_m,
+            block_to_group,
+            starts_tensor,
+            actual_ms_tensor,
+            ks_tensor,
+            block_starts_tensor,
+            USE_POWER_OF_TWO_SCALES,
+            GROUP_ALIGNMENT,
+        )
+        grouped_weight_grad = deep_gemm.k_grouped_fp8_gemm_nt_contiguous
+
     grad_weight = torch.zeros(weight_shape, device=x.device, dtype=torch.float32)
-    deep_gemm.k_grouped_fp8_gemm_nt_contiguous(
-        x_k_major,
-        dy_k_major,
+    grouped_weight_grad(
+        x_fp8,
+        dy_fp8,
         grad_weight,
         aligned_ms,
         ks_tensor,
@@ -90,12 +122,12 @@ class _GroupedFP8Gemm(torch.autograd.Function):
             starts_tensor,
             actual_ms_tensor,
             block_starts_tensor,
-            False,
+            USE_POWER_OF_TWO_SCALES,
             GROUP_ALIGNMENT,
         )
         weight_fp8 = grouped_per_block_cast_to_fp8_triton(
             weight.transpose(1, 2),
-            False,
+            USE_POWER_OF_TWO_SCALES,
             GROUP_ALIGNMENT,
         )
 
@@ -174,12 +206,12 @@ class _GroupedFP8Gemm(torch.autograd.Function):
                 starts_tensor,
                 actual_ms_tensor,
                 block_starts_tensor,
-                False,
+                USE_POWER_OF_TWO_SCALES,
                 GROUP_ALIGNMENT,
             )
             weight_dx_fp8 = grouped_per_block_cast_to_fp8_triton(
                 weight,
-                False,
+                USE_POWER_OF_TWO_SCALES,
                 GROUP_ALIGNMENT,
             )
             grad_x_padded = torch.empty(

--- a/src/prime_rl/trainer/models/layers/fp8_grouped_gemm.py
+++ b/src/prime_rl/trainer/models/layers/fp8_grouped_gemm.py
@@ -19,8 +19,6 @@ from prime_rl.trainer.models.kernels.fp8_utils import (
     unpack_rows_triton,
 )
 
-USE_POWER_OF_TWO_SCALES = True
-
 
 def _compute_grad_weight(
     x: torch.Tensor,
@@ -44,7 +42,7 @@ def _compute_grad_weight(
             actual_ms_tensor,
             ks_tensor,
             block_starts_tensor,
-            USE_POWER_OF_TWO_SCALES,
+            True,
             GROUP_ALIGNMENT,
         )
         dy_fp8 = grouped_per_channel_cast_to_fp8_rowmajor_triton(
@@ -55,7 +53,7 @@ def _compute_grad_weight(
             actual_ms_tensor,
             ks_tensor,
             block_starts_tensor,
-            USE_POWER_OF_TWO_SCALES,
+            True,
             GROUP_ALIGNMENT,
         )
         grouped_weight_grad = deep_gemm.k_grouped_fp8_gemm_tn_contiguous
@@ -68,7 +66,7 @@ def _compute_grad_weight(
             actual_ms_tensor,
             ks_tensor,
             block_starts_tensor,
-            USE_POWER_OF_TWO_SCALES,
+            True,
             GROUP_ALIGNMENT,
         )
         dy_fp8 = grouped_per_channel_cast_to_fp8_sm90_kmajor_triton(
@@ -79,7 +77,7 @@ def _compute_grad_weight(
             actual_ms_tensor,
             ks_tensor,
             block_starts_tensor,
-            USE_POWER_OF_TWO_SCALES,
+            True,
             GROUP_ALIGNMENT,
         )
         grouped_weight_grad = deep_gemm.k_grouped_fp8_gemm_nt_contiguous
@@ -122,12 +120,12 @@ class _GroupedFP8Gemm(torch.autograd.Function):
             starts_tensor,
             actual_ms_tensor,
             block_starts_tensor,
-            USE_POWER_OF_TWO_SCALES,
+            True,
             GROUP_ALIGNMENT,
         )
         weight_fp8 = grouped_per_block_cast_to_fp8_triton(
             weight.transpose(1, 2),
-            USE_POWER_OF_TWO_SCALES,
+            True,
             GROUP_ALIGNMENT,
         )
 
@@ -206,12 +204,12 @@ class _GroupedFP8Gemm(torch.autograd.Function):
                 starts_tensor,
                 actual_ms_tensor,
                 block_starts_tensor,
-                USE_POWER_OF_TWO_SCALES,
+                True,
                 GROUP_ALIGNMENT,
             )
             weight_dx_fp8 = grouped_per_block_cast_to_fp8_triton(
                 weight,
-                USE_POWER_OF_TWO_SCALES,
+                True,
                 GROUP_ALIGNMENT,
             )
             grad_x_padded = torch.empty(

--- a/src/prime_rl/trainer/models/layers/fp8_linear.py
+++ b/src/prime_rl/trainer/models/layers/fp8_linear.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import re
 
+import torch
+from torch import nn
+
 try:
     import deep_gemm
 except ImportError:
     deep_gemm = None  # CPU-only environments don't ship deep_gemm; FP8 paths
     # are GPU-only at runtime, so leaving the symbol None is safe — only the
     # autograd Function bodies below actually call into it.
-import torch
-from torch import nn
 
 from prime_rl.trainer.models.kernels.fp8_utils import (
     per_block_cast_to_fp8_tp_triton,
@@ -25,8 +26,8 @@ class _FP8BlockwiseMM(torch.autograd.Function):
     def forward(ctx, x, weight, block_size, out_dtype=torch.bfloat16):
         x_shape = x.shape
         x_2d = x.reshape(-1, x_shape[-1]).contiguous()
-        x_fp8 = per_token_cast_to_fp8_triton(x_2d, False, block_size)
-        weight_fp8 = per_block_cast_to_fp8_triton(weight, False, block_size)
+        x_fp8 = per_token_cast_to_fp8_triton(x_2d, True, block_size)
+        weight_fp8 = per_block_cast_to_fp8_triton(weight, True, block_size)
 
         out = torch.empty((x_2d.size(0), weight.size(0)), device=x.device, dtype=out_dtype)
         deep_gemm.fp8_gemm_nt(x_fp8, weight_fp8, out)
@@ -44,8 +45,8 @@ class _FP8BlockwiseMM(torch.autograd.Function):
 
         grad_x = grad_weight = None
         if ctx.needs_input_grad[0]:
-            grad_output_fp8 = per_token_cast_to_fp8_triton(grad_output_2d, False, block_size)
-            weight_dx_fp8 = per_block_cast_to_fp8_tp_triton(weight, False, block_size)
+            grad_output_fp8 = per_token_cast_to_fp8_triton(grad_output_2d, True, block_size)
+            weight_dx_fp8 = per_block_cast_to_fp8_tp_triton(weight, True, block_size)
             grad_x_2d = torch.empty_like(x_2d)
             deep_gemm.fp8_gemm_nt(grad_output_fp8, weight_dx_fp8, grad_x_2d)
             grad_x = grad_x_2d.reshape(ctx.x_shape)
@@ -63,8 +64,8 @@ class _FP8BlockwiseMM(torch.autograd.Function):
             else:
                 grad_output_2d_padded = grad_output_2d
                 x_2d_padded = x_2d
-            grad_output_t_fp8 = per_token_cast_to_fp8_tp_triton(grad_output_2d_padded, False, block_size)
-            x_t_fp8 = per_token_cast_to_fp8_tp_triton(x_2d_padded, False, block_size)
+            grad_output_t_fp8 = per_token_cast_to_fp8_tp_triton(grad_output_2d_padded, True, block_size)
+            x_t_fp8 = per_token_cast_to_fp8_tp_triton(x_2d_padded, True, block_size)
             grad_weight_fp32 = torch.zeros_like(weight, dtype=torch.float32)
             deep_gemm.fp8_gemm_nt(
                 grad_output_t_fp8,
@@ -82,7 +83,7 @@ class Float8BlockwiseLinear(nn.Linear):
     """nn.Linear replacement that uses FP8 blockwise matmul via DeepGEMM.
 
     Requires:
-    - SM90 (Hopper) GPU
+    - SM90 (Hopper) or SM100 (Blackwell) GPU
     - bfloat16 inputs/weights
     - No bias
     - in_features and out_features divisible by 128

--- a/uv.lock
+++ b/uv.lock
@@ -1302,7 +1302,21 @@ wheels = [
 [[package]]
 name = "deep-gemm"
 version = "2.5.0+891d57b"
+source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_aarch64.whl" }
+resolution-markers = [
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
+wheels = [
+    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_aarch64.whl", hash = "sha256:a1cbc53414e26b70f9e283e4d57bbe48ba2a3ec84254a72052af8e06f6d0fb1a" },
+]
+
+[[package]]
+name = "deep-gemm"
+version = "2.5.0+891d57b"
 source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+]
 wheels = [
     { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl", hash = "sha256:3a9e4472b86e8e7e2c77cc76951c886bbe7a23a1f5908958969ab5b9c707a2f3" },
 ]
@@ -4845,7 +4859,8 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "deep-ep", marker = "platform_machine == 'x86_64'" },
-    { name = "deep-gemm", marker = "platform_machine == 'x86_64'" },
+    { name = "deep-gemm", version = "2.5.0+891d57b", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "deep-gemm", version = "2.5.0+891d57b", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "flash-attn", marker = "platform_machine == 'x86_64'" },
     { name = "flash-attn-3" },
     { name = "flash-attn-4" },
@@ -4856,7 +4871,8 @@ all = [
 ]
 disagg = [
     { name = "deep-ep", marker = "platform_machine == 'x86_64'" },
-    { name = "deep-gemm", marker = "platform_machine == 'x86_64'" },
+    { name = "deep-gemm", version = "2.5.0+891d57b", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "deep-gemm", version = "2.5.0+891d57b", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nixl" },
     { name = "nixl-cu12", version = "0.10.1", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64'" },
@@ -4899,6 +4915,8 @@ requires-dist = [
     { name = "beartype", specifier = ">=0.21.0" },
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "deep-ep", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.2.1+29d31c0-cp312-cp312-linux_x86_64.whl" },
+    { name = "deep-gemm", marker = "platform_machine == 'aarch64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_aarch64.whl" },
+    { name = "deep-gemm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'disagg'" },
     { name = "deep-gemm", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl" },
     { name = "dion", git = "https://github.com/samsja/dion.git?rev=d891eeb" },
     { name = "flash-attn", marker = "platform_machine == 'x86_64' and extra == 'flash-attn'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.4/flash_attn-2.8.3+cu128torch2.11-cp312-cp312-linux_x86_64.whl" },


### PR DESCRIPTION
## Summary

- install the matching DeepGEMM wheel on Linux x86_64 and aarch64 through `uv`; the new aarch64 wheel is published in the existing [v0.5.0 release](https://github.com/PrimeIntellect-ai/prime-rl/releases/tag/v0.5.0)
- use power-of-two FP32 scale values for dense and grouped FP8 GEMMs, which remain valid input on SM90 and can be converted to the packed UE8M0 layout required by SM100
- use DeepGEMM's row-major TN K-grouped API for SM100 weight gradients while preserving the K-major NT path on SM90
- remove the stale install-skill reference to the nonexistent `fp8-inference` dependency group

## Validation

- `uv 0.11.1 lock --check`
- Ruff format and lint checks for the changed Python modules
- on Linux aarch64, `uv 0.11.25` selected and installed `deep_gemm-2.5.0+891d57b-cp312-cp312-linux_aarch64.whl` from the PrimeRL release; SHA-256 `a1cbc53414e26b70f9e283e4d57bbe48ba2a3ec84254a72052af8e06f6d0fb1a`
- NVIDIA GB200 (SM100), Torch 2.11.0+cu129, DeepGEMM 2.5.0: forward, input-gradient, and weight-gradient checks passed for GLM-5.2 MoE gate/up (`K=6144`, `N=2048`) and down (`K=2048`, `N=6144`) projections with uneven expert token counts `(193, 257, 321, 385)`
- the same forward and backward checks passed for dense GLM-5.2 projections `6144 -> 12288` and `12288 -> 6144` with 257 tokens, exercising the weight-gradient padding path
- maximum observed NRMSE was `0.037508`; minimum cosine similarity was `0.999296`

The default cluster has no H200 nodes, so the SM90 path was not rerun on hardware. DeepGEMM's SM90 scale-layout implementation accepts FP32 scale tensors, including these power-of-two values, and its existing K-major NT path is retained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core FP8 training math, layouts, and DeepGEMM APIs on GPU-specific paths; SM90 behavior is intended to be preserved but was not re-validated on H200 in this PR.
> 
> **Overview**
> Enables **DeepGEMM-based FP8 training on SM100 (Blackwell)** while keeping the existing Hopper path, and ships matching **deep-gemm** wheels on **Linux x86_64 and aarch64** via `uv` (including the `disagg` extra).
> 
> FP8 quantization now uses **power-of-two FP32 scales** (`use_ue8m0=True`) across dense and grouped paths so scales stay valid on SM90 and can map to the **UE8M0 layout SM100 expects**. The grouped per-channel Triton kernel is unified with a **`K_MAJOR` layout flag**, and a new **row-major** cast backs SM100 weight gradients.
> 
> **Grouped MoE GEMM** branches on compute capability: SM100 uses row-major activations/grads with `k_grouped_fp8_gemm_tn_contiguous`; SM90 keeps the K-major path and `k_grouped_fp8_gemm_nt_contiguous`. **`Float8BlockwiseLinear`** docs now list SM100 alongside SM90.
> 
> Install docs drop the obsolete **`fp8-inference`** extra; **`uv.lock`** picks up the aarch64 **deep-gemm** wheel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ef1b389cb21ff099b24899fa68dd5184b2c75c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->