### PR TITLE
feat(trainer): use seq_lens as the packed-sample boundary contract

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -34,9 +34,6 @@ class BaseDataConfig(BaseConfig):
     seq_len: int = Field(128, ge=1)
     """Sequence length."""
 
-    pack_function: Literal["cat", "stack"] = "cat"
-    """Sample packing strategy. ``cat`` concatenates; ``stack`` requires ``seq_len`` divisible by 256."""
-
     micro_batch_size: int = Field(1, ge=1)
     """Per-step micro batch size. ``batch_size`` must be divisible by this."""
 
@@ -287,15 +284,6 @@ class SFTConfig(BaseConfig):
         )
 
     @model_validator(mode="after")
-    def validate_pack_function(self):
-        if self.model.cp > 1:
-            if self.data.pack_function != "cat":
-                raise ValueError("Packing function must be 'cat' when CP is enabled")
-            if self.val is not None and self.val.data.pack_function != "cat":
-                raise ValueError("Validation packing function must be 'cat' when CP is enabled")
-        return self
-
-    @model_validator(mode="after")
     def validate_cp_seq_len(self):
         if self.model.cp > 1:
             if self.data.seq_len % self.model.cp != 0:
@@ -311,14 +299,6 @@ class SFTConfig(BaseConfig):
                 raise ValueError("Micro batch size must be 1 when CP is enabled")
             if self.val is not None and self.val.data.micro_batch_size != 1:
                 raise ValueError("Validation micro batch size must be 1 when CP is enabled")
-        return self
-
-    @model_validator(mode="after")
-    def validate_seq_len(self):
-        if self.data.pack_function == "stack" and self.data.seq_len % 256 != 0:
-            raise ValueError("The sequence length must be divisible by 256 when using pack function stack")
-        if self.val is not None and self.val.data.pack_function == "stack" and self.val.data.seq_len % 256 != 0:
-            raise ValueError("The validation sequence length must be divisible by 256 when using pack function stack")
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -208,6 +208,8 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         rl_weights=rl_weights,
         ce_weights=ce_weights,
         ref_kl_weights=ref_kl_weights,
+        seq_lens=[len(input_ids)],
+        padding_len=0,
     )
 
 
@@ -285,6 +287,7 @@ def _materialize_bin(bin_content: _MicroBatchBin, num_loras: int) -> MicroBatch:
     ref_logprobs: list[float] | None = [] if has_ref_logprobs else None
     mm_token_type_ids: list[int] | None = [] if has_mm_token_type_ids else None
     streams: dict[str, list[float] | None] = {name: ([] if has_stream[name] else None) for name in STREAM_FILL}
+    seq_lens: list[int] = []
     routed_experts: RoutedExperts | None = None
     lora_num_tokens = [0] * num_loras
 
@@ -316,10 +319,12 @@ def _materialize_bin(bin_content: _MicroBatchBin, num_loras: int) -> MicroBatch:
                 assert routed_experts.shape[1:] == sample.routed_experts.shape[1:]
                 routed_experts.data += sample.routed_experts.data
                 routed_experts.shape[0] += sample.routed_experts.shape[0]
+        seq_lens.extend(sample.seq_lens)
         lora_num_tokens[lora_idx] += sample_len
 
     sequence_lengths = [len(sample.input_ids) for _, sample in bin_content.samples]
     assert sum(sequence_lengths) == len(input_ids), (sequence_lengths, len(input_ids))
+    assert sum(seq_lens) == len(input_ids), (seq_lens, len(input_ids))
     first_sample = bin_content.first_sample
 
     return MicroBatch(
@@ -339,6 +344,8 @@ def _materialize_bin(bin_content: _MicroBatchBin, num_loras: int) -> MicroBatch:
         rl_weights=streams["rl_weights"],
         ce_weights=streams["ce_weights"],
         ref_kl_weights=streams["ref_kl_weights"],
+        seq_lens=seq_lens,
+        padding_len=0,
     )
 
 
@@ -439,7 +446,9 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
     micro_batch.advantages.extend([0.0] * padding_size)
     micro_batch.loss_mask.extend([False] * padding_size)
     micro_batch.position_ids.extend(list(range(padding_size)))
-    micro_batch.sequence_lengths.append(padding_size)
+    micro_batch.sequence_lengths[-1] += padding_size
+    micro_batch.seq_lens[-1] += padding_size
+    micro_batch.padding_len += padding_size
     micro_batch.inference_logprobs.extend([0.0] * padding_size)
     # Use temperature 1.0 for padding tokens (doesn't matter since loss_mask is False)
     micro_batch.temperatures.extend([1.0] * padding_size)
@@ -491,6 +500,11 @@ def _assert_token_arrays_aligned(micro_batch: MicroBatch) -> None:
     assert sum(micro_batch.sequence_lengths) == num_tokens, (
         f"sequence_lengths sum {sum(micro_batch.sequence_lengths)} != {num_tokens} tokens"
     )
+    assert micro_batch.seq_lens and all(seq_len > 0 for seq_len in micro_batch.seq_lens)
+    assert sum(micro_batch.seq_lens) == num_tokens, f"seq_lens sum {sum(micro_batch.seq_lens)} != {num_tokens} tokens"
+    assert micro_batch.padding_len >= 0
+    if micro_batch.padding_len:
+        assert micro_batch.seq_lens[-1] > micro_batch.padding_len
     if micro_batch.routed_experts is not None:
         assert micro_batch.routed_experts.shape[0] == num_tokens, (
             f"routed_experts misaligned after packing: {micro_batch.routed_experts.shape[0]} != {num_tokens} tokens"

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -209,7 +209,6 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         ce_weights=ce_weights,
         ref_kl_weights=ref_kl_weights,
         seq_lens=[len(input_ids)],
-        padding_len=0,
     )
 
 
@@ -345,7 +344,6 @@ def _materialize_bin(bin_content: _MicroBatchBin, num_loras: int) -> MicroBatch:
         ce_weights=streams["ce_weights"],
         ref_kl_weights=streams["ref_kl_weights"],
         seq_lens=seq_lens,
-        padding_len=0,
     )
 
 
@@ -448,7 +446,6 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
     micro_batch.position_ids.extend(list(range(padding_size)))
     micro_batch.sequence_lengths[-1] += padding_size
     micro_batch.seq_lens[-1] += padding_size
-    micro_batch.padding_len += padding_size
     micro_batch.inference_logprobs.extend([0.0] * padding_size)
     # Use temperature 1.0 for padding tokens (doesn't matter since loss_mask is False)
     micro_batch.temperatures.extend([1.0] * padding_size)
@@ -500,11 +497,7 @@ def _assert_token_arrays_aligned(micro_batch: MicroBatch) -> None:
     assert sum(micro_batch.sequence_lengths) == num_tokens, (
         f"sequence_lengths sum {sum(micro_batch.sequence_lengths)} != {num_tokens} tokens"
     )
-    assert micro_batch.seq_lens and all(seq_len > 0 for seq_len in micro_batch.seq_lens)
     assert sum(micro_batch.seq_lens) == num_tokens, f"seq_lens sum {sum(micro_batch.seq_lens)} != {num_tokens} tokens"
