### PR TITLE
refactor: share training batch production

### DIFF
--- a/src/prime_rl/orchestrator/batch_producer.py
+++ b/src/prime_rl/orchestrator/batch_producer.py
@@ -1,0 +1,55 @@
+"""Shared publication loop for trainer-bound batches."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, Protocol, TypeVar
+
+from prime_rl.transport.base import TrainingBatchSender
+from prime_rl.transport.types import TrainingBatch, TrainingSample
+
+ContextT = TypeVar("ContextT")
+
+
+class StepProgress(Protocol):
+    step: int
+
+
+@dataclass
+class PreparedTrainingBatch(Generic[ContextT]):
+    examples: list[TrainingSample]
+    context: ContextT
+
+
+class TrainingBatchSource(Protocol[ContextT]):
+    async def next_training_batch(self, step: int) -> PreparedTrainingBatch[ContextT] | None: ...
+
+    async def on_training_batch_sent(self, batch: PreparedTrainingBatch[ContextT], step: int) -> None: ...
+
+
+class TrainingBatchProducer(Generic[ContextT]):
+    """Publish batches from any source and keep its step aligned with the trainer."""
+
+    def __init__(
+        self,
+        *,
+        source: TrainingBatchSource[ContextT],
+        sender: TrainingBatchSender,
+        progress: StepProgress,
+    ) -> None:
+        self.source = source
+        self.sender = sender
+        self.progress = progress
+
+    async def run(self) -> None:
+        while True:
+            step = self.progress.step
+            batch = await self.source.next_training_batch(step)
+            if batch is None:
+                return
+            if not batch.examples:
+                raise ValueError(f"Training batch source returned an empty batch for step {step}")
+
+            await self.sender.send(TrainingBatch(examples=batch.examples, step=step))
+            self.progress.step += 1
+            await self.source.on_training_batch_sent(batch, step)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -16,7 +16,7 @@ and drives the pipeline. Components are single-purpose:
   ``_timestamp``-axis pipeline log.
 
 Components don't reference the orchestrator. The orchestrator wires them
-in ``setup()`` and drives them from ``main_loop()``.
+in ``setup()`` and exposes trainer-bound batches to the shared producer.
 """
 
 from __future__ import annotations
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import os
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import tomli_w
@@ -38,6 +39,7 @@ if TYPE_CHECKING:
     from prime_rl.utils.monitor.base import Monitor
 import prime_rl._compat  # noqa: F401 — patch ring_flash_attn compat before transitive imports
 from prime_rl.configs.orchestrator import OrchestratorConfig
+from prime_rl.orchestrator.batch_producer import PreparedTrainingBatch, TrainingBatchProducer
 from prime_rl.orchestrator.ckpt import setup_ckpt_manager
 from prime_rl.orchestrator.dispatcher import DispatcherMetrics, DispatcherMode, RolloutDispatcher
 from prime_rl.orchestrator.envs import EvalEnvs, TrainEnvs
@@ -69,7 +71,7 @@ from prime_rl.orchestrator.utils import (
 )
 from prime_rl.orchestrator.watcher import WeightWatcher
 from prime_rl.trainer.model import setup_tokenizer
-from prime_rl.transport import TrainingBatch, setup_training_batch_sender
+from prime_rl.transport import setup_training_batch_sender
 from prime_rl.utils.async_utils import EventLoopLagMonitor, EventLoopLagStats, safe_cancel
 from prime_rl.utils.client import init_nccl_broadcast
 from prime_rl.utils.config import to_toml_dict
@@ -105,6 +107,12 @@ TARGET_LAG = 1
 # configures ``wait_for_weights_timeout`` (e.g. a from-scratch run). The
 # broadcast is always coming, so wait rather than fail immediately.
 STARTUP_WEIGHT_WAIT_TIMEOUT_S = 1200
+
+
+@dataclass
+class RolloutBatchContext:
+    batch: TrainBatch
+    step_time: float
 
 
 class Orchestrator:
