### PR TITLE
fix: auto-attn falls back to FA2 on non-SM100 Blackwell

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1138,15 +1138,15 @@ def resolve_auto_attn(config: ModelConfig) -> None:
     """Resolve ``attn='auto'`` to a concrete flash attention implementation based on GPU architecture.
 
     FA4 on datacenter Blackwell (SM100), FA3 on Hopper (SM90), FA2 otherwise.
-    Workstation Blackwell GPUs (SM103, e.g. RTX PRO 6000) lack FA4 kernels,
-    so they fall back to FA2.
+    Workstation Blackwell GPUs (e.g. RTX PRO 6000, SM120) lack FA4 kernels and
+    can't run the Hopper-only FA3 kernels, so they fall back to FA2.
     """
     if config.attn != "auto":
         return
     major, minor = torch.cuda.get_device_capability()
-    if major == 10 and minor == 0:
+    if (major, minor) == (10, 0):
         resolved = "flash_attention_4"
-    elif major >= 9:
+    elif major == 9:
         resolved = "flash_attention_3"
     else:
         resolved = "flash_attention_2"


### PR DESCRIPTION
## Summary

- Fix `resolve_auto_attn` so `attn="auto"` falls back to **FA2 on non-SM100 Blackwell** GPUs (e.g. RTX PRO 6000, SM120).
- Gate FA3 on Hopper (SM90) **exactly** instead of `major >= 9`. FA3's kernels are Hopper-only, so routing Blackwell to FA3 produced a runtime `no kernel image is available for execution on the device`.
- Previously the `else: flash_attention_2` branch was unreachable for any Blackwell/Hopper card (only `major < 9` reached it), so the FA2 fallback the prior fix advertised never actually applied to Blackwell.

Resolution matrix after this change:

| GPU | device capability | resolved attn |
|---|---|---|
| Hopper (H100) | SM90 | `flash_attention_3` |
| Datacenter Blackwell (B200) | SM100 | `flash_attention_4` |
| Workstation Blackwell (RTX PRO 6000) | SM120 | `flash_attention_2` |
| Ampere / Ada and older | < SM90 | `flash_attention_2` |

## Verification

On an RTX PRO 6000 Blackwell (compute capability 12.0 = SM120):

**Before** (two failure modes depending on which auto-resolution was on main):
- `attn="auto"` → `flash_attention_4`: CuTe-DSL compile error in `flash_attn/cute/pack_gqa.py` (`unable to compute crd2idx ... Operation creation failed`).
- `attn="auto"` → `flash_attention_3`: `CUDA error (.../flash-attention/hopper/flash_fwd_launch_template.h:164): no kernel image is available for execution on the device`.

**After:**
```
$ python -c "resolve_auto_attn logic on this device"
device cap = SM120 -> flash_attention_2
```
FA2 (`flash_attn 2.8.3+cu128`) ships sm_120 kernels and imports cleanly on this box, so `auto` no longer selects a kernel with no SM120 image.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-function GPU capability routing change with no auth or data impact; behavior improves correctness on SM120 while leaving Hopper SM90 and datacenter SM100 paths unchanged.
> 
> **Overview**
> Fixes **`resolve_auto_attn`** so `attn="auto"` no longer picks Hopper-only **FA3** or datacenter-only **FA4** on workstation Blackwell GPUs (e.g. RTX PRO 6000, **SM120**).
> 
> **FA4** is now selected only for **SM100** (`(10, 0)`). **FA3** is limited to **SM90** (`major == 9`) instead of `major >= 9`, so newer Blackwell parts hit the **FA2** branch instead of failing at runtime with missing kernel images or FA4 compile errors. The docstring is updated to describe SM120 and the FA3 limitation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4d91dea5de70a6a39e41e6e0ed3b334c5e0b494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->