-    assert micro_batch.padding_len >= 0
-    if micro_batch.padding_len:
-        assert micro_batch.seq_lens[-1] > micro_batch.padding_len
     if micro_batch.routed_experts is not None:
         assert micro_batch.routed_experts.shape[0] == num_tokens, (
             f"routed_experts misaligned after packing: {micro_batch.routed_experts.shape[0]} != {num_tokens} tokens"

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1235,6 +1235,8 @@ def forward(
     model: nn.Module,
     input_ids: Int[Tensor, "batch seq"],
     position_ids: Int[Tensor, "batch seq"],
+    *,
+    seq_lens: Int[Tensor, "segments"],
     labels: Int[Tensor, "batch seq"] | None = None,
     temperature: Tensor | None = None,
     routed_experts: Int[Tensor, "batch seq layers topk"] | None = None,
@@ -1269,6 +1271,9 @@ def forward(
             kwargs["position_ids"] = position_ids
     else:
         kwargs["position_ids"] = position_ids
+
+    if isinstance(model, PreTrainedModelPrimeRL):
+        kwargs["seq_lens"] = seq_lens
 
     if routed_experts is not None:
         kwargs["routed_experts"] = routed_experts

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -6,10 +6,6 @@ import torch
 from torch import nn
 from transformers.cache_utils import Cache
 from transformers.generation import GenerationMixin
-from transformers.masking_utils import (
-    create_causal_mask,
-    create_sliding_window_causal_mask,
-)
 from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import (
     MoeModelOutputWithPast,
@@ -32,7 +28,7 @@ from prime_rl.trainer.models.layers.rotary_emb import (
     RotaryEmbeddingConfig,
     apply_rotary_pos_emb,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 from .configuration_afmoe import AfmoeConfig
 from .converting_afmoe import (
@@ -388,6 +384,8 @@ class AfmoeModel(AfmoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> MoeModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
@@ -402,29 +400,11 @@ class AfmoeModel(AfmoePreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        use_flash = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "flash_attention_4")
-
-        if use_flash:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-            causal_mask_mapping = None
-        else:
-            cu_seqlens = None
-            max_seqlen = None
-            cache_position = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device)
-            if not isinstance(causal_mask_mapping := attention_mask, dict):
-                mask_kwargs = {
-                    "config": self.config,
-                    "inputs_embeds": inputs_embeds,
-                    "attention_mask": attention_mask,
-                    "cache_position": cache_position,
-                    "past_key_values": None,
-                    "position_ids": position_ids,
-                }
-                causal_mask_mapping = {
-                    "full_attention": create_causal_mask(**mask_kwargs),
-                    "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
-                }
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        causal_mask_mapping = None
 
         hidden_states = inputs_embeds
 
@@ -497,6 +477,8 @@ class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
         token_type_ids: Optional[torch.Tensor] = None,  # will be ignored
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
@@ -517,6 +499,7 @@ class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -39,7 +39,7 @@ from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 
 class Glm4MoeDecoderLayer(GradientCheckpointingLayer):
@@ -205,10 +205,14 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -216,12 +220,10 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "flash_attention_4"):
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            max_seqlen = None
-            cu_seqlens = None
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
@@ -272,9 +274,13 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -317,6 +323,7 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -308,9 +308,16 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        # Document boundaries derive from position_ids (sparse MLA builds its
+        # varlen indices from them); seq_lens is accepted to satisfy the
+        # trainer's universal contract.
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not

--- a/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
@@ -305,9 +305,15 @@ class GptOssForCausalLM(GptOssPreTrainedModel, GenerationMixin):
         use_cache: bool | None = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: torch.Tensor | None = None,
+        # Document boundaries derive from position_ids (HF packed-sequence masks);
+        # seq_lens is accepted to satisfy the trainer's universal contract.
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Per-token temperatures for logprobs/entropy computation when `labels` are provided.
         """

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -6,7 +6,6 @@ import torch.nn.functional as F
 from torch import Tensor, nn
 from transformers.cache_utils import Cache
 from transformers.generation import GenerationMixin
-from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
 from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import MoeModelOutputWithPast
 from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
@@ -27,7 +26,7 @@ from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.moe import FeedForward, MoE, MoEArgs
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 
 class LagunaRotaryEmbedding(nn.Module):
@@ -291,6 +290,8 @@ class LagunaModel(LagunaPreTrainedModel):
         position_ids: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         routed_experts: torch.LongTensor | None = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> MoeModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -300,27 +301,11 @@ class LagunaModel(LagunaPreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "flash_attention_4"):
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-            causal_mask_mapping = dict.fromkeys(set(self.config.layer_types), None)
-        else:
-            cu_seqlens = None
-            max_seqlen = None
-            if isinstance(attention_mask, dict):
-                causal_mask_mapping = attention_mask
-            else:
-                mask_kwargs = {
-                    "config": self.config,
-                    "inputs_embeds": inputs_embeds,
-                    "attention_mask": attention_mask,
-                    "past_key_values": None,
-                    "position_ids": position_ids,
-                }
-                causal_mask_mapping = {
-                    "full_attention": create_causal_mask(**mask_kwargs),
-                    "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
-                }
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        causal_mask_mapping = dict.fromkeys(set(self.config.layer_types), None)
 
         hidden_states = inputs_embeds
         position_embeddings = {
@@ -379,6 +364,8 @@ class LagunaForCausalLM(LagunaPreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: torch.Tensor | None = None,
         routed_experts: torch.LongTensor | None = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom Laguna"
@@ -390,6 +377,7 @@ class LagunaForCausalLM(LagunaPreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
         hidden_states = outputs.last_hidden_state
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -40,7 +40,7 @@ from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 logger = logging.get_logger(__name__)
 
@@ -181,19 +181,23 @@ class LlamaModel(LlamaPreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> BaseModelOutputWithPast:
+        r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "flash_attention_4"):
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            max_seqlen = None
-            cu_seqlens = None
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
@@ -241,9 +245,13 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
         cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -283,6 +291,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
             input_ids=input_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -22,7 +22,7 @@ from prime_rl.trainer.models.minimax_m2.converting_minimax_m2 import (
     convert_tt_layer_to_hf,
     convert_tt_to_hf_moe,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 logger = logging.get_logger(__name__)
 
@@ -166,10 +166,14 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -177,12 +181,10 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "flash_attention_4"):
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            max_seqlen = None
-            cu_seqlens = None
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
@@ -230,9 +232,13 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -258,6 +264,7 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -31,7 +31,7 @@ from prime_rl.trainer.models.nemotron_h.converting_nemotron_h import (
     convert_prime_layer_to_hf,
     convert_prime_to_hf,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 logger = logging.get_logger(__name__)
 
@@ -509,11 +509,15 @@ class NemotronHModel(NemotronHPreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token, indexed by global layer index. Only used for router replay; slots
             for non-MoE (Mamba/attention) layers are ignored.
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -521,13 +525,10 @@ class NemotronHModel(NemotronHPreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        # Compute cu_seqlens and max_seqlen for flash attention
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "flash_attention_4"):
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            max_seqlen = None
-            cu_seqlens = None
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids) if self.rotary_emb is not None else None
@@ -570,6 +571,8 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
         logits_to_keep: int = 0,
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs,
     ) -> PrimeLmOutput:
         if position_ids is None:
@@ -583,6 +586,7 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
+++ b/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
@@ -16,7 +16,7 @@ from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 
 def _get_rope_type(config: Qwen3Config) -> str:
@@ -154,7 +154,13 @@ class Qwen3Model(Qwen3PreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> BaseModelOutputWithPast:
+        r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
@@ -163,12 +169,10 @@ class Qwen3Model(Qwen3PreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "flash_attention_4"):
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            cu_seqlens = None
-            max_seqlen = None
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
@@ -219,9 +223,13 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
         cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility; prime-rl asserts `use_cache is None` since training does not
@@ -239,6 +247,7 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
             input_ids=input_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
+            seq_lens=seq_lens,
         )
         hidden_states = outputs.last_hidden_state
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -25,7 +25,7 @@ from prime_rl.trainer.models.qwen3_5_moe.modeling_qwen3_5_moe import (
     Qwen3_5MoeRotaryEmbedding,
     normalize_qwen3_5_attn_implementation,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 
 class Qwen3_5GatedFlashAttention(Qwen3_5MoeGatedFlashAttention):
@@ -190,6 +190,8 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> BaseModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -200,18 +202,10 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        flash_attn_enabled = self.config._attn_implementation in (
-            "flash_attention_2",
-            "flash_attention_3",
-            "flash_attention_4",
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
         )
-        if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            cu_seqlens = None
-            max_seqlen = None
-
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
@@ -263,6 +257,8 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         use_cache: Optional[bool] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom qwen3_5 for now"
@@ -278,6 +274,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
             input_ids=input_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -25,7 +25,7 @@ from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.moe import FeedForward, MoE, MoEArgs
 from prime_rl.trainer.models.layers.rotary_emb import apply_rotary_pos_emb
 from prime_rl.trainer.models.layers.ulysses_attn import ULYSSES_PARAMS
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 from .configuration_qwen3_5_moe import Qwen3_5MoeConfig
 from .converting_qwen3_5_moe import (
@@ -818,7 +818,8 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> MoeModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -829,36 +830,12 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        flash_attn_enabled = self.config._attn_implementation in (
-            "flash_attention_2",
-            "flash_attention_3",
-            "flash_attention_4",
+        if position_ids.ndim == 3 and inputs_embeds.shape[0] != 1:
+            raise ValueError("3D Qwen3.5 MRoPE positions require batch size 1 for varlen attention")
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
         )
-        if flash_attn_enabled:
-            if position_ids.ndim == 3:
-                if inputs_embeds.shape[0] != 1:
-                    raise ValueError("3D Qwen3.5 MRoPE positions require batch size 1 for varlen attention")
-                seq_len = inputs_embeds.shape[1]
-                if seq_lens is None:
-                    cu_seqlens = torch.tensor([0, seq_len], dtype=torch.int32, device=inputs_embeds.device)
-                    max_seqlen = seq_len
-                else:
-                    cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                        seq_lens.to(device=inputs_embeds.device),
-                        total_tokens=seq_len,
-                    )
-            else:
-                cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        elif position_ids.ndim == 3 and seq_lens is not None:
-            seq_lens = seq_lens.to(device=inputs_embeds.device)
-            if seq_lens.numel() > 1 and "full_attention" in self.config.layer_types:
-                raise ValueError("Packed Qwen3.5 MRoPE batches with full_attention layers require flash attention")
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(seq_lens, total_tokens=inputs_embeds.shape[1])
-        else:
-            max_seqlen = None
-            cu_seqlens = None
-
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
@@ -929,7 +906,8 @@ class Qwen3_5MoeVLMModel(nn.Module):
         image_grid_thw: torch.LongTensor | None = None,
         mm_token_type_ids: torch.LongTensor | None = None,
         routed_experts: torch.LongTensor | None = None,
-        seq_lens: torch.LongTensor | None = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs,
     ) -> MoeModelOutputWithPast:
         if inputs_embeds is None:
@@ -1142,7 +1120,8 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
         pixel_values: Optional[torch.Tensor] = None,
         image_grid_thw: Optional[torch.LongTensor] = None,
         mm_token_type_ids: Optional[torch.LongTensor] = None,
-        seq_lens: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom qwen3_5_moe for now"

--- a/src/prime_rl/trainer/models/qwen3_5_moe/mrope.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/mrope.py
@@ -34,7 +34,7 @@ def build_qwen3_5_mrope_position_ids(
     mm_token_type_ids: torch.LongTensor,
     image_grid_thw: torch.LongTensor | None,
     spatial_merge_size: int,
-    seq_lens: torch.Tensor | None = None,
+    seq_lens: torch.Tensor,
 ) -> torch.LongTensor:
     if input_ids.ndim != 2:
         raise ValueError(f"input_ids must be 2D, got shape={tuple(input_ids.shape)}")
@@ -47,10 +47,7 @@ def build_qwen3_5_mrope_position_ids(
         raise ValueError("Packed Qwen3.5 MRoPE builder currently supports batch size 1")
 
     total_seq_len = input_ids.shape[1]
-    if seq_lens is None:
-        seq_lens = torch.tensor([total_seq_len], dtype=torch.long, device=input_ids.device)
-    else:
-        seq_lens = seq_lens.to(device=input_ids.device, dtype=torch.long)
+    seq_lens = seq_lens.to(device=input_ids.device, dtype=torch.long)
 
     if seq_lens.ndim != 1:
         raise ValueError(f"seq_lens must be 1D, got shape={tuple(seq_lens.shape)}")

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -40,7 +40,7 @@ from prime_rl.trainer.models.qwen3_moe.converting_qwen3_moe import (
     convert_tt_layer_to_hf,
     convert_tt_to_hf_moe,
 )
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 logger = logging.get_logger(__name__)
 
@@ -206,10 +206,14 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
     ) -> MoeModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -217,12 +221,10 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "flash_attention_4"):
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            max_seqlen = None
-            cu_seqlens = None
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
@@ -282,9 +284,13 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract).
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -332,6 +338,7 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
+            seq_lens=seq_lens,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -34,6 +34,8 @@ class TensorMicroBatch(TypedDict):
 
     # Batch level
     lora_num_tokens: Int[Tensor, "n_loras"]
+    seq_lens: Int[Tensor, "segments"]
+    padding_len: int
 
     # MoE router replay
     routed_experts: Int[Tensor, "batch seq layers topk"] | None
@@ -129,6 +131,8 @@ class FakeDataLoader:
             "sequence_lengths": sequence_lengths,
             "loss_mask": loss_mask.unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
+            "seq_lens": torch.tensor(sequence_lengths, dtype=torch.long),
+            "padding_len": 0,
             "routed_experts": None,
             "mm_kwargs": None,
             "mm_token_type_ids": None,
@@ -161,6 +165,8 @@ class FakeDataLoader:
             "sequence_lengths": [self.seq_len],
             "loss_mask": torch.ones(self.seq_len, dtype=torch.bool).unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
+            "seq_lens": torch.tensor([self.seq_len], dtype=torch.long),
+            "padding_len": 0,
             "routed_experts": None,
             "mm_kwargs": None,
             "mm_token_type_ids": None,
@@ -256,6 +262,8 @@ class DataLoader:
             env_names=micro_batch.env_names,
             sequence_lengths=micro_batch.sequence_lengths,
             lora_num_tokens=torch.tensor(micro_batch.lora_num_tokens, dtype=torch.int32),
+            seq_lens=torch.tensor(micro_batch.seq_lens, dtype=torch.long),
+            padding_len=micro_batch.padding_len,
             mm_kwargs=mm_kwargs,
             mm_token_type_ids=torch.tensor(micro_batch.mm_token_type_ids, dtype=torch.long).unsqueeze(0)
             if micro_batch.mm_token_type_ids is not None

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -35,7 +35,6 @@ class TensorMicroBatch(TypedDict):
     # Batch level
     lora_num_tokens: Int[Tensor, "n_loras"]
     seq_lens: Int[Tensor, "segments"]
-    padding_len: int
 
     # MoE router replay
     routed_experts: Int[Tensor, "batch seq layers topk"] | None
@@ -132,7 +131,6 @@ class FakeDataLoader:
             "loss_mask": loss_mask.unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
             "seq_lens": torch.tensor(sequence_lengths, dtype=torch.long),
-            "padding_len": 0,
             "routed_experts": None,
             "mm_kwargs": None,
             "mm_token_type_ids": None,
@@ -166,7 +164,6 @@ class FakeDataLoader:
             "loss_mask": torch.ones(self.seq_len, dtype=torch.bool).unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
             "seq_lens": torch.tensor([self.seq_len], dtype=torch.long),
-            "padding_len": 0,
             "routed_experts": None,
             "mm_kwargs": None,
             "mm_token_type_ids": None,
@@ -263,7 +260,6 @@ class DataLoader:
             sequence_lengths=micro_batch.sequence_lengths,
             lora_num_tokens=torch.tensor(micro_batch.lora_num_tokens, dtype=torch.int32),
             seq_lens=torch.tensor(micro_batch.seq_lens, dtype=torch.long),
-            padding_len=micro_batch.padding_len,
             mm_kwargs=mm_kwargs,
             mm_token_type_ids=torch.tensor(micro_batch.mm_token_type_ids, dtype=torch.long).unsqueeze(0)
             if micro_batch.mm_token_type_ids is not None

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -65,6 +65,7 @@ from prime_rl.utils.metrics_server import HealthServer, MetricsServer, RunStats
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.config import cli
 from prime_rl.utils.process import set_proc_title
+from prime_rl.utils.sequence import get_cp_local_seq_lens
 from prime_rl.utils.utils import clean_exit, resolve_latest_ckpt_step, to_col_format
 from ring_flash_attn import substitute_hf_flash_attn
 from torchtitan.distributed.utils import clip_grad_norm_
@@ -369,6 +370,8 @@ def train(config: TrainerConfig):
                 else None
             )
 
+            seq_lens = micro_batch["seq_lens"].to("cuda")
+
             labels = shift_tensor_left(input_ids)
 
             # VLM + CP is not supported: MRoPE requires global positions but CP shards the sequence
@@ -376,9 +379,17 @@ def train(config: TrainerConfig):
                 raise NotImplementedError("Context parallelism is not supported with VLM/multimodal training")
 
             if cp_enabled:
+                total_tokens = input_ids.shape[1]
                 input_ids, forward_position_ids = setup_cp_params(
-                    input_ids, position_ids, cp_rank, cp_size, cp_group, cp_style=config.model.cp_style
+                    input_ids,
+                    position_ids,
+                    cp_rank,
+                    cp_size,
+                    cp_group,
+                    seq_lens=seq_lens,
+                    cp_style=config.model.cp_style,
                 )
+                seq_lens = get_cp_local_seq_lens(seq_lens, total_tokens, cp_rank, cp_size)
                 labels = shard_for_cp(labels, cp_rank=cp_rank, cp_world_size=cp_size)
                 if routed_experts is not None:
                     routed_experts = shard_for_cp(routed_experts, cp_rank=cp_rank, cp_world_size=cp_size)
@@ -413,6 +424,7 @@ def train(config: TrainerConfig):
                     temperature=temperatures,
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_token_type_ids,
+                    seq_lens=seq_lens,
                     routed_experts=routed_experts,
                 )
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -25,7 +25,6 @@ class Sample(TypedDict):
     loss_mask: list[bool]
     target_ids: list[int]
     seq_lens: list[int]
-    padding_len: int
 
 
 class Batch(TypedDict):
@@ -34,7 +33,6 @@ class Batch(TypedDict):
     target_ids: Int[Tensor, "batch seq"]
     loss_mask: Bool[Tensor, "batch seq"]
     seq_lens: Int[Tensor, "packed"]
-    padding_len: int
 
 
 class StatefulIterableDataset(Stateful, IterableDataset):
@@ -105,7 +103,6 @@ class FakeDataset(StatefulIterableDataset):
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
                 "seq_lens": [seq_len],
-                "padding_len": 0,
             }
             self.num_samples["fake"] += 1
             self.num_tokens["fake"] += len(input_ids)
@@ -283,7 +280,6 @@ class SFTDataset(StatefulIterableDataset):
             "loss_mask": loss_mask,
             "position_ids": list(range(len(input_ids))),
             "seq_lens": [len(input_ids)],
-            "padding_len": 0,
         }
 
     def __iter__(self):
@@ -391,7 +387,6 @@ class CatDataset(StatefulIterableDataset):
             k: packed[k][:seq_len] for k in ("input_ids", "position_ids", "loss_mask", "target_ids")
         }
         result["seq_lens"] = []
-        result["padding_len"] = 0
         remaining = len(result["input_ids"])
         for sample_len in packed["seq_lens"]:
             if remaining <= 0:
@@ -407,22 +402,17 @@ class CatDataset(StatefulIterableDataset):
             result["loss_mask"].extend([False] * pad_len)
             result["target_ids"].extend([0] * pad_len)
             result["seq_lens"][-1] += pad_len
-            result["padding_len"] = pad_len
         return result
 
 
 def cat_collate(samples: list[Sample]) -> Batch:
-    if len(samples) != 1:
-        raise ValueError(f"CatDataset collate expects exactly one packed row, got {len(samples)}")
+    (sample,) = samples
     return {
-        "input_ids": torch.stack([torch.tensor(sample["input_ids"]) for sample in samples], dim=0).long().to("cuda"),
-        "position_ids": torch.stack([torch.tensor(sample["position_ids"]) for sample in samples], dim=0)
-        .long()
-        .to("cuda"),
-        "loss_mask": torch.stack([torch.tensor(sample["loss_mask"]) for sample in samples], dim=0).bool().to("cuda"),
-        "target_ids": torch.stack([torch.tensor(sample["target_ids"]) for sample in samples], dim=0).long().to("cuda"),
-        "seq_lens": torch.tensor(samples[0]["seq_lens"], dtype=torch.long, device="cuda"),
-        "padding_len": samples[0]["padding_len"],
+        "input_ids": torch.tensor(sample["input_ids"], dtype=torch.long, device="cuda").unsqueeze(0),
+        "position_ids": torch.tensor(sample["position_ids"], dtype=torch.long, device="cuda").unsqueeze(0),
+        "loss_mask": torch.tensor(sample["loss_mask"], dtype=torch.bool, device="cuda").unsqueeze(0),
+        "target_ids": torch.tensor(sample["target_ids"], dtype=torch.long, device="cuda").unsqueeze(0),
+        "seq_lens": torch.tensor(sample["seq_lens"], dtype=torch.long, device="cuda"),
     }
 
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -18,14 +18,14 @@ from prime_rl.trainer.world import get_world
 from prime_rl.utils.chat_template import deserialize_tool_calls, normalize_messages
 from prime_rl.utils.logger import get_logger
 
-STACKING_DATASET_BUCKET_TIMEOUT = 10
-
 
 class Sample(TypedDict):
     input_ids: list[int]
     position_ids: list[int]
     loss_mask: list[bool]
     target_ids: list[int]
+    seq_lens: list[int]
+    padding_len: int
 
 
 class Batch(TypedDict):
@@ -33,6 +33,8 @@ class Batch(TypedDict):
     position_ids: Int[Tensor, "batch seq"]
     target_ids: Int[Tensor, "batch seq"]
     loss_mask: Bool[Tensor, "batch seq"]
+    seq_lens: Int[Tensor, "packed"]
+    padding_len: int
 
 
 class StatefulIterableDataset(Stateful, IterableDataset):
@@ -102,6 +104,8 @@ class FakeDataset(StatefulIterableDataset):
                 "target_ids": input_ids[1:],
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
+                "seq_lens": [seq_len],
+                "padding_len": 0,
             }
             self.num_samples["fake"] += 1
             self.num_tokens["fake"] += len(input_ids)
@@ -278,6 +282,8 @@ class SFTDataset(StatefulIterableDataset):
             "target_ids": target_ids,
             "loss_mask": loss_mask,
             "position_ids": list(range(len(input_ids))),
+            "seq_lens": [len(input_ids)],
+            "padding_len": 0,
         }
 
     def __iter__(self):
@@ -331,152 +337,83 @@ class CatDataset(StatefulIterableDataset):
         self.logger = get_logger()
         self.dataset = dataset
         self.seq_len = seq_len
+        self.pending_sample: Sample | None = None
 
     def state_dict(self) -> dict:
-        return {"dataset": self.dataset.state_dict()}
+        state = {"dataset": self.dataset.state_dict()}
+        if self.pending_sample is not None:
+            state["pending_sample"] = self.pending_sample
+        return state
 
     def load_state_dict(self, state_dict: dict):
         self.dataset.load_state_dict(state_dict["dataset"])
+        self.pending_sample = state_dict.get("pending_sample")
 
     def __iter__(self):
-        packed_samples, seq_len = defaultdict(list), 0
-        for sample in self.dataset:
-            # Add sample to packed samples
-            for key, value in sample.items():
-                assert isinstance(value, list), f"Value for key {key} must be a list"
-                packed_samples[key].extend(value)
+        packed_samples = defaultdict(list)
+        seq_len = 0
 
-            # Update sequence length
-            seq_len += len(sample["input_ids"])
+        pending_sample = self.pending_sample
+        self.pending_sample = None
 
-            # If batch is full, truncate and yield it
-            if seq_len >= self.seq_len:
-                for key, value in packed_samples.items():
-                    assert isinstance(value, list), f"Value for key {key} must be a list"
-                    packed_samples[key] = value[: self.seq_len]
-                yield packed_samples
-                packed_samples, seq_len = defaultdict(list), 0
+        def samples():
+            if pending_sample is not None:
+                yield pending_sample
+            yield from self.dataset
 
-
-class StackDataset(StatefulIterableDataset):
-    """A dataset that stacks samples into batch with a fixed area"""
-
-    def __init__(self, dataset: StatefulIterableDataset, max_area: int):
-        self.logger = get_logger()
-        self.dataset = dataset
-        self.max_area = max_area
-        assert self.max_area % 256 == 0
-        self.bucket_sizes = []
-        while max_area % 256 == 0:
-            self.bucket_sizes.insert(0, max_area)
-            max_area //= 2
-        self.logger.debug(f"Initialized {len(self.bucket_sizes)} buckets (bucket_sizes={self.bucket_sizes})")
-        # Checkpoint state
-        self.step = 0
-        self.buckets = [[] for _ in range(len(self.bucket_sizes))]
-        self.bucket_timers: list[int | None] = [None] * len(self.buckets)
-
-    def state_dict(self) -> dict:
-        return {
-            "dataset": self.dataset.state_dict(),
-            "step": self.step,
-            "buckets": self.buckets,
-            "bucket_timers": self.bucket_timers,
-        }
-
-    def load_state_dict(self, state_dict: dict):
-        self.dataset.load_state_dict(state_dict["dataset"])
-        self.step = state_dict["step"]
-        self.buckets = state_dict["buckets"]
-        self.bucket_timers = state_dict["bucket_timers"]
-
-    def __iter__(self):
-        for sample in self.dataset:
-            # Truncate sample if it's longer than max area
-            len_sample = len(sample["input_ids"])
-            if len_sample > self.max_area:
-                for key, value in sample.items():
-                    assert isinstance(value, list)
-                    sample[key] = sample[key][: self.max_area]
-                len_sample = self.max_area
-
-            # Add sample to bucket
-            def find_bucket_idx(len_sample: int) -> int:
-                bucket_idx = 0
-                while bucket_idx < len(self.bucket_sizes) - 1 and len_sample > self.bucket_sizes[bucket_idx]:
-                    bucket_idx += 1
-                return bucket_idx
-
-            bucket_idx = find_bucket_idx(len_sample)
-            self.buckets[bucket_idx].append(sample)
-
-            # Check if bucket has timed out
-            bucket_timer = self.bucket_timers[bucket_idx]
-            if bucket_timer is not None:
-                hit_timeout = bucket_timer + STACKING_DATASET_BUCKET_TIMEOUT < self.step
-            else:
-                hit_timeout = False
-
-            # Check if bucket is full
-            is_full = self.bucket_sizes[bucket_idx] * len(self.buckets[bucket_idx]) >= self.max_area
-
-            if is_full or hit_timeout:
-                if hit_timeout:
-                    while bucket_idx < len(self.buckets) - 1:
-                        if (
-                            self.bucket_sizes[bucket_idx + 1]
-                            * (len(self.buckets[bucket_idx]) + len(self.buckets[bucket_idx + 1]))
-                            < self.max_area
-                        ):
-                            self.buckets[bucket_idx + 1].extend(self.buckets[bucket_idx])
-                            self.buckets[bucket_idx] = []
-                            self.bucket_timers[bucket_idx] = None
-                            bucket_idx += 1
-                        else:
-                            break
-
-                    while self.bucket_sizes[bucket_idx] * len(self.buckets[bucket_idx]) < self.max_area:
-                        dummy_sample = {}
-                        for key, value in sample.items():
-                            dummy_sample[key] = [0]
-                        self.buckets[bucket_idx].append(dummy_sample)
-
+        for sample in samples():
+            sample_len = len(sample["input_ids"])
+            would_overflow = seq_len + sample_len > self.seq_len
+            if seq_len > 0 and would_overflow:
+                self.pending_sample = sample
+                yield self._finalize_pack(packed_samples, self.seq_len)
+                self.pending_sample = None
                 packed_samples = defaultdict(list)
-                num_samples, num_tokens, num_trainable_tokens, num_pad_tokens = 0, 0, 0, 0
-                for bucket_item in self.buckets[bucket_idx]:
-                    num_samples += 1
-                    for key, value in bucket_item.items():
-                        pad_tokens = [0] * (self.bucket_sizes[bucket_idx] - len(value))
-                        if key == "loss_mask":
-                            num_tokens += len(value)
-                            num_trainable_tokens += sum(value)
-                            num_pad_tokens += len(pad_tokens)
-                        packed_samples[key].append(value + pad_tokens)
-                reason = "bucket is full" if is_full else "because bucket timed out"
-                reason += " and " if is_full and hit_timeout else ""
-                reason += "bucket timed out" if hit_timeout else ""
-                self.logger.debug(
-                    f"Yield bucket {bucket_idx} because {reason} with {num_samples=}, {num_tokens=}, {num_trainable_tokens=}, {num_pad_tokens=}"
-                )
-                yield packed_samples
-                self.step += 1
-                self.buckets[bucket_idx] = []
-                self.bucket_timers[bucket_idx] = None
-            else:
-                if self.bucket_timers[bucket_idx] is None:
-                    self.bucket_timers[bucket_idx] = self.step
+                seq_len = 0
 
+            for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
+                value = sample[key]
+                assert isinstance(value, list)
+                packed_samples[key].extend(value)
+            packed_samples["seq_lens"].append(sample_len)
+            seq_len += sample_len
 
-def stack_collate(samples: list[Sample]) -> Batch:
-    return {
-        "input_ids": torch.tensor(samples[0]["input_ids"], dtype=torch.long, device="cuda"),
-        "position_ids": torch.tensor(samples[0]["position_ids"], dtype=torch.long, device="cuda"),
-        "loss_mask": torch.tensor(samples[0]["loss_mask"], dtype=torch.bool, device="cuda"),
-        "target_ids": torch.tensor(samples[0]["target_ids"], dtype=torch.long, device="cuda"),
-    }
+            if seq_len >= self.seq_len:
+                yield self._finalize_pack(packed_samples, self.seq_len)
+                packed_samples = defaultdict(list)
+                seq_len = 0
+
+        if seq_len > 0:
+            yield self._finalize_pack(packed_samples, self.seq_len)
+
+    def _finalize_pack(self, packed: dict[str, Any], seq_len: int) -> dict:
+        result: dict[str, Any] = {
+            k: packed[k][:seq_len] for k in ("input_ids", "position_ids", "loss_mask", "target_ids")
+        }
+        result["seq_lens"] = []
+        result["padding_len"] = 0
+        remaining = len(result["input_ids"])
+        for sample_len in packed["seq_lens"]:
+            if remaining <= 0:
+                break
+            kept = min(sample_len, remaining)
+            if kept > 0:
+                result["seq_lens"].append(kept)
+            remaining -= kept
+        pad_len = seq_len - len(result["input_ids"])
+        if pad_len > 0:
+            result["input_ids"].extend([0] * pad_len)
+            result["position_ids"].extend(range(pad_len))
+            result["loss_mask"].extend([False] * pad_len)
+            result["target_ids"].extend([0] * pad_len)
+            result["seq_lens"][-1] += pad_len
+            result["padding_len"] = pad_len
+        return result
 
 
 def cat_collate(samples: list[Sample]) -> Batch:
+    if len(samples) != 1:
+        raise ValueError(f"CatDataset collate expects exactly one packed row, got {len(samples)}")
     return {
         "input_ids": torch.stack([torch.tensor(sample["input_ids"]) for sample in samples], dim=0).long().to("cuda"),
         "position_ids": torch.stack([torch.tensor(sample["position_ids"]) for sample in samples], dim=0)
@@ -484,6 +421,8 @@ def cat_collate(samples: list[Sample]) -> Batch:
         .to("cuda"),
         "loss_mask": torch.stack([torch.tensor(sample["loss_mask"]) for sample in samples], dim=0).bool().to("cuda"),
         "target_ids": torch.stack([torch.tensor(sample["target_ids"]) for sample in samples], dim=0).long().to("cuda"),
+        "seq_lens": torch.tensor(samples[0]["seq_lens"], dtype=torch.long, device="cuda"),
+        "padding_len": samples[0]["padding_len"],
     }
 
 
@@ -591,11 +530,5 @@ def setup_dataset(
 
 
 def setup_dataloader(dataset: StatefulIterableDataset, config: DataConfig) -> StatefulDataLoader:
-    if config.pack_function == "stack":
-        stacking_dataset = StackDataset(dataset, config.seq_len * config.micro_batch_size)
-        return StatefulDataLoader(stacking_dataset, batch_size=1, collate_fn=stack_collate)
-    elif config.pack_function == "cat":
-        packing_dataset = CatDataset(dataset, config.seq_len * config.micro_batch_size)
-        return StatefulDataLoader(packing_dataset, batch_size=1, collate_fn=cat_collate)
-    else:
-        raise ValueError(f"Invalid pack function: {config.pack_function}")
+    packing_dataset = CatDataset(dataset, config.seq_len * config.micro_batch_size)
+    return StatefulDataLoader(packing_dataset, batch_size=1, collate_fn=cat_collate)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -49,6 +49,7 @@ from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.config import cli
 from prime_rl.utils.process import set_proc_title
+from prime_rl.utils.sequence import get_cp_local_seq_lens
 from prime_rl.utils.utils import clean_exit, to_col_format
 import torch.distributed as dist
 
@@ -228,11 +229,20 @@ def train(config: SFTConfig):
         position_ids = micro_batch["position_ids"].to("cuda")
         target_ids = micro_batch["target_ids"].to("cuda")
         loss_mask = micro_batch["loss_mask"].to("cuda")
+        seq_lens = micro_batch["seq_lens"].to("cuda")
 
         if cp_enabled:
+            total_tokens = input_ids.shape[1]
             input_ids, position_ids = setup_cp_params(
-                input_ids, position_ids, cp_rank, cp_size, cp_group, cp_style=config.model.cp_style
+                input_ids,
+                position_ids,
+                cp_rank,
+                cp_size,
+                cp_group,
+                seq_lens=seq_lens,
+                cp_style=config.model.cp_style,
             )
+            seq_lens = get_cp_local_seq_lens(seq_lens, total_tokens, cp_rank, cp_size)
             target_ids = shard_for_cp(target_ids, cp_rank=cp_rank, cp_world_size=cp_size)
             loss_mask = shard_for_cp(loss_mask, cp_rank=cp_rank, cp_world_size=cp_size)
 
@@ -247,10 +257,17 @@ def train(config: SFTConfig):
                 # logprobs without materializing the [N, V] logits, and per-token
                 # cross-entropy is the negative target logprob.
                 temperature = torch.ones_like(target_ids, dtype=torch.float32)
-                out = forward(model, input_ids, position_ids, labels=target_ids, temperature=temperature)
+                out = forward(
+                    model,
+                    input_ids,
+                    position_ids,
+                    seq_lens=seq_lens,
+                    labels=target_ids,
+                    temperature=temperature,
+                )
                 loss_sum = -out["logprobs"][loss_mask].sum()
             else:
-                out = forward(model, input_ids, position_ids)
+                out = forward(model, input_ids, position_ids, seq_lens=seq_lens)
                 logits = out["logits"]
                 B, L, V = logits.shape
                 token_loss = CrossEntropyLoss(reduction="none")(logits.view(-1, V), target_ids.view(-1)).view(B, L)

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -90,7 +90,6 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     temperatures: list[float]  # Per-token temperatures used during generation
     env_names: list[str]
     seq_lens: list[int]
-    padding_len: int
     ref_logprobs: list[float] | None = None
     lora_num_tokens: list[int] | None = None
     routed_experts: RoutedExperts | None = None

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -89,6 +89,8 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     sequence_lengths: list[int]
     temperatures: list[float]  # Per-token temperatures used during generation
     env_names: list[str]
+    seq_lens: list[int]
+    padding_len: int
     ref_logprobs: list[float] | None = None
     lora_num_tokens: list[int] | None = None
     routed_experts: RoutedExperts | None = None

--- a/src/prime_rl/utils/cp.py
+++ b/src/prime_rl/utils/cp.py
@@ -11,7 +11,7 @@ import torch.distributed.nn as dist_nn
 import torch.nn as nn
 from ring_flash_attn import update_ring_flash_attn_params
 
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 CPStyle = Literal["ring", "ulysses"]
 
@@ -161,20 +161,25 @@ def setup_cp_params(
     cp_rank: int,
     cp_world_size: int,
     cp_group: dist.ProcessGroup,
+    *,
+    seq_lens: torch.Tensor,
     cp_style: CPStyle = "ring",
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Prepare the input for context parallelism and set required attention params.
 
-    Both ring and ulysses styles need cu_seqlens computed from the *full*
-    (un-sharded) position_ids, then publish them to the patched attention layer:
+    Both ring and ulysses styles need cu_seqlens computed from the full,
+    unsharded sequence lengths, then publish them to the patched attention layer:
       - ring: via ring_flash_attn's DATA_PARAMS (with local_k_slice).
       - ulysses: via ULYSSES_PARAMS (just the full cu_seqlens / max_seqlen).
 
     Returns the sequence-sharded input_ids and position_ids — the rest of the
     model still runs sequence-sharded; only attention sees the full sequence.
     """
-    cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+    cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+        seq_lens.to(device=position_ids.device),
+        total_tokens=position_ids.shape[-1],
+    )
 
     if cp_style == "ring":
         update_ring_flash_attn_params(cu_seqlens, cp_group)

--- a/src/prime_rl/utils/sequence.py
+++ b/src/prime_rl/utils/sequence.py
@@ -59,11 +59,6 @@ def get_cp_local_seq_lens(
     cp_world_size: int,
 ) -> torch.Tensor:
     """Intersect global sequence boundaries with one contiguous CP shard."""
-    if total_tokens % cp_world_size != 0:
-        raise ValueError(f"Sequence length {total_tokens} must be divisible by CP size {cp_world_size}")
-    if not 0 <= cp_rank < cp_world_size:
-        raise ValueError(f"CP rank {cp_rank} must be in [0, {cp_world_size})")
-
     shard_size = total_tokens // cp_world_size
     shard_start = seq_lens.new_tensor(cp_rank * shard_size)
     shard_end = shard_start + shard_size

--- a/src/prime_rl/utils/sequence.py
+++ b/src/prime_rl/utils/sequence.py
@@ -50,3 +50,24 @@ def get_cu_seqlens_from_seq_lens(seq_lens: torch.Tensor, total_tokens: int | Non
     cu_seqlens[0] = 0
     cu_seqlens[1:] = seq_lens.cumsum(dim=0, dtype=torch.int32)
     return cu_seqlens, int(seq_lens.max().item())
+
+
+def get_cp_local_seq_lens(
+    seq_lens: torch.Tensor,
+    total_tokens: int,
+    cp_rank: int,
+    cp_world_size: int,
+) -> torch.Tensor:
+    """Intersect global sequence boundaries with one contiguous CP shard."""
+    if total_tokens % cp_world_size != 0:
+        raise ValueError(f"Sequence length {total_tokens} must be divisible by CP size {cp_world_size}")
+    if not 0 <= cp_rank < cp_world_size:
+        raise ValueError(f"CP rank {cp_rank} must be in [0, {cp_world_size})")
+
+    shard_size = total_tokens // cp_world_size
+    shard_start = seq_lens.new_tensor(cp_rank * shard_size)
+    shard_end = shard_start + shard_size
+    seq_ends = seq_lens.cumsum(dim=0)
+    seq_starts = torch.cat([seq_lens.new_zeros(1), seq_ends[:-1]])
+    overlaps = torch.minimum(seq_ends, shard_end) - torch.maximum(seq_starts, shard_start)
+    return overlaps[overlaps > 0]

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -161,6 +161,7 @@ def test_randomized_packing_invariants():
         for batch in flat_batches:
             assert len(batch.input_ids) <= seq_len
             assert sum(batch.sequence_lengths) == len(batch.input_ids)
+            assert batch.seq_lens == batch.sequence_lengths
             assert sum(batch.lora_num_tokens) == len(batch.input_ids)
             assert len(batch.env_names) == len(batch.input_ids)
 
@@ -175,7 +176,9 @@ def test_pad_micro_batch_preserves_explicit_sequence_lengths():
     padded = pad_micro_batch(micro_batch, pad_to_multiple_of=6)
 
     assert len(padded.input_ids) == 6
-    assert padded.sequence_lengths == [4, 2]
+    assert padded.sequence_lengths == [6]
+    assert padded.seq_lens == [6]
+    assert padded.padding_len == 2
     assert sum(padded.sequence_lengths) == len(padded.input_ids)
     assert padded.loss_mask[-2:] == [False, False]
 
@@ -271,6 +274,7 @@ def test_prepare_batch_packs_different_temperatures(make_training_example):
     # Second sample (4 tokens): all get temp 1.1
     assert flat_batches[0].temperatures[4:8] == [1.1, 1.1, 1.1, 1.1]
     assert flat_batches[0].env_names == ["env-a"] * 4 + ["env-b"] * 4
+    assert flat_batches[0].seq_lens == [4, 4]
 
 
 def test_prepare_sample_propagates_weight_streams(make_training_example):

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -178,7 +178,6 @@ def test_pad_micro_batch_preserves_explicit_sequence_lengths():
     assert len(padded.input_ids) == 6
     assert padded.sequence_lengths == [6]
     assert padded.seq_lens == [6]
-    assert padded.padding_len == 2
     assert sum(padded.sequence_lengths) == len(padded.input_ids)
     assert padded.loss_mask[-2:] == [False, False]
 

--- a/tests/unit/train/models/test_afmoe.py
+++ b/tests/unit/train/models/test_afmoe.py
@@ -87,7 +87,11 @@ def test_afmoe_attn_only() -> None:
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(
+        input_ids,
+        position_ids=position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"),
+    )
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -120,7 +124,11 @@ def test_afmoe_mlp_only() -> None:
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(
+        input_ids,
+        position_ids=position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"),
+    )
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -140,7 +148,11 @@ def test_afmoe() -> None:
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(
+        input_ids,
+        position_ids=position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"),
+    )
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 

--- a/tests/unit/train/models/test_glm4_moe.py
+++ b/tests/unit/train/models/test_glm4_moe.py
@@ -64,7 +64,7 @@ def test_glm4_moe_attn_only() -> None:
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -92,7 +92,7 @@ def test_glm4_moe_mlp_only() -> None:
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -112,7 +112,7 @@ def test_glm4_moe() -> None:
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 

--- a/tests/unit/train/models/test_llama.py
+++ b/tests/unit/train/models/test_llama.py
@@ -52,7 +52,7 @@ def test_llama_attn_only():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -80,7 +80,7 @@ def test_llama_mlp_only():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -100,7 +100,7 @@ def test_llama():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 

--- a/tests/unit/train/models/test_nemotron_h.py
+++ b/tests/unit/train/models/test_nemotron_h.py
@@ -44,6 +44,10 @@ _BASE = dict(
 )
 
 
+def _seq_lens(input_ids: torch.Tensor) -> torch.Tensor:
+    return torch.tensor([input_ids.shape[1]], device=input_ids.device)
+
+
 def get_model_pairs():
     """Create an HF model and a PrimeRL model with shared weights."""
     hf_config = HFNemotronHConfig(**_BASE, hybrid_override_pattern="ME*E")
@@ -90,7 +94,7 @@ def test_nemotron_h_mamba_moe_only():
         position_ids = torch.arange(0, 32).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(input_ids, position_ids=position_ids, seq_lens=_seq_lens(input_ids))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -144,7 +148,7 @@ def test_nemotron_h_reverse():
         position_ids = torch.arange(0, 32).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(input_ids, position_ids=position_ids, seq_lens=_seq_lens(input_ids))
 
     logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=1e-2), (
@@ -161,7 +165,7 @@ def test_nemotron_h():
         position_ids = torch.arange(0, 32).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(input_ids, position_ids=position_ids, seq_lens=_seq_lens(input_ids))
     # Slightly larger tolerance due to different SDPA attention implementations
     logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=5e-2), (
@@ -180,7 +184,7 @@ def test_nemotron_h_backward():
     inject_prime_lm_head(model)
 
     input_ids = torch.randint(0, 256, (2, 16), device="cuda")
-    output = model(input_ids)
+    output = model(input_ids, seq_lens=_seq_lens(input_ids))
     output["logits"].sum().backward()
 
     zero_grads = []
@@ -231,7 +235,7 @@ def test_nemotron_h_no_latent_projection():
     inject_prime_lm_head(model)
 
     input_ids = torch.randint(0, 256, (2, 16), device="cuda")
-    output = model(input_ids)
+    output = model(input_ids, seq_lens=_seq_lens(input_ids))
     assert output["logits"].shape == (2, 16, 256)
 
     output["logits"].sum().backward()

--- a/tests/unit/train/models/test_nemotron_h_kl.py
+++ b/tests/unit/train/models/test_nemotron_h_kl.py
@@ -62,10 +62,14 @@ def _make_model(device="cuda"):
     return model
 
 
+def _seq_lens(input_ids: torch.Tensor) -> torch.Tensor:
+    return torch.tensor([input_ids.shape[1]], device=input_ids.device)
+
+
 def _get_logprobs_vanilla(model, input_ids):
     """Get logprobs using VanillaOutputLinear (returns logits, we compute logprobs)."""
     with torch.no_grad():
-        out = model(input_ids)
+        out = model(input_ids, seq_lens=_seq_lens(input_ids))
     logits = out["logits"]
     labels = torch.cat(
         [input_ids[:, 1:], torch.zeros(input_ids.shape[0], 1, dtype=torch.long, device=input_ids.device)], dim=1
@@ -197,7 +201,7 @@ def test_kl_with_fused_lm_head():
     labels = torch.cat([input_ids[:, 1:], torch.zeros(1, 1, dtype=torch.long, device="cuda")], dim=1)
 
     with torch.no_grad():
-        vanilla_out = model(input_ids)
+        vanilla_out = model(input_ids, seq_lens=_seq_lens(input_ids))
     vanilla_logits = vanilla_out["logits"]
     temperature = torch.ones(1, 16, device="cuda")
     vanilla_logprobs = selective_log_softmax(vanilla_logits / temperature.unsqueeze(-1), labels)
@@ -205,7 +209,7 @@ def test_kl_with_fused_lm_head():
     # Now switch to fused head and compare
     inject_prime_lm_head(model, chunk_size=16)
     with torch.no_grad():
-        fused_out = model(input_ids, labels=labels, temperature=temperature)
+        fused_out = model(input_ids, labels=labels, temperature=temperature, seq_lens=_seq_lens(input_ids))
     fused_logprobs = fused_out["logprobs"]
 
     diff = (vanilla_logprobs - fused_logprobs).abs().max()
@@ -220,7 +224,7 @@ def test_kl_logprob_alignment():
 
     # Simulate what the training loop does
     with torch.no_grad():
-        out = model(input_ids)
+        out = model(input_ids, seq_lens=_seq_lens(input_ids))
     logits = out["logits"]
 
     # Labels = shifted input_ids (predict next token)
@@ -257,14 +261,14 @@ def test_kl_backward_through_policy():
 
     # Reference logprobs (detached)
     with torch.no_grad():
-        ref_out = ref_model(input_ids)
+        ref_out = ref_model(input_ids, seq_lens=_seq_lens(input_ids))
     ref_logprobs = selective_log_softmax(ref_out["logits"], labels)
     ref_logprobs = shift_tensor_right(
         ref_logprobs, pad_value=torch.log(torch.tensor(1.0 / ref_model.config.vocab_size)).item()
     ).detach()
 
     # Policy logprobs (with grad)
-    policy_out = policy_model(input_ids)
+    policy_out = policy_model(input_ids, seq_lens=_seq_lens(input_ids))
     policy_logprobs = selective_log_softmax(policy_out["logits"], labels)
     policy_logprobs = shift_tensor_right(
         policy_logprobs, pad_value=torch.log(torch.tensor(1.0 / policy_model.config.vocab_size)).item()

--- a/tests/unit/train/models/test_qwen3_5_moe.py
+++ b/tests/unit/train/models/test_qwen3_5_moe.py
@@ -53,7 +53,11 @@ def test_qwen3_5_moe():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids=position_ids)
+    prime_output = prime_model(
+        input_ids,
+        position_ids=position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"),
+    )
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -98,14 +102,20 @@ def test_qwen3_5_moe_router_replay():
         input_ids = torch.randint(0, prime_model.config.vocab_size, (1, 100))
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
-    out_normal = prime_model(input_ids, position_ids=position_ids)
+    seq_lens = torch.tensor([input_ids.shape[1]], device="cuda")
+    out_normal = prime_model(input_ids, position_ids=position_ids, seq_lens=seq_lens)
 
     num_layers = prime_model.config.num_hidden_layers
     topk = prime_model.config.num_experts_per_tok
     routed_experts = torch.randint(0, prime_model.config.num_experts, (1, 100, num_layers, topk), device="cuda")
 
     prime_model.zero_grad()
-    out_replay = prime_model(input_ids, position_ids=position_ids, routed_experts=routed_experts)
+    out_replay = prime_model(
+        input_ids,
+        position_ids=position_ids,
+        routed_experts=routed_experts,
+        seq_lens=seq_lens,
+    )
 
     assert out_replay["logits"].shape == out_normal["logits"].shape
 

--- a/tests/unit/train/models/test_qwen3_5_moe_mrope.py
+++ b/tests/unit/train/models/test_qwen3_5_moe_mrope.py
@@ -36,6 +36,7 @@ def test_qwen35_mrope_text_only_positions():
         mm_token_type_ids=mm_token_type_ids,
         image_grid_thw=None,
         spatial_merge_size=2,
+        seq_lens=torch.tensor([input_ids.shape[1]]),
     )
 
     expected = torch.arange(4).view(1, 1, -1).expand(3, 1, -1)
@@ -52,6 +53,7 @@ def test_qwen35_mrope_single_image_with_surrounding_text():
         mm_token_type_ids=mm_token_type_ids,
         image_grid_thw=image_grid_thw,
         spatial_merge_size=2,
+        seq_lens=torch.tensor([input_ids.shape[1]]),
     )
 
     expected = torch.tensor(
@@ -74,6 +76,7 @@ def test_qwen35_mrope_adjacent_images_consume_multiple_grids():
         mm_token_type_ids=mm_token_type_ids,
         image_grid_thw=image_grid_thw,
         spatial_merge_size=2,
+        seq_lens=torch.tensor([input_ids.shape[1]]),
     )
 
     expected = torch.tensor(
@@ -121,6 +124,7 @@ def test_qwen35_mrope_packed_matches_standalone_segments():
         mm_token_type_ids=segment_token_types,
         image_grid_thw=image_grid_thw,
         spatial_merge_size=2,
+        seq_lens=torch.tensor([segment_input_ids.shape[1]]),
     )
     packed = build_qwen3_5_mrope_position_ids(
         input_ids=torch.cat([segment_input_ids, segment_input_ids], dim=1),
@@ -145,6 +149,7 @@ def test_qwen35_mrope_rejects_image_length_grid_mismatch():
             mm_token_type_ids=mm_token_type_ids,
             image_grid_thw=image_grid_thw,
             spatial_merge_size=2,
+            seq_lens=torch.tensor([input_ids.shape[1]]),
         )
 
 
@@ -158,6 +163,7 @@ def test_qwen35_mrope_rejects_video_tokens():
             mm_token_type_ids=mm_token_type_ids,
             image_grid_thw=None,
             spatial_merge_size=2,
+            seq_lens=torch.tensor([input_ids.shape[1]]),
         )
 
 

--- a/tests/unit/train/models/test_qwen3_5_moe_vlm.py
+++ b/tests/unit/train/models/test_qwen3_5_moe_vlm.py
@@ -71,6 +71,10 @@ def _make_mm_token_type_ids(input_ids, image_token_id):
     return mm_token_type_ids
 
 
+def _seq_lens(input_ids: torch.Tensor) -> torch.Tensor:
+    return torch.tensor([input_ids.shape[1]], device=input_ids.device)
+
+
 def test_vlm_forward():
     """Custom VLM produces logits for both text-only and multimodal inputs."""
     config = _tiny_vlm_config()
@@ -83,7 +87,7 @@ def test_vlm_forward():
     # Text-only (avoid special token range 250-253)
     input_ids = torch.randint(0, 200, (1, 20), device="cuda")
     position_ids = torch.arange(1, 21, device="cuda").unsqueeze(0)
-    out_text = model(input_ids=input_ids, position_ids=position_ids)
+    out_text = model(input_ids=input_ids, position_ids=position_ids, seq_lens=_seq_lens(input_ids))
     assert out_text["logits"].shape == (1, 20, vocab)
 
     # Multimodal
@@ -98,6 +102,7 @@ def test_vlm_forward():
         pixel_values=pixel_values,
         image_grid_thw=image_grid_thw,
         mm_token_type_ids=mm_token_type_ids,
+        seq_lens=_seq_lens(input_ids_mm),
     )
     assert out_mm["logits"].shape == (1, input_ids_mm.shape[1], vocab)
 
@@ -120,6 +125,7 @@ def test_vlm_backward():
         pixel_values=pixel_values,
         image_grid_thw=image_grid_thw,
         mm_token_type_ids=mm_token_type_ids,
+        seq_lens=_seq_lens(input_ids),
     )
     out["logits"].sum().backward()
 
@@ -153,7 +159,7 @@ def test_vlm_weight_load_from_hf():
     # Verify model produces output after weight loading
     input_ids = torch.randint(0, 200, (1, 20), device="cuda")
     position_ids = torch.arange(1, 21, device="cuda").unsqueeze(0)
-    out = prime_model(input_ids=input_ids, position_ids=position_ids)
+    out = prime_model(input_ids=input_ids, position_ids=position_ids, seq_lens=_seq_lens(input_ids))
     assert out["logits"].shape[2] == config.text_config.vocab_size
     assert not torch.isnan(out["logits"]).any()
 
@@ -202,7 +208,12 @@ def test_vlm_forward_requires_mm_token_type_ids():
     input_ids = torch.full((1, n_img_tokens), config.image_token_id, device="cuda")
 
     with pytest.raises(ValueError, match="mm_token_type_ids"):
-        model(input_ids=input_ids, pixel_values=pixel_values, image_grid_thw=image_grid_thw)
+        model(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+            seq_lens=_seq_lens(input_ids),
+        )
 
 
 def test_vlm_forward_rejects_2d_positions_with_images():
@@ -224,6 +235,7 @@ def test_vlm_forward_rejects_2d_positions_with_images():
             pixel_values=pixel_values,
             image_grid_thw=image_grid_thw,
             mm_token_type_ids=mm_token_type_ids,
+            seq_lens=_seq_lens(input_ids),
         )
 
 
