### PR TITLE
fix(sft): tolerate trace-shape tool calls; opt-in skip for unrenderable samples

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -98,6 +98,9 @@ class SFTDataConfig(BaseDataConfig):
     loss_mask: LossMaskConfig = LossMaskConfig()
     """Which message types contribute to the loss."""
 
+    skip_invalid_samples: bool = False
+    """Skip (and log) samples the renderer cannot render instead of crashing the run. Off by default so data problems fail loudly."""
+
     @model_validator(mode="after")
     def validate_subsets_and_splits(self):
         if self.subsets is not None or self.splits is not None:

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -143,12 +143,14 @@ class SFTDataset(StatefulIterableDataset):
         loss_mask_config: LossMaskConfig = LossMaskConfig(),
         max_examples: int | None = None,
         max_epochs: int | None = None,
+        skip_invalid_samples: bool = False,
     ):
         super().__init__()
         self.logger = get_logger()
         self.dataset = dataset
         self.num_examples = len(self.dataset)
         self.renderer = renderer
+        self.skip_invalid_samples = skip_invalid_samples
         self.shuffle = shuffle
         self.seed = seed
         self.seq_len = seq_len
@@ -307,7 +309,15 @@ class SFTDataset(StatefulIterableDataset):
             example = dataset[(self.step - 1) % self.num_examples]
 
             # Process example
-            processed_example = self._process(cast(dict, example))
+            try:
+                processed_example = self._process(cast(dict, example))
+            except ValueError as e:
+                if not self.skip_invalid_samples:
+                    raise
+                self.logger.warning(
+                    f"Skipping example {cast(dict, example).get('__index', '')} because it could not be rendered: {e}"
+                )
+                continue
 
             # If processed example is None, skip it (e.g. if tokenized sample exceeds context window)
             if processed_example is None:
@@ -514,6 +524,7 @@ def setup_dataset(
             loss_mask_config=config.loss_mask,
             non_dp_size=non_dp_size,
             max_epochs=max_epochs,
+            skip_invalid_samples=config.skip_invalid_samples,
         )
     else:
         raise ValueError(f"Invalid dataset type: {config.type}")

--- a/src/prime_rl/utils/chat_template.py
+++ b/src/prime_rl/utils/chat_template.py
@@ -23,7 +23,16 @@ def normalize_messages(messages: Any, default_role: str) -> list[dict[str, Any]]
 
 
 def deserialize_tool_calls(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    def _deserialize_tool_call(tool_call: dict[str, Any]) -> dict[str, Any]:
+    def _deserialize_tool_call(tool_call: dict[str, Any] | str) -> dict[str, Any]:
+        # Verifiers traces store tool calls as JSON strings in a flat
+        # {"id", "name", "arguments"} shape; normalize to the OAI form.
+        if isinstance(tool_call, str):
+            tool_call = json.loads(tool_call)
+        if "function" not in tool_call:
+            tool_call = {
+                **{k: tool_call[k] for k in ("id", "type") if k in tool_call},
+                "function": {k: v for k, v in tool_call.items() if k not in ("id", "type")},
+            }
         function = tool_call.get("function", {})
         arguments = function.get("arguments")
         if isinstance(arguments, str):

--- a/tests/unit/train/sft/test_sft_dataset.py
+++ b/tests/unit/train/sft/test_sft_dataset.py
@@ -399,3 +399,41 @@ def test_null_messages_falls_back_to_prompt_and_completion():
     )
 
     assert next(iter(mixed_row_dataset)) == next(iter(expected_dataset))