@@ -421,8 +429,8 @@ class Orchestrator:
         start_time = time.perf_counter()
 
         # Spawn background loops (dispatcher schedules, watcher polls). The
-        # pipeline ``main_loop`` runs inline in this task; the single
-        # ``PeriodicLogger`` polls dispatcher / watcher / sinks / lag
+        # batch source runs inline in this task; the single ``PeriodicLogger``
+        # polls dispatcher / watcher / sinks / lag
         # monitor each ``log.interval`` seconds for the pipeline-view log
         self.lag_task = asyncio.create_task(self.lag_monitor.run(), name="event_loop_lag")
         await self.periodic_logger.start()
@@ -438,12 +446,16 @@ class Orchestrator:
         # Anchor step-time clock so the first step measures startup → first batch
         self.last_batch_at = time.perf_counter()
 
-        # ``clean_exit`` stays False if ``main_loop`` raises (signal-driven
+        # ``clean_exit`` stays False if batch production raises (signal-driven
         # CancelledError, KeyboardInterrupt, or a real error), so the teardown
         # logs a forced-cleanup warning instead of a clean-exit success.
         clean_exit = False
         try:
-            await self.main_loop()
+            await TrainingBatchProducer(
+                source=self,
+                sender=self.sender,
+                progress=self.progress,
+            ).run()
             clean_exit = True
         finally:
             elapsed = format_time(time.perf_counter() - start_time)
@@ -466,15 +478,14 @@ class Orchestrator:
                 get_logger().warning("Orchestrator cleanup complete (forced).")
             trim_process_memory()
 
-    async def main_loop(self) -> None:
-        """Consume ``Rollout``\\ s from the dispatcher and route them
-        to the train / eval sink. Both sinks return a finalized batch (or
-        ``None``) from ``add()``; we just dispatch on the result."""
+    async def next_training_batch(self, batch_step: int) -> PreparedTrainingBatch[RolloutBatchContext] | None:
+        """Consume rollouts until the next trainer-bound batch is ready."""
+        assert batch_step == self.progress.step
         while not self.stopped.is_set():
             if self.draining and self.dispatcher.is_idle:
                 get_logger().info("Pipeline drained, exiting main loop")
                 self.stopped.set()
-                break
+                return None
 
             try:
                 rollout: Rollout = await asyncio.wait_for(self.dispatcher.out_q.get(), timeout=0.5)
@@ -485,12 +496,12 @@ class Orchestrator:
             # ``all`` trace file the moment it arrives, so it survives crashes and drains.
             # Train rollouts belong to the batch window currently collecting (``progress.step``),
             # eval rollouts to the step whose eval triggered them.
-            step = rollout.eval_step if rollout.kind == "eval" else self.progress.step
-            assert step is not None
+            rollout_step = rollout.eval_step if rollout.kind == "eval" else batch_step
+            assert rollout_step is not None
             await asyncio.to_thread(
                 save_rollouts,
                 [rollout.to_record()],
-                get_trace_path(self.config.output_dir, step, rollout.kind, "all"),
+                get_trace_path(self.config.output_dir, rollout_step, rollout.kind, "all"),
             )
 
             if rollout.kind == "eval":
@@ -504,15 +515,16 @@ class Orchestrator:
             # In drain mode any late-arriving train batch is dropped — we
             # don't want to ship past ``max_steps``
             if train_batch is not None and not self.draining and not self.stopped.is_set():
-                await self.finalize_train_batch(train_batch)
+                batch = await self.prepare_train_batch(train_batch, batch_step)
+                if batch is not None:
+                    return batch
+        return None
 
