### PR TITLE
feat: always-on UUID log directories with symlink

### DIFF
--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -10,7 +10,7 @@ import tomli_w
 from prime_rl.configs.inference import InferenceConfig
 from prime_rl.utils.config import cli, to_toml_dict
 from prime_rl.utils.logger import setup_logger
-from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir
+from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir, setup_log_dir
 from prime_rl.utils.process import DEFAULT_COMMON_ENV_VARS, DEFAULT_INFERENCE_ENV_VARS, set_proc_title
 
 INFERENCE_TOML = "inference.toml"
@@ -168,6 +168,8 @@ def inference_local(config: InferenceConfig):
 
 
 def inference(config: InferenceConfig):
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    setup_log_dir(config.output_dir)
     if config.slurm is not None:
         inference_slurm(config)
     else:

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -24,6 +24,7 @@ from prime_rl.utils.pathing import (
     get_ckpt_dir,
     get_log_dir,
     resolve_latest_ckpt_step,
+    setup_log_dir,
     validate_output_dir,
 )
 from prime_rl.utils.process import (
@@ -534,6 +535,10 @@ def rl(config: RLConfig):
     config.output_dir.mkdir(parents=True, exist_ok=True)
     if ckpt_output_dir is not None:
         ckpt_output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create a UUID-isolated log directory and symlink output_dir/logs to it.
+    # When resuming, reuse the existing run's log directory.
+    setup_log_dir(config.output_dir, resuming=resuming)
 
     # Clean stale rollouts and broadcasts. When resuming, anything past the resume
     # step is stale. When training from scratch, every existing step directory is

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -11,7 +11,13 @@ import tomli_w
 from prime_rl.configs.sft import SFTConfig
 from prime_rl.utils.config import cli, to_toml_dict
 from prime_rl.utils.logger import setup_logger
-from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir, validate_output_dir
+from prime_rl.utils.pathing import (
+    format_log_message,
+    get_config_dir,
+    get_log_dir,
+    setup_log_dir,
+    validate_output_dir,
+)
 from prime_rl.utils.process import (
     DEFAULT_COMMON_ENV_VARS,
     DEFAULT_TRAINER_ENV_VARS,
@@ -122,7 +128,7 @@ def sft_local(config: SFTConfig):
         logger.success("Dry run complete. To start an SFT run locally, remove --dry-run from your command.")
         return
 
-    log_dir = config.output_dir / "logs"
+    log_dir = get_log_dir(config.output_dir)
     log_dir.mkdir(parents=True, exist_ok=True)
 
     from prime_rl.utils.utils import get_free_port
@@ -132,7 +138,7 @@ def sft_local(config: SFTConfig):
         "--role=trainer",
         f"--rdzv-endpoint=localhost:{get_free_port()}",
         f"--rdzv-id={uuid.uuid4().hex}",
-        f"--log-dir={config.output_dir / 'logs' / 'trainer' / 'torchrun'}",
+        f"--log-dir={log_dir / 'trainer' / 'torchrun'}",
         f"--local-ranks-filter={','.join(map(str, config.log.ranks_filter))}",
         "--redirect=3",
         "--tee=3",
@@ -210,6 +216,10 @@ def sft(config: SFTConfig):
     clean = config.clean_output_dir and not os.environ.get("NEVER_CLEAN_OUTPUT_DIR")
     validate_output_dir(config.output_dir, resuming=resuming, clean=clean)
     config.output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create a UUID-isolated log directory and symlink output_dir/logs to it.
+    # When resuming, reuse the existing run's log directory.
+    setup_log_dir(config.output_dir, resuming=resuming)
 
     if not config.dry_run:
         from prime_rl.trainer.model import pre_download_model

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import shutil
 import time
 from pathlib import Path
@@ -7,7 +8,55 @@ from prime_rl.utils.logger import get_logger
 
 
 def get_log_dir(output_dir: Path) -> Path:
+    """Return the log directory for ``output_dir``.
+
+    ``logs`` is a symlink to ``runs/<uuid>/`` (see :func:`setup_log_dir`).
+    Falls back to the plain ``output_dir / "logs"`` directory when no
+    symlink exists yet (e.g. in unit tests that don't call ``setup_log_dir``).
+    """
     return output_dir / "logs"
+
+
+def setup_log_dir(output_dir: Path, *, resuming: bool = False) -> Path:
+    """Create a per-run UUID log directory and symlink ``logs`` to it.
+
+    ``output_dir/runs/<uuid>/`` holds the actual log files for this run.
+    ``output_dir/logs`` is a symlink pointing there, so existing code that
+    reads ``get_log_dir(output_dir) / "trainer.log"`` continues to work.
+
+    When *resuming* and the symlink already exists, the existing run
+    directory is reused so logs from the resumed run are appended to the
+    same directory.
+
+    Returns the resolved log directory (the symlink path, i.e. what
+    ``get_log_dir`` would return).
+    """
+    import uuid
+
+    logger = get_logger()
+    logs_link = output_dir / "logs"
+    runs_dir = output_dir / "runs"
+
+    # Reuse existing run directory when resuming
+    if resuming and logs_link.is_symlink():
+        target = logs_link.resolve()
+        logger.debug(f"Reusing existing log directory: {target}")
+        return logs_link
+
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    run_uuid = uuid.uuid4().hex
+    run_dir = runs_dir / run_uuid
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    # Atomically update the symlink: create a temp link then rename
+    tmp_link = output_dir / f".logs.tmp.{run_uuid}"
+    if tmp_link.exists() or tmp_link.is_symlink():
+        tmp_link.unlink()
+    os.symlink(run_dir, tmp_link)
+    os.replace(tmp_link, logs_link)
+
+    logger.debug(f"Created log directory: {run_dir} (symlinked at {logs_link})")
+    return logs_link
 
 
 def format_log_message(

--- a/tests/unit/utils/test_pathing.py
+++ b/tests/unit/utils/test_pathing.py
@@ -1,6 +1,6 @@
 import pytest
 
-from prime_rl.utils.pathing import validate_output_dir
+from prime_rl.utils.pathing import get_log_dir, setup_log_dir, validate_output_dir
 
 
 def test_nonexistent_dir_passes(tmp_path):
@@ -55,3 +55,94 @@ def test_clean_on_nonexistent_dir_is_noop(tmp_path):
     output_dir = tmp_path / "does_not_exist"
     validate_output_dir(output_dir, resuming=False, clean=True)
     assert not output_dir.exists()
+
+
+def test_setup_log_dir_creates_symlink(tmp_path):
+    """setup_log_dir creates runs/<uuid>/ and symlinks logs to it."""
+    output_dir = tmp_path / "outputs"
+    output_dir.mkdir()
+
+    log_dir = setup_log_dir(output_dir)
+
+    assert log_dir == output_dir / "logs"
+    assert log_dir.is_symlink()
+    target = log_dir.resolve()
+    assert target.parent == (output_dir / "runs").resolve()
+    assert target.is_dir()
+    # The symlink target should be a UUID directory under runs/
+    assert target.parent.name == "runs"
+    assert len(target.name) == 32  # uuid4().hex length
+
+
+def test_setup_log_dir_writable_through_symlink(tmp_path):
+    """Files written through the symlink land in the UUID directory."""
+    output_dir = tmp_path / "outputs"
+    output_dir.mkdir()
+
+    log_dir = setup_log_dir(output_dir)
+    (log_dir / "trainer.log").write_text("test")
+
+    target = log_dir.resolve()
+    assert (target / "trainer.log").read_text() == "test"
+    assert (log_dir / "trainer.log").read_text() == "test"
+
+
+def test_setup_log_dir_creates_fresh_uuid_each_call(tmp_path):
+    """Each call to setup_log_dir creates a new UUID run directory."""
+    output_dir = tmp_path / "outputs"
+    output_dir.mkdir()
+
+    log_dir_1 = setup_log_dir(output_dir)
+    target_1 = log_dir_1.resolve()
+
+    # Write a file to the first run
+    (log_dir_1 / "trainer.log").write_text("run1")
+
+    log_dir_2 = setup_log_dir(output_dir)
+    target_2 = log_dir_2.resolve()
+
+    # New UUID directory
+    assert target_1 != target_2
+    # Both directories exist
+    assert target_1.is_dir()
+    assert target_2.is_dir()
+    # Symlink now points to the second run
+    assert log_dir_2.resolve() == target_2
+    # First run's files are preserved
+    assert (target_1 / "trainer.log").read_text() == "run1"
+
+
+def test_setup_log_dir_resuming_reuses_existing(tmp_path):
+    """When resuming and symlink exists, reuse the existing run directory."""
+    output_dir = tmp_path / "outputs"
+    output_dir.mkdir()
+
+    log_dir_1 = setup_log_dir(output_dir)
+    target_1 = log_dir_1.resolve()
+    (log_dir_1 / "trainer.log").write_text("run1")
+
+    # Resume should reuse the same directory
+    log_dir_2 = setup_log_dir(output_dir, resuming=True)
+    assert log_dir_2.resolve() == target_1
+    assert (log_dir_2 / "trainer.log").read_text() == "run1"
+
+
+def test_setup_log_dir_resuming_without_symlink_creates_new(tmp_path):
+    """When resuming but no symlink exists, create a new run directory."""
+    output_dir = tmp_path / "outputs"
+    output_dir.mkdir()
+
+    log_dir = setup_log_dir(output_dir, resuming=True)
+    assert log_dir.is_symlink()
+    assert log_dir.resolve().is_dir()
+
+
+def test_get_log_dir_returns_symlink_path(tmp_path):
+    """get_log_dir returns output_dir/logs (the symlink path)."""
+    output_dir = tmp_path / "outputs"
+    output_dir.mkdir()
+
+    setup_log_dir(output_dir)
+    log_dir = get_log_dir(output_dir)
+    assert log_dir == output_dir / "logs"
+    assert log_dir.is_symlink()


### PR DESCRIPTION
## What

Logs are now always written to `output_dir/runs/<uuid>/` with `output_dir/logs` symlinked to the current run's directory. This isolates logs per run while preserving full backward compatibility — all existing code that reads `get_log_dir(output_dir) / "trainer.log"` continues to work unchanged through the symlink.

## Why

SLURM retrials and re-runs were clobbering logs from previous attempts. With UUID-isolated run directories, historical logs are preserved automatically without any config changes or user opt-in.

## How

```
output_dir/
  logs → runs/a1b2c3d4.../     # symlink (backward compatible)
  runs/
    a1b2c3d4.../               # current run's actual logs
    f7e6d5c4.../               # previous run's logs (preserved)
```

- `setup_log_dir()` in `pathing.py` creates `runs/<uuid>/` and atomically symlinks `logs` to it
- On resume (`ckpt.resume_step` set), the existing symlinked directory is reused
- On `clean_output_dir`, the entire `output_dir` is wiped (existing behavior), so a fresh UUID is generated
- No config changes, no SLURM template changes — everything goes through the symlink transparently

## Files changed

- `src/prime_rl/utils/pathing.py` — new `setup_log_dir()` function
- `src/prime_rl/entrypoints/rl.py` — call `setup_log_dir()` in `rl()`
- `src/prime_rl/entrypoints/sft.py` — call `setup_log_dir()` in `sft()`, fix inline `output_dir / "logs"` to use `get_log_dir()`
- `src/prime_rl/entrypoints/inference.py` — call `setup_log_dir()` in `inference()`
- `tests/unit/utils/test_pathing.py` — 6 new tests for symlink creation, writability, UUID isolation, and resume reuse

## Test plan

```bash
uv run python -m pytest tests/unit/utils/test_pathing.py -v
# 13 passed (7 existing + 6 new)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging layout only; backward-compatible symlink preserves existing log paths with no auth, checkpoint, or training logic changes.
> 
> **Overview**
> Training and inference launches now **isolate logs per run** under `output_dir/runs/<uuid>/`, while **`output_dir/logs` stays a symlink** to the active run so existing `get_log_dir()` paths keep working.
> 
> A new **`setup_log_dir()`** in `pathing.py` creates the UUID directory and **atomically repoints** the `logs` symlink; **`rl`**, **`sft`**, and **`inference`** call it after `output_dir` is created. **Resume** (`resuming=True`) **reuses** the symlink target so continued runs append to the same log tree; each fresh start gets a new UUID and prior `runs/*` dirs are left intact. **SFT local** torchrun `--log-dir` now goes through `get_log_dir()` instead of a hardcoded `output_dir / "logs"`.
> 
> Unit tests cover symlink creation, writes through the link, new UUID per non-resume call, and resume reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0bbeaee3da0e6c08b26d21bebb5b959d00414e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->