### PR TITLE
fix: add VLM support for dense Qwen3.5 models (Qwen3.5-4B etc)

### DIFF
--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -75,6 +75,7 @@ def supports_custom_impl(model_config: PretrainedConfig) -> bool:
 # Used by get_model() to dispatch VLMs that have a custom text model implementation.
 # Points to the same unified class — the config drives text-only vs VLM behavior.
 _CUSTOM_VLM_MAPPING: dict[str, type] = {
+    "qwen3_5": Qwen3_5ForCausalLM,
     "qwen3_5_moe": Qwen3_5MoeForCausalLM,
 }
 

--- a/src/prime_rl/trainer/models/qwen3_5/__init__.py
+++ b/src/prime_rl/trainer/models/qwen3_5/__init__.py
@@ -1,3 +1,3 @@
-from .modeling_qwen3_5 import Qwen3_5ForCausalLM, Qwen3_5Model, Qwen3_5PreTrainedModel
+from .modeling_qwen3_5 import Qwen3_5ForCausalLM, Qwen3_5Model, Qwen3_5PreTrainedModel, Qwen3_5VLMModel
 
-__all__ = ["Qwen3_5ForCausalLM", "Qwen3_5Model", "Qwen3_5PreTrainedModel"]
+__all__ = ["Qwen3_5ForCausalLM", "Qwen3_5Model", "Qwen3_5PreTrainedModel", "Qwen3_5VLMModel"]

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -4,12 +4,14 @@ from typing import Optional, Union
 import torch
 from torch import Tensor, nn
 from transformers.cache_utils import Cache
+from transformers.configuration_utils import PretrainedConfig
 from transformers.generation import GenerationMixin
 from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast
 from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
 from transformers.models.qwen3_5.modeling_qwen3_5 import (
     Qwen3_5PreTrainedModel as HFQwen3_5PreTrainedModel,
+    Qwen3_5VisionModel,
 )
 from transformers.processing_utils import Unpack
 from transformers.utils import TransformersKwargs
@@ -25,6 +27,7 @@ from prime_rl.trainer.models.qwen3_5_moe.modeling_qwen3_5_moe import (
     Qwen3_5MoeRotaryEmbedding,
     normalize_qwen3_5_attn_implementation,
 )
+from prime_rl.trainer.models.qwen3_5_moe.mrope import build_qwen3_5_mrope_position_ids
 from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
 
 