@@ -252,6 +264,7 @@ def test_vlm_router_replay():
         image_grid_thw=image_grid_thw,
         mm_token_type_ids=mm_token_type_ids,
         routed_experts=routed_experts,
+        seq_lens=_seq_lens(input_ids),
     )
     assert out["logits"].shape == (1, seq_len, vocab)
 

--- a/tests/unit/train/models/test_qwen3_moe.py
+++ b/tests/unit/train/models/test_qwen3_moe.py
@@ -63,7 +63,7 @@ def test_qwen3_moe_attn_only():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -91,7 +91,7 @@ def test_qwen3_moe_mlp_only():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -111,7 +111,7 @@ def test_qwen3_moe():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     hf_output = hf_model(input_ids, position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=torch.tensor([input_ids.shape[1]], device="cuda"))
     hf_output.logits.sum().backward()
     prime_output["logits"].sum().backward()
 
@@ -132,7 +132,8 @@ def test_qwen3_moe_router_replay():
         position_ids = torch.arange(1, 101).unsqueeze(0)
 
     # Forward without router replay
-    out_normal = prime_model(input_ids, position_ids)
+    seq_lens = torch.tensor([input_ids.shape[1]], device="cuda")
+    out_normal = prime_model(input_ids, position_ids, seq_lens=seq_lens)
 
     # Construct routed_experts with fixed expert indices
     # Shape: [batch=1, seq_len=100, num_hidden_layers=3, num_experts_per_tok=4]
