### PR TITLE
feat(config): allow prime-rl conversions to be stored separately from model

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -117,6 +117,9 @@ class DebugModelConfig(BaseConfig):
 
 
 class ModelConfig(BaseModelConfig):
+    primerl_conversion_dir: Path | None = None
+    """Override the location for the converted weights in Prime-RL format. Defaults to the model snapshot directory."""
+
     seq_len: int = 2048
     """Sequence length the model is trained on."""
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -117,8 +117,8 @@ class DebugModelConfig(BaseConfig):
 
 
 class ModelConfig(BaseModelConfig):
-    primerl_conversion_dir: Path | None = None
-    """Override the location for the converted weights in Prime-RL format. Defaults to the model snapshot directory."""
+    conversion_dir: Path | None = None
+    """Directory for the auto-converted weights (written to a `prime`/`hf` subdirectory). If not set, we write into the model snapshot directory."""
 
     seq_len: int = 2048
     """Sequence length the model is trained on."""

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -834,19 +834,21 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
     # All ranks read just the key names (cheap) to determine the path independently.
     # Only master loads the full state dict when conversion is actually needed.
     if isinstance(model, PreTrainedModelPrimeRL):
-        snapshot_keys = dict.fromkeys(load_state_dict_keys(snapshot_path))
+        source_path = snapshot_path
+        convert_dir = config.primerl_conversion_dir or source_path
+        snapshot_keys = dict.fromkeys(load_state_dict_keys(source_path))
         model_keys = dict.fromkeys(model.state_dict().keys())
 
         if model.is_hf_state_dict(snapshot_keys) and model.is_prime_state_dict(model_keys):
             logger.warning(
                 "Found HF weight format in snapshot state dict and PrimeRL weight format in model state dict. Trying to auto-convert..."
             )
-            snapshot_path = snapshot_path / "prime"
+            snapshot_path = convert_dir / "prime"
             if not snapshot_path.exists() and get_world().is_master:
                 logger.debug(
                     f"Converting snapshot state dict to PrimeRL format and saving to {snapshot_path} on master rank. This is a one-time operation."
                 )
-                snapshot_state_dict = load_state_dict(snapshot_path.parent)
+                snapshot_state_dict = load_state_dict(source_path)
                 model.convert_to_prime(snapshot_state_dict)
                 save_state_dict(snapshot_state_dict, snapshot_path)
                 del snapshot_state_dict
@@ -855,12 +857,12 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
             logger.warning(
                 "Found PrimeRL weight format in snapshot state dict and HF weight format in model state dict. Trying to auto-convert..."
             )
-            snapshot_path = snapshot_path / "hf"
+            snapshot_path = convert_dir / "hf"
             if not snapshot_path.exists() and get_world().is_master:
                 logger.debug(
                     f"Converting snapshot state dict to HF format and saving to {snapshot_path} on master rank. This is a one-time operation."
                 )
-                snapshot_state_dict = load_state_dict(snapshot_path.parent)
+                snapshot_state_dict = load_state_dict(source_path)
                 model.convert_to_hf(snapshot_state_dict)
                 save_state_dict(snapshot_state_dict, snapshot_path)
                 del snapshot_state_dict

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -835,7 +835,7 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
     # Only master loads the full state dict when conversion is actually needed.
     if isinstance(model, PreTrainedModelPrimeRL):
         source_path = snapshot_path
-        convert_dir = config.primerl_conversion_dir or source_path
+        convert_dir = config.conversion_dir or source_path
         snapshot_keys = dict.fromkeys(load_state_dict_keys(source_path))
         model_keys = dict.fromkeys(model.state_dict().keys())
 


### PR DESCRIPTION
## Summary

When loading a HuggingFace model, Prime-RL auto-converts weights between HF and PrimeRL formats and writes the converted weights into the model's snapshot directory (`snapshot_path / "prime"` or `snapshot_path / "hf"`). This is a problem when the model directory is immutable (e.g., a shared, read-only HF model cache).

This PR adds a `primerl_conversion_dir` config field to `ModelConfig` that lets you specify a separate writable location for converted weights. When unset, it falls back to the model snapshot directory (existing behavior).

## Changes

- **`packages/prime-rl-configs/src/prime_rl/configs/trainer.py`** — add `primerl_conversion_dir: Path | None = None` to `ModelConfig`
- **`src/prime_rl/trainer/model.py`** — use `config.primerl_conversion_dir or source_path` as the base directory for conversions. The original snapshot is always read from `source_path`; converted weights are written to `convert_dir / "prime"` or `convert_dir / "hf"`. Also fixes `load_state_dict` to always read from `source_path` instead of `snapshot_path.parent` (which after reassignment would point to the conversion dir, not the original model).

## Notes

- The HRT fork PR had a naming mismatch: config field was `primerl_conversion_dir` but model.py referenced `prime_rl_conversion_dir`. Fixed here to use `primerl_conversion_dir` consistently.
- Backward-compatible: `None` default preserves existing behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional config on the weight-load/conversion path only; no auth or training-loop changes.
> 
> **Overview**
> Adds optional **`model.conversion_dir`** on trainer `ModelConfig` so one-time HF ↔ PrimeRL weight conversions can be written to a writable directory instead of under the model snapshot (e.g. read-only HF caches).
> 
> In **`load_dcp_from_hf`**, the snapshot is always inspected and loaded from **`source_path`**, while converted artifacts go to **`conversion_dir / "prime"`** or **`conversion_dir / "hf"`** when formats differ; unset **`conversion_dir`** keeps the previous behavior (convert next to the snapshot). **`load_state_dict`** during conversion now always reads from **`source_path`**, fixing a bug where **`snapshot_path.parent`** could point at the conversion dir after **`snapshot_path`** was reassigned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c1ed01883b92d4ed84180aca99b16801eae255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->