### PR TITLE
fix: restrict startup weight sync to resume and NCCL

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -323,25 +323,23 @@ class Orchestrator:
         else:
             get_logger().info("Training from scratch")
 
-        # Sync inference to the incoming policy before the first step, whether fresh (v0 = base) or
-        # resumed (v{resume_step}). This pauses inference and rendezvouses with the trainer's
-        # first-step broadcast (train.py), so inference serves the correct policy from step 1. Keeping
-        # it unconditional makes trainer/orchestrator startup symmetric and avoids the resume deadlock
-        # where inference waited for weights the trainer only sent at the end of a step.
-        sync_version = self.resume_step if self.resume_step is not None else 0
-        check_exists = config.weight_broadcast.type != "nccl"
-        # Wait for the trainer's startup broadcast to land. On a fresh start there is no ckpt block,
-        # so fall back to a default timeout instead of not waiting at all (which would raise before
-        # broadcasts/step_0/STABLE is written when using filesystem weight broadcast).
-        wait_timeout = config.ckpt.wait_for_weights_timeout if config.ckpt else STARTUP_WEIGHT_WAIT_TIMEOUT_S
-        weights_path = get_weight_dir(
-            config.output_dir, sync_version, check_exists=check_exists, wait_timeout=wait_timeout
-        )
-        await self.policy_inference.update_weights(weights_path, lora_name=self.lora_name, step=sync_version)
-        if self.lora_name is not None:
-            self.policy_inference.update_model_name(self.lora_name)
-            self.policy.model_name = self.lora_name
-        self.policy.version = sync_version
+        # Sync inference to the incoming policy before the first step when resuming or when using
+        # NCCL, which rendezvouses with the trainer's first-step broadcast (train.py). A fresh
+        # filesystem run needs no sync (the base model IS policy v0) and must not wait for a
+        # startup broadcast: runs registered after the trainer's first step never receive one.
+        if self.resume_step is not None or config.weight_broadcast.type == "nccl":
+            sync_version = self.resume_step if self.resume_step is not None else 0
+            check_exists = config.weight_broadcast.type != "nccl"
+            # Without a ckpt block, fall back to a default timeout instead of not waiting at all.
+            wait_timeout = config.ckpt.wait_for_weights_timeout if config.ckpt else STARTUP_WEIGHT_WAIT_TIMEOUT_S
+            weights_path = get_weight_dir(
+                config.output_dir, sync_version, check_exists=check_exists, wait_timeout=wait_timeout
+            )
+            await self.policy_inference.update_weights(weights_path, lora_name=self.lora_name, step=sync_version)
+            if self.lora_name is not None:
+                self.policy_inference.update_model_name(self.lora_name)
+                self.policy.model_name = self.lora_name
+            self.policy.version = sync_version
 
         self.train_source = TrainSource(self.train_envs, seed=42)
         self.eval_source: EvalSource | None = (

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -266,12 +266,13 @@ def train(config: TrainerConfig):
         logger.debug(f"Starting training step {progress.step}")
         step_start_time = time.perf_counter()
 
-        # Broadcast the incoming policy (v{progress.step-1}) before waiting for its rollouts. #2896
-        # broadcasts at the END of a step, so the first step would otherwise block on rollouts the
-        # inference engines cannot produce until they receive v{progress.step-1} (the orchestrator
-        # pauses inference at startup to sync it). This happens whether resuming (v{checkpoint_step})
-        # or starting fresh (v0), keeping trainer and orchestrator startup symmetric.
-        if progress.step == start_step and weight_broadcast is not None:
+        # With NCCL, broadcast the incoming policy (v{progress.step-1}) before waiting for its
+        # rollouts: #2896 broadcasts at the END of a step, so the first step would otherwise block
+        # on rollouts the paused inference engines cannot produce until they receive
+        # v{progress.step-1}. Filesystem broadcast needs no startup rendezvous (fresh: base model
+        # = v0; resume: the orchestrator reads its checkpoint dir), and a one-shot startup
+        # broadcast would miss multi-run runs registered after the first step.
+        if progress.step == start_step and weight_broadcast is not None and config.weight_broadcast.type == "nccl":
             logger.info(f"Broadcasting startup policy weights (v{progress.step - 1}) to inference engines")
             multi_run_manager.wait_for_run(0)
             for idx in multi_run_manager.used_idxs:


### PR DESCRIPTION
## Problem

`reverse_text_multi_run` has failed on every main CI run since #3004 landed (passing at `cb43db2ad`, failing from `2fdffa7d3` onward — e.g. runs [29294719493](https://github.com/PrimeIntellect-ai/prime-rl/actions/runs/29294719493), [29298376325](https://github.com/PrimeIntellect-ai/prime-rl/actions/runs/29298376325), [29300225509](https://github.com/PrimeIntellect-ai/prime-rl/actions/runs/29300225509)), always with:

```
TimeoutError: Timed out waiting for conditions ['Orchestrator finished.'] in /tmp/outputs/run_beta/logs/orchestrator.log after 300s
```

#3004 made the trainer/orchestrator startup weight sync unconditional:

- every orchestrator now pauses inference at startup and blocks in `get_weight_dir(...)` waiting for `broadcasts/step_{resume_step or 0}/STABLE` in its own run dir (default wait 1200s);
- the trainer broadcasts startup weights **exactly once**, at the top of its first loop iteration, covering only the runs discovered at that moment.

In multi-run, orchestrators register at arbitrary times (the integration test starts alpha/beta/gamma staggered by 5s with `max_concurrent_runs = 2`, plus `alpha_resume` much later). Any run registered after the trainer's first step never receives a `step_0` broadcast, but its orchestrator still waits for one — end-of-step broadcasts don't help since they write `step_1, step_2, ...`. The orchestrator hangs at startup and `"Orchestrator finished."` never appears.

There is also a second latent bug: on a fresh filesystem start with a `[ckpt]` block that doesn't set `wait_for_weights_timeout` (the CI config), `wait_timeout=None` means `get_weight_dir` raises `FileNotFoundError` immediately instead of waiting.

## Fix

Filesystem broadcast needs no startup rendezvous at all:

- **fresh**: inference already serves the base model, which *is* policy v0 — nothing to sync;
- **resume**: the orchestrator reads `v{resume_step}` from `checkpoints/step_N/weight`, which exists on disk before it starts.

Only NCCL has a receiver that must rendezvous with a trainer-side send — the deadlock #3004 legitimately fixed. And NCCL never has to deal with late-registering runs: multi-run implies LoRA, and NCCL+LoRA is rejected at config validation (also added in #3004).

So this PR gates the startup sync accordingly:

- `orchestrator.py`: startup weight sync only when `resume_step is not None or weight_broadcast.type == "nccl"`;
- `trainer/rl/train.py`: first-step startup broadcast only when `weight_broadcast.type == "nccl"`.

| Scenario | After this PR |
|---|---|
| Filesystem, fresh (incl. late multi-run runs) | no sync attempted — pre-#3004 behavior that passed CI |
| Filesystem, resume | syncs `v{resume_step}` from the checkpoint dir |
| NCCL, fresh & resume | #3004's startup rendezvous fully preserved |

## Validation

- `ruff check` / `ruff format --check` clean; both files compile.
- No unit tests reference the previous unconditional behavior.
- The real test is CI's `reverse_text_multi_run` (needs 2 GPUs; not runnable locally).

Unblocks the `reverse_text_multi_run` check currently failing on all PRs (e.g. #3014).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trainer–orchestrator weight handoff at startup, which can deadlock training if mis-gated; scope is narrow (filesystem fresh vs resume vs NCCL) and aligns both sides.
> 
> **Overview**
> **Restricts startup policy weight synchronization** so filesystem multi-run orchestrators no longer block at launch waiting for a one-time trainer broadcast they will never receive.
> 
> In **`orchestrator.py`**, the pre-first-step `get_weight_dir` / `update_weights` path now runs only when **resuming** (`resume_step` set) or when **`weight_broadcast.type == "nccl"`**. Fresh filesystem runs skip startup sync because inference already serves the base model as policy v0.
> 
> In **`train.py`**, the **first-iteration startup broadcast** is likewise limited to **NCCL**, matching the orchestrator so trainer and inference only rendezvous when NCCL actually requires it. Filesystem resume still syncs from checkpoint weight dirs on the orchestrator side.
> 
> NCCL fresh/resume startup behavior from the prior unconditional sync is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180c7358890c26ddb4bbd8ab1bbcbd678a2b5b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->