### PR TITLE
feat(inference): uint16 routed-experts payload for >256-expert models

### DIFF
--- a/src/prime_rl/inference/vllm/routed_experts.py
+++ b/src/prime_rl/inference/vllm/routed_experts.py
@@ -15,15 +15,21 @@ def serialize_routed_experts(routed_experts: Any, start: int = 0) -> dict[str, A
     array = np.asarray(routed_experts)
     assert array.ndim == 3
     assert np.issubdtype(array.dtype, np.integer)
+    dtype = np.uint8
     if array.size:
         assert array.min() >= 0
-        assert array.max() <= np.iinfo(np.uint8).max
+        if array.max() > np.iinfo(np.uint8).max:
+            # Models with >256 experts (e.g. NemotronH Super/Ultra: 512) need wider
+            # indices. The payload self-describes via "dtype" so consumers pick it up.
+            assert array.max() <= np.iinfo(np.uint16).max
+            dtype = np.uint16
 
-    compact = np.ascontiguousarray(array.astype(np.uint8, copy=False))
+    compact = np.ascontiguousarray(array.astype(dtype, copy=False))
     return {
         "data": pybase64.b64encode(memoryview(compact)).decode("ascii"),
         "shape": list(compact.shape),
         "start": start,
+        "dtype": np.dtype(dtype).name,
     }
 
 

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -7,12 +7,6 @@ import numpy as np
 from prime_rl.trainer.utils import balanced_partition
 from prime_rl.transport.types import EncodedTensor, MicroBatch, RoutedExperts, TrainingSample
 
-ROUTED_EXPERTS_DTYPE_ITEMSIZE = {
-    "uint8": 1,
-    "int16": 2,
-    "int32": 4,
-}
-
 # Backfill value per component weight stream when a packed sample doesn't
 # carry it: absent rl means weight 1.0 on the loss mask, absent ce/ref_kl
 # means no component (weight 0.0).
@@ -28,7 +22,7 @@ def _copy_routed_experts(routed_experts: RoutedExperts) -> RoutedExperts:
 
 
 def _routed_experts_row_size(routed_experts: RoutedExperts) -> int:
-    return routed_experts.shape[1] * routed_experts.shape[2] * ROUTED_EXPERTS_DTYPE_ITEMSIZE[routed_experts.dtype]
+    return routed_experts.shape[1] * routed_experts.shape[2] * np.dtype(routed_experts.dtype).itemsize
 
 
 def _slice_routed_experts(routed_experts: RoutedExperts, seq_len: int) -> RoutedExperts:

--- a/uv.lock
+++ b/uv.lock
@@ -7631,7 +7631,7 @@ requires-dist = [
     { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },
     { name = "pyzmq", specifier = ">=27.1.0" },
     { name = "reasoning-gym", marker = "extra == 'rg'" },
-    { name = "renderers", specifier = ">=0.1.8.dev40" },
+    { name = "renderers", specifier = ">=0.1.8" },
     { name = "requests" },
     { name = "requests", marker = "extra == 'rl'" },
     { name = "rich" },


### PR DESCRIPTION
Encoder half of the >256-expert router-replay fix (design per Slack w/ @S1ro1: self-describing payload — uint8 when it fits, uint16 otherwise).

## Problem
`serialize_routed_experts` packs expert indices as **uint8**; NemotronH Super/Ultra route top-22 over **512 experts**, so every `/generate` call with routed-experts capture 500s (`assert array.max() <= iinfo(uint8).max`) — router replay is unusable and train batches never fill (hit on the Super 131k SWE run; replay is currently disabled there as a workaround).

## Change
- Pick `uint8` when `max <= 255`, else `uint16` (assert `<= 65535`), and emit `"dtype"` in the payload.
- Payloads from ≤256-expert models are **byte-identical** to before (plus the new field, which old decoders ignore).
- Verified: encode/decode roundtrip for uint8 (legacy-decoder compatible) and uint16 (max 511).

## Deploy order
1. ~~verifiers decoder change~~ **merged** (PrimeIntellect-ai/verifiers#2043) and **pinned in this PR** (`deps/verifiers` → verifiers main `19fdd9ca`)
2. merge this PR
3. re-enable `enable_router_replay` / `enable_return_routed_experts` for NemotronH runs

## Caveat
The llm-d/P-D router path that merges prefill/decode routed-experts payloads should be checked for a uint8 assumption before using replay with P/D disaggregation on a >256-expert model (not exercised by the current runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inference payload encoding and trainer byte accounting for router replay; wrong dtype handling could corrupt training batches, but scope is narrow and backward-compatible for small expert counts.
> 
> **Overview**
> Fixes router-replay capture for MoE models with more than 256 experts (e.g. NemotronH Super/Ultra with 512 experts), where expert indices previously tripped a hard **uint8** cap and caused `/generate` failures during routed-experts capture.
> 
> **`serialize_routed_experts`** now keeps **uint8** when all indices fit in 255, otherwise packs as **uint16** (up to 65535), and adds a **`dtype`** field on the payload so decoders know the width. ≤256-expert runs stay the same on the wire aside from the extra metadata field.
> 
> On the trainer side, **`batch.py`** drops the fixed `uint8`/`int16`/`int32` byte-size table and derives row size from **`np.dtype(routed_experts.dtype).itemsize`**, so slicing, padding, and packing stay correct for wider encoded buffers.
> 
> The lockfile bumps the **`renderers`** dependency floor (aligned with the merged verifiers decoder that reads the new `dtype`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e0bd22ed6bcf5e4c67a899ca39613dd3881853a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