-    async def finalize_train_batch(self, batch: TrainBatch) -> None:
-        """Ship one ``TrainBatch`` out to the trainer and handle the I/O
-        side-effects (ckpt, save_rollouts, reference scoring, sender.send,
-        metrics, heartbeat, progress, eval trigger). The sink has already
-        done all data-transformation work."""
+    async def prepare_train_batch(
+        self, batch: TrainBatch, step: int
+    ) -> PreparedTrainingBatch[RolloutBatchContext] | None:
+        """Validate and persist a rollout batch before publication."""
         config = self.config
-        step = self.progress.step
 
         # Sink-to-sink cycle time — the actual time between batches, not
         # including the orchestrator's ship I/O (overlapped with the
@@ -529,7 +541,7 @@ class Orchestrator:
                 f"Draining pipeline (cancelled {n_cancelled} in-flight train rollout(s); "
                 f"any in-flight evals will complete)"
             )
-            return
+            return None
 
         if not batch.samples:
             self.consecutive_empty_batches += 1
@@ -543,7 +555,7 @@ class Orchestrator:
                     f"{self.consecutive_empty_batches} consecutive empty train batches — "
                     "check filter config (pre_batch_filters / post_batch_filters) or task difficulty."
                 )
-            return
+            return None
         self.consecutive_empty_batches = 0
         n_trainable = sum(1 for r in batch.rollouts if r.is_trainable)
         if n_trainable / len(batch.rollouts) <= 0.1:
@@ -560,8 +572,19 @@ class Orchestrator:
         records = [r.to_record() for r in effective]
         await asyncio.to_thread(save_rollouts, records, get_trace_path(config.output_dir, step, "train", "effective"))
 
-        await self.sender.send(TrainingBatch(examples=batch.samples, step=step))
-        self.progress.step += 1
+        return PreparedTrainingBatch(
+            examples=batch.samples,
+            context=RolloutBatchContext(batch=batch, step_time=step_time),
+        )
+
+    async def on_training_batch_sent(
+        self,
+        prepared: PreparedTrainingBatch[RolloutBatchContext],
+        step: int,
+    ) -> None:
+        """Run rollout-specific side effects after the shared producer sends a batch."""
+        batch = prepared.context.batch
+        step_time = prepared.context.step_time
         self.update_dispatch_gate()
         # Checkpoint the step we just shipped (resume point: continue at step + 1).
         save_ckpt_time = await self.maybe_save_ckpt(step)
