### PR TITLE
fix(docker): bake optional dependencies into CUDA image

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -91,10 +91,6 @@ COPY scripts/docker-editable-pretend-versions.sh /app/scripts/docker-editable-pr
 # Use submodule git metadata from the build context when present. Docker copies
 # only the submodule .git pointer files into /app/deps, so we temporarily link
 # /app/.git/modules to the read-only context before resolving versions.
-# Opt-in extras for disaggregated P/D inference (deep-ep, deep-gemm, quack).
-# Default off — they're heavy source builds only the disagg-MoE path needs.
-# Enable via `--build-arg INCLUDE_DISAGG_EXTRAS=1`.
-ARG INCLUDE_DISAGG_EXTRAS=0
 ARG VERIFIERS_PRETEND_VERSION
 ARG RENDERERS_PRETEND_VERSION
 RUN --mount=type=cache,target=/app/.cache/uv \
@@ -109,9 +105,9 @@ RUN --mount=type=cache,target=/app/.cache/uv \
     && \
     sed -i "s/fallback-version = \"0.0.0\"/fallback-version = \"${RENDERERS_PRETEND_VERSION}\"/" /app/deps/renderers/pyproject.toml \
     && \
-    EXTRA_DISAGG_FLAG=""; if [ "$INCLUDE_DISAGG_EXTRAS" = "1" ]; then EXTRA_DISAGG_FLAG="--extra disagg"; fi \
+    uv sync --all-packages --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra disagg --extra gpt-oss --extra modelexpress --extra quack --group mamba-ssm --locked --no-dev \
     && \
-    uv sync --all-packages --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra gpt-oss --extra modelexpress $EXTRA_DISAGG_FLAG --group mamba-ssm --locked --no-dev
+    /app/.venv/bin/python -c 'from importlib.metadata import version; [version(name) for name in ("deep-ep", "deep-gemm", "mamba-ssm", "nixl", "quack-kernels", "vllm", "vllm-router")]'
 
 # Optional: build NIXL from source against the UCX 1.19 baked above. The PyPI
 # nixl wheel ships its own UCX which segfaults on prefill→decode KV transfer


### PR DESCRIPTION
## Summary

- bake every current Prime-RL optional dependency group into the standard CUDA image
- install the locked NIXL wheel instead of enabling the optional source build
- fail the Docker build when the inference dependencies are missing

## Why

The standard Prime-RL image excludes the `disagg` and `quack` extras. The GLM-5.2 GB200 Kubernetes deployment compensates by running `uv sync --all-packages --all-extras` in every prefill and decode pod. On the target cluster this causes twelve independent downloads of the 472 MB ARM vLLM wheel from GitHub, preventing the inference servers from starting for more than an hour.

This keeps a single image and tag contract. The dependency list remains explicit rather than using `--all-extras`, so adding a future optional extra cannot silently alter the image. NIXL resolves from the architecture-specific wheel pinned in `uv.lock`; the existing optional source-build argument remains disabled.

## Validation

- `docker buildx build --check --file Dockerfile.cuda .`
- locked dependency dry run with all explicit extras and `mamba-ssm`
- `git diff --check`

The full CUDA image build is intentionally left to the repository's native AMD64 and ARM64 image-builder runners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default CUDA image dependency surface and build-time guarantees for disaggregated inference stacks; NIXL source rebuild remains opt-in via `INCLUDE_NIXL_FROM_SOURCE`.
> 
> **Overview**
> The CUDA builder **always** installs the previously opt-in **`disagg`** and **`quack`** extras (along with the other named flash-attn / gpt-oss / modelexpress groups and **`mamba-ssm`**) via an explicit `uv sync` list instead of the removed **`INCLUDE_DISAGG_EXTRAS`** build arg and conditional flag.
> 
> After sync, the image build **fails** if any of **`deep-ep`**, **`deep-gemm`**, **`mamba-ssm`**, **`nixl`**, **`quack-kernels`**, **`vllm`**, or **`vllm-router`** cannot be resolved from installed package metadata—so inference-related wheels must be present in the standard image without per-pod `uv sync`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d4853e429642e118482a5bcc8b66608c238b95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->