### PR TITLE
fix: re-pin verifiers for MCP transport resilience under high concurrency

### DIFF
--- a/examples/glm5_pd_disag/rl.toml
+++ b/examples/glm5_pd_disag/rl.toml
@@ -74,7 +74,7 @@ interval = 20
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
 taskset = { id = "swebench-verified-v1" }
-harness = { id = "default", runtime = { type = "prime", labels = ["glm5-pd-disag", "swe-bench-verified"] } }
+harness = { id = "bash", runtime = { type = "prime", labels = ["glm5-pd-disag", "swe-bench-verified"] } }
 
 [[orchestrator.post_batch_filters]]
 type = "gibberish"

--- a/examples/intellect-3.1/rl.toml
+++ b/examples/intellect-3.1/rl.toml
@@ -51,7 +51,7 @@ oversampling_factor = 2
 name = "swe"
 ratio = 0.3
 taskset = { id = "r2e-gym-v1" }
-harness = { id = "default", runtime = { type = "prime", labels = ["intellect-3.1", "swe"] } }
+harness = { id = "bash", runtime = { type = "prime", labels = ["intellect-3.1", "swe"] } }
 
 [[orchestrator.train.env]]
 name = "deepdive"
@@ -87,7 +87,7 @@ interval = 25
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
 taskset = { id = "swebench-verified-v1" }
-harness = { id = "default", runtime = { type = "prime", labels = ["intellect-3.1", "swe-bench-verified"] } }
+harness = { id = "bash", runtime = { type = "prime", labels = ["intellect-3.1", "swe-bench-verified"] } }
 
 [[orchestrator.eval.env]]
 name = "aime2025"

--- a/examples/minimax_m2.5_swe/rl.toml
+++ b/examples/minimax_m2.5_swe/rl.toml
@@ -52,7 +52,7 @@ max_off_policy_steps = 16
 [[orchestrator.train.env]]
 name = "swe"
 taskset = { id = "r2e-gym-v1" }
-harness = { id = "default", runtime = { type = "prime", labels = ["minimax-swe", "swe"] } }
+harness = { id = "bash", runtime = { type = "prime", labels = ["minimax-swe", "swe"] } }
 
 [orchestrator.eval]
 interval = 25
@@ -60,7 +60,7 @@ interval = 25
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
 taskset = { id = "swebench-verified-v1" }
-harness = { id = "default", runtime = { type = "prime", labels = ["minimax-swe", "swe-bench-verified"] } }
+harness = { id = "bash", runtime = { type = "prime", labels = ["minimax-swe", "swe-bench-verified"] } }
 
 [inference.parallel]
 tp = 8

--- a/examples/qwen30b_swe/rl.toml
+++ b/examples/qwen30b_swe/rl.toml
@@ -49,7 +49,7 @@ max_off_policy_steps = 16
 [[orchestrator.train.env]]
 name = "swe"
 taskset = { id = "r2e-gym-v1" }
-harness = { id = "default", runtime = { type = "prime", labels = ["qwen30b-swe", "swe"] } }
+harness = { id = "bash", runtime = { type = "prime", labels = ["qwen30b-swe", "swe"] } }
 
 [orchestrator.eval]
 interval = 25
@@ -57,7 +57,7 @@ interval = 25
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
 taskset = { id = "swebench-verified-v1" }
-harness = { id = "default", runtime = { type = "prime", labels = ["qwen30b-swe", "swe-bench-verified"] } }
+harness = { id = "bash", runtime = { type = "prime", labels = ["qwen30b-swe", "swe-bench-verified"] } }
 
 [inference.parallel]
 tp = 8


### PR DESCRIPTION
## Summary

- Re-pin `deps/verifiers` to verifiers **main** (`4a3c1eb4c`), which includes the merged MCP transport-resilience fix (PrimeIntellect-ai/verifiers#2062).
- Fixes rollouts failing under high concurrency on the subprocess/docker runtimes. When many rollouts start at once (e.g. 512 inflight), the v1 user-sim and tool MCP connections drop at rollout-start churn (`httpx.ReadError` → `anyio.ClosedResourceError`). Previously that surfaced as `WARNING Rollout failed in group ... — ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)` (the opaque wrapper around a `HarnessError('harness 'null' exited 1: ... 500 Internal Server Error')`).
- The verifiers fix reconnects the (stateless-HTTP) MCP servers per call and retries a dropped connection, so the churn is invisible to rollout success — no prime-rl code change beyond the submodule bump.

## Breaking

The verifiers bump also pulls in PrimeIntellect-ai/verifiers#2063, which **renames the built-in `default` harness to `bash`** (and the fallback harness id used when none is specified). This PR migrates the affected in-repo configs (`examples/{minimax_m2.5_swe,intellect-3.1,glm5_pd_disag,qwen30b_swe}/rl.toml`); any external config using `harness = { id = "default" }` must switch to `harness = { id = "bash" }`. Configs that omit `harness` (or use `null`/other ids) are unaffected.

## Verification

End-to-end, **512 concurrency / 1 step, subprocess runtime**, one env per MCP shape:

| Env | Shape | Rollout error before | after |
|---|---|---|---|
| `alphabet-sort-v1` | user simulator | **15.1%** | **0.0%** |
| `gsm8k-v1` | vanilla (no MCP) | 0.0% | **0.0%** |
| `wiki-search-v1` | tool (shared, fan-in) | — | **0.0%** |

`alphabet-sort-v1` (the user-sim shape) was additionally run for **5 consecutive steps at 512 concurrency with 0.0% error on every step** across the final code.

Commands (per env):
```
uv run rl @ configs/debug/v1/alphabet_sort.toml --max-steps 1 --orchestrator.max-inflight-rollouts 512
uv run rl @ configs/debug/v1/gsm8k.toml         --max-steps 1 --orchestrator.max-inflight-rollouts 512
uv run rl @ configs/wiki_search/rl.toml         --max-steps 1 --orchestrator.oversampling-factor 1.0 --orchestrator.max-inflight-rollouts 512
```
