### PR TITLE
feat(inference): add online quantization config

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -441,7 +441,10 @@ class InferenceConfig(BaseConfig):
         if self.quantization != "mxfp8":
             return self
 
-        import torch
+        try:
+            import torch
+        except ModuleNotFoundError as exc:
+            raise ValueError("inference.quantization='mxfp8' requires torch to validate SM100 support.") from exc
 
         if torch.cuda.is_available():
             capability = torch.cuda.get_device_capability()

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -366,6 +366,9 @@ class InferenceConfig(BaseConfig):
     gpu_memory_utilization: float = 0.9
     """GPU memory utilization. Forwarded as ``--gpu-memory-utilization``."""
 
+    quantization: Literal["mxfp8", "fp8_per_block"] | None = None
+    """Online inference quantization method. Forwarded as ``--quantization``."""
+
     api_server_count: int = Field(1, ge=0)
     """API servers to run. Forwarded as ``--api-server-count``. Set to 0 for headless mode."""
 
@@ -430,6 +433,21 @@ class InferenceConfig(BaseConfig):
     def validate_multi_node_requires_slurm(self):
         if self.deployment.type in ("multi_node", "disaggregated") and self.slurm is None:
             raise ValueError("Must use SLURM for multi-node / disaggregated deployment.")
+        return self
+
+    @model_validator(mode="after")
+    def validate_mxfp8_requires_sm100(self):
+        """Reject MXFP8 when validation runs on a non-SM100 CUDA host."""
+        if self.quantization != "mxfp8":
+            return self
+
+        import torch
+
+        if torch.cuda.is_available():
+            capability = torch.cuda.get_device_capability()
+            if capability != (10, 0):
+                detected = f"SM{capability[0]}{capability[1]}"
+                raise ValueError(f"inference.quantization='mxfp8' requires SM100, detected {detected}.")
         return self
 
     @model_validator(mode="after")
@@ -576,6 +594,7 @@ class InferenceConfig(BaseConfig):
             "max_lora_rank": "max_lora_rank",
             "lora_target_modules": "lora_target_modules",
             "gpu_memory_utilization": "gpu_memory_utilization",
+            "quantization": "quantization",
             "api_server_count": "api_server_count",
             "enable_return_routed_experts": "enable_return_routed_experts",
             "enable_expert_parallel": "enable_expert_parallel",
@@ -624,6 +643,10 @@ class InferenceConfig(BaseConfig):
         # Remove lora_target_modules if not set (vLLM doesn't accept None)
         if hasattr(namespace, "lora_target_modules") and namespace.lora_target_modules is None:
             delattr(namespace, "lora_target_modules")
+
+        # Remove quantization if not set so vLLM can infer it from the checkpoint.
+        if namespace.quantization is None:
+            delattr(namespace, "quantization")
 
         # Remove rope_scaling if not set (vLLM doesn't accept None)
         if hasattr(namespace, "rope_scaling"):

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -19,6 +19,31 @@ def apply_shared_vllm_patches():
     monkey_patch_vllm_padded_input_scrub()
     monkey_patch_return_routed_experts_with_nixl_connector()
     monkey_patch_kv_xfer_finished_tolerate_freed()
+    monkey_patch_online_fp8_parameter_cast()
+
+
+def monkey_patch_online_fp8_parameter_cast():
+    """Pass plain tensors to vLLM's compiled block-FP8 caster.
+
+    Layerwise reload restores ``ModelWeightParameter`` objects before online
+    quantization. TorchDynamo recursively dispatches that tensor subclass while
+    tracing ``per_block_cast_to_fp8``. ``Parameter.data`` shares storage but is
+    a plain tensor, matching the input accepted during the initial model load.
+    """
+    from torch.nn import Parameter
+    from vllm.model_executor.layers.quantization.online import fp8
+
+    original_cast = fp8.per_block_cast_to_fp8
+    if getattr(original_cast, "_prime_rl_unwraps_parameters", False):
+        return
+
+    def _per_block_cast_to_fp8(x, *args, **kwargs):
+        if isinstance(x, Parameter):
+            x = x.data
+        return original_cast(x, *args, **kwargs)
+
+    _per_block_cast_to_fp8._prime_rl_unwraps_parameters = True
+    fp8.per_block_cast_to_fp8 = _per_block_cast_to_fp8
 
 
 def monkey_patch_kv_xfer_finished_tolerate_freed():


### PR DESCRIPTION
## Summary

- add inference.quantization as a first-class optional config with vLLM values mxfp8 and fp8_per_block
- require SM100 when mxfp8 is selected and config validation runs on a CUDA host
- unwrap restored Parameter objects before vLLM block-FP8 online casting during layerwise weight reload
- keep quantize_in_weight_transfer and vllm_extra behavior unchanged

## Experimental validation

- Blockwise FP8: completed 10 training steps with inference-side online quantization; mismatch KL mean 0.00921 (range 0.00396-0.01535) with no monotonic divergence. [Trainer W&B](https://wandb.ai/primeintellect/laguna-online-quant/runs/3nwnymym) · [Orchestrator W&B](https://wandb.ai/primeintellect/laguna-online-quant/runs/01546q4o)
- MXFP8: completed a 3-step Qwen3-4B smoke run on GB200; mismatch KL 0.00536, 0.00492, 0.00815. [Trainer W&B](https://wandb.ai/primeintellect/online-quantization/runs/anyamryk) · [Orchestrator W&B](https://wandb.ai/primeintellect/online-quantization/runs/mwsy1ik3)

## Checks

- ruff check: passed
- ruff format --check: passed
- pytest not run locally: the repository lockfile supports Linux environments only, while this checkout is on macOS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inference numerics and the layerwise weight-reload path; misconfiguration or patch regressions could affect rollout logprobs, though scope is limited to optional quantization and a targeted vLLM monkey-patch.
> 
> **Overview**
> Adds optional **`inference.quantization`** (`mxfp8` or `fp8_per_block`) on the inference config, forwarded to vLLM as `--quantization` and omitted when unset so vLLM can still infer quantization from the checkpoint.
> 
> **MXFP8** selection is validated on CUDA hosts: capability must be SM100 (with torch required for that check). A shared vLLM patch unwraps `nn.Parameter` to `.data` before vLLM’s compiled `per_block_cast_to_fp8`, fixing online quantization after layerwise weight reload when restored weights are `ModelWeightParameter` subclasses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eab484397c7ff732c8f33e5a2752cf76fe9c5d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->