### PR TITLE
chore: bump all workflow actions to Node 24 majors

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -146,7 +146,7 @@ jobs:
         id: artifact
         run: echo "name=benchmark-${{ matrix.runner }}-$(echo '${{ matrix.model }}' | sed 's/\//--/')-${{ matrix.type }}-${{ matrix.lora_rank || 'full' }}-${{ matrix.num_gpus }}gpu-${{ matrix.ac }}-${{ matrix.attention }}-${{ matrix.seq_len }}-cp${{ matrix.cp }}-ep${{ matrix.ep }}" >> "$GITHUB_OUTPUT"
       - name: Upload benchmark result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: ${{ steps.artifact.outputs.name }}
@@ -163,16 +163,16 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository # We can't use the image because then no git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Install dependencies
         run: uv sync
       - name: Download all benchmark artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: /tmp/benchmark_artifacts
           pattern: benchmark-*

--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -71,7 +71,7 @@ jobs:
           esac
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.BUILD_REF }}
           fetch-depth: 0
@@ -129,7 +129,7 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare.outputs.ref }}
           fetch-depth: 0
@@ -143,18 +143,18 @@ jobs:
           fi
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.cuda
@@ -198,7 +198,7 @@ jobs:
       packages: write
     steps:
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/cpu_tests.yaml
+++ b/.github/workflows/cpu_tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: false
       - name: Init public submodules
@@ -20,7 +20,7 @@ jobs:
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments deps/pydantic-config
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/devx_tag.yaml
+++ b/.github/workflows/devx_tag.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create next .dev tag from latest release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -26,7 +26,7 @@ jobs:
           apt-get install -y git
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: false
       - name: Init public submodules
@@ -34,7 +34,7 @@ jobs:
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments deps/pydantic-config
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         run: uv sync --all-extras --all-packages --locked
       - name: Run unit tests
@@ -97,7 +97,7 @@ jobs:
           apt-get install -y git
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: false
       - name: Init public submodules
@@ -105,7 +105,7 @@ jobs:
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments deps/pydantic-config
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         run: uv sync --all-extras --all-packages --locked
       - name: Run integration tests

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -23,7 +23,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: false
 
@@ -73,7 +73,7 @@ jobs:
                   apt-get install -y git
                   git config --global --add safe.directory "$GITHUB_WORKSPACE"
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: false
             - name: Init public submodules
@@ -81,7 +81,7 @@ jobs:
                   git config --global url."https://github.com/".insteadOf "git@github.com:"
                   git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments deps/pydantic-config
             - name: Install uv
-              uses: astral-sh/setup-uv@v5
+              uses: astral-sh/setup-uv@v7
               with:
                   enable-cache: true
                   cache-dependency-glob: "uv.lock"

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -20,12 +20,12 @@ jobs:
         with:
           submodules: false
       - name: Run ruff
-        uses: astral-sh/ruff-action@v4
+        uses: astral-sh/ruff-action@v4.1.0
         with:
           version: "0.13.0"
           args: "check --config=pyproject.toml"
       - name: Run ruff format (check)
-        uses: astral-sh/ruff-action@v4
+        uses: astral-sh/ruff-action@v4.1.0
         with:
           version: "0.13.0"
           args: "format --check --config=pyproject.toml"

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         # Submodules are excluded from ruff via pyproject.toml; no need to fetch them.
         with:
           submodules: false
       - name: Run ruff
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4
         with:
           version: "0.13.0"
           args: "check --config=pyproject.toml"
       - name: Run ruff format (check)
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4
         with:
           version: "0.13.0"
           args: "format --check --config=pyproject.toml"

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -12,7 +12,7 @@ jobs:
   trigger-docs-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate mint.json pages exist
         run: |
@@ -46,7 +46,7 @@ jobs:
           echo "All mint.json pages verified."
 
       - name: Trigger public-docs workflow
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.DOCS_SYNC_PAT }}
           repository: PrimeIntellect-ai/public-docs

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -29,7 +29,7 @@ jobs:
       version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -135,14 +135,14 @@ jobs:
     steps:
       - name: Checkout tagged release (dispatch)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: refs/tags/${{ inputs.tag }}
 
       - name: Checkout tagged release (push)
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- Bump every action in `.github/workflows` from Node 20-era versions to its **first Node 24 major**, fixing the `Node.js 20 is deprecated` warning on every run while minimizing behavior change:
  - `actions/checkout` v4 → v5
  - `actions/upload-artifact` v4 → v5, `actions/download-artifact` v4 → v6 (v5's breaking path change only affects downloads by `artifact-ids`; benchmarks downloads by `pattern`, unchanged)
  - `actions/github-script` v7 → v8
  - `astral-sh/setup-uv` v5 → v7 — v6's breaking changes (default `cache-dependency-glob`, removed `pyproject-file`/`uv-file` inputs) don't apply since we pass `enable-cache` + `cache-dependency-glob` explicitly
  - `astral-sh/ruff-action` v3 → v4.1.0 (exact pin: v4+ publishes immutable releases only, no floating `v4` tag)
  - `docker/login-action` v3 → v4, `docker/setup-buildx-action` v3 → v4, `docker/build-push-action` v5 → v7 (ghcr `build_image.yaml`)
  - `peter-evans/repository-dispatch` v3 → v4

Note: Node 24 actions require Actions Runner ≥ 2.327.1. GitHub-hosted runners are fine; the self-hosted runners (`image-builder`, `image-builder-arm-2204`, `vm-runner-*`) are all on 2.335.1 (checked recent job logs).

Unrelated to the current red sync-docs runs on `main` — those fail because the `DOCS_SYNC_PAT` secret (and `PUSH_TOKEN`/`DOCS_UPDATE_TOKEN` in `public-docs`) expired 2026-07-17 and needs a rotated PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)