@@ -227,7 +230,154 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         return BaseModelOutputWithPast(last_hidden_state=hidden_states)
 
 
+def _build_text_config(composite_config: PretrainedConfig) -> Qwen3_5TextConfig:
+    """Build custom PrimeRL text config from HF's composite VLM config."""
+    text_dict = composite_config.text_config.to_dict()
+    text_config = Qwen3_5TextConfig(**text_dict)
+    attn_impl = getattr(
+        composite_config.text_config,
+        "_attn_implementation",
+        getattr(composite_config, "_attn_implementation", None),
+    )
+    if attn_impl is not None:
+        text_config._attn_implementation = attn_impl
+    return text_config
+
+
+class Qwen3_5VLMModel(nn.Module):
+    """Composite VLM body: HF vision encoder + custom PrimeRL text model.
+
+    Mirrors :class:`Qwen3_5MoeVLMModel` from the MoE variant but uses the dense
+    :class:`Qwen3_5Model` text backbone and HF's :class:`Qwen3_5VisionModel`.
+    """
+
+    def __init__(self, config: PretrainedConfig):
+        super().__init__()
+        self.config = config
+        self.visual = Qwen3_5VisionModel._from_config(config.vision_config)
+        self.language_model = Qwen3_5Model(_build_text_config(config))
+
+    def get_input_embeddings(self):
+        return self.language_model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.language_model.embed_tokens = value
+
+    def _dummy_vision_inputs(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+        """Smallest valid vision input: a single merged token (grid [1, m, m])."""
+        vcfg = self.config.vision_config
+        m = vcfg.spatial_merge_size
+        num_patches = m * m
+        patch_dim = vcfg.in_channels * vcfg.temporal_patch_size * vcfg.patch_size * vcfg.patch_size
+        pixel_values = torch.zeros(num_patches, patch_dim, device=device, dtype=self.visual.dtype)
+        grid_thw = torch.tensor([[1, m, m]], dtype=torch.long, device=device)
+        return pixel_values, grid_thw
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        mm_token_type_ids: torch.LongTensor | None = None,
+        seq_lens: torch.LongTensor | None = None,
+        **kwargs,
+    ) -> BaseModelOutputWithPast:
+        if inputs_embeds is None:
+            inputs_embeds = self.language_model.embed_tokens(input_ids)
+
+        if image_grid_thw is not None and input_ids is None:
+            raise ValueError("input_ids are required to compute Qwen3.5 multimodal MRoPE positions")
+        if image_grid_thw is not None and mm_token_type_ids is None:
+            raise ValueError(
+                "Qwen3.5 multimodal forward requires mm_token_type_ids to compute MRoPE positions correctly"
+            )
+        if image_grid_thw is not None and position_ids is not None and position_ids.ndim != 3:
+            raise ValueError(
+                f"Qwen3.5 multimodal forward requires 3D MRoPE position_ids; got shape={tuple(position_ids.shape)}"
+            )
+
+        # Keep distributed collectives in the same order when a batch mixes text-only
+        # and image samples across ranks. The frozen dummy pass is discarded below.
+        has_images = pixel_values is not None
+        vision_grid_thw = image_grid_thw
+        if has_images:
+            if input_ids is None:
+                raise ValueError("input_ids are required when scattering Qwen3.5 image features")
+            if image_grid_thw is None:
+                raise ValueError("image_grid_thw is required when pixel_values are provided")
+            pixel_values = pixel_values.type(self.visual.dtype)
+        else:
+            pixel_values, vision_grid_thw = self._dummy_vision_inputs(inputs_embeds.device)
+
+        vision_output = self.visual(pixel_values, grid_thw=vision_grid_thw, return_dict=True)
+        image_embeds = vision_output.pooler_output.to(inputs_embeds.device, inputs_embeds.dtype)
+
+        if has_images:
+            image_mask = input_ids == self.config.image_token_id
+            image_token_count = int(image_mask.sum().item())
+            image_feature_count = int(image_embeds.shape[0])
+            if image_token_count != image_feature_count:
+                raise ValueError(
+                    "Qwen VLM image token/feature mismatch before scatter: "
+                    f"image_token_id={self.config.image_token_id}, "
+                    f"image_tokens={image_token_count}, image_features={image_feature_count}, "
+                    f"input_ids_shape={tuple(input_ids.shape)}, "
+                    f"pixel_values_shape={tuple(pixel_values.shape)}, "
+                    f"image_grid_thw_shape={tuple(image_grid_thw.shape) if image_grid_thw is not None else None}"
+                )
+            image_mask = image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
+            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+
+        if position_ids is None:
+            if image_grid_thw is not None:
+                position_ids = build_qwen3_5_mrope_position_ids(
+                    input_ids=input_ids,
+                    mm_token_type_ids=mm_token_type_ids,
+                    image_grid_thw=image_grid_thw,
+                    spatial_merge_size=self.config.vision_config.spatial_merge_size,
+                    seq_lens=seq_lens,
+                )
+            else:
+                position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+
+        return self.language_model(
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unified CausalLM / VLM class
+# ---------------------------------------------------------------------------
+
+
+def _has_vlm_keys(state_dict: dict[str, Tensor]) -> bool:
+    return any(k.startswith("model.language_model.") for k in state_dict)
+
+
+def _remap_lm_keys(state_dict: dict[str, Tensor], to_flat: bool = True) -> None:
+    """Remap language model keys between VLM and flat format for weight conversion.
+
+    to_flat=True:  model.language_model.* -> model.*
+    to_flat=False: model.*               -> model.language_model.*
+
+    Vision keys (model.visual.*) are never touched.
+    """
+    src = "model.language_model." if to_flat else "model."
+    dst = "model." if to_flat else "model.language_model."
+    for k in [k for k in list(state_dict.keys()) if k.startswith(src) and not k.startswith("model.visual.")]:
+        state_dict[dst + k[len(src) :]] = state_dict.pop(k)
+
+
 class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
+    """Unified Qwen3.5 dense model for both text-only and VLM configs.
+
+    When config has a vision_config, creates a composite model with HF's frozen
+    vision encoder + custom text model. Otherwise creates a text-only model.
+    """
+
     _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _checkpoint_conversion_mapping = {}
     _tp_plan = {"lm_head": "colwise_gather_output"}
@@ -235,22 +385,80 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
 
     def __init__(self, config, **kwargs):
         super().__init__(config, **kwargs)
-        self.model = Qwen3_5Model(config)
-        self.vocab_size = config.vocab_size
-        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self._is_vlm = hasattr(config, "vision_config")
+
+        if self._is_vlm:
+            self.model = Qwen3_5VLMModel(config)
+            text_config = config.text_config
+            self._tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
+        else:
+            self.model = Qwen3_5Model(config)
+            text_config = config
+
+        self.vocab_size = text_config.vocab_size
+        self.lm_head = nn.Linear(text_config.hidden_size, text_config.vocab_size, bias=False)
         self.post_init()
 
     def get_input_embeddings(self):
+        if self._is_vlm:
+            return self.model.get_input_embeddings()
         return self.model.embed_tokens
 
     def set_input_embeddings(self, value):
-        self.model.embed_tokens = value
+        if self._is_vlm:
+            self.model.set_input_embeddings(value)
+        else:
+            self.model.embed_tokens = value
 
     def set_decoder(self, decoder):
         self.model = decoder
 
     def get_decoder(self):
         return self.model
+
+    # ------------------------------------------------------------------
+    # State dict detection & conversion (handles both text-only and VLM)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def is_hf_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return True
+
+    @classmethod
+    def is_prime_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return True
+
+    @classmethod
+    def convert_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        if _has_vlm_keys(state_dict):
+            _remap_lm_keys(state_dict, to_flat=True)
+            _remap_lm_keys(state_dict, to_flat=False)
+        return state_dict
+
+    @classmethod
+    def convert_to_prime(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        if _has_vlm_keys(state_dict):
+            _remap_lm_keys(state_dict, to_flat=True)
+            _remap_lm_keys(state_dict, to_flat=False)
+        return state_dict
+
+    @classmethod
+    def convert_layer_to_hf(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        if _has_vlm_keys(state_dict):
+            _remap_lm_keys(state_dict, to_flat=True)
+            _remap_lm_keys(state_dict, to_flat=False)
+        return state_dict
+
+    @classmethod
+    def convert_layer_to_prime(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        if _has_vlm_keys(state_dict):
+            _remap_lm_keys(state_dict, to_flat=True)
+            _remap_lm_keys(state_dict, to_flat=False)
+        return state_dict
+
+    # ------------------------------------------------------------------
+    # Forward
+    # ------------------------------------------------------------------
 
     def forward(
         self,
@@ -263,22 +471,38 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         use_cache: Optional[bool] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        image_grid_thw: Optional[torch.LongTensor] = None,
+        mm_token_type_ids: Optional[torch.LongTensor] = None,
+        seq_lens: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom qwen3_5 for now"
         assert past_key_values is None, "past_key_values is not supported for custom qwen3_5 for now"
 
-        if position_ids is None:
+        has_vlm_image_inputs = self._is_vlm and image_grid_thw is not None
+        if position_ids is None and not has_vlm_image_inputs:
             if inputs_embeds is not None:
                 position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
             elif input_ids is not None:
                 position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).unsqueeze(0)
 
-        outputs = self.model(
-            input_ids=input_ids,
-            position_ids=position_ids,
-            inputs_embeds=inputs_embeds,
-        )
+        if self._is_vlm:
+            outputs: BaseModelOutputWithPast = self.model(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                inputs_embeds=inputs_embeds,
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+                mm_token_type_ids=mm_token_type_ids,
+                seq_lens=seq_lens,
+            )
+        else:
+            outputs = self.model(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                inputs_embeds=inputs_embeds,
+            )
 
         hidden_states = outputs.last_hidden_state
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
@@ -288,11 +512,29 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
             temperature=temperature,
         )
 
+    # ------------------------------------------------------------------
+    # Buffer init after meta-device loading
+    # ------------------------------------------------------------------
+
     def init_buffers_post_meta(self):
-        lm_rope = self.model.rotary_emb
+        if self._is_vlm:
+            lm_rope = self.model.language_model.rotary_emb
+        else:
+            lm_rope = self.model.rotary_emb
+
         if hasattr(lm_rope, "rope_init_fn"):
             inv_freq, lm_rope.attention_scaling = lm_rope.rope_init_fn(lm_rope.config, lm_rope.inv_freq.device)
             lm_rope.inv_freq.copy_(inv_freq)
+
+        if self._is_vlm:
+            vis_rope = self.model.visual.rotary_pos_emb
+            if hasattr(vis_rope, "inv_freq"):
+                dim = vis_rope.inv_freq.shape[0]
+                inv_freq = 1.0 / (
+                    10000.0
+                    ** (torch.arange(0, dim * 2, 2, dtype=torch.float32, device=vis_rope.inv_freq.device) / (dim * 2))
+                )
+                vis_rope.inv_freq.copy_(inv_freq)
 
 
 __all__ = [
@@ -300,4 +542,5 @@ __all__ = [
     "Qwen3_5GatedFlashAttention",
     "Qwen3_5Model",
     "Qwen3_5PreTrainedModel",
+    "Qwen3_5VLMModel",
 ]


### PR DESCRIPTION
## Problem

`Qwen/Qwen3.5-4B` is rejected as **"unsupported architecture"** by the model-cache converter sidecar.

All Qwen3.5 dense models (0.8B, 2B, 4B, 9B, 27B) ship as **composite VLM configs** with `model_type="qwen3_5"` and a `vision_config`. However, `_CUSTOM_VLM_MAPPING` in `models/__init__.py` only registered the MoE variant (`"qwen3_5_moe"`) — the dense `"qwen3_5"` entry was missing. This caused:

1. The model-cache converter sidecar to reject dense Qwen3.5 models as unsupported.
2. The trainer to fall back to stock HF `AutoModelForImageTextToText` instead of the custom PrimeRL implementation.
3. vLLM inference would have worked (vLLM 0.24.0 supports `Qwen3_5ForConditionalGeneration`), but the model never got past the converter.

## Root Cause

```python
# src/prime_rl/trainer/models/__init__.py (before)
_CUSTOM_VLM_MAPPING: dict[str, type] = {
    "qwen3_5_moe": Qwen3_5MoeForCausalLM,   # ✅ MoE VLM
    # "qwen3_5": <missing>                    # ❌ Dense VLM
}
```

Additionally, `Qwen3_5ForCausalLM` (the dense custom class) was text-only — no `vision_config` detection, no VLM model wrapper, no multimodal forward path — unlike `Qwen3_5MoeForCausalLM` which already handles both text-only and VLM configs.

## Changes

### 1. Register dense VLM architecture (`models/__init__.py`)
Added `"qwen3_5": Qwen3_5ForCausalLM` to `_CUSTOM_VLM_MAPPING`.

### 2. Add `Qwen3_5VLMModel` and extend `Qwen3_5ForCausalLM` (`modeling_qwen3_5.py`)
- **`Qwen3_5VLMModel`**: Composite VLM body (HF `Qwen3_5VisionModel` + custom dense `Qwen3_5Model` text backbone), mirroring `Qwen3_5MoeVLMModel` from the MoE variant. Includes:
  - Image feature scattering into input embeddings
  - MRoPE position building via `build_qwen3_5_mrope_position_ids`
  - Dummy vision inputs for distributed collective ordering
- **`Qwen3_5ForCausalLM`**: Extended to detect `vision_config` and branch between text-only and VLM paths across `__init__`, `get_input_embeddings`, `set_input_embeddings`, `forward`, `init_buffers_post_meta`, and state-dict conversion methods.
- **Helpers**: `_build_text_config`, `_has_vlm_keys`, `_remap_lm_keys` for VLM state-dict key conversion.

### 3. Tests
- **`test_qwen3_5_vlm.py`** (new): Forward (text-only + multimodal), backward gradient flow, VLM flag detection, text-only non-VLM path.
- **`test_parsers.py`**: Added `Qwen3.5-2B` and `Qwen3.5-4B` to parser test cases.

## Design

The implementation mirrors the existing MoE VLM path (`Qwen3_5MoeVLMModel` / `Qwen3_5MoeForCausalLM`) exactly:
- Same vision encoder integration pattern (frozen HF vision model + custom text model)
- Same MRoPE position building
- Same dummy-vision-inputs trick for distributed collective ordering
- Same state-dict key remapping (`model.language_model.*` ↔ `model.*`)

## Impact

Fixes all dense Qwen3.5 VLMs: 0.8B, 2B, 4B, 9B, 27B. MoE variants (35B-A3B, 122B-A10B, 397B-A17B) were already working and are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new multimodal forward path and weight key remapping on a core model class; mistakes could break loading or training for all dense Qwen3.5 VLMs, though the design mirrors the already-shipped MoE VLM implementation.
> 
> **Overview**
> Dense **Qwen3.5** checkpoints ship as composite VLMs (`model_type="qwen3_5"` with `vision_config`) but were not routed to the custom trainer implementation, so the model-cache converter and `get_model()` treated them as unsupported and fell back to stock Hugging Face VLMs.
> 
> This PR registers **`"qwen3_5": Qwen3_5ForCausalLM`** in `_CUSTOM_VLM_MAPPING` and extends the dense stack to match the existing MoE VLM pattern. **`Qwen3_5VLMModel`** wires HF’s `Qwen3_5VisionModel` to the custom dense `Qwen3_5Model`, scatters image features into embeddings, builds **MRoPE** positions via `build_qwen3_5_mrope_position_ids`, and runs a **dummy vision pass** on text-only batches for consistent distributed collectives. **`Qwen3_5ForCausalLM`** now branches on `vision_config` for init, embeddings, multimodal `forward` (`pixel_values`, `image_grid_thw`, `mm_token_type_ids`), VLM state-dict key remapping, and post-meta RoPE buffer init for both language and vision towers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61ce80ae3057e0ece4a1db1b48d372006e3f975a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->