@@ -916,9 +939,9 @@ async def run_orchestrator(config: OrchestratorConfig) -> None:
     on exit (success or crash); keeps that out of the class.
     """
     if config.is_static_sft:
-        from prime_rl.orchestrator.static_sft import DatasetBatchProducer
+        from prime_rl.orchestrator.static_sft import DatasetBatchSource
 
-        await DatasetBatchProducer(config).start()
+        await DatasetBatchSource(config).start()
         return
     await Orchestrator(config).start()
 

--- a/src/prime_rl/orchestrator/static_sft.py
+++ b/src/prime_rl/orchestrator/static_sft.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 import tomli_w
@@ -13,10 +14,11 @@ from renderers.base import Renderer, build_training_sample, create_renderer
 from prime_rl.configs.algorithm import DatasetSourceConfig
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.algo.routing import stamp_loss_routing
+from prime_rl.orchestrator.batch_producer import PreparedTrainingBatch, TrainingBatchProducer
 from prime_rl.orchestrator.ckpt import CheckpointManager, setup_ckpt_manager
 from prime_rl.orchestrator.trajectories import _encode_mm_kwargs
 from prime_rl.orchestrator.types import Progress
-from prime_rl.transport import TrainingBatch, TrainingSample, setup_training_batch_sender
+from prime_rl.transport import TrainingSample, setup_training_batch_sender
 from prime_rl.utils.chat_template import deserialize_tool_calls, normalize_messages, strip_message_content
 from prime_rl.utils.config import to_toml_dict
 from prime_rl.utils.heartbeat import Heartbeat
@@ -186,8 +188,14 @@ class DatasetSampleSource:
         return await asyncio.to_thread(self._build_batch, batch_size, token_batch_size)
 
 
-class DatasetBatchProducer:
-    """Produces dataset-backed training batches for the trainer."""
+@dataclass
+class DatasetBatchContext:
+    attempts: int
+    started: float
+
+
+class DatasetBatchSource:
+    """Adapts a static SFT dataset to the shared training-batch producer."""
 
     def __init__(self, config: OrchestratorConfig) -> None:
         self.config = config
@@ -198,9 +206,11 @@ class DatasetBatchProducer:
         self.ckpt_manager: CheckpointManager | None = setup_ckpt_manager(config.output_dir, config.ckpt)
         self.sender: TrainingBatchSender | None = None
         self.monitor: Monitor | None = None
+        self.source: DatasetSampleSource | None = None
         self.heart = Heartbeat(config.heartbeat.url) if config.heartbeat is not None else None
+        self.last_completed_step = 0
 
-    async def setup(self) -> DatasetSampleSource:
+    async def setup(self) -> None:
         config = self.config
         config_dir = config.output_dir / "control"
         config_dir.mkdir(parents=True, exist_ok=True)
@@ -224,14 +234,14 @@ class DatasetBatchProducer:
 
         tokenizer = setup_tokenizer(config.tokenizer)
         renderer = create_renderer(tokenizer, config.renderer)
-        source = DatasetSampleSource(
+        self.source = DatasetSampleSource(
             self.dataset_config,
             renderer=renderer,
             tokenizer=tokenizer,
             seq_len=config.seq_len,
             cursor=self.progress.total_problems,
         )
-        await source.load()
+        await self.source.load()
         from prime_rl.utils.monitor import setup_monitor
 
         self.monitor = setup_monitor(
@@ -245,58 +255,76 @@ class DatasetBatchProducer:
             eval_env_names=[],
         )
         self.sender = setup_training_batch_sender(config.output_dir, config.rollout_transport)
-        return source
+        self.last_completed_step = self.progress.step - 1
 
     async def start(self) -> None:
-        source = await self.setup()
+        await self.setup()
         assert self.sender is not None and self.monitor is not None
         config = self.config
         get_logger().info(f"Starting static SFT loop (max_steps={config.max_steps or 'infinite'})")
-        last_completed_step = self.progress.step - 1
         try:
-            while config.max_steps is None or self.progress.step <= config.max_steps:
-                step = self.progress.step
-                started = time.perf_counter()
-                samples, attempts = await source.build_batch(config.batch_size, config.token_batch_size)
-                await self.sender.send(TrainingBatch(examples=samples, step=step))
-
-                stable = get_step_path(get_broadcast_dir(config.output_dir), step) / "STABLE"
-                await wait_for_path(stable)
-
-                num_tokens = sum(len(sample.token_ids) for sample in samples)
-                self.progress.total_tokens += num_tokens
-                self.progress.total_samples += len(samples)
-                self.progress.total_problems += attempts
-                self.progress.step += 1
-                last_completed_step = step
-                if (
-                    self.ckpt_manager is not None
-                    and config.ckpt is not None
-                    and config.ckpt.interval is not None
-                    and step % config.ckpt.interval == 0
-                    and (config.max_steps is None or step < config.max_steps)
-                ):
-                    await asyncio.to_thread(self.ckpt_manager.save, self.progress, step)
-
-                elapsed = time.perf_counter() - started
-                self.monitor.log(
-                    {
-                        "progress/tokens": num_tokens,
-                        "progress/samples": len(samples),
-                        "progress/total_tokens": self.progress.total_tokens,
-                        "progress/total_samples": self.progress.total_samples,
-                        "time/step": elapsed,
-                        "step": step,
-                    },
-                    step=step,
-                )
-                get_logger().success(
-                    f"Step {step} | {format_time(elapsed):>7} | {len(samples)} samples | {num_tokens} tokens"
-                )
-                if self.heart is not None:
-                    self.heart.beat()
+            await TrainingBatchProducer(
+                source=self,
+                sender=self.sender,
+                progress=self.progress,
+            ).run()
         finally:
             self.monitor.save_final_summary()
-            if self.ckpt_manager is not None and last_completed_step > 0:
-                await asyncio.to_thread(self.ckpt_manager.save, self.progress, last_completed_step)
+            if self.ckpt_manager is not None and self.last_completed_step > 0:
+                self.progress.step = self.last_completed_step + 1
+                await asyncio.to_thread(self.ckpt_manager.save, self.progress, self.last_completed_step)
             self.sender.close()
+
+    async def next_training_batch(self, step: int) -> PreparedTrainingBatch[DatasetBatchContext] | None:
+        config = self.config
+        if config.max_steps is not None and step > config.max_steps:
+            return None
+        assert self.source is not None
+        started = time.perf_counter()
+        samples, attempts = await self.source.build_batch(config.batch_size, config.token_batch_size)
+        return PreparedTrainingBatch(
+            examples=samples,
+            context=DatasetBatchContext(attempts=attempts, started=started),
+        )
+
+    async def on_training_batch_sent(
+        self,
+        batch: PreparedTrainingBatch[DatasetBatchContext],
+        step: int,
+    ) -> None:
+        config = self.config
+        assert self.monitor is not None
+        stable = get_step_path(get_broadcast_dir(config.output_dir), step) / "STABLE"
+        await wait_for_path(stable)
+
+        num_tokens = sum(len(sample.token_ids) for sample in batch.examples)
+        self.progress.total_tokens += num_tokens
+        self.progress.total_samples += len(batch.examples)
+        self.progress.total_problems += batch.context.attempts
+        self.last_completed_step = step
+        if (
+            self.ckpt_manager is not None
+            and config.ckpt is not None
+            and config.ckpt.interval is not None
+            and step % config.ckpt.interval == 0
+            and (config.max_steps is None or step < config.max_steps)
+        ):
+            await asyncio.to_thread(self.ckpt_manager.save, self.progress, step)
+
+        elapsed = time.perf_counter() - batch.context.started
+        self.monitor.log(
+            {
+                "progress/tokens": num_tokens,
+                "progress/samples": len(batch.examples),
+                "progress/total_tokens": self.progress.total_tokens,
+                "progress/total_samples": self.progress.total_samples,
+                "time/step": elapsed,
+                "step": step,
+            },
+            step=step,
+        )
+        get_logger().success(
+            f"Step {step} | {format_time(elapsed):>7} | {len(batch.examples)} samples | {num_tokens} tokens"
+        )
+        if self.heart is not None:
+            self.heart.beat()


### PR DESCRIPTION
## What

Extracts the trainer-bound batch lifecycle behind a source-independent interface:

- `TrainingBatchSource` prepares examples and handles source-specific post-send work.
- `TrainingBatchProducer` is the single loop that publishes `TrainingBatch`, advances the trainer-aligned step, and notifies the source.
- The online rollout orchestrator and static dataset source both use that loop.

This is a stacked architectural draft on #2954 for examining whether this is the right invariant boundary.

## Why

#2954's `DatasetBatchProducer` still owned its own send/step loop, making it structurally close to a renamed static orchestrator. The first interface shared by rollout training and static SFT is the prepared trainer batch, not environments, dataset rows, or rollouts.

This change shares the lifecycle at that boundary while leaving source-specific behavior on the appropriate side:

- Rollout draining, eval handling, traces, and rollout metrics remain in `Orchestrator`.
- Dataset rendering, cursor accounting, trainer acknowledgement, and static metrics remain in `DatasetBatchSource`.

No config, transport, trainer, normalization, or checkpoint format changes are intended.

## Validation

- Ruff check and format check passed for the three changed files.
- Python compilation passed for the three changed files.
- A focused in-memory producer check verified publication order, step advancement, and the post-send callback contract.
- `git diff --check` passed.

No README changes or new test files.