@@ -142,7 +143,7 @@ def test_qwen3_moe_router_replay():
 
     # Forward with router replay
     prime_model.zero_grad()
-    out_replay = prime_model(input_ids, position_ids, routed_experts=routed_experts)
+    out_replay = prime_model(input_ids, position_ids, routed_experts=routed_experts, seq_lens=seq_lens)
 
     # Outputs should differ because routing is forced to different experts
     assert out_replay["logits"].shape == out_normal["logits"].shape

--- a/tests/unit/train/rl/test_fused_lm_head.py
+++ b/tests/unit/train/rl/test_fused_lm_head.py
@@ -208,11 +208,12 @@ def test_full_model_fused_vs_vanilla():
             labels = torch.randint(0, config.vocab_size, (batch_size, seq_len))
             position_ids = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
             temperature = torch.full((batch_size, seq_len), temp_value, dtype=torch.float32, device="cuda")
+            seq_lens = torch.tensor([seq_len])
 
         # Vanilla forward (returns logits, compute logprobs/entropy using RL train functions)
         optimizer_vanilla.zero_grad()
         out_vanilla = cast_float_and_contiguous(
-            model_vanilla(labels, position_ids, labels=labels, temperature=temperature)
+            model_vanilla(labels, position_ids, labels=labels, temperature=temperature, seq_lens=seq_lens)
         )
         if out_vanilla.get("logprobs") is None:
             assert out_vanilla.get("logits") is not None
