### PR TITLE
feat: add SUCCESS window to tmux helper

### DIFF
--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -86,7 +86,20 @@ tmux send-keys -t "$SESSION_NAME:Logs.2" \
 tmux send-keys -t "$SESSION_NAME:Logs.3" \
   "tail -F ${LOG_DIR}/inference.log 2>/dev/null" C-m
 
-# Window 2: Claude Code with log context
+# Window 2: SUCCESS - grep SUCCESS on orch and trainer logs (two stacked panes)
+tmux new-window -t "$SESSION_NAME" -n "SUCCESS"
+
+tmux split-window -v -t "$SESSION_NAME:SUCCESS.0"
+tmux select-layout -t "$SESSION_NAME:SUCCESS" even-vertical
+
+tmux select-pane -t "$SESSION_NAME:SUCCESS.0" -T "Orchestrator"
+tmux select-pane -t "$SESSION_NAME:SUCCESS.1" -T "Trainer"
+
+tmux send-keys -t "$SESSION_NAME:SUCCESS.0"   "tail -F ${LOG_DIR}/orchestrator.log 2>/dev/null | grep --line-buffered SUCCESS" C-m
+
+tmux send-keys -t "$SESSION_NAME:SUCCESS.1"   "tail -F ${LOG_DIR}/trainer.log 2>/dev/null | grep --line-buffered SUCCESS" C-m
+
+# Window 3: Claude Code with log context
 tmux new-window -t "$SESSION_NAME" -n "Claude"
 tmux send-keys -t "$SESSION_NAME:Claude" \
   "claude --permission-mode auto --append-system-prompt 'You are monitoring a prime-rl training run. The output directory is ${OUTPUT_DIR}. Log paths:


### PR DESCRIPTION
## Summary

Add a new **SUCCESS** window to `scripts/tmux.sh` with two stacked panes:

- **Top pane** (Orchestrator): `tail -F orchestrator.log | grep --line-buffered SUCCESS`
- **Bottom pane** (Trainer): `tail -F trainer.log | grep --line-buffered SUCCESS`

This makes it easy to monitor key training milestones (step completions, environment readiness, trainer finish) at a glance, without scrolling through full logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only tmux helper script change with no runtime, auth, or data impact.
> 
> **Overview**
> Adds a new **SUCCESS** tmux window to `scripts/tmux.sh` between **Logs** and **Agent**, so training milestones are visible without scrolling full logs.
> 
> The window uses two evenly split vertical panes: **Orchestrator** runs `tail -F` on `orchestrator.log` and **Trainer** on `trainer.log`, each piped through `grep --line-buffered SUCCESS`. The **Agent** window is unchanged aside from becoming window 3 in the session order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71f804bcb173b4d05fadaf70b87c45652351e56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->