### PR TITLE
fix(trainer): require complete multi-run checkpoint publication

### DIFF
--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -4,6 +4,7 @@ MultiCheckpointManager owns per-run CheckpointManagers and AppStates,
 each saving to its own run directory.
 """
 
+import bisect
 import shutil
 from dataclasses import asdict
 from pathlib import Path
@@ -97,6 +98,14 @@ class MultiCheckpointManager:
         )
         run_dir = self.multi_run_manager.get_run_dir(idx)
         manager = CheckpointManager(run_dir, config)
+        # A failed save can leave an unpublished step, and older versions could
+        # publish STABLE without its matching weight snapshot. Only resumable
+        # checkpoints may suppress retries or participate in retention.
+        manager.ckpt_steps = [
+            step
+            for step in get_stable_ckpt_steps(manager.ckpt_dir)
+            if (manager.get_ckpt_path(step).parent / "weight").exists()
+        ]
         self.managers[idx] = manager
         return manager
 
@@ -109,6 +118,12 @@ class MultiCheckpointManager:
             return False
         # Check if already saved this step
         return step not in self.managers[idx].ckpt_steps
+
+    def _all_ranks_succeeded(self, local_success: bool) -> bool:
+        """Return whether every trainer rank completed the current checkpoint phase."""
+        success = self.multi_run_manager.lora_num_tokens.new_tensor([int(local_success)], dtype=torch.int32)
+        dist.all_reduce(success, op=dist.ReduceOp.MIN)
+        return bool(success.item())
 
     def save(
         self,
@@ -124,7 +139,9 @@ class MultiCheckpointManager:
 
             manager = self.managers[idx]
 
-            # We have a very wide try-except because we dont want to crash the trainer over one run having issues
+            # Every rank must reach the phase reductions, including after a local
+            # write failure, so one failed rank cannot leave the others blocked.
+            saved_state = True
             try:
                 model_state_dict = {
                     k: v.data.detach().clone() for k, v in self.multi_run_manager.get_named_parameters_for_run(idx)
@@ -141,38 +158,48 @@ class MultiCheckpointManager:
                     f"Saving checkpoint for run {idx} at step {step} to {ckpt_path / f'rank_{self.world.rank}.pt'}"
                 )
                 torch.save(run_state.state_dict(), ckpt_path / f"rank_{self.world.rank}.pt")
-
-                # Copy broadcast weights so a stable checkpoint can restore the matching policy.
-                copied_weights = True
-                if self.world.is_master:
-                    run_dir = self.multi_run_manager.get_run_dir(idx)
-                    broadcast_src = run_dir / "broadcasts" / f"step_{step}"
-                    weight_dst = run_dir / "checkpoints" / f"step_{step}" / "weight"
-                    try:
-                        shutil.copytree(broadcast_src, weight_dst)
-                    except (OSError, shutil.Error) as exc:
-                        copied_weights = False
-                        self.logger.error(
-                            f"Failed to copy broadcast weights for run {idx} at step {step} from {broadcast_src}: {exc}"
-                        )
-
-                # The stable marker and ckpt_steps must agree on every rank. Use the
-                # existing multi-run tensor device so this works with NCCL and Gloo.
-                copy_status = self.multi_run_manager.lora_num_tokens.new_tensor(
-                    [int(copied_weights)], dtype=torch.int32
-                )
-                dist.all_reduce(copy_status, op=dist.ReduceOp.MIN)
-                if copy_status.item():
-                    manager.mark_stable(step)
-                    manager.ckpt_steps.append(step)
-                elif self.world.is_master:
-                    self.logger.warning(
-                        f"Checkpoint for run {idx} at step {step} remains incomplete because its policy weights were not copied"
-                    )
             except FileNotFoundError:
+                saved_state = False
                 self.logger.warning(f"Run {idx} deleted during checkpoint, skipping")
             except Exception as e:
+                saved_state = False
                 self.logger.error(f"Error checkpointing run {idx}: {e}")
+
+            all_states_saved = self._all_ranks_succeeded(saved_state)
+
+            copied_weights = all_states_saved
+            if all_states_saved and self.world.is_master:
+                run_dir = self.multi_run_manager.get_run_dir(idx)
+                broadcast_src = run_dir / "broadcasts" / f"step_{step}"
+                weight_dst = run_dir / "checkpoints" / f"step_{step}" / "weight"
+                try:
+                    if not (broadcast_src / "STABLE").exists():
+                        raise FileNotFoundError(f"Stable broadcast weights not found at {broadcast_src}")
+                    # A prior incomplete attempt is never published, so replacing
+                    # its partial weight snapshot is safe and makes the step retryable.
+                    if weight_dst.exists():
+                        shutil.rmtree(weight_dst)
+                    shutil.copytree(broadcast_src, weight_dst)
+                except (OSError, shutil.Error) as exc:
+                    copied_weights = False
+                    self.logger.error(
+                        f"Failed to copy broadcast weights for run {idx} at step {step} from {broadcast_src}: {exc}"
+                    )
+
+            all_weights_copied = self._all_ranks_succeeded(copied_weights)
+
+            published = all_weights_copied
+            if all_weights_copied and self.world.is_master:
+                try:
+                    manager.mark_stable(step)
+                except OSError as exc:
+                    published = False
+                    self.logger.error(f"Failed to publish checkpoint for run {idx} at step {step}: {exc}")
+
+            if self._all_ranks_succeeded(published):
+                bisect.insort(manager.ckpt_steps, step)
+            elif self.world.is_master:
+                self.logger.warning(f"Checkpoint for run {idx} at step {step} remains incomplete")
             dist.barrier()
             # If the run is deleted, remove the run directory
             # This is avoid the creation of zombie runs when the directory is deleted while we are checkpointing which recreates the directory

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -142,21 +142,33 @@ class MultiCheckpointManager:
                 )
                 torch.save(run_state.state_dict(), ckpt_path / f"rank_{self.world.rank}.pt")
 
-                # Copy broadcast folder to checkpoint
-                # This way, we only need to save the checkpoint folder
+                # Copy broadcast weights so a stable checkpoint can restore the matching policy.
+                copied_weights = True
                 if self.world.is_master:
                     run_dir = self.multi_run_manager.get_run_dir(idx)
                     broadcast_src = run_dir / "broadcasts" / f"step_{step}"
                     weight_dst = run_dir / "checkpoints" / f"step_{step}" / "weight"
                     try:
                         shutil.copytree(broadcast_src, weight_dst)
-                    except FileNotFoundError:
+                    except (OSError, shutil.Error) as exc:
+                        copied_weights = False
                         self.logger.error(
-                            f"Broadcast folder not found for run {idx} at step {step}. Looking for it in {broadcast_src}"
+                            f"Failed to copy broadcast weights for run {idx} at step {step} from {broadcast_src}: {exc}"
                         )
-                dist.barrier()
-                manager.mark_stable(step)
-                manager.ckpt_steps.append(step)
+
+                # The stable marker and ckpt_steps must agree on every rank. Use the
+                # existing multi-run tensor device so this works with NCCL and Gloo.
+                copy_status = self.multi_run_manager.lora_num_tokens.new_tensor(
+                    [int(copied_weights)], dtype=torch.int32
+                )
+                dist.all_reduce(copy_status, op=dist.ReduceOp.MIN)
+                if copy_status.item():
+                    manager.mark_stable(step)
+                    manager.ckpt_steps.append(step)
+                elif self.world.is_master:
+                    self.logger.warning(
+                        f"Checkpoint for run {idx} at step {step} remains incomplete because its policy weights were not copied"
+                    )
             except FileNotFoundError:
                 self.logger.warning(f"Run {idx} deleted during checkpoint, skipping")
             except Exception as e:

--- a/tests/unit/train/test_multi_ckpt.py
+++ b/tests/unit/train/test_multi_ckpt.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import prime_rl.trainer.multi_ckpt as multi_ckpt
+from prime_rl.orchestrator.utils import get_weight_dir
+from prime_rl.trainer.runs import Progress
+
+
+class FakeCheckpointManager:
+    def __init__(self, output_dir: Path, _config) -> None:
+        self.ckpt_dir = output_dir / "checkpoints"
+        self.ckpt_steps: list[int] = []
+
+    def get_ckpt_path(self, step: int) -> Path:
+        return self.ckpt_dir / f"step_{step}" / "trainer"
+
+    def mark_stable(self, step: int) -> None:
+        step_dir = self.ckpt_dir / f"step_{step}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+        (step_dir / "STABLE").touch()
+
+
+class FakeMultiRunManager:
+    def __init__(self, output_dir: Path) -> None:
+        self.max_runs = 1
+        self.used_idxs = [0]
+        self.idx_2_id = {0: "run"}
+        self.config = {0: SimpleNamespace(ckpt=SimpleNamespace(interval=1, keep_last=None, keep_interval=None))}
+        self.progress = {0: Progress(step=2)}
+        self.lora_num_tokens = torch.zeros(1, dtype=torch.int32)
+        self.output_dir = output_dir
+
+    def register_deletion_hook(self, _hook) -> None:
+        pass
+
+    def register_creation_hook(self, _hook) -> None:
+        pass
+
+    def get_named_parameters_for_run(self, _idx: int) -> list[tuple[str, torch.nn.Parameter]]:
+        return []
+
+    def get_run_dir(self, _idx: int) -> Path:
+        return self.output_dir / "run"
+
+    def get_orchestrator_config(self, _run_id: str) -> object:
+        return object()
+
+
+def make_checkpoint_manager(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[multi_ckpt.MultiCheckpointManager, Path]:
+    run_manager = FakeMultiRunManager(tmp_path)
+    monkeypatch.setattr(multi_ckpt, "get_multi_run_manager", lambda: run_manager)
+    monkeypatch.setattr(multi_ckpt, "get_world", lambda: SimpleNamespace(rank=0, is_master=True))
+    monkeypatch.setattr(multi_ckpt, "CheckpointManager", FakeCheckpointManager)
+    monkeypatch.setattr(multi_ckpt.dist, "all_reduce", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(multi_ckpt.dist, "barrier", lambda: None)
+
+    checkpoint_manager = multi_ckpt.MultiCheckpointManager(tmp_path)
+    checkpoint_manager.managers[0] = checkpoint_manager._maybe_create_manager(0)
+    return checkpoint_manager, run_manager.get_run_dir(0)
+
+
+def test_multi_checkpoint_skips_stable_marker_when_broadcast_weights_are_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkpoint_manager, run_dir = make_checkpoint_manager(tmp_path, monkeypatch)
+    optimizer = SimpleNamespace(optimizers=[None])
+    scheduler = SimpleNamespace(schedulers=[None])
+
+    checkpoint_manager.save(optimizer, scheduler)
+
+    step_dir = run_dir / "checkpoints" / "step_1"
+    assert (step_dir / "trainer" / "rank_0.pt").exists()
+    assert not (step_dir / "STABLE").exists()
+    assert checkpoint_manager.managers[0].ckpt_steps == []
+    with pytest.raises(FileNotFoundError):
+        get_weight_dir(run_dir, 1)
+
+
+def test_multi_checkpoint_marks_stable_after_copying_broadcast_weights(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkpoint_manager, run_dir = make_checkpoint_manager(tmp_path, monkeypatch)
+    broadcast_dir = run_dir / "broadcasts" / "step_1"
+    broadcast_dir.mkdir(parents=True)
+    (broadcast_dir / "model.safetensors").write_bytes(b"weights")
+    (broadcast_dir / "STABLE").touch()
+    optimizer = SimpleNamespace(optimizers=[None])
+    scheduler = SimpleNamespace(schedulers=[None])
+
+    checkpoint_manager.save(optimizer, scheduler)
+
+    step_dir = run_dir / "checkpoints" / "step_1"
+    assert (step_dir / "STABLE").exists()
+    assert (step_dir / "weight" / "model.safetensors").read_bytes() == b"weights"
+    assert checkpoint_manager.managers[0].ckpt_steps == [1]
+    assert get_weight_dir(run_dir, 1) == step_dir / "weight"

--- a/tests/unit/train/test_multi_ckpt.py
+++ b/tests/unit/train/test_multi_ckpt.py
@@ -7,12 +7,13 @@ import torch
 import prime_rl.trainer.multi_ckpt as multi_ckpt
 from prime_rl.orchestrator.utils import get_weight_dir
 from prime_rl.trainer.runs import Progress
+from prime_rl.utils.pathing import get_all_ckpt_steps
 
 
 class FakeCheckpointManager:
     def __init__(self, output_dir: Path, _config) -> None:
         self.ckpt_dir = output_dir / "checkpoints"
-        self.ckpt_steps: list[int] = []
+        self.ckpt_steps = get_all_ckpt_steps(self.ckpt_dir)
 
     def get_ckpt_path(self, step: int) -> Path:
         return self.ckpt_dir / f"step_{step}" / "trainer"
@@ -81,6 +82,19 @@ def test_multi_checkpoint_skips_stable_marker_when_broadcast_weights_are_missing
         get_weight_dir(run_dir, 1)
 
 
+def test_multi_checkpoint_ignores_a_stable_checkpoint_without_weights(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = tmp_path / "run"
+    incomplete_step_dir = run_dir / "checkpoints" / "step_1"
+    incomplete_step_dir.mkdir(parents=True)
+    (incomplete_step_dir / "STABLE").touch()
+
+    checkpoint_manager, _ = make_checkpoint_manager(tmp_path, monkeypatch)
+
+    assert checkpoint_manager.managers[0].ckpt_steps == []
+
+
 def test_multi_checkpoint_marks_stable_after_copying_broadcast_weights(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -99,3 +113,70 @@ def test_multi_checkpoint_marks_stable_after_copying_broadcast_weights(
     assert (step_dir / "weight" / "model.safetensors").read_bytes() == b"weights"
     assert checkpoint_manager.managers[0].ckpt_steps == [1]
     assert get_weight_dir(run_dir, 1) == step_dir / "weight"
+
+
+def test_multi_checkpoint_skips_an_unstable_broadcast_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    run_dir = tmp_path / "run"
+    broadcast_dir = run_dir / "broadcasts" / "step_1"
+    broadcast_dir.mkdir(parents=True)
+    (broadcast_dir / "model.safetensors").write_bytes(b"partial weights")
+    checkpoint_manager, run_dir = make_checkpoint_manager(tmp_path, monkeypatch)
+    optimizer = SimpleNamespace(optimizers=[None])
+    scheduler = SimpleNamespace(schedulers=[None])
+
+    checkpoint_manager.save(optimizer, scheduler)
+
+    step_dir = run_dir / "checkpoints" / "step_1"
+    assert (step_dir / "trainer" / "rank_0.pt").exists()
+    assert not (step_dir / "STABLE").exists()
+    assert not (step_dir / "weight").exists()
+    assert checkpoint_manager.managers[0].ckpt_steps == []
+
+
+def test_multi_checkpoint_does_not_publish_when_another_rank_state_save_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = tmp_path / "run"
+    broadcast_dir = run_dir / "broadcasts" / "step_1"
+    broadcast_dir.mkdir(parents=True)
+    (broadcast_dir / "model.safetensors").write_bytes(b"weights")
+    (broadcast_dir / "STABLE").touch()
+    checkpoint_manager, run_dir = make_checkpoint_manager(tmp_path, monkeypatch)
+
+    def report_failed_rank(status: torch.Tensor, *_args, **_kwargs) -> None:
+        status.zero_()
+
+    monkeypatch.setattr(multi_ckpt.dist, "all_reduce", report_failed_rank)
+
+    optimizer = SimpleNamespace(optimizers=[None])
+    scheduler = SimpleNamespace(schedulers=[None])
+    checkpoint_manager.save(optimizer, scheduler)
+
+    step_dir = run_dir / "checkpoints" / "step_1"
+    assert not (step_dir / "STABLE").exists()
+    assert not (step_dir / "weight").exists()
+    assert checkpoint_manager.managers[0].ckpt_steps == []
+
+
+def test_multi_checkpoint_retries_an_incomplete_weight_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = tmp_path / "run"
+    incomplete_weight_dir = run_dir / "checkpoints" / "step_1" / "weight"
+    incomplete_weight_dir.mkdir(parents=True)
+    (incomplete_weight_dir / "stale.safetensors").write_bytes(b"stale")
+    broadcast_dir = run_dir / "broadcasts" / "step_1"
+    broadcast_dir.mkdir(parents=True)
+    (broadcast_dir / "model.safetensors").write_bytes(b"weights")
+    (broadcast_dir / "STABLE").touch()
+
+    checkpoint_manager, run_dir = make_checkpoint_manager(tmp_path, monkeypatch)
+    optimizer = SimpleNamespace(optimizers=[None])
+    scheduler = SimpleNamespace(schedulers=[None])
+    checkpoint_manager.save(optimizer, scheduler)
+
+    step_dir = run_dir / "checkpoints" / "step_1"
+    assert (step_dir / "STABLE").exists()
+    assert (step_dir / "weight" / "model.safetensors").read_bytes() == b"weights"
+    assert not (step_dir / "weight" / "stale.safetensors").exists()
+    assert checkpoint_manager.managers[0].ckpt_steps == [1]


### PR DESCRIPTION
Fixes #3037.

Problem

MultiCheckpointManager could publish checkpoints/step_N/STABLE when its matching policy snapshot was unavailable or incomplete: a rank could fail while writing trainer state, a filesystem broadcast could contain partial files without its own STABLE marker, or the copy into checkpoint storage could fail. A stable marker is the resumability contract, so those states could be selected for resume or retention without a restorable inference policy.

Fix

Checkpoint publication now has three consensus-gated phases: every rank writes its trainer state, the master copies a stable broadcast snapshot, then the master writes the checkpoint STABLE marker. Each result is reduced across ranks, so every rank either records the step or leaves it incomplete.

The copy requires broadcasts/step_N/STABLE, rejects partial broadcast directories, and replaces an unpublished partial weight snapshot on a same-step retry. Multi-run checkpoint history now includes only directories with both STABLE and weight/, so legacy corrupt markers cannot block a retry or evict the last resumable checkpoint.

Verification

Ruff check and format verification pass for the changed files. The focused multi-checkpoint test file passes all six cases: missing broadcast, unstable broadcast, a failed remote rank state write, retry after a partial weight copy, a legacy stable marker without weights, and successful publication. The isolated CPU test harness stubs only the unused optional ring_flash_attn import required during model-module collection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed checkpoint publication and resume eligibility for multi-run training; incorrect consensus logic could block saves or leave bad checkpoints, but scope is limited to multi_ckpt and is covered by new unit tests.
> 
> **Overview**
> **Multi-run checkpoints are only published when trainer state, weight copy, and `STABLE` all succeed across ranks**, so resume/retention no longer treats half-written steps as valid.
> 
> `MultiCheckpointManager.save` is split into three **all_reduce(MIN)**-gated phases: per-rank trainer writes, master copy from `broadcasts/step_N` only if that broadcast has its own `STABLE` (replacing any unpublished partial `weight/` on retry), then master `mark_stable`. The step is added to `ckpt_steps` only when every rank agrees publication succeeded; otherwise the step stays incomplete and can be retried.
> 
> On manager creation, **`ckpt_steps` is rebuilt from stable steps that also have a `weight/` directory**, ignoring legacy `STABLE` markers without matching policy snapshots.
> 
> Adds **six unit tests** covering missing/unstable broadcasts, cross-rank save failure, partial weight retry, and successful publication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e61ee999af9617ee80db17fd09a7be70c56434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->