@@ -225,7 +226,9 @@ def test_full_model_fused_vs_vanilla():
 
         # Fused forward (returns logprobs and entropy directly)
         optimizer_fused.zero_grad()
-        out_fused = cast_float_and_contiguous(model_fused(labels, position_ids, labels=labels, temperature=temperature))
+        out_fused = cast_float_and_contiguous(
+            model_fused(labels, position_ids, labels=labels, temperature=temperature, seq_lens=seq_lens)
+        )
         if out_fused.get("logprobs") is None:
             assert out_fused.get("logits") is not None
             logits = out_fused["logits"] / temp_value

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import torch
 from transformers import AutoTokenizer
 
 from prime_rl.configs.sft import FakeDataConfig
@@ -114,7 +115,30 @@ def test_fake_dataset_single_rank_state_with_packing():
     step = 0
     for _ in range(8):
         micro_batch = next(dataiter)
-        num_packed_examples = len(micro_batch["input_ids"].unique())
+        num_packed_examples = len(micro_batch["input_ids"][micro_batch["loss_mask"]].unique())
         step += num_packed_examples
         assert micro_batch["input_ids"].shape == (1, 128)
-        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step, "epoch": 0}}
+        assert micro_batch["seq_lens"].sum() == micro_batch["input_ids"].shape[1]
+        if micro_batch["padding_len"]:
+            assert micro_batch["seq_lens"][-1] > micro_batch["padding_len"]
+        dataset_state = dataloader.state_dict()["dataset_state"]
+        pending_sample = dataset_state.get("pending_sample")
+        expected_dataset_step = step + (pending_sample is not None)
+        assert dataset_state["dataset"] == {"step": expected_dataset_step, "epoch": 0}
+        if pending_sample is not None:
+            assert pending_sample["input_ids"][0] == step
+
+    state_dict = dataloader.state_dict()
+    rng_state = torch.random.get_rng_state()
+    expected_batch = next(dataiter)
+
+    resumed_dataset = setup_dataset(tokenizer, config)
+    resumed_dataloader = setup_dataloader(resumed_dataset, config)
+    resumed_dataloader.load_state_dict(state_dict)
+    resumed_dataiter = iter(resumed_dataloader)
+    torch.random.set_rng_state(rng_state)
+    resumed_batch = next(resumed_dataiter)
+
+    for key in ("input_ids", "position_ids", "target_ids", "loss_mask", "seq_lens"):
+        torch.testing.assert_close(resumed_batch[key], expected_batch[key])
+    assert resumed_batch["padding_len"] == expected_batch["padding_len"]

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -119,8 +119,6 @@ def test_fake_dataset_single_rank_state_with_packing():
         step += num_packed_examples
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["seq_lens"].sum() == micro_batch["input_ids"].shape[1]
-        if micro_batch["padding_len"]:
-            assert micro_batch["seq_lens"][-1] > micro_batch["padding_len"]
         dataset_state = dataloader.state_dict()["dataset_state"]
         pending_sample = dataset_state.get("pending_sample")
         expected_dataset_step = step + (pending_sample is not None)
