### PR TITLE
feat(trainer): ulysses CP beyond num_kv_heads via GQA KV-head replication

### DIFF
--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -107,6 +107,8 @@ ep_comm_backend = "torch"  # or "deepep"
 
 CP shards a single sequence across multiple GPUs along the token dimension — for long-context sequences. We reccomend using `ulysses` style CP for most of the models to get the most throughput. Some models (e.g. GLM-5) only support `ring` style CP. Wrong setting will be rejected on validation.
 
+`ulysses` head-shards Q/K/V, so the CP degree must divide `num_attention_heads`. GQA models with fewer KV heads than the CP degree (e.g. NemotronH: 32 query heads, 2 KV heads) are supported via KV-head replication; the CP degree must then be a multiple of `num_key_value_heads`. Hybrid Mamba layers head-shard independently (`cp_mamba`), which requires the CP degree to divide `mamba_num_heads` and `n_groups`.
+
 ```toml
 [trainer.model]
 impl = "custom"

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -798,7 +798,12 @@ class MoE(nn.Module):
                 self.expert_bias = torch.zeros(self.experts.num_experts, dtype=torch.float32)
 
 
+@torch.compile(dynamic=True)
 def relu2(x: torch.Tensor) -> torch.Tensor:
+    # Fused via inductor: relu+square become a single pointwise kernel that reads x and
+    # writes the output directly, instead of materializing an extra full-size relu(x)
+    # tensor. This is the largest MoE activation and the OOM site for high top-k models
+    # (NemotronH: top-22, interm 2688).
     return F.relu(x).square()
 
 

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -800,10 +800,6 @@ class MoE(nn.Module):
 
 @torch.compile(dynamic=True)
 def relu2(x: torch.Tensor) -> torch.Tensor:
-    # Fused via inductor: relu+square become a single pointwise kernel that reads x and
-    # writes the output directly, instead of materializing an extra full-size relu(x)
-    # tensor. This is the largest MoE activation and the OOM site for high top-k models
-    # (NemotronH: top-22, interm 2688).
     return F.relu(x).square()
 
 

--- a/src/prime_rl/trainer/models/layers/ulysses_attn.py
+++ b/src/prime_rl/trainer/models/layers/ulysses_attn.py
@@ -19,8 +19,17 @@ Key benefit: the attention kernel itself does not need to be CP-aware. The
 all-to-all is purely on Q/K/V tensors, so this works out of the box with
 softmax flash-attn, linear attention, mamba, etc., without rewriting kernels.
 
+GQA models with fewer KV heads than cp_size (e.g. NemotronH: 32 query heads, 2
+KV heads) are handled by replicating each KV head cp_size / num_key_value_heads
+times before the seq->head all-to-all. Query heads are grouped contiguously in
+GQA, so the replicated layout lands every rank on exactly the KV head its local
+query-head slice attends to; the backward of the replication sums gradients
+over replicas, which is the exact GQA KV gradient.
+
 Constraints:
-- cp_size must divide both num_attention_heads and num_key_value_heads.
+- cp_size must divide num_attention_heads.
+- cp_size must divide num_key_value_heads, OR num_key_value_heads must divide
+  cp_size (the KV-replication path).
 - Sequence length must be divisible by cp_size.
 """
 
@@ -41,6 +50,24 @@ def update_ulysses_params(cu_seqlens: torch.Tensor, max_seqlen: int) -> None:
     ULYSSES_PARAMS["max_seqlen"] = int(max_seqlen)
 
 
+def _replicate_kv_heads(t: torch.Tensor, cp_size: int) -> torch.Tensor:
+    """Replicate KV heads so a GQA tensor with fewer heads than cp_size can be
+    head-sharded: [S_local, H_kv, D] -> [S_local, cp_size, D].
+
+    Each KV head is repeated cp_size / H_kv times. GQA groups query heads
+    contiguously (query head j attends KV head j // (H_q / H_kv)), so after the
+    seq->head all-to-all rank r holds query heads [r * H_q/cp, (r+1) * H_q/cp)
+    — all attending KV head floor(r * H_kv / cp) — and replica index r maps to
+    the same head: floor(r / (cp / H_kv)). The backward sums gradients over
+    replicas, which is exactly the GQA KV gradient.
+    """
+    s_local, h, d = t.shape
+    assert cp_size % h == 0, (
+        f"num_key_value_heads ({h}) must divide cp_size ({cp_size}) for the ulysses KV-replication path"
+    )
+    return t.repeat_interleave(cp_size // h, dim=1)
+
+
 def _all_to_all_seq_to_head(t: torch.Tensor, cp_size: int, cp_group: dist.ProcessGroup) -> torch.Tensor:
     """Redistribute [S_local, H, D] -> [S_global, H_local, D].
 
@@ -48,7 +75,10 @@ def _all_to_all_seq_to_head(t: torch.Tensor, cp_size: int, cp_group: dist.Proces
     ends up with the full sequence but only H/cp_size heads. Differentiable.
     """
     s_local, h, d = t.shape
-    assert h % cp_size == 0, f"num_heads ({h}) must be divisible by cp_size ({cp_size})"
+    assert h % cp_size == 0, (
+        f"num_heads ({h}) must be divisible by cp_size ({cp_size}); "
+        "for GQA KV tensors with fewer heads than cp_size, replicate first via _replicate_kv_heads"
+    )
     h_local = h // cp_size
 
     # [S_local, cp_size, H_local, D] -> [cp_size, S_local, H_local, D]
@@ -96,8 +126,15 @@ def ulysses_flash_attn_varlen_func(
 
     `cu_seqlens_*` and `max_seqlen_*` describe the *full* (un-sharded) sequence,
     because after the seq->head all-to-all each rank holds the full sequence.
+
+    GQA with num_key_value_heads < cp_size: K/V heads are replicated up to
+    cp_size before the all-to-all (see `_replicate_kv_heads`), so each rank runs
+    grouped attention on its query-head slice with the single matching KV head.
     """
     q = _all_to_all_seq_to_head(q, cp_size, cp_group)
+    if k.shape[1] < cp_size:
+        k = _replicate_kv_heads(k, cp_size)
+        v = _replicate_kv_heads(v, cp_size)
     k = _all_to_all_seq_to_head(k, cp_size, cp_group)
     v = _all_to_all_seq_to_head(v, cp_size, cp_group)
 


### PR DESCRIPTION
## Problem

Ulysses CP head-shards Q/K/V, capping the CP degree at `num_key_value_heads`. Hybrid-Mamba GQA models — NemotronH Super/Ultra/Nano all have **2 KV heads** — are therefore stuck at `cp <= 2` (ring CP is softmax-only and rejects Mamba). At cp=2, 131k context puts 65k tokens/GPU through Super's top-22/512-expert MoE and is memory-infeasible on H200 regardless of node count. NVIDIA post-trained Super at 256k–512k with CP=64 (Megatron's sequence-sharded, Mamba-aware CP).

## Approach

**GQA KV-head replication** (the DeepSpeed-Ulysses GQA scheme), ~20 lines in `ulysses_attn.py`:

- When `num_kv_heads < cp`, replicate each KV head `cp / num_kv_heads` times (`repeat_interleave`) before the *existing* seq→head all-to-all.
- GQA groups query heads contiguously: after the Q all-to-all, rank `r` holds query heads `[r·Hq/cp, (r+1)·Hq/cp)`, which all attend KV head `⌊r·Hkv/cp⌋` — exactly the replica the all-to-all lands on rank `r` (index algebra in the docstring).
- Backward of `repeat_interleave` sums gradients over replicas — the exact GQA KV gradient.
- Q path and the `num_kv_heads >= cp` case are byte-identical to before. Ring path untouched. Mamba layers already head-shard independently via `cp_mamba` (NemotronH: 128 mamba heads, `n_groups=8` → mamba caps cp at 8).
- Constraints (asserted): `cp % num_kv_heads == 0` (replication path), `num_attention_heads % cp == 0` (existing).
- The RL trainer uses the same `substitute_ulysses_attn` and inherits the fix.

Separate commit: **fuse `relu2` via `torch.compile`** — the eager `F.relu(x).square()` materialized an extra full-size copy of the MoE intermediate (the empirical OOM site for Super; the expert path graph-breaks out of the layer-level compile at `@expert_parallel` / `_grouped_mm`). Measured: Super @16k tokens/GPU on 2 nodes goes from OOM to 126.5/139.8 GiB peak.

## Verification

All runs: SFT trainer, `PrimeIntellect/INTELLECT-3-SFT-10K` (subsets=default, splits=math), seq 8192, global batch 16, adamw lr 1e-5 constant, seed 42, `liger_fused`, fa2, 15 steps. Within each comparison the **dp size is held constant** (world size scales with cp), so per-step global batches are identical — loss/grad-norm must match iff the CP math is exact.

### 1. Parity: cp=1 vs cp=2 — Nano-30B (same 32q/2kv layout as Super), dp=8

cp=1: 1 node ×8 GPUs · cp=2: 2 nodes ×16 GPUs

| step | cp1 loss | cp2 loss | cp1 gnorm | cp2 gnorm |
|---|---|---|---|---|
| 1 | 0.4240 | 0.4241 | 4.1684 | 4.1538 |
| 5 | 0.3585 | 0.3584 | 0.8203 | 0.8206 |
| 10 | 0.3944 | 0.3944 | 0.7885 | 0.7870 |
| 15 | 0.2978 | 0.2976 | 0.4775 | 0.4793 |

Max |Δloss| = 2e-4 over 15 steps; gnorm within ~1% (bf16 reduction-order noise).

### 2. Parity: cp=2 (existing path) vs cp=4 (**new replication path**) — Nano-30B, dp=4

cp=2: 1 node ×8 GPUs · cp=4: 2 nodes ×16 GPUs

| step | cp2 loss | cp4 loss | cp2 gnorm | cp4 gnorm |
|---|---|---|---|---|
| 1 | 0.4344 | 0.4346 | 4.0827 | 4.1073 |
| 5 | 0.3407 | 0.3409 | 0.8009 | 0.7981 |
| 10 | 0.3885 | 0.3884 | 0.7372 | 0.7441 |
| 15 | 0.2979 | 0.2981 | 0.4613 | 0.4609 |

Max |Δloss| = 2e-4.

### 3. Parity: cp=2 vs cp=4 — **Super-120B, real weights**, dp=16

cp=2: 4 nodes · cp=4: 8 nodes

| step | cp2 loss | cp4 loss | cp2 gnorm | cp4 gnorm |
|---|---|---|---|---|
| 1 | 0.4019 | 0.4019 | 8.3973 | 8.4311 |
| 5 | 0.3122 | 0.3123 | 0.8765 | 0.8779 |
| 10 | 0.2849 | 0.2853 | 0.4600 | 0.4571 |
| 15 | 0.2725 | 0.2723 | 0.3415 | 0.3418 |

Max |Δloss| = 4e-4.

### 4. Max context, Super on 2×H200 nodes (SFT, `fsdp_cpu_offload`, liger, fused relu2)

Memory/perf measured with fake fixed-length data + `random_init` + `force_balanced_routing` (loss column not meaningful there; parity above uses real data/weights).

| cp | seq_len | tokens/GPU | peak mem | MFU | tokens/s |
|---|---|---|---|---|---|
| 2 | 49,152 | 24k | 114.8/139.8 GiB (82%) | 10.4% | 2,668 |
| 4 | 98,304 | 24k | 114.8 GiB (82%) | 20.6% | 3,914 |
| 8 | 131,072 | 16k | **79.8 GiB (57%)** | 22.4% | 3,640 |
| 8 | **196,608** | 24k | 114.8 GiB (82%) | 37.5% | 4,720 |
| 8 | **229,376** | 28k | 130.3 GiB (93%) | **45.4%** | 5,139 |

- Peak memory tracks tokens/GPU exactly (same 24k tokens/GPU → same 114.8 GiB at cp=2/4/8): the CP degree linearly extends reachable context.
- **Before this PR, Super could not fit 131k on any node count** (cp capped at 2 → 65k tokens/GPU). With cp=8, 131k fits on 2 nodes with 43% headroom, and **~224k is the practical ceiling (93% mem, 45% MFU)**. MFU rises with context at fixed memory (10→37%) as compute amortizes fixed costs.
- Constraint recap for NemotronH: attention allows cp ∈ {4, 8, 16, 32} (32 q-heads), Mamba caps at cp=8 (`n_groups=8`).

## Caveats

- KV all-to-all volume grows by `cp/num_kv_heads` (replicas are exchanged); negligible for NemotronH (2 KV heads × 128 dim, 8 attention layers of 88).
- `cp > num_attention_heads` remains unsupported (existing constraint).
- Loss/gnorm parity is bf16-level (≤4e-4), not bit-exact — reduction order changes with world size, same as any dp/world-size change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed attention math and all-to-all volume for GQA at high CP; MoE compile affects activation memory but is localized to relu2.
> 
> **Overview**
> Extends **Ulysses context parallelism** so CP degree is no longer capped at `num_key_value_heads` on GQA models. When `num_key_value_heads < cp_size`, K/V are **replicated** with `repeat_interleave` before the existing seq→head all-to-all; gradients sum over replicas on backward (correct GQA KV behavior). The Q path and `num_kv_heads >= cp` cases are unchanged.
> 
> Documents the new rules in **scaling**: `cp` must divide `num_attention_heads`; for low-KV GQA, `cp` must be a multiple of `num_key_value_heads` (plus existing Mamba `cp_mamba` constraints).
> 
> Separately wraps MoE **`relu2`** in `@torch.compile(dynamic=True)` to avoid an extra full-size intermediate activation in the eager `relu().square()` path (memory win for large Nemotron-style MoE).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0ffe5ce4946c4b85bb1e85df88fc8d0ca3316c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->