### PR TITLE
fix(orchestrator): align train metrics with trainer cohort

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -111,7 +111,9 @@ Pulled from the console logs and mirrored to W&B.
 
 **Progress** (orchestrator):
 
-- `reward/{all,env}/mean` — main signal. Should trend upward over hundreds of steps.
+- `train/{agg,<env>}/effective/reward/mean` — mean reward over the exact post-filter cohort
+  shipped to the trainer. This is the main training signal and should trend upward over hundreds
+  of steps.
 - `seq_len/{all,env}/mean` and `is_truncated/{all,env}/mean` — rollout length and truncation rate.
 - `num_turns/{all,env}/mean` — for multi-turn envs.
 - `empty_rollouts/{all,env}`, `errored_rollouts/{all,env}` — non-zero is fine in small numbers; sustained > 5% is a smell.
@@ -315,7 +317,7 @@ uv run rl @ rl.toml --wandb \
   --no-trainer.wandb.log-extras.distributions
 ```
 
-prime-rl deliberately logs a **large number of metrics** for maximum observability: every rollout metric is emitted per subset (`all`/`effective`), per statistic (`mean`/`max`/`min`/`p10`/`p90`), and per environment alongside a cross-env aggregate, so a multi-env run can emit thousands of series. To keep that navigable, W&B mode **auto-creates an `overview` saved view** on the first run into a project — curating the handful of metrics that matter into `train`, `eval`, `stability`, and `performance` sections (with per-env breakdowns). The view is created once per project and adapts to the run's environments; if a later run uses a different set of environments, a new versioned view (`overview-v2`, …) is created instead of overwriting the first.
+prime-rl deliberately logs a **large number of metrics** for maximum observability: every rollout metric is emitted per subset (`all`/`effective`), per statistic (`mean`/`max`/`min`/`p10`/`p90`), and per environment alongside a cross-env aggregate, so a multi-env run can emit thousands of series. For train metrics, `all` is the finalized-group observation window used for operational and error diagnostics, while `effective` is the exact post-filter cohort shipped to the trainer. To keep that navigable, W&B mode **auto-creates an `overview` saved view** on the first run into a project — curating the handful of metrics that matter into `train`, `eval`, `stability`, and `performance` sections (with per-env breakdowns). The view is created once per project and adapts to the run's environments; if a later run uses a different set of environments or an older overview schema, a new versioned view (`overview-v2`, …) is created instead of overwriting the first.
 
 ### Platform Monitoring
 

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -27,7 +27,7 @@ Default cadence: **1 hour** (researcher can override). At each check-in:
 **Step**: {current_step} / {max_steps}
 **Health**: {Healthy | Degraded | Down}
 
-**Progress**: reward/mean, seq_len, truncation, eval scores, env-specific metrics.
+**Progress**: trainer-batch reward, seq_len, truncation, eval scores, env-specific metrics.
 **Stability**: entropy, mismatch_kl, grad_norm — flag spikes.
 **Performance**: trainer vs orchestrator step time, env lag, inference pressure.
 
@@ -93,7 +93,7 @@ All metrics print to the console log (and W&B when configured).
 
 | Metric | Description |
 |--------|-------------|
-| `reward/{all,env}/mean` | mean training reward |
+| `train/{agg,<env>}/effective/reward/mean` | mean reward over the exact post-filter trainer-bound cohort |
 | `seq_len/{all,env}/mean` | avg sequence length (tokens) |
 | `num_turns/{all,env}/mean` | avg turns per rollout (multi-turn only) |
 | `is_truncated/{all,env}/mean` | fraction truncated |
@@ -139,8 +139,9 @@ curl -s http://localhost:8000/metrics | grep -E "num_requests|gpu_cache_usage"
 
 JSONL files of `vf.Trace` records (training tensors excluded). `all` gets every completed
 rollout the moment it arrives — errored, filtered, and never-batched ones included — so it's
-crash-durable; `effective` gets the clean subset that went into the step's train batch (eval:
-the non-errored epoch cohort; multiple eval envs share the step file). Each record carries
+crash-durable; train `effective` gets the exact post-filter cohort that went into the trainer
+batch (eval: the non-errored epoch cohort; multiple eval envs share the step file). Each record
+carries
 `kind`, `env_name`, `group_id`, `policy_version`, and `eval_step`, plus `runtime` (config +
 provisioned resource id, e.g. the sandbox id).
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -9,8 +9,7 @@ and drives the pipeline. Components are single-purpose:
   and returns a ``TrainBatch`` when the threshold is met.
 - ``EvalSink`` ingests eval rollouts and returns an ``EvalBatch`` (the full
   returned cohort) on epoch completion.
-- ``TrainRollouts`` / ``EvalRollouts`` carry the rollouts and build the per-step W&B metrics
-  (``batch.rollouts.metrics`` / ``.effective.metrics``).
+- ``TrainRollouts`` / ``EvalRollouts`` carry rollout cohorts and build per-step W&B metrics.
 - ``WeightWatcher`` advances ``Policy`` and notifies observers.
 - ``PeriodicLogger`` polls the components on a shared interval for the
   ``_timestamp``-axis pipeline log.
@@ -543,18 +542,19 @@ class Orchestrator:
                 )
             return
         self.consecutive_empty_batches = 0
-        n_trainable = sum(1 for r in batch.rollouts if r.is_trainable)
-        if n_trainable / len(batch.rollouts) <= 0.1:
+        n_trainable = sum(1 for r in batch.trainer_rollouts if r.is_trainable)
+        if n_trainable / len(batch.trainer_rollouts) <= 0.1:
             get_logger().warning(
-                f"Only {n_trainable}/{len(batch.rollouts)} generated rollouts are trainable "
-                f"({n_trainable / len(batch.rollouts):.1%}) — consider reviewing task difficulty / filter config"
+                f"Only {n_trainable}/{len(batch.trainer_rollouts)} trainer-bound rollouts are trainable "
+                f"({n_trainable / len(batch.trainer_rollouts):.1%}) — "
+                "consider reviewing task difficulty / filter config"
             )
 
-        # The effective (clean, trained-on) subset lands in the per-step ``effective`` trace file
-        # at ship time; the full arrival window already streamed into ``all`` on arrival.
+        # The exact trainer-bound cohort lands in the per-step ``effective`` trace file at ship
+        # time; the full arrival window already streamed into ``all`` on arrival.
         # to_record drops the per-node training tensors — they're for training, not the rollout
         # record, and can't round-trip json (raw numpy bytes).
-        effective = batch.rollouts.effective
+        effective = batch.trainer_rollouts
         records = [r.to_record() for r in effective]
         await asyncio.to_thread(save_rollouts, records, get_trace_path(config.output_dir, step, "train", "effective"))
 
@@ -565,8 +565,8 @@ class Orchestrator:
         save_ckpt_time = await self.maybe_save_ckpt(step)
         trim_process_memory()
 
-        # Rollout metrics over the {agg,<env>} × {all,effective} matrix. ``batch.rollouts`` is the
-        # full arrival window (errored + filtered included); ``.effective`` is the clean subset.
+        # Rollout metrics over the {agg,<env>} × {all,effective} matrix. ``all`` is the finalized-
+        # group observation window; ``effective`` is the exact trainer-bound cohort.
         metrics: dict[str, float] = {}
         for subset, pool in (("all", batch.rollouts), ("effective", effective)):
             metrics |= pool.metrics.to_wandb(prefix="train/agg", subset=subset)
@@ -596,8 +596,8 @@ class Orchestrator:
             "time/wait_for_policy": self.wait_for_policy_time,
             "step": step,
         }
-        for env_name, env_pool in batch.rollouts.by_env().items():
-            metrics[f"batch/{env_name}"] = len(env_pool) / len(batch.rollouts)
+        for env_name, env_pool in effective.by_env().items():
+            metrics[f"batch/{env_name}"] = len(env_pool) / len(effective)
         if self.train_sink.pre_filter_seen > 0:
             metrics["pre_filters/all/dropped_rate"] = (
                 self.train_sink.pre_filter_dropped / self.train_sink.pre_filter_seen
@@ -722,19 +722,18 @@ class Orchestrator:
     def log_train_batch(self, batch: TrainBatch, *, step: int, step_time: float) -> None:
         """Per-step ``Step …`` success line. Multi-env runs append an indented ``╰─`` line per env.
         ``Error`` is the sink-level rate (errored arrivals / total arrivals, over the full window);
-        the quality metrics are over the effective (clean, trained-on) subset; ``Trainable`` is
-        relative to all generated rollouts."""
+        the quality metrics and ``Trainable`` are over the exact trainer-bound cohort."""
         rollouts = batch.rollouts
-        effective = rollouts.effective
+        effective = batch.trainer_rollouts
         eff = effective.metrics
-        n_generated = len(rollouts)
-        n_trainable = sum(1 for r in rollouts if r.is_trainable)
-        trainable_rate = (n_trainable / n_generated) if n_generated else 0.0
+        n_effective = len(effective)
+        n_trainable = sum(1 for r in effective if r.is_trainable)
+        trainable_rate = (n_trainable / n_effective) if n_effective else 0.0
         max_off_policy = max((r.off_policy_steps for r in effective), default=0)
 
         head = (
             f"Step {step} | {format_time(step_time):>7} | Reward {eff.reward.mean():.4f} | "
-            f"Trainable {n_trainable}/{n_generated} ({trainable_rate:.1%}) | "
+            f"Trainable {n_trainable}/{n_effective} ({trainable_rate:.1%}) | "
             f"Turns {eff.num_turns.mean():.1f} | Branches {eff.num_branches.mean():.1f} | "
             f"Max Off-Policy {max_off_policy} | "
             f"Error {rollouts.metrics.has_error.mean():.1%} | Truncation {eff.is_truncated.mean():.1%}"
@@ -743,19 +742,21 @@ class Orchestrator:
             get_logger().success(head)
             return
 
-        by_env = rollouts.by_env()
+        by_env = effective.by_env()
+        arrivals_by_env = rollouts.by_env()
         name_width = max((len(n) for n in by_env), default=0)
         lines = [head]
         for env_name in sorted(by_env):
             pool = by_env[env_name]
-            env_eff_pool = pool.effective
-            env_eff = env_eff_pool.metrics
-            ratio = (len(pool) / n_generated) if n_generated else 0.0
+            env_eff = pool.metrics
+            ratio = (len(pool) / n_effective) if n_effective else 0.0
+            arrivals = arrivals_by_env.get(env_name)
+            error_rate = f"{arrivals.metrics.has_error.mean():.1%}" if arrivals is not None else "n/a"
             lines.append(
                 f"╰─ {env_name:<{name_width}} | Ratio {ratio:.1%} | Reward {env_eff.reward.mean():.4f} | "
                 f"Turns {env_eff.num_turns.mean():.1f} | Branches {env_eff.num_branches.mean():.1f} | "
-                f"Max Off-Policy {max((r.off_policy_steps for r in env_eff_pool), default=0)} | "
-                f"Error {pool.metrics.has_error.mean():.1%} | Truncation {env_eff.is_truncated.mean():.1%}"
+                f"Max Off-Policy {max((r.off_policy_steps for r in pool), default=0)} | "
+                f"Error {error_rate} | Truncation {env_eff.is_truncated.mean():.1%}"
             )
         get_logger().success("\n\t\t ".join(lines))
 

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -277,19 +277,19 @@ class TrainSink:
             apply_filters(self.post_filters, cohort)
 
         # Samples are pre-built by ``process_rollout``; ``process_group`` already stamped the
-        # advantage stream and loss routing on each sample. Filtered rollouts don't ship.
-        samples: list[TrainingSample] = [sample for r in cohort if not r.is_filtered for sample in r.samples]
+        # advantage stream and loss routing on each sample. Retain the exact rollout cohort
+        # represented by the payload so trainer-batch metrics use the same slice.
+        trainer_rollouts = TrainRollouts([r for r in cohort if not r.is_filtered and r.samples])
+        samples: list[TrainingSample] = [sample for r in trainer_rollouts for sample in r.samples]
 
         # ``rollouts`` is the observation window — every rollout of every group finalized since the
-        # last ship (errored + filtered + survivors) — while ``samples`` is the shipped cohort's
-        # trainable payload. ``rollouts.effective`` / ``rollouts.metrics`` derive the clean subset +
-        # metric views on demand. Reset the window only when the batch actually ships (non-empty
-        # samples) — an empty batch is dropped unlogged by the orchestrator, so keep accumulating its
-        # finalized groups (and any overflow) into the next shipped batch's window.
+        # last ship (errored + filtered + survivors). Reset it only when the batch actually ships;
+        # an empty batch is dropped unlogged by the orchestrator, so keep accumulating its finalized
+        # groups (and any overflow) into the next shipped batch's window.
         rollouts = self.pending_rollouts
         if samples:
             self.pending_rollouts = TrainRollouts()
-        return TrainBatch(rollouts=rollouts, samples=samples)
+        return TrainBatch(rollouts=rollouts, trainer_rollouts=trainer_rollouts, samples=samples)
 
     def reset_pre_filter_stats(self) -> None:
         self.pre_filter_seen = 0

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -147,14 +147,13 @@ class Rollout(vf.Trace[DataT], Generic[DataT]):
 
 @dataclass
 class TrainBatch:
-    """``rollouts`` is the observation window since the last ship — every rollout of every group
-    finalized in that span (errored + filtered included; rollouts of still-incomplete groups wait
-    for a later window). Its ``.effective`` / ``.metrics`` views drive logging. ``samples`` is the
-    trainer-bound payload (the shipped cohort's post-filter survivors) — an empty list means nothing
-    ships, which would stall the trainer. Trainable counts derive from ``rollouts``
-    (``r.is_trainable``) and token totals from ``samples``, so neither is carried as a field."""
+    """``rollouts`` is the finalized-group observation window since the last ship (errored and
+    filtered included). ``trainer_rollouts`` is the exact sliced, post-filter, non-empty-sample
+    cohort represented by the trainer-bound ``samples``. An empty sample list means nothing ships,
+    which would stall the trainer."""
 
     rollouts: TrainRollouts
+    trainer_rollouts: TrainRollouts
     samples: list[TrainingSample]
 
 

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -297,8 +297,8 @@ class WandbMonitor(Monitor):
 
 OVERVIEW_NAME = "overview"
 
-# Per-rollout metrics (under "<scope>/all/") shown for BOTH train and eval. Only the reward metric
-# differs — train uses "reward/mean", eval uses "avg@k" — and each section builder prepends its own.
+# Operational per-rollout metrics shown for both train and eval live under ``all``. Train reward
+# instead uses the exact trainer-bound ``effective`` cohort; eval reward uses ``avg@k``.
 COMMON_METRICS = [
     "has_error/mean",
     "is_truncated/mean",
@@ -345,12 +345,15 @@ def section(name: str, metrics: Sequence[str] = (), regexes: Sequence[str] = ())
 
 
 def train_section(name: str, scope: str) -> ws.Section:
-    return section(name, metrics=[f"{scope}/all/reward/mean"] + [f"{scope}/all/{m}" for m in COMMON_METRICS])
+    return section(
+        name,
+        metrics=[f"{scope}/effective/reward/mean"] + [f"{scope}/all/{m}" for m in COMMON_METRICS],
+    )
 
 
 def eval_section(name: str, env_pattern: str) -> ws.Section:
     # Same metrics as train, but eval's reward is "avg@k" (dynamic k → regex). Everything is a regex so
-    # one section can also serve any env (env_pattern=".*"). Only the "all" subset, like train.
+    # one section can also serve any env (env_pattern=".*"). Eval panels remain on the "all" subset.
     return section(
         name,
         regexes=[f"eval/{env_pattern}/all/avg@.*"] + [f"eval/{env_pattern}/all/{m}" for m in COMMON_METRICS],
@@ -405,6 +408,19 @@ def view_env_signature(sections: Sequence[ws.Section]) -> tuple:
     return (tuple(train), tuple(evals))
 
 
+def has_effective_train_reward_panels(sections: Sequence[ws.Section]) -> bool:
+    """Whether every train section displays reward from the exact trainer-bound cohort."""
+    train_sections = [s for s in sections if s.name == "train" or s.name.startswith("train/")]
+    return bool(train_sections) and all(
+        any(
+            (metric if isinstance(metric, str) else getattr(metric, "name", "")).endswith("/effective/reward/mean")
+            for panel in train_section.panels
+            for metric in (getattr(panel, "y", None) or [])
+        )
+        for train_section in train_sections
+    )
+
+
 def next_overview_name(base: str, existing: Sequence[str]) -> str:
     if base not in existing:
         return base
@@ -420,8 +436,8 @@ def ensure_overview_view(
     train_envs: Sequence[str] = (),
     eval_envs: Sequence[str] = (),
 ) -> str | None:
-    """Ensure an overview saved view exists for this run's env set. Reuses an existing overview built
-    for the same envs; when the env set is new, creates a fresh versioned view (``overview`` →
+    """Ensure an overview saved view exists for this run's env set and current panel schema.
+    Reuses a compatible overview; otherwise creates a fresh versioned view (``overview`` →
     ``overview-v2`` → …). Returns the URL of a newly created view, else None."""
     target = env_signature(train_envs, eval_envs)
     overviews = [(dn, iname) for dn, iname in list_views(entity, project) if dn == name or dn.startswith(f"{name}-v")]
@@ -429,7 +445,9 @@ def ensure_overview_view(
         slug = internal_name.removeprefix("nw-").removesuffix("-v")
         try:
             existing = ws.Workspace.from_url(f"https://wandb.ai/{entity}/{project}?nw={slug}")
-            matches = view_env_signature(existing.sections) == target
+            matches = view_env_signature(existing.sections) == target and has_effective_train_reward_panels(
+                existing.sections
+            )
         except Exception as e:
             # A single unreadable view must not abort reuse detection / versioning for the rest.
             get_logger().warning(f"Could not inspect overview view {internal_name} - {e}")

--- a/tests/unit/orchestrator/test_metrics.py
+++ b/tests/unit/orchestrator/test_metrics.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import pytest
 
 from prime_rl.orchestrator.metrics import EvalRollouts, Stat, TrainRollouts
+from prime_rl.orchestrator.train_sink import TrainSink
 from prime_rl.orchestrator.utils import compute_pass_metrics
 
 
@@ -85,6 +86,38 @@ def test_container_effective_by_env_and_listlike():
     assert set(by_env) == {"a", "b"} and len(by_env["a"]) == 2 and isinstance(by_env["a"], TrainRollouts)
     rc.append(mk())
     assert len(rc) == 5
+
+
+def test_train_batch_retains_exact_trainer_rollouts():
+    arrivals = TrainRollouts([mk(reward=-1.0), mk(reward=-1.0), mk(reward=-1.0)])
+    selected = [
+        mk(reward=1.0),
+        mk(reward=0.0, is_filtered=True),
+        mk(reward=0.0),
+        mk(reward=1.0),
+        mk(reward=0.5),
+    ]
+    selected[0].samples = ["sample-0"]
+    selected[1].samples = ["filtered-sample"]
+    selected[2].samples = []
+    selected[3].samples = ["sample-3"]
+    selected[4].samples = ["sample-4"]
+
+    sink = TrainSink.__new__(TrainSink)
+    sink.batch_size = 4
+    sink.token_batch_size = None
+    sink.post_filters = []
+    sink.pending_batch = selected.copy()
+    sink.pending_rollouts = arrivals
+
+    batch = sink.process_batch()
+
+    assert batch.rollouts is arrivals
+    assert batch.rollouts.metrics.reward.mean() == -1.0
+    assert batch.trainer_rollouts.rollouts == [selected[0], selected[3]]
+    assert batch.trainer_rollouts.metrics.reward.mean() == 1.0
+    assert batch.samples == ["sample-0", "sample-3"]
+    assert sink.pending_batch == [selected[4]]
 
 
 def test_to_wandb_distributions():

--- a/tests/unit/utils/test_wandb.py
+++ b/tests/unit/utils/test_wandb.py
@@ -1,0 +1,20 @@
+from types import SimpleNamespace
+
+import wandb_workspaces.reports.v2 as wr
+
+from prime_rl.utils.monitor.wandb import build_sections, has_effective_train_reward_panels, section
+
+
+def test_overview_requires_effective_train_reward_panels():
+    current_sections = build_sections(train_envs=["env-a", "env-b"])
+    deserialized_sections = [
+        SimpleNamespace(
+            name="train/agg",
+            panels=[SimpleNamespace(y=[wr.Metric("train/agg/effective/reward/mean")])],
+        )
+    ]
+    legacy_sections = [section("train/agg", metrics=["train/agg/all/reward/mean"])]
+
+    assert has_effective_train_reward_panels(current_sections)
+    assert has_effective_train_reward_panels(deserialized_sections)
+    assert not has_effective_train_reward_panels(legacy_sections)


### PR DESCRIPTION
## Summary

- retain the exact post-filter rollout cohort represented by each trainer batch
- compute effective reward, input/output usage, traces, and trainer-batch summaries from that cohort
- keep finalized-group diagnostics separate from trainer-bound metrics
- refresh older W&B overview views so their reward panel uses the trainer cohort

## Problem

`TrainBatch.rollouts` is the finalized-group observation window, not necessarily the payload sent to the trainer. `TrainSink` can finalize more clean rollouts than fit in the current batch, retain overflow for the next step, or exclude rollouts that have no samples.

For example, with a batch size of six, two finalized groups of four put eight clean rollouts in the observation window. Only six ship in the current trainer batch; two remain buffered for the next one. Metrics currently treat all eight as effective now, then can omit the buffered two when they actually train. The same mismatch affects input/output usage, traces, sample tables, and environment-mix summaries.

## Regression

Before [#2907](https://github.com/PrimeIntellect-ai/prime-rl/pull/2907), `TrainSink.process_batch()` returned the sliced trainer cohort as `TrainBatch.rollouts`, so each step's reward was calculated from the rollouts selected for that trainer batch. This behavior is visible in [v0.6.1.dev30](https://github.com/PrimeIntellect-ai/prime-rl/tree/v0.6.1.dev30) ([`16efd8a`](https://github.com/PrimeIntellect-ai/prime-rl/commit/16efd8afda3581f81477cb7ef7e0cf036df80afa)).

[#2907](https://github.com/PrimeIntellect-ai/prime-rl/pull/2907) introduced the broader observation window while consolidating train and eval metrics, and used its non-errored, non-filtered `effective` view as an approximation of what trained. The two sets diverge at batch overflow, so the reward mismatch appears to be an unintended consequence of that consolidation rather than an intended change to training semantics.

[#3013](https://github.com/PrimeIntellect-ai/prime-rl/pull/3013) later corrected which finalized groups belong to each observation window, but deliberately retained a window that can be broader than the sliced trainer cohort.

## Fix

Carry an explicit `trainer_rollouts` cohort alongside the observation window. It is derived from the same sliced, post-filter, non-empty-sample rollouts that produce the trainer payload.

Use that cohort for effective metrics and trainer-bound observability while retaining the full finalized-group window for all-rollout, error, and pre-filter diagnostics. Point the curated reward panel at the effective trainer-cohort metric and document the distinction. When an existing W&B overview still uses the older all-rollout reward panel, create a versioned overview with the corrected schema instead of reusing or overwriting the saved view.

This changes accounting and observability only. It does not change rollout filtering, batching, reward assignment, samples, losses, or optimizer behavior.

## Verification

All commands ran against this checkout using the existing shared environment with `uv run --active --no-sync` and an explicit `PYTHONPATH`.

- `pytest tests/unit/orchestrator/test_metrics.py tests/unit/utils/test_wandb.py -v` — 13 passed
- `pytest tests/unit/orchestrator -m "not gpu" -v` — 95 passed, 1 skipped
- `pytest tests/unit -m "not gpu" --ignore=tests/unit/test_configs.py --ignore=tests/unit/utils/test_metrics_server.py -q` — 352 passed, 1 skipped, 81 deselected
- `pytest tests/unit/utils/test_metrics_server.py -q` with proxy variables unset for localhost — 16 passed
- `pre-commit run --files <touched files>` — Ruff check and Ruff format passed

`tests/unit/test_configs.py` was excluded from the broad shared-environment run because that environment intentionally does not contain every optional taskset package referenced by the repository's config catalog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and logging only—no changes to filtering, batching, rewards, or trainer payloads beyond aligning what gets measured.
> 
> **Overview**
> Train observability was treating the finalized-group **observation window** as the cohort that actually trained, which diverges when batching overflows or rollouts have no samples.
> 
> This PR adds an explicit **`trainer_rollouts`** on `TrainBatch`—the same sliced, post-filter rollouts that produce the shipped `samples`—and uses it for **effective** reward, traces, W&B samples/distributions, env mix (`batch/*`), and console **Step** lines. The broader **`rollouts`** window stays on **`all`** metrics for errors and diagnostics.
> 
> Docs and the monitor skill now point at `train/.../effective/reward/mean` as the main progress signal. W&B **overview** train panels use that metric; legacy overviews that still chart `all/reward` trigger a versioned view instead of reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9bd6f8667ee891db787b36aa2903346b5675679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->