### PR TITLE
fix(inference): emit SM100 FP8 weights in vLLM kernel format

### DIFF
--- a/src/prime_rl/trainer/models/fp8.py
+++ b/src/prime_rl/trainer/models/fp8.py
@@ -37,3 +37,28 @@ def quantize_to_fp8_blockwise(weight: Tensor, block_size: int = 128) -> tuple[Te
 
     quantized = blocks_fp8.permute(0, 2, 1, 3).reshape(padded_rows, padded_cols)[:rows, :cols].contiguous()
     return quantized, scales.float().contiguous()
+
+
+def quantize_to_vllm_kernel_format(weight: Tensor, block_size: int = 128) -> tuple[Tensor, Tensor]:
+    """Quantize a weight into the FP8 layout used by vLLM kernels.
+
+    Hopper kernels consume the regular blockwise scale grid. On SM100, vLLM's
+    DeepGEMM kernels instead use UE8M0 scales in an architecture-specific packed
+    layout. Reuse vLLM's own post-processing so tensors sent over the kernel
+    weight-transfer path have the same representation as the loaded parameters.
+    """
+    quantized, scales = quantize_to_fp8_blockwise(weight, block_size)
+
+    if not weight.is_cuda or torch.cuda.get_device_capability(weight.device) != (10, 0):
+        return quantized, scales
+
+    from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+        deepgemm_post_process_fp8_weight_block,
+    )
+
+    return deepgemm_post_process_fp8_weight_block(
+        wq=quantized,
+        ws=scales,
+        quant_block_shape=(block_size, block_size),
+        use_e8m0=True,
+    )

--- a/src/prime_rl/trainer/models/glm_moe_dsa/converting_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/converting_glm_moe_dsa.py
@@ -2,7 +2,7 @@ import torch
 from torch import Tensor
 
 from prime_rl.trainer.conversion_utils import get_max_layer_num
-from prime_rl.trainer.models.fp8 import quantize_to_fp8_blockwise
+from prime_rl.trainer.models.fp8 import quantize_to_vllm_kernel_format
 
 
 def _is_moe_layer(state_dict: dict[str, Tensor], layer_idx: int) -> bool:
@@ -157,7 +157,7 @@ def convert_tt_layer_to_vllm_kernel(
 
     def add_maybe_fp8(name: str, tensor: Tensor) -> None:
         if quantize_fp8 and tensor.ndim == 2:
-            fp8_weight, scale = quantize_to_fp8_blockwise(tensor)
+            fp8_weight, scale = quantize_to_vllm_kernel_format(tensor)
             out[name] = fp8_weight
             scale_name = name.removesuffix(".weight") + ".weight_scale_inv"
             out[scale_name] = scale
@@ -231,8 +231,8 @@ def convert_tt_layer_to_vllm_kernel(
             w2_fp8: list[Tensor] = []
             w2_scales: list[Tensor] = []
             for expert_idx in range(w1.shape[0]):
-                expert_w13_fp8, expert_w13_scales = quantize_to_fp8_blockwise(w13[expert_idx])
-                expert_w2_fp8, expert_w2_scales = quantize_to_fp8_blockwise(w2[expert_idx])
+                expert_w13_fp8, expert_w13_scales = quantize_to_vllm_kernel_format(w13[expert_idx])
+                expert_w2_fp8, expert_w2_scales = quantize_to_vllm_kernel_format(w2[expert_idx])
                 w13_fp8.append(expert_w13_fp8)
                 w13_scales.append(expert_w13_scales)
                 w2_fp8.append(expert_w2_fp8)


### PR DESCRIPTION
## Summary

- keep the existing blockwise FP8 kernel-transfer format on SM90
- detect SM100 during trainer-side kernel conversion
- reuse vLLM's DeepGEMM post-processing to requantize weights to UE8M0 and pack inverse scales into the SM100 kernel layout
- leave the inference reload path as an in-place kernel tensor copy (no layerwise reload)

## Why

On SM100, vLLM's loaded DeepGEMM parameters do not retain checkpoint-grid inverse scales. For example, a received `[21, 48]` scale tensor targets a packed `[2624, 12]` parameter. Direct copying works on the existing SM90 path but failed on GB200 with 639 `weight_scale_inv` shape mismatches.

A scale-only reshape is insufficient because SM100 also requires the FP8 weights to be requantized against power-of-two UE8M0 scales. This calls vLLM's own `deepgemm_post_process_fp8_weight_block` during trainer conversion so the wire representation matches the live kernel parameters.

## Verification

- `ruff check` and `ruff format --check` pass for the changed files
- isolated GB200/SM100 check using the production image:
  - `(2624, 6144)` weight -> `(2624, 12)` packed scale
  - `(4096, 6144)` weight -> `(4096, 12)` packed scale
  - `(6144, 2048)` weight -> `(6144, 4)` packed scale
  - all packed scales are `torch.int32`
- live GLM-5.2 E2E on GB200:
  - trainer: 48 GPUs, EP16, BF16
  - inference: FP8 checkpoint, prefill DP/EP32 + decode DP/EP16
  - 49-rank NCCL weight-transfer communicator initialized over GDRDMA
  - startup policy transfer completed all 79/79 state dictionaries without the prior shape mismatch
  - router reached 32/32 prefill and 16/16 decode workers
  - orchestrator began reverse-text rollouts after policy v0 reload

W&B: https://wandb.ai/primeintellect/glm52-native-fp8-e2e/runs/ntbx0wph

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FP8 weight and scale tensor layouts for SM100 inference reload; wrong behavior would break policy sync or silently skew numerics, but scope is limited to trainer conversion and delegates post-processing to vLLM.
> 
> **Overview**
> Trainer-side FP8 conversion for the vLLM kernel weight-transfer path now goes through **`quantize_to_vllm_kernel_format`** instead of raw blockwise quantization. On **SM90 (Hopper)** the output is unchanged: standard blockwise FP8 weights and float scale grids. On **SM100 (CUDA capability 10.0)** it additionally runs vLLM’s **`deepgemm_post_process_fp8_weight_block`** with **UE8M0** scales so FP8 values and **`weight_scale_inv`** tensors match the packed layout live DeepGEMM parameters expect—fixing GB200 shape mismatches during in-place kernel copies.
> 
> **GLM MoE DSA** layer conversion (`convert_tt_layer_to_vllm_kernel`) uses this helper for all FP8 paths (dense `add_maybe_fp8` weights and per-expert MoE stacks), replacing direct **`quantize_to_fp8_blockwise`** calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12ba100ccd694135be281474be50962bc79c0de8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->