### PR TITLE
fix(orchestrator): pin eval epochs to one policy version

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -63,6 +63,12 @@ A condensed view of the knobs you'll most often tune. For trainer-side paralleli
 | `[[orchestrator.train.env]]` | Training environments. List multiple tables for multi-env training; weight them via `ratio`. See [Configuration § Environments](configuration.md#environments-orchestratortrainenv). |
 | `[[orchestrator.eval.env]]` + `orchestrator.eval.interval` | Eval environments and cadence (default every 100 steps). |
 
+Each eval step runs against one pinned policy version. The orchestrator finishes and drains
+pre-existing train work before dispatching the complete eval cohort, then may refill train capacity
+while the eval tail completes. Seeing train and eval rollouts in flight together is therefore
+expected; live-policy weight updates remain paused until every eval environment due at that step has
+finished.
+
 **Monitoring:**
 
 | Knob | What it does |

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -123,6 +123,11 @@ All metrics print to the console log (and W&B when configured).
 | orchestrator | `scheduler/async_level`, `scheduler/inflight_rollouts` | scheduler state |
 | env server | event loop lag (min/mean/p90/p99/max), active task distribution | periodic |
 
+During an eval, `Starting evals ... with policy vN pinned until completion` marks the live-policy
+lease. Simultaneous train and eval rollouts are expected after the full eval cohort has been
+dispatched. A delayed watcher may then jump directly to the latest stable checkpoint when the eval
+finishes instead of applying every intermediate checkpoint.
+
 For live vLLM stats, query Prometheus directly:
 
 ```bash

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -8,14 +8,13 @@
   (env error, empty trajectory, task exception, off-policy cancel) carry
   ``trace.error`` set; sinks decide drop / partial-train policy.
 - ``DispatcherMode.PREFER_TRAIN`` / ``PREFER_EVAL`` controls which kind to
-  schedule next. Transitions are level-triggered (driven by the eval
-  source's emptiness), so in-flight rollouts of the opposite kind drain
-  naturally on either side of an eval boundary.
+  schedule next. An eval window drains pre-existing train work, dispatches
+  the complete eval cohort, then refills spare capacity with train while the
+  version-pinned eval tail finishes.
 - ``on_version_pending`` (called by the watcher before the engines pause for
   the weight update) bumps ``off_policy_steps`` on in-flight train rollouts and
   drops groups past ``max_off_policy_steps``.
-  Eval rollouts are measurements for the policy version they started with,
-  so they are allowed to finish even if training advances. Train rollouts
+  Eval epochs hold the live-policy update lock until they finish. Train rollouts
   sampled from a frozen model never age — their sampler doesn't change
   with policy updates.
   Cancellations surface as synthetic ``Cancelled`` markers so the sink's
@@ -212,6 +211,11 @@ class RolloutDispatcher:
         )
 
     @property
+    def train_has_open_groups(self) -> bool:
+        """Whether a train group still has members that have not been dispatched."""
+        return any(g.kind == "train" and g.rollouts_to_schedule > 0 for g in self.groups.values())
+
+    @property
     def is_idle(self) -> bool:
         """True once nothing is in flight, no eval work remains (queued *or* a partly-scheduled eval
         group), and ``out_q`` is empty — the pipeline has fully drained."""
@@ -270,7 +274,7 @@ class RolloutDispatcher:
         """Bump off-policy counters and drop groups past
         ``max_off_policy_steps`` (drop_group emits ``Cancelled`` markers so
         the sink still finalizes the partial group). Eval rollouts are not
-        aged because they are tied to their start-time policy version.
+        aged because their epoch holds the live-policy update lock.
 
         Runs *before* the inference engines are paused for the weight update so
         the resulting aborts are processed while the engine is still stepping —
@@ -306,8 +310,9 @@ class RolloutDispatcher:
         """Schedule new rollouts up to ``max_inflight``, honoring
         ``self.mode``. Eval scheduling ignores the orchestrator's dispatch
         gate (evals are version-pinned measurements); only train scheduling
-        respects it. When ``PREFER_EVAL``'s source exhausts we flip back to
-        ``PREFER_TRAIN`` so the eval tail drains alongside fresh train."""
+        respects it. ``PREFER_EVAL`` drains existing train work before sampling
+        eval, then returns spare capacity to train once the full eval cohort is
+        dispatched."""
         while True:
             if self.available_permits <= 0:
                 return
@@ -316,11 +321,20 @@ class RolloutDispatcher:
                 # PREFER_EVAL is only entered when the orchestrator triggers
                 # eval, which requires ``eval_source`` to be configured
                 assert self.eval_source is not None
+                # Finish a train group opened before the mode flip, then let the existing train
+                # tail drain. No fresh train group opens until the eval cohort starts dispatching.
+                if not self.train_scheduling_disabled and self.train_has_open_groups:
+                    scheduled = await self.try_schedule_existing("train")
+                    if not scheduled:
+                        return
+                    continue
+                if self.inflight_train_count:
+                    return
                 if not self.eval_has_work:
                     # Eval source + all eval groups fully dispatched. Flip
                     # to PREFER_TRAIN so any remaining permits go to train
                     # while the in-flight eval tail completes naturally
-                    self.switch_mode(DispatcherMode.PREFER_TRAIN, reason="the eval queue drained")
+                    self.switch_mode(DispatcherMode.PREFER_TRAIN, reason="the eval rollouts were dispatched")
                     continue
                 scheduled = await self.try_schedule("eval")
                 if not scheduled:
@@ -346,17 +360,13 @@ class RolloutDispatcher:
         scheduled."""
         if kind == "train" and self.train_scheduling_disabled:
             return False
+        scheduled = await self.try_schedule_existing(kind)
+        if scheduled:
+            return True
+
         envs = self.train_envs if kind == "train" else self.eval_envs
         if envs is None:
             return False
-
-        for gid, group in list(self.groups.items()):
-            if group.kind != kind or group.rollouts_to_schedule <= 0:
-                continue
-            env = envs.get(group.env_name)
-            cost = group.rollouts_to_schedule if env.requires_group_scoring else 1
-            if cost <= self.available_permits:
-                return await self.schedule_group_rollout(gid, group)
 
         fresh = self.next_fresh_group(kind, envs)
         if fresh is None:
@@ -364,6 +374,20 @@ class RolloutDispatcher:
         gid = uuid.uuid4()
         self.groups[gid] = fresh
         return await self.schedule_group_rollout(gid, fresh)
+
+    async def try_schedule_existing(self, kind: RolloutKind) -> bool:
+        """Schedule one remaining member from an already-opened group."""
+        envs = self.train_envs if kind == "train" else self.eval_envs
+        if envs is None:
+            return False
+        for gid, group in list(self.groups.items()):
+            if group.kind != kind or group.rollouts_to_schedule <= 0:
+                continue
+            env = envs.get(group.env_name)
+            cost = group.rollouts_to_schedule if env.requires_group_scoring else 1
+            if cost <= self.available_permits:
+                return await self.schedule_group_rollout(gid, group)
+        return False
 
     def next_fresh_group(self, kind: RolloutKind, envs) -> GroupState | None:
         """Pop the next example from the corresponding source and wrap it in

--- a/src/prime_rl/orchestrator/eval_source.py
+++ b/src/prime_rl/orchestrator/eval_source.py
@@ -47,13 +47,8 @@ class EvalSource:
     def trigger(self, step: int) -> list[str]:
         """Fire eligible envs for ``step`` and return their names. On resume
         ``first_trigger`` is False, so the startup/base eval doesn't re-run."""
-        is_first, self.first_trigger = self.first_trigger, False
-        if is_first and self.eval_config.skip_first_step:
-            return []
-        fired: list[str] = []
-        for name, interval in self.intervals.items():
-            if is_first or step % interval == 0:
-                fired.append(name)
+        fired = self.eligible_envs(step)
+        self.first_trigger = False
         # Round-robin across fired envs (A₁, B₁, A₂, B₂, …) so the
         # dispatcher rotates at example granularity. ``try_schedule``'s
         # continue-group branch still keeps each example's group_size
@@ -67,6 +62,12 @@ class EvalSource:
                 row["eval_step"] = step
                 self.queue.append(row)
         return fired
+
+    def eligible_envs(self, step: int) -> list[str]:
+        """Return the envs due at ``step`` without mutating trigger state or the queue."""
+        if self.first_trigger:
+            return [] if self.eval_config.skip_first_step else list(self.intervals)
+        return [name for name, interval in self.intervals.items() if step % interval == 0]
 
     def next_example(self, available_permits: int) -> dict | None:
         """Pop the next eval example if the head's permit cost fits in

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import os
 import time
+from collections import deque
 from typing import TYPE_CHECKING
 
 import tomli_w
@@ -117,6 +118,11 @@ class Orchestrator:
     last_batch_at: float | None
     consecutive_empty_batches: int
     eval_triggered_at: dict[tuple[str, int], float]
+    active_eval_epochs: set[tuple[str, int]]
+    pending_eval_steps: deque[int]
+    eval_trigger_task: asyncio.Task | None
+    eval_trigger_error: BaseException | None
+    eval_policy_lock_held: bool
     ckpt_manager: CheckpointManager | None
     component_tasks: list[asyncio.Task]
 
@@ -170,6 +176,11 @@ class Orchestrator:
         self.last_batch_at = None
         # Trigger timestamps so eval success logs can report epoch duration
         self.eval_triggered_at = {}
+        self.active_eval_epochs = set()
+        self.pending_eval_steps = deque()
+        self.eval_trigger_task = None
+        self.eval_trigger_error = None
+        self.eval_policy_lock_held = False
         self.consecutive_empty_batches = 0
         self.gate_closed_at = None
         self.wait_for_policy_time = 0.0
@@ -353,6 +364,15 @@ class Orchestrator:
         )
 
         assert config.max_inflight_rollouts is not None, "max_inflight_rollouts must be resolved before dispatcher init"
+        if self.eval_envs is not None:
+            for env in self.eval_envs:
+                if not env.examples:
+                    raise ValueError(f"Eval environment {env.name!r} has no examples")
+                if env.requires_group_scoring and env.config.group_size > config.max_inflight_rollouts:
+                    raise ValueError(
+                        f"Eval environment {env.name!r} requires all {env.config.group_size} group rollouts "
+                        f"to run together, but max_inflight_rollouts={config.max_inflight_rollouts}"
+                    )
         log_interval = config.log.interval
         wandb_enabled = config.wandb is not None
         self.dispatcher = RolloutDispatcher(
@@ -418,29 +438,33 @@ class Orchestrator:
         get_logger().info(f"Starting orchestrator loop (max_steps={config.max_steps or 'infinite'})")
         start_time = time.perf_counter()
 
-        # Spawn background loops (dispatcher schedules, watcher polls). The
-        # pipeline ``main_loop`` runs inline in this task; the single
-        # ``PeriodicLogger`` polls dispatcher / watcher / sinks / lag
-        # monitor each ``log.interval`` seconds for the pipeline-view log
-        self.lag_task = asyncio.create_task(self.lag_monitor.run(), name="event_loop_lag")
-        await self.periodic_logger.start()
-        self.component_tasks = [
-            asyncio.create_task(self.dispatcher.start(), name="dispatcher"),
-            asyncio.create_task(self.watcher.start(), name="watcher"),
-        ]
-
-        # Base-model eval (policy v0) — fires before any train rollouts, logged at the first
-        # step, unless ``eval.skip_first_step=True`` (or this is a resume)
-        self.maybe_trigger_eval(self.progress.step)
-
-        # Anchor step-time clock so the first step measures startup → first batch
-        self.last_batch_at = time.perf_counter()
-
         # ``clean_exit`` stays False if ``main_loop`` raises (signal-driven
         # CancelledError, KeyboardInterrupt, or a real error), so the teardown
         # logs a forced-cleanup warning instead of a clean-exit success.
         clean_exit = False
         try:
+            # Spawn background loops (dispatcher schedules, watcher polls). The
+            # pipeline ``main_loop`` runs inline in this task; the single
+            # ``PeriodicLogger`` polls dispatcher / watcher / sinks / lag
+            # monitor each ``log.interval`` seconds for the pipeline-view log.
+            self.lag_task = asyncio.create_task(self.lag_monitor.run(), name="event_loop_lag")
+            await self.periodic_logger.start()
+
+            # Pin the startup eval before the watcher can advance the policy or the dispatcher can
+            # schedule train work. Resumed runs skip the unconditional eval but still honor an
+            # interval due at the resumed step; skip_first_step consumes only the fresh-run trigger.
+            self.maybe_trigger_eval(self.progress.step)
+            startup_eval = self.eval_trigger_task
+            if startup_eval is not None:
+                await startup_eval
+
+            self.component_tasks = [
+                asyncio.create_task(self.dispatcher.start(), name="dispatcher"),
+                asyncio.create_task(self.watcher.start(), name="watcher"),
+            ]
+
+            # Anchor step-time clock so the first step measures startup → first batch.
+            self.last_batch_at = time.perf_counter()
             await self.main_loop()
             clean_exit = True
         finally:
@@ -469,7 +493,8 @@ class Orchestrator:
         to the train / eval sink. Both sinks return a finalized batch (or
         ``None``) from ``add()``; we just dispatch on the result."""
         while not self.stopped.is_set():
-            if self.draining and self.dispatcher.is_idle:
+            self._raise_if_eval_trigger_failed()
+            if self.draining and self.dispatcher.is_idle and self.eval_pipeline_idle:
                 get_logger().info("Pipeline drained, exiting main loop")
                 self.stopped.set()
                 break
@@ -637,13 +662,64 @@ class Orchestrator:
         trim_process_memory()
 
     def maybe_trigger_eval(self, step: int) -> None:
-        """Fire eligible eval epochs and flip to ``PREFER_EVAL`` if anything
-        fires. No-op when eval is not configured."""
+        """Queue a due eval step without blocking the rollout-queue consumer."""
         if self.eval_source is None:
             return
-        fired = self.eval_source.trigger(step)
-        if not fired:
+
+        if not self.eval_source.eligible_envs(step):
+            # ``trigger`` consumes the first-trigger state even when the startup eval is skipped.
+            fired = self.eval_source.trigger(step)
+            if fired:
+                raise RuntimeError(f"Eval source eligibility changed while triggering step {step}: {fired}")
             return
+
+        if step not in self.pending_eval_steps:
+            self.pending_eval_steps.append(step)
+        self._ensure_eval_trigger_task()
+
+    @property
+    def eval_pipeline_idle(self) -> bool:
+        """Whether no due, triggering, or active eval epoch remains."""
+        return not self.pending_eval_steps and not self.active_eval_epochs and self.eval_trigger_task is None
+
+    def _ensure_eval_trigger_task(self) -> None:
+        if (
+            self.stopped.is_set()
+            or self.active_eval_epochs
+            or not self.pending_eval_steps
+            or self.eval_trigger_task is not None
+        ):
+            return
+        task = asyncio.create_task(self._trigger_next_eval(), name="eval_trigger")
+        self.eval_trigger_task = task
+        task.add_done_callback(self._on_eval_trigger_done)
+
+    def _on_eval_trigger_done(self, task: asyncio.Task) -> None:
+        if self.eval_trigger_task is task:
+            self.eval_trigger_task = None
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            self.eval_trigger_error = error
+            return
+        self._ensure_eval_trigger_task()
+
+    async def _trigger_next_eval(self) -> None:
+        """Acquire the policy lease off the main consumer task, then enqueue one eval epoch."""
+        assert self.eval_source is not None
+        step = self.pending_eval_steps.popleft()
+        await self.watcher.update_lock.acquire()
+        self.eval_policy_lock_held = True
+        try:
+            fired = self.eval_source.trigger(step)
+            if not fired:
+                raise RuntimeError(f"Eval step {step} was queued but no environment was eligible")
+        except BaseException:
+            self._release_eval_policy_lease()
+            raise
+
+        self.active_eval_epochs.update((env_name, step) for env_name in fired)
         reason = f"eval was triggered at step {step}"
         self.dispatcher.switch_mode(DispatcherMode.PREFER_EVAL, reason=reason)
         now = time.perf_counter()
@@ -654,7 +730,22 @@ class Orchestrator:
             self.eval_envs.get(env_name).config.group_size * len(self.eval_envs.get(env_name).examples)
             for env_name in fired
         )
-        get_logger().info(f"Starting evals in {', '.join(fired)} ({total_rollouts} total rollouts)")
+        get_logger().info(
+            f"Starting evals in {', '.join(fired)} ({total_rollouts} total rollouts) "
+            f"with policy v{self.policy.version} pinned until completion"
+        )
+
+    def _raise_if_eval_trigger_failed(self) -> None:
+        if self.eval_trigger_error is None:
+            return
+        error, self.eval_trigger_error = self.eval_trigger_error, None
+        raise RuntimeError("Eval trigger failed") from error
+
+    def _release_eval_policy_lease(self) -> None:
+        if not self.eval_policy_lock_held:
+            return
+        self.watcher.update_lock.release()
+        self.eval_policy_lock_held = False
 
     def collect_pipeline_view(self) -> tuple[str, dict[str, float]]:
         """Pipeline view for the orchestrator's ``PeriodicLogger``. Returns
@@ -760,6 +851,19 @@ class Orchestrator:
         get_logger().success("\n\t\t ".join(lines))
 
     async def finalize_eval_batch(self, batch: EvalBatch) -> None:
+        """Release completed inference work, then persist and log one eval epoch."""
+        key = (batch.env_name, batch.step)
+        if key not in self.active_eval_epochs:
+            raise RuntimeError(f"Completed unexpected eval epoch env={batch.env_name!r} step={batch.step}")
+        self.active_eval_epochs.remove(key)
+        if not self.active_eval_epochs:
+            if not self.eval_policy_lock_held:
+                raise RuntimeError("Eval policy lease was lost before the epoch completed")
+            self._release_eval_policy_lease()
+            self._ensure_eval_trigger_task()
+        await self._finalize_eval_batch(batch)
+
+    async def _finalize_eval_batch(self, batch: EvalBatch) -> None:
         """Persist + log one completed eval epoch (save_rollouts,
         monitor.log_eval_samples, monitor.log)."""
         if not batch.rollouts:
@@ -873,8 +977,15 @@ class Orchestrator:
                 self.sender.close()
             if self.dispatcher is not None:
                 await self.dispatcher.stop()
+            if self.eval_trigger_task is not None:
+                await safe_cancel(self.eval_trigger_task)
+                self.eval_trigger_task = None
             if self.watcher is not None:
                 await self.watcher.stop()
+            self._release_eval_policy_lease()
+            self.active_eval_epochs.clear()
+            self.pending_eval_steps.clear()
+            self.eval_trigger_error = None
             if self.periodic_logger is not None:
                 await self.periodic_logger.stop()
             if self.lag_task is not None:

--- a/src/prime_rl/orchestrator/watcher.py
+++ b/src/prime_rl/orchestrator/watcher.py
@@ -72,25 +72,42 @@ class WeightWatcher:
         return max(self.policy.version, latest_ckpt_step)
 
     async def apply_policy_update(self, next_step: int) -> None:
-        async with self.update_lock:
-            if next_step <= self.ckpt_step:
-                # Another caller raced us — bail without re-applying
-                return
+        if next_step <= self.ckpt_step:
+            return
 
-            broadcast_dir = get_broadcast_dir(self.config.output_dir)
+        # Waiting for a checkpoint does not mutate the live policy, so eval can safely retain the
+        # current version while the trainer finishes publishing the requested step.
+        requested_step = next_step
+        broadcast_dir = get_broadcast_dir(self.config.output_dir)
+        weights_path = get_step_path(broadcast_dir, next_step)
+        stable_marker = weights_path / "STABLE"
+        if not stable_marker.exists():
+            refreshed_step = self.compute_next_ckpt_step()
+            if refreshed_step > next_step:
+                next_step = refreshed_step
+                weights_path = get_step_path(broadcast_dir, next_step)
+                stable_marker = weights_path / "STABLE"
+        if not stable_marker.exists():
+            get_logger().info(
+                f"Orchestrator paused: waiting for trainer to broadcast checkpoint {next_step}. "
+                "Training is progressing normally."
+            )
+            t0 = time.perf_counter()
+            await wait_for_path(stable_marker)
+            self.last_wait_for_ckpt_time = time.perf_counter() - t0
+            get_logger().info(
+                f"Orchestrator resumed: checkpoint {next_step} ready (after {format_time(self.last_wait_for_ckpt_time)})"
+            )
+
+        async with self.update_lock:
+            next_step = self.compute_next_ckpt_step()
+            if next_step <= self.ckpt_step:
+                return
+            if next_step != requested_step:
+                get_logger().info(
+                    f"Coalescing policy update from checkpoint {requested_step} to latest stable checkpoint {next_step}"
+                )
             weights_path = get_step_path(broadcast_dir, next_step)
-            stable_marker = weights_path / "STABLE"
-            if not stable_marker.exists():
-                get_logger().info(
-                    f"Orchestrator paused: waiting for trainer to broadcast checkpoint {next_step}. "
-                    "Training is progressing normally."
-                )
-                t0 = time.perf_counter()
-                await wait_for_path(stable_marker)
-                self.last_wait_for_ckpt_time = time.perf_counter() - t0
-                get_logger().info(
-                    f"Orchestrator resumed: checkpoint {next_step} ready (after {format_time(self.last_wait_for_ckpt_time)})"
-                )
 
             # Drain off-policy rollouts BEFORE pausing the inference engines.
             # Aborting a rollout triggers vLLM's KV-connector cleanup (NIXL's

--- a/tests/unit/orchestrator/test_orchestrator_setup.py
+++ b/tests/unit/orchestrator/test_orchestrator_setup.py
@@ -1,10 +1,18 @@
 import asyncio
+from collections import deque
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from renderers import Qwen3VLRendererConfig
 
+from prime_rl.orchestrator.dispatcher import DispatcherMode, RolloutDispatcher
+from prime_rl.orchestrator.eval_source import EvalSource
+from prime_rl.orchestrator.orchestrator import Orchestrator
+from prime_rl.orchestrator.types import Policy
 from prime_rl.orchestrator.utils import setup_policy_inference_pool
+from prime_rl.orchestrator.watcher import WeightWatcher
+from prime_rl.utils.pathing import get_broadcast_dir, get_step_path
 
 
 def test_setup_policy_inference_pool_uses_renderer_when_enabled():
@@ -94,5 +102,289 @@ def test_setup_policy_inference_pool_keeps_renderer_without_policy_sampling():
             renderer_config=renderer_settings,
             pool_size=None,
         )
+
+    asyncio.run(run())
+
+
+def test_eval_source_eligibility_does_not_consume_startup_trigger():
+    source = EvalSource.__new__(EvalSource)
+    source.eval_config = SimpleNamespace(skip_first_step=True)
+    source.first_trigger = True
+    source.intervals = {"eval": 2}
+    source.examples_by_env = {"eval": []}
+    source.queue = deque()
+
+    assert source.eligible_envs(2) == []
+    assert source.first_trigger
+    assert source.trigger(2) == []
+    assert not source.first_trigger
+    assert source.eligible_envs(2) == ["eval"]
+
+
+def test_weight_watcher_coalesces_after_eval_policy_lock(tmp_path):
+    async def run() -> None:
+        broadcast_dir = get_broadcast_dir(tmp_path)
+        first_weights_path = get_step_path(broadcast_dir, 1)
+        first_weights_path.mkdir(parents=True)
+        (first_weights_path / "STABLE").touch()
+        policy = Policy(model_name="policy", version=0)
+        inference = SimpleNamespace(
+            update_weights=AsyncMock(),
+            update_model_name=lambda _name: None,
+        )
+        observer = SimpleNamespace(
+            on_version_pending=AsyncMock(),
+            on_new_version=AsyncMock(),
+        )
+        watcher = WeightWatcher(
+            SimpleNamespace(output_dir=tmp_path),
+            policy=policy,
+            inference=inference,
+            observers=[observer],
+            lora_name=None,
+        )
+
+        await watcher.update_lock.acquire()
+        update = asyncio.create_task(watcher.apply_policy_update(1))
+        await asyncio.sleep(0)
+
+        inference.update_weights.assert_not_awaited()
+        assert policy.version == 0
+
+        latest_weights_path = get_step_path(broadcast_dir, 2)
+        latest_weights_path.mkdir(parents=True)
+        (latest_weights_path / "STABLE").touch()
+        (first_weights_path / "STABLE").unlink()
+        first_weights_path.rmdir()
+
+        watcher.update_lock.release()
+        await update
+
+        inference.update_weights.assert_awaited_once_with(
+            latest_weights_path,
+            lora_name=None,
+            step=2,
+        )
+        observer.on_version_pending.assert_awaited_once_with(2)
+        observer.on_new_version.assert_awaited_once_with(2)
+        assert watcher.ckpt_step == 2
+        assert policy.version == 2
+
+    asyncio.run(run())
+
+
+def test_weight_watcher_waits_for_stable_marker_without_holding_policy_lock(tmp_path):
+    async def run() -> None:
+        weights_path = get_step_path(get_broadcast_dir(tmp_path), 1)
+        weights_path.mkdir(parents=True)
+        wait_started = asyncio.Event()
+        finish_wait = asyncio.Event()
+
+        async def controlled_wait(_path) -> None:
+            wait_started.set()
+            await finish_wait.wait()
+
+        policy = Policy(model_name="policy", version=0)
+        inference = SimpleNamespace(
+            update_weights=AsyncMock(),
+            update_model_name=lambda _name: None,
+        )
+        watcher = WeightWatcher(
+            SimpleNamespace(output_dir=tmp_path),
+            policy=policy,
+            inference=inference,
+            observers=[],
+            lora_name=None,
+        )
+
+        with patch("prime_rl.orchestrator.watcher.wait_for_path", side_effect=controlled_wait):
+            update = asyncio.create_task(watcher.apply_policy_update(1))
+            await wait_started.wait()
+            await asyncio.wait_for(watcher.update_lock.acquire(), timeout=0.1)
+            watcher.update_lock.release()
+            (weights_path / "STABLE").touch()
+            finish_wait.set()
+            await update
+
+        inference.update_weights.assert_awaited_once_with(weights_path, lora_name=None, step=1)
+        assert policy.version == 1
+
+    asyncio.run(run())
+
+
+def test_weight_watcher_retargets_when_requested_checkpoint_was_deleted(tmp_path):
+    async def run() -> None:
+        latest_weights_path = get_step_path(get_broadcast_dir(tmp_path), 2)
+        latest_weights_path.mkdir(parents=True)
+        (latest_weights_path / "STABLE").touch()
+        policy = Policy(model_name="policy", version=0)
+        inference = SimpleNamespace(
+            update_weights=AsyncMock(),
+            update_model_name=lambda _name: None,
+        )
+        watcher = WeightWatcher(
+            SimpleNamespace(output_dir=tmp_path),
+            policy=policy,
+            inference=inference,
+            observers=[],
+            lora_name=None,
+        )
+
+        with patch("prime_rl.orchestrator.watcher.wait_for_path", new=AsyncMock()) as wait_mock:
+            await watcher.apply_policy_update(1)
+
+        wait_mock.assert_not_awaited()
+        inference.update_weights.assert_awaited_once_with(latest_weights_path, lora_name=None, step=2)
+        assert policy.version == 2
+
+    asyncio.run(run())
+
+
+def test_eval_trigger_waits_off_consumer_and_holds_lease_for_all_envs():
+    async def run() -> None:
+        orchestrator = Orchestrator.__new__(Orchestrator)
+        orchestrator.stopped = asyncio.Event()
+        orchestrator.active_eval_epochs = set()
+        orchestrator.pending_eval_steps = deque()
+        orchestrator.eval_trigger_task = None
+        orchestrator.eval_trigger_error = None
+        orchestrator.eval_policy_lock_held = False
+        orchestrator.eval_triggered_at = {}
+        orchestrator.policy = Policy(version=3, model_name="policy")
+        orchestrator.watcher = SimpleNamespace(update_lock=asyncio.Lock())
+        orchestrator.dispatcher = SimpleNamespace(switch_mode=MagicMock())
+        orchestrator.eval_source = SimpleNamespace(
+            eligible_envs=lambda _step: ["a", "b"],
+            trigger=lambda _step: ["a", "b"],
+        )
+        env = SimpleNamespace(config=SimpleNamespace(group_size=1), examples=[{"task_idx": 0}])
+        orchestrator.eval_envs = SimpleNamespace(get=lambda _name: env)
+
+        await orchestrator.watcher.update_lock.acquire()
+        orchestrator.maybe_trigger_eval(10)
+        trigger = orchestrator.eval_trigger_task
+        assert trigger is not None
+        await asyncio.sleep(0)
+
+        assert not trigger.done()
+        assert not orchestrator.active_eval_epochs
+
+        orchestrator.watcher.update_lock.release()
+        await trigger
+
+        assert orchestrator.watcher.update_lock.locked()
+        assert orchestrator.active_eval_epochs == {("a", 10), ("b", 10)}
+
+        orchestrator._finalize_eval_batch = AsyncMock()
+        await orchestrator.finalize_eval_batch(SimpleNamespace(env_name="a", step=10))
+        assert orchestrator.watcher.update_lock.locked()
+        await orchestrator.finalize_eval_batch(SimpleNamespace(env_name="b", step=10))
+        assert not orchestrator.watcher.update_lock.locked()
+        assert orchestrator.eval_pipeline_idle
+
+    asyncio.run(run())
+
+
+def test_eval_trigger_failure_releases_policy_lease():
+    async def run() -> None:
+        orchestrator = Orchestrator.__new__(Orchestrator)
+        orchestrator.stopped = asyncio.Event()
+        orchestrator.active_eval_epochs = set()
+        orchestrator.pending_eval_steps = deque()
+        orchestrator.eval_trigger_task = None
+        orchestrator.eval_trigger_error = None
+        orchestrator.eval_policy_lock_held = False
+        orchestrator.eval_triggered_at = {}
+        orchestrator.watcher = SimpleNamespace(update_lock=asyncio.Lock())
+        orchestrator.eval_source = SimpleNamespace(
+            eligible_envs=lambda _step: ["eval"],
+            trigger=MagicMock(side_effect=ValueError("invalid eval")),
+        )
+
+        orchestrator.maybe_trigger_eval(10)
+        trigger = orchestrator.eval_trigger_task
+        assert trigger is not None
+        with pytest.raises(ValueError, match="invalid eval"):
+            await trigger
+        await asyncio.sleep(0)
+
+        assert not orchestrator.watcher.update_lock.locked()
+        assert not orchestrator.eval_policy_lock_held
+        with pytest.raises(RuntimeError, match="Eval trigger failed") as exc_info:
+            orchestrator._raise_if_eval_trigger_failed()
+        assert isinstance(exc_info.value.__cause__, ValueError)
+
+    asyncio.run(run())
+
+
+def test_pending_eval_does_not_resume_train_after_scheduling_is_disabled():
+    async def run() -> None:
+        dispatcher = RolloutDispatcher.__new__(RolloutDispatcher)
+        dispatcher.mode = DispatcherMode.PREFER_EVAL
+        dispatcher.max_inflight = 1
+        dispatcher.inflight_permits = 0
+        dispatcher.inflight = {}
+        dispatcher.groups = {object(): SimpleNamespace(kind="train", rollouts_to_schedule=1)}
+        dispatcher.eval_source = deque([object()])
+        dispatcher.train_scheduling_disabled = True
+        dispatcher.try_schedule_existing = AsyncMock()
+        dispatcher.try_schedule = AsyncMock(return_value=False)
+
+        await dispatcher.fill_inflight()
+
+        dispatcher.try_schedule_existing.assert_not_awaited()
+        dispatcher.try_schedule.assert_awaited_once_with("eval")
+
+    asyncio.run(run())
+
+
+def test_eval_scheduling_drains_train_then_refills_during_eval_tail():
+    async def run() -> None:
+        dispatcher = RolloutDispatcher.__new__(RolloutDispatcher)
+        dispatcher.mode = DispatcherMode.PREFER_EVAL
+        dispatcher.max_inflight = 2
+        dispatcher.inflight_permits = 0
+        dispatcher.inflight = {}
+        train_group = SimpleNamespace(kind="train", rollouts_to_schedule=1)
+        dispatcher.groups = {object(): train_group}
+        dispatcher.eval_source = deque([object(), object()])
+        dispatcher.train_scheduling_disabled = False
+        dispatcher.dispatch_allowed = asyncio.Event()
+        dispatcher.dispatch_allowed.set()
+
+        async def finish_open_train(_kind: str) -> bool:
+            train_group.rollouts_to_schedule = 0
+            dispatcher.inflight[object()] = SimpleNamespace(kind="train", rollout_count=1)
+            dispatcher.inflight_permits += 1
+            return True
+
+        dispatcher.try_schedule_existing = AsyncMock(side_effect=finish_open_train)
+        await dispatcher.fill_inflight()
+        dispatcher.try_schedule_existing.assert_awaited_once_with("train")
+
+        dispatcher.inflight.clear()
+        dispatcher.inflight_permits = 0
+
+        async def schedule_eval(_kind: str) -> bool:
+            dispatcher.eval_source.popleft()
+            dispatcher.inflight[object()] = SimpleNamespace(kind="eval", rollout_count=1)
+            dispatcher.inflight_permits += 1
+            return True
+
+        dispatcher.try_schedule = AsyncMock(side_effect=schedule_eval)
+        await dispatcher.fill_inflight()
+        assert dispatcher.try_schedule.await_count == 2
+        assert not dispatcher.eval_source
+        assert dispatcher.inflight_eval_count == 2
+
+        completed = next(iter(dispatcher.inflight))
+        dispatcher.inflight.pop(completed)
+        dispatcher.inflight_permits -= 1
+        dispatcher.try_schedule = AsyncMock(return_value=False)
+        await dispatcher.fill_inflight()
+
+        assert dispatcher.mode == DispatcherMode.PREFER_TRAIN
+        dispatcher.try_schedule.assert_awaited_once_with("train")
+        assert dispatcher.inflight_eval_count == 1
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary

- pin each complete eval step to one live policy version
- drain pre-existing train work, dispatch the full eval cohort, then refill train capacity during the pinned eval tail
- retarget delayed watcher updates to the latest stable checkpoint after the eval lease is available
- fail fast when an eval configuration cannot complete and release its lease

## Problem

Eval groups record the policy version and cache salt present when they are scheduled, but the live inference pool is not pinned to that version. The watcher can pause, update, and resume inference between requests or turns of the same eval step. A trajectory can therefore execute against multiple policies while being labeled as one version, and an eval cohort can contain mixed weights or hit provider failures while its model or adapter is replaced.

Holding the existing watcher update lock across eval exposes a related race. The watcher can select checkpoint N and then wait behind the eval lease while the trainer publishes newer checkpoints and deletes N. Loading the path selected before that wait then fails because it no longer exists.

## Fix

Queue each due eval step and acquire the watcher lock in a supervised side task before adding its work to the dispatcher. Keeping lease acquisition off the bounded rollout consumer lets completed train and eval rollouts continue draining while a watcher already ahead of the trigger finishes its update. The lease remains held until every eval environment due at that step has returned; startup eval uses the same path, and failure and shutdown paths release it explicitly.

The dispatcher finishes any train group already being scheduled and drains the pre-existing train tail before starting eval. Once the complete eval cohort has been dispatched, it returns spare permits to train while the eval tail finishes under the pinned policy. Empty eval environments and group-scoring cohorts larger than `max_inflight_rollouts` are rejected up front because they could never complete the epoch and release the lease.

The watcher waits for checkpoint publication without holding the live-policy lock. If the originally requested checkpoint has already disappeared, it first retargets to a newer stable checkpoint. After acquiring the lock, it resolves the latest stable checkpoint again and uses that version consistently for the weight path, pending and completed observer callbacks, inference, and policy state.

Interval eligibility is unchanged. If another eval step becomes due while an epoch is active, it is queued and starts after the current epoch releases the lease. Eval sampling, scoring, and trainer data are unchanged.

## Verification

- `pytest -q tests/unit/orchestrator/test_orchestrator_setup.py` — 10 passed
- `pytest -q tests/unit/orchestrator -m 'not gpu'` — 102 passed, 1 skipped
- `ruff check --config=pyproject.toml .`
- `ruff format --check --config=pyproject.toml .`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes orchestrator scheduling, live inference weight updates, and eval correctness guarantees on a critical training path; mistakes could deadlock the pipeline or mis-label eval policy versions.
> 
> **Overview**
> **Pins each eval step to a single live policy version** by holding the watcher’s `update_lock` from a background `eval_trigger` task until every env due at that step finishes. Due steps are queued (non-blocking on the rollout consumer); startup eval runs and completes its lease **before** the dispatcher and watcher start.
> 
> **Dispatcher `PREFER_EVAL`** now finishes open train groups, drains in-flight train work, dispatches the full eval cohort, then flips back to `PREFER_TRAIN` so spare capacity can run train while the pinned eval tail completes. Train scheduling stays off when `train_scheduling_disabled`.
> 
> **WeightWatcher** waits for checkpoint `STABLE` **without** the update lock, retargets if the requested step was deleted, and **coalesces** to the latest stable checkpoint after acquiring the lock.
> 
> **Fail-fast** on eval envs with no examples or group-scoring `group_size` above `max_inflight_rollouts`. **`EvalSource.eligible_envs`** peeks due envs without consuming startup trigger state. Docs and monitor-run skill describe the pinned-eval log line and overlapping train/eval inflight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbdc11ca7d255138635f403a27ff9db119c00fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->