@@ -141,4 +139,3 @@ def test_fake_dataset_single_rank_state_with_packing():
 
     for key in ("input_ids", "position_ids", "target_ids", "loss_mask", "seq_lens"):
         torch.testing.assert_close(resumed_batch[key], expected_batch[key])
-    assert resumed_batch["padding_len"] == expected_batch["padding_len"]

--- a/tests/unit/train/test_model.py
+++ b/tests/unit/train/test_model.py
@@ -47,7 +47,7 @@ def test_model_forward(model):
     model = model.to("cuda")
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
-        outputs = model(input_ids=inputs_ids)
+        outputs = model(input_ids=inputs_ids, seq_lens=torch.tensor([SEQ_LEN], device="cuda"))
         logits = outputs["logits"]
 
         assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)
@@ -59,7 +59,11 @@ def test_model_with_position_ids(model):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
         position_ids = torch.arange(SEQ_LEN).unsqueeze(0).repeat(BS, 1).to("cuda")
 
-        outputs = model(input_ids=inputs_ids, position_ids=position_ids)
+        outputs = model(
+            input_ids=inputs_ids,
+            position_ids=position_ids,
+            seq_lens=torch.tensor([SEQ_LEN], device="cuda"),
+        )
         logits = outputs["logits"]
 
         assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)
