### PR TITLE
fix: count length penalty per trace (last branch) instead of per branch (summed)

### DIFF
--- a/src/prime_rl/orchestrator/algo/grpo.py
+++ b/src/prime_rl/orchestrator/algo/grpo.py
@@ -27,9 +27,10 @@ class GRPOAlgorithm(Algorithm):
         if length_penalty is None:
             advantages = rewards - rewards.mean()
         else:
-            output = torch.tensor([rollout.num_output_tokens for rollout in group], dtype=rewards.dtype)
-            total = torch.tensor([rollout.num_total_tokens for rollout in group], dtype=rewards.dtype)
-            turns = torch.tensor([rollout.num_turns for rollout in group], dtype=rewards.dtype)
+            output, total, turns = (
+                torch.tensor([getattr(r.branches[-1], attr) for r in group], dtype=rewards.dtype)
+                for attr in ("num_output_tokens", "num_total_tokens", "num_turns")
+            )
             input = total - output
             penalty_frac = (
                 length_penalty.num_output_tokens_weight * (output / output.max().clamp(min=1))


### PR DESCRIPTION
## Summary

The GRPO length penalty was calculated using trace-level token/turn counts, which **sum across all branches** of the message graph. For multi-branch rollouts (tree search, forking), this inflates the penalty proportionally to the number of branches, incentivizing the model to compact to avoid the disproportionate penalty.

## Fix

Use the last branch (`branches[-1]` — the main root-to-leaf path) instead of the trace-level sums for `num_output_tokens`, `num_total_tokens`, and `num_turns` in the length penalty calculation. This follows the existing convention where `branches[-1]` is the main path (used for `transcript`, `tool_messages`, etc.).

For single-branch rollouts (the common linear case), behavior is unchanged — the fix only affects multi-branch traces.