+
+
+def test_deserialize_tool_calls_accepts_trace_shapes():
+    """Verifiers traces store tool calls as flat JSON strings; both they and
+    the OAI dict shape must deserialize to the OAI form."""
+    from prime_rl.utils.chat_template import deserialize_tool_calls
+
+    flat_string = '{"id": "t1", "name": "ipython", "arguments": "{\\"code\\": \\"print(1)\\"}"}'
+    oai_dict = {"id": "t2", "type": "function", "function": {"name": "ipython", "arguments": '{"code": "print(2)"}'}}
+    [message] = deserialize_tool_calls([{"role": "assistant", "content": "", "tool_calls": [flat_string, oai_dict]}])
+
+    first, second = message["tool_calls"]
+    assert first["id"] == "t1"
+    assert first["function"] == {"name": "ipython", "arguments": {"code": "print(1)"}}
+    assert second["function"] == {"name": "ipython", "arguments": {"code": "print(2)"}}
+
+
+class _RaisingRenderer(_DummyRenderer):
+    def render(self, messages, **kwargs):
+        if "bad" in messages[-1]["content"]:
+            raise ValueError("unrenderable sample")
+        return super().render(messages, **kwargs)
+
+
+def test_skip_invalid_samples_knob():
+    """A raising sample crashes by default and is skipped (with the good
+    samples still yielded) when skip_invalid_samples is on."""
+    dataset = Dataset.from_list(
+        [{"messages": [{"role": "assistant", "content": content}]} for content in ("a0", "bad", "a1")]
+    )
+
+    crashing = SFTDataset(dataset, _RaisingRenderer(), shuffle=False, max_epochs=1)
+    with pytest.raises(ValueError, match="unrenderable sample"):
+        list(crashing)
+
+    skipping = SFTDataset(dataset, _RaisingRenderer(), shuffle=False, max_epochs=1, skip_invalid_samples=True)
+    samples = list(skipping)
+    assert len(samples) == 2


### PR DESCRIPTION
## Problem
Plugging a verifiers rollout dataset (e.g. `PrimeIntellect/SyntheticData-GLM5.2-scaleswe-reward0`, `scaleswe_rlm_glm51`) into SFT crashes twice over:
1. **Immediately, on the first tool-call sample**: these datasets store `tool_calls` entries as flat JSON **strings** (`'{"id", "name", "arguments"}'`), and `deserialize_tool_calls` calls `.get` on them → `AttributeError` (`src/prime_rl/utils/chat_template.py`).
2. **On any sample the renderer rejects**: `SFTDataset.__iter__` calls `_process` bare, so a renderer `ValueError` propagates through the dataloader and kills the run. Measured on the dataset above: ~1% of samples are degenerate teacher outputs (garbage tool names like `'ipy'`/`'ipython<tool_call>ipython…'`, missing `code` arg) that a strict renderer correctly refuses.

## Change
- `deserialize_tool_calls` now accepts tool-call entries as JSON strings and normalizes the flat verifiers shape into the OAI `{"function": {...}}` form (id/type preserved). Dict-shaped OAI entries behave exactly as before.
- New **opt-in** `data.skip_invalid_samples: bool = False`: when on, `SFTDataset.__iter__` catches `ValueError` from `_process`, warns (mirroring the existing zero-trainable-tokens skip log), and continues. Default off — data problems keep failing loudly.

## Tests
`tests/unit/train/sft/test_sft_dataset.py`: trace-shape + OAI-shape deserialization; raising sample crashes with the knob off and is skipped (good samples still yielded) with it on. Full file: 22 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SFT data preprocessing and an opt-in flag; default behavior stays fail-loud, with no auth or persistence changes.
> 
> **Overview**
> Makes SFT usable on verifiers rollout datasets that store tool calls differently and may include a small fraction of unrenderable rows.
> 
> **`deserialize_tool_calls`** now accepts each tool-call entry as a JSON string or a flat `{id, name, arguments}` dict, normalizes them to the OAI `function` shape, and still parses string `arguments` the same way as before for dict-shaped entries.
> 
> **`data.skip_invalid_samples`** (default `false`) wires through to **`SFTDataset`**: when enabled, `ValueError` from rendering/`_process` is logged and the example is skipped instead of aborting the run; when off, behavior is unchanged (fail fast).
> 
> Unit tests cover trace vs OAI deserialization and the skip knob.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9acf6ba110eabce1441a1fc36ebb68af6dd1e89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->