@@ -84,7 +88,7 @@ def test_model_with_sequence_packing(model, correct_position_ids):
 
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.Tensor(inputs).repeat(1, 1).int().to("cuda")
-        outputs = model(input_ids=inputs_ids)
+        outputs = model(input_ids=inputs_ids, seq_lens=torch.tensor([len(inputs)], device="cuda"))
         output_base = outputs["logits"]
 
         assert output_base.shape == (1, len(inputs), model.config.vocab_size)
@@ -97,7 +101,11 @@ def test_model_with_sequence_packing(model, correct_position_ids):
         else:
             position_ids = torch.Tensor([0, 1, 2, 3, 4, 5, 6, 7]).repeat(1, 1).int().to("cuda")
             # should fail
-        outputs = model(input_ids=inputs_ids, position_ids=position_ids)
+        outputs = model(
+            input_ids=inputs_ids,
+            position_ids=position_ids,
+            seq_lens=torch.tensor([len(inputs), len(inputs)], device="cuda"),
+        )
         outputs_packed = outputs["logits"]
 
         assert outputs_packed.shape == (1, 2 * len(inputs), model.config.vocab_size)
@@ -126,7 +134,7 @@ def test_moe_custom_impl():
     inject_prime_lm_head(model, chunk_size=None)
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
-        outputs = model(input_ids=inputs_ids)
+        outputs = model(input_ids=inputs_ids, seq_lens=torch.tensor([SEQ_LEN], device="cuda"))
         logits = outputs["logits"]
 
         assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)
