### PR TITLE
fix(trainer): skip no-op weight conversion for dense models

### DIFF
--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -124,8 +124,10 @@ class LlamaPreTrainedModel(PreTrainedModelPrimeRL):
 
     @classmethod
     def is_prime_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
-        """Check if the state dict is in PrimeRL training format."""
-        return True
+        # Dense models use identical key names in HF and PrimeRL format, so we
+        # never claim to be in a separate PrimeRL format. This disables the
+        # auto-conversion path in load_dcp_from_hf and lets DCP load directly.
+        return False
 
     @classmethod
     def convert_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:

--- a/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
+++ b/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
@@ -107,7 +107,10 @@ class Qwen3PreTrainedModel(PreTrainedModelPrimeRL):
 
     @classmethod
     def is_prime_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
-        return True
+        # Dense models use identical key names in HF and PrimeRL format, so we
+        # never claim to be in a separate PrimeRL format. This disables the
+        # auto-conversion path in load_dcp_from_hf and lets DCP load directly.
+        return False
 
     @classmethod
     def convert_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -149,7 +149,10 @@ class Qwen3_5PreTrainedModel(PreTrainedModelPrimeRL, HFQwen3_5PreTrainedModel):
 
     @classmethod
     def is_prime_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
-        return True
+        # Dense models use identical key names in HF and PrimeRL format, so we
+        # never claim to be in a separate PrimeRL format. This disables the
+        # auto-conversion path in load_dcp_from_hf and lets DCP load directly.
+        return False
 
     @classmethod
     def convert_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:


### PR DESCRIPTION
## Problem

Training a dense (non-MoE) model like `Qwen3-0.6B` from a read-only HF cache crashes:

```
OSError: [Errno 30] Read-only file system: '/model-cache/.../Qwen3-0.6B.../snapshots/.../prime'
```

## Root cause

`load_dcp_from_hf` auto-converts between HF and PrimeRL weight formats when a format mismatch is detected. The conversion is only needed for **MoE models** (HF stores per-expert tensors `expert.0.w1`, PrimeRL stores stacked `experts.w1`).

Dense models (Qwen3, Qwen3.5, Llama) have identical key names in both formats, so both `is_hf_state_dict` and `is_prime_state_dict` unconditionally returned `True`. The conversion branch fired anyway — performing a no-op convert and trying to write the unchanged weights back into the (read-only) snapshot directory.

## Fix

Make `is_prime_state_dict` return `False` for the 3 affected dense models (following the pattern already used by GPT-OSS). This makes the format checks mutually exclusive, so the conversion branches naturally skip when there's no format difference.

Only 3 files changed — one-line edit each:

- `src/prime_rl/trainer/models/qwen3/modeling_qwen3.py`
- `src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py`
- `src/prime_rl/trainer/models/llama/modeling_llama.py`

No other models are affected — all MoE models already use mutually exclusive pattern checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to checkpoint format detection for three dense model families; MoE conversion paths are untouched.
> 
> **Overview**
> Fixes dense-model training from read-only HF caches by stopping `load_dcp_from_hf` from treating Llama, Qwen3, and Qwen3.5 weights as a separate PrimeRL format.
> 
> **`is_prime_state_dict` now returns `False`** on those three dense model classes (same idea as GPT-OSS). HF and PrimeRL already use the same checkpoint keys, so both `is_hf_state_dict` and `is_prime_state_dict` no longer agree that a “format mismatch” exists. That skips the auto-convert branch that wrote a no-op converted copy under `.../prime` in the snapshot directory and hit **read-only filesystem** errors.
> 
> MoE models are unchanged; they still use key-pattern checks so real HF ↔ PrimeRL conversion can run when needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea4f927299a435e3a62fd7c51ac8808ea7c16508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->