### PR TITLE
fix: make flash_attention_2 the default attention implementation again

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -153,7 +153,7 @@ class ModelConfig(BaseModelConfig):
     seq_len: int = 2048
     """Sequence length the model is trained on."""
 
-    attn: AttnImplementation = "flash_attention_3"
+    attn: AttnImplementation = "flash_attention_2"
     """Attention implementation. With CP enabled, ring attention uses the matching kernel family (FA2/FA3/FA4)."""
 
     compile: CompileConfig | None = CompileConfig()

--- a/src/prime_rl/trainer/models/base.py
+++ b/src/prime_rl/trainer/models/base.py
@@ -34,7 +34,7 @@ class PreTrainedModelPrimeRL(PreTrainedModel):
         attention dispatch for custom models.
         """
         if attn_implementation is None:
-            attn_implementation = "flash_attention_3"
+            attn_implementation = "flash_attention_2"
         return attn_implementation
 
     def get_correct_experts_implementation(self, requested_experts: str | None) -> str:

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -135,7 +135,7 @@ class Qwen3_5PreTrainedModel(PreTrainedModelPrimeRL, HFQwen3_5PreTrainedModel):
     def _check_and_adjust_attn_implementation(
         self, attn_implementation: str | None, is_init_check: bool = False, allow_all_kernels: bool = False
     ) -> str:
-        attn_impl = normalize_qwen3_5_attn_implementation(attn_implementation or "flash_attention_3")
+        attn_impl = normalize_qwen3_5_attn_implementation(attn_implementation or "flash_attention_2")
         if attn_impl not in QWEN35_ATTN_IMPL2CLASS:
             supported = list(QWEN35_ATTN_IMPL2CLASS.keys())
             raise ValueError(

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -597,7 +597,7 @@ class Qwen3_5MoePreTrainedModel(PreTrainedModelPrimeRL):
     def _check_and_adjust_attn_implementation(
         self, attn_implementation: str | None, is_init_check: bool = False, allow_all_kernels: bool = False
     ) -> str:
-        attn_impl = normalize_qwen3_5_attn_implementation(attn_implementation or "flash_attention_3")
+        attn_impl = normalize_qwen3_5_attn_implementation(attn_implementation or "flash_attention_2")
         if attn_impl not in QWEN35MOE_ATTN_IMPL2CLASS:
             supported = list(QWEN35MOE_ATTN_IMPL2CLASS.keys())
             raise ValueError(


### PR DESCRIPTION
## Summary

- Flips the default attention implementation back from `flash_attention_3` to `flash_attention_2`, undoing the default change from #3057 (the rest of #3057 — the `fa4` → `flash_attention_4` rename and the sdpa/eager removal — is kept).
- Changed sites: the `ModelConfig.attn` default, the `attn_implementation is None` fallback in `PreTrainedModelPrimeRL._check_and_adjust_attn_implementation`, and the matching `None`-fallbacks in the qwen3_5 / qwen3_5_moe custom models.
- FA3 requires the separately-installed `flash_attn_3` package, so it stays opt-in via `attn = "flash_attention_3"`.

Note: this does **not** fix the model unit tests currently failing on main (`FlashAttention only support fp16 and bf16 data type`). Those fail because #3057 removed sdpa and switched the float32 model-parity tests to `flash_attention_2`, which rejects fp32 regardless of the default — that needs a separate fix (verified the failure reproduces identically with this change applied).

## Breaking

- The default `[trainer.model] attn` is `flash_attention_2` again. Runs that relied on the (day-old) FA3 default must set `attn = "flash_attention_3"` explicitly.

## Verification

- `uv run pytest tests/unit/test_configs.py`: 119 passed
- `uv run pytest tests/unit -m "not gpu"`: 485 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)