### PR TITLE
fix(laguna): use factor-derived YaRN scaling

### DIFF
--- a/src/prime_rl/trainer/models/laguna/configuration_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/configuration_laguna.py
@@ -148,7 +148,7 @@ class LagunaConfig(PretrainedConfig):
         for params in nested.values():
             params.setdefault("rope_type", "default")
 
-        # Laguna full-attention layers use YaRN's factor-derived attention scaling.
+        # vLLM ignores this override and derives YaRN scaling from factor; match it for rollout/trainer parity.
         nested["full_attention"].pop("attention_factor", None)
 
         self.rope_parameters = nested

--- a/src/prime_rl/trainer/models/laguna/configuration_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/configuration_laguna.py
@@ -148,6 +148,9 @@ class LagunaConfig(PretrainedConfig):
         for params in nested.values():
             params.setdefault("rope_type", "default")
 
+        # Laguna full-attention layers use YaRN's factor-derived attention scaling.
+        nested["full_attention"].pop("attention_factor", None)
+
         self.rope_parameters = nested
         self.partial_rotary_factor = None
 


### PR DESCRIPTION
## Summary

The Laguna checkpoint explicitly sets `attention_factor=1.0`, which the Transformers trainer treats as the final YaRN cosine/sine scale. vLLM only forwards its legacy `attn_factor` key, ignores `attention_factor`, and therefore derives `0.1 * ln(factor) + 1 = 1.4159` from `factor=64`.

This normalization deliberately removes the checkpoint override in PrimeRL so trainer logprobs use the same rotary embeddings as vLLM rollouts. It is a runtime compatibility override, not a claim that the checkpoint field is invalid. Sliding-attention layers are unchanged.

## Validation

A five-step GB200 A/B run reduced mean `mismatch_kl/all/mean` from [0.02423](https://wandb.ai/primeintellect/laguna-pr2802-repro/runs/ihny5m8t) to [0.00267](https://wandb.ai/primeintellect/laguna-pr2802-repro/runs/61h13jji), a 9.07x reduction.

<img width="434" height="299" alt="image" src="https://github.com/user-attachments/assets/28549465-29e6-402f-81a7-f3c883166573" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches attention/RoPE scaling for Laguna, which can change numerics on long sequences, but scope is a small config normalization aimed at rollout/trainer parity rather than new logic paths.
> 
> **Overview**
> **Laguna** RoPE normalization now **removes** `attention_factor` from `full_attention` rope parameters after merging defaults, so the trainer does not apply a YaRN attention scaling override that **vLLM ignores**.
> 
> vLLM derives YaRN attention scaling from `factor` instead; keeping `attention_factor` in config caused **rollout vs trainer mismatch** on long-context attention. The change is limited to `_normalize_rope_parameters` in `configuration_laguna.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49c8ea8598dbc53e9b39505c2e97a61272005f0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->