### PR TITLE
chore(ci): remove ghcr-publish environment approval gate

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -116,7 +116,6 @@ jobs:
   build:
     name: Build and push (${{ matrix.suffix }})
     needs: prepare
-    environment: ghcr-publish
     strategy:
       fail-fast: true
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}


### PR DESCRIPTION
## Summary

Removes the `environment: ghcr-publish` line from the `build` job in `build_image.yaml`, eliminating the manual approval gate on ghcr image builds.

## Why

The `build` job opted into the `ghcr-publish` GitHub environment solely for its **required-reviewers** protection rule. Because ghcr builds are triggered automatically — on `release: published` and via the `.devN`-tag dispatch on every merge to `main` (`devx_tag.yaml` → `build_image.yaml`) — each build paused waiting for a human to approve the deployment.

The environment provided **nothing functional**:
- No scoped secrets or variables were attached to it.
- The job already declares `permissions: packages: write` and authenticates to ghcr via the auto-provisioned `GITHUB_TOKEN`.
- Ref restrictions (`main`, `v*`, `*.dev*`) are independently enforced in the `prepare` job, so dropping the environment's branch policy doesn't loosen which refs can publish.

With this change, ghcr images build and push automatically with no approval step.

## Notes

- The `ghcr-publish` environment can be deleted from repo settings separately (it's now unreferenced), or left in place harmlessly.
- Docker Hub publishing (`docker-push.yaml`) is unaffected — it never used an environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1507c30fa08665bcd101ef6d48ca43a2daf0a37e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->