### PR TITLE
feat: allow choosing between claude code and codex in tmux agent window

### DIFF
--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -2,11 +2,13 @@
 
 SESSION_NAME="prime-rl"
 OUTPUT_DIR="outputs"
+AGENT="claude"
 
 # Optional CLI parsing
 # Supports:
 #   -s|--session-name NAME
 #   -o|--output-dir DIR
+#   -a|--agent AGENT       (claude|codex, default: claude)
 #   Positional: [SESSION_NAME [OUTPUT_DIR]]
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
@@ -27,8 +29,17 @@ while [[ $# -gt 0 ]]; do
       OUTPUT_DIR="$2"
       shift 2
       ;;
+    -a|--agent)
+      if [[ -z "$2" ]]; then
+        echo "Error: --agent requires a value (claude|codex)" >&2
+        exit 1
+      fi
+      AGENT="$2"
+      shift 2
+      ;;
     -h|--help)
-      echo "Usage: $0 [-s SESSION_NAME] [-o OUTPUT_DIR] [SESSION_NAME [OUTPUT_DIR]]" >&2
+      echo "Usage: $0 [-s SESSION_NAME] [-o OUTPUT_DIR] [-a AGENT] [SESSION_NAME [OUTPUT_DIR]]" >&2
+      echo "  -a, --agent  claude|codex  (default: claude)" >&2
       exit 0
       ;;
     --)
@@ -86,10 +97,10 @@ tmux send-keys -t "$SESSION_NAME:Logs.2" \
 tmux send-keys -t "$SESSION_NAME:Logs.3" \
   "tail -F ${LOG_DIR}/inference.log 2>/dev/null" C-m
 
-# Window 2: Claude Code with log context
-tmux new-window -t "$SESSION_NAME" -n "Claude"
-tmux send-keys -t "$SESSION_NAME:Claude" \
-  "claude --permission-mode auto --append-system-prompt 'You are monitoring a prime-rl training run. The output directory is ${OUTPUT_DIR}. Log paths:
+# Window 2: Agent (claude code or codex) with log context
+tmux new-window -t "$SESSION_NAME" -n "Agent"
+
+AGENT_PROMPT="You are monitoring a prime-rl training run. The output directory is ${OUTPUT_DIR}. Log paths:
   Trainer:        ${LOG_DIR}/trainer.log
   All nodes:      ${LOG_DIR}/trainer/node_*.log
   All ranks:      ${LOG_DIR}/trainer/torchrun/*/*/*/*.log
@@ -98,7 +109,22 @@ tmux send-keys -t "$SESSION_NAME:Claude" \
   Envs:           ${LOG_DIR}/envs/*/*.log
   Train envs:     ${LOG_DIR}/envs/train/*.log
 You are running inside tmux session \"${SESSION_NAME}\". The Launcher window (window 0) is where the user runs launch commands. You can read its contents with: tmux capture-pane -t ${SESSION_NAME}:Launcher -p
-Help the user monitor and debug this run.'" C-m
+Help the user monitor and debug this run."
+
+case "$AGENT" in
+  claude)
+    tmux send-keys -t "$SESSION_NAME:Agent" \
+      "claude --permission-mode auto --append-system-prompt \"${AGENT_PROMPT}\"" C-m
+    ;;
+  codex)
+    tmux send-keys -t "$SESSION_NAME:Agent" \
+      "codex --dangerously-bypass-approvals-and-sandbox \"${AGENT_PROMPT}\"" C-m
+    ;;
+  *)
+    echo "Error: unknown agent '$AGENT' (expected claude|codex)" >&2
+    exit 1
+    ;;
+esac
 
 # Pane title styling
 tmux set-option -t "$SESSION_NAME" -g pane-border-status top

--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -118,7 +118,7 @@ case "$AGENT" in
     ;;
   codex)
     tmux send-keys -t "$SESSION_NAME:Agent" \
-      "codex --dangerously-bypass-approvals-and-sandbox \"${AGENT_PROMPT}\"" C-m
+      "codex --yolo \"${AGENT_PROMPT}\"" C-m
     ;;
   *)
     echo "Error: unknown agent '$AGENT' (expected claude|codex)" >&2


### PR DESCRIPTION
## Summary

Add a `--agent` flag (`claude|codex`, default `claude`) to `scripts/tmux.sh` so the coding-agent window can launch either agent:

- **`claude`** → `claude --permission-mode auto --append-system-prompt ...`
- **`codex`** → `codex --dangerously-bypass-approvals-and-sandbox ...`

Both receive the same monitoring context (log paths, tmux session info). The window is renamed from "Claude" to "Agent" to reflect the choice.

### Usage

```bash
# Default: claude code
./scripts/tmux.sh

# Use codex instead
./scripts/tmux.sh -a codex
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local dev convenience script only; no runtime training, auth, or data-path changes.
> 
> **Overview**
> **`scripts/tmux.sh`** now accepts **`-a|--agent`** (`claude` or `codex`, default `claude`) so the monitoring window can start either coding agent with the same training-run context prompt.
> 
> The former **Claude** tmux window is renamed **Agent**, and the shared system prompt is factored into **`AGENT_PROMPT`** before a **`case`** branch runs **`claude --permission-mode auto --append-system-prompt`** or **`codex --yolo`**. Help text and validation cover the new flag and reject unknown agent values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60f8f23807571d05fe9ddf5e948870ac95af1706. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->