@@ -142,7 +150,7 @@ def test_model_forward_custom_impl(model_name):
     model = model.to("cuda")
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
-        outputs = model(input_ids=inputs_ids)
+        outputs = model(input_ids=inputs_ids, seq_lens=torch.tensor([SEQ_LEN], device="cuda"))
         logits = outputs["logits"]
 
         assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)

--- a/tests/unit/train/test_model_forward.py
+++ b/tests/unit/train/test_model_forward.py
@@ -33,6 +33,7 @@ def test_forward_passes_renderer_mm_token_type_ids_through():
         model,
         input_ids,
         position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]]),
         mm_kwargs={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw},
         mm_token_type_ids=mm_token_type_ids,
     )
@@ -57,6 +58,7 @@ def test_forward_omits_mm_token_type_ids_when_renderer_does_not_supply():
         model,
         input_ids,
         position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]]),
         mm_kwargs={"pixel_values": torch.ones(2, 3), "image_grid_thw": torch.tensor([[1, 1, 2]])},
     )
 
@@ -76,6 +78,7 @@ def test_forward_keeps_position_ids_for_non_mrope_vlm():
         model,
         input_ids,
         position_ids,
+        seq_lens=torch.tensor([input_ids.shape[1]]),
         mm_kwargs={"pixel_values": torch.ones(2, 3)},
     )
 

--- a/tests/unit/utils/test_sequence.py
+++ b/tests/unit/utils/test_sequence.py
@@ -1,7 +1,11 @@
 import pytest
 import torch
 
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
+from prime_rl.utils.sequence import (
+    get_cp_local_seq_lens,
+    get_cu_seqlens_from_position_ids,
+    get_cu_seqlens_from_seq_lens,
+)
 
 
 @pytest.mark.parametrize(
@@ -36,3 +40,10 @@ def test_get_cu_seqlens_from_seq_lens():
 def test_get_cu_seqlens_from_seq_lens_rejects_wrong_total():
     with pytest.raises(ValueError, match="sum must equal"):
         get_cu_seqlens_from_seq_lens(torch.tensor([4, 3]), total_tokens=9)
+
+
+@pytest.mark.parametrize(("cp_rank", "expected"), [(0, [3, 1]), (1, [4])])
+def test_get_cp_local_seq_lens(cp_rank: int, expected: list[int]):
+    local_seq_lens = get_cp_local_seq_lens(torch.tensor([3, 5]), 8, cp_rank, 2)
+
+    assert local_seq_lens.tolist() == expected


### PR DESCRIPTION
## Summary

Rebased replacement for #2944, now targeting `main` directly.

- Remove the unused `stack` SFT path and `pack_function`; SFT now has one cat-packed data path with an explicit single-row contract.
- Carry required `seq_lens` through internal SFT/RL batches, transport, dataloaders, and trainer forward. Generic Hugging Face models never receive PrimeRL-only kwargs.
- Derive custom-model FlashAttention `cu_seqlens` only from explicit lengths; public custom-model forwards require keyword-only `seq_lens` and never infer boundaries from `position_ids`.
- Rework SFT cat packing to preserve overflow samples, emit the tail pack, and checkpoint the read-ahead sample so resume cannot skip data.
- Merge trailing padding directly into the final `seq_lens` segment when batches are built, so models receive valid attention lengths without separate padding metadata or forward-time normalization.
- Dense and MoE Qwen3.5 consume boundaries for non-flash linear-attention state resets. Under existing CP, trainers use global lengths for attention setup and derive explicit shard-local lengths for custom model forwards.

## Tests

- GitHub CI: CPU/GPU unit jobs, Ruff, CodeQL, and all integration jobs passed
- Final-stack Slurm H100: reverse-text SFT 4/4, CP-focused 10/10, and RL boundary/packing 35/35 passed; broader model coverage passed 66 tests, with two Qwen3.5 MoE backward tests blocked by the node image missing `cuda/atomic` for TileLang compilation
- Cleanup validation: 30 batch/sequence tests and 22 SFT dataset tests passed; Ruff passed on all changed files
- Direct checkpoint/resume simulation confirms resumed packed output exactly matches uninterrupted execution
- H100 control: resumed steps 11–20 matched uninterrupted training exactly (max loss difference `0.0`); PR and `main` had nearly identical convergence slopes
- Resume integration runs through step 20 so the assertion covers ten post-checkpoint updates
- H100 boundary microbenchmark: explicit `seq_lens` took ~82–83 µs versus ~138–143 µs for position-reset inference across 1K–16K and packed rows

Historical end-to-end validation from #2944:
- Dense and MoE text SFT: 10/10 steps
- RL text run with `seq_lens` end-to-end: 10/10 steps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how packed attention boundaries are computed across many custom model forwards and both SFT/RL training paths; incorrect `seq_lens` or CP sharding would silently break causality or loss alignment.
> 
> **Overview**
> Introduces **`seq_lens`** and **`padding_len`** as the canonical packed-row boundary metadata from SFT/RL dataloaders through transport, batch packing, and trainer **`forward`**. Custom PrimeRL models now require keyword-only **`seq_lens`** and build FlashAttention **`cu_seqlens`** via **`get_cu_seqlens_from_seq_lens`** instead of inferring document breaks from **`position_ids`**; several models drop the non-flash causal-mask fallback and always use the varlen path.
> 
> **SFT** removes **`pack_function`** / the **`stack`** packing path and validators tied to it, leaving a single cat-pack pipeline with overflow read-ahead, tail packs, checkpointed pending samples, and collate that expects one packed row per step. **RL** padding extends the last segment’s **`seq_lens`** (and **`padding_len`**) rather than appending a separate padding segment.
> 
> **Context parallelism** passes global **`seq_lens`** into **`setup_cp_params`**, then **`get_cp_local_seq_lens`** for shard-local custom forwards. Generic HF models still do not receive PrimeRL-only kwargs; **`seq_lens`** is injected only for **`PreTrainedModelPrimeRL`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c77428920ecd5b7d5dd3bd0b1f9b63483bb12b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
