### PR TITLE
fix: replace wandb_gql import with execute_graphql for wandb>=0.27.1 compat

### DIFF
--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -15,8 +15,6 @@ import wandb_workspaces.workspaces as ws
 from transformers.tokenization_utils import PreTrainedTokenizer
 from wandb.errors import CommError
 from wandb.sdk.mailbox.mailbox_handle import ServerResponseError
-from wandb_gql import gql
-
 from prime_rl.configs.shared import WandbConfig, WandbWithExtrasConfig
 from prime_rl.utils.config import BaseConfig
 from prime_rl.utils.logger import get_logger
@@ -381,16 +379,14 @@ def build_sections(train_envs: Sequence[str] = (), eval_envs: Sequence[str] = ()
 
 def list_views(entity: str, project: str) -> list[tuple[str, str]]:
     """``(display_name, internal_name)`` for every saved view in the project."""
-    query = gql(
-        """
+    query = """
         query Views($entity: String!, $project: String!) {
           project(name: $project, entityName: $entity) {
             allViews(viewType: "project-view") { edges { node { name displayName } } }
           }
         }
-        """
-    )
-    res = wandb.Api().client.execute(query, variable_values={"entity": entity, "project": project})
+    """
+    res = wandb.Api()._service_api.execute_graphql(query, {"entity": entity, "project": project})
     edges = ((res.get("project") or {}).get("allViews") or {}).get("edges") or []
     return [(e["node"]["displayName"], e["node"]["name"]) for e in edges if e.get("node")]
 


### PR DESCRIPTION
# Bug: `wandb_gql` import fails with W&B SDK >=0.27.1

**Package:** prime-rl
**File:** `prime_rl/utils/monitor/wandb.py`
**Commit:** `256809b` (latest main)

## Description

`prime_rl/utils/monitor/wandb.py` imports `from wandb_gql import gql` — a private, vendored module that was bundled inside the W&B Python SDK. W&B SDK **v0.27.1** removed this vendored module as part of [PR #11818](https://github.com/wandb/wandb/pull/11818) (routing GraphQL through `wandb-core`). 

This means a fresh `pip install prime-rl` resolves to `wandb>=0.27.1` and fails at import time:

```
$ python3 -c "from prime_rl.utils.monitor.wandb import WandbMonitor"
Traceback (most recent call last):
  ...
  File "prime_rl/utils/monitor/wandb.py", line 18, in <module>
    from wandb_gql import gql
ModuleNotFoundError: No module named 'wandb_gql'
```

This also breaks the `orchestrator` and `rl` entrypoints since the monitor is imported at startup:

```
File "/home/ubuntu/wordle/.venv/bin/orchestrator", line 10, in <module>
    sys.exit(main())
  ...
  File "prime_rl/utils/monitor/wandb.py", line 18, in <module>
    from wandb_gql import gql
ModuleNotFoundError: No module named 'wandb_gql'
```

## Root Cause

The file uses two private/internal APIs from the wandb SDK:

1. **`from wandb_gql import gql`** — `wandb_gql` was a vendored copy of the `gql` GraphQL library inside `wandb/vendor/gql-0.2.0/wandb_gql/`. W&B SDK v0.27.1 deleted it.
2. **`wandb.Api().client.execute()`** — `wandb.Api().client` was the `gql.Client` instance. The modern replacement is `wandb.Api()._service_api.execute_graphql()`.

Both were never public API — they were internal implementation details that happened to be importable.

## Fix

**Replacement API:** `wandb.Api()._service_api.execute_graphql()` accepts a raw GraphQL query string (no `gql()` parsing needed) and returns a plain dict — same shape as before.

### Changes (3 lines in one file)

**File:** `prime_rl/utils/monitor/wandb.py`

**1. Remove the import** (line 18):
```diff
-from wandb_gql import gql
```

**2. Replace `gql()` parsing + `client.execute()`** with raw string + `execute_graphql()`:
```diff
-def list_views(entity: str, project: str) -> list[tuple[str, str]]:
-    query = gql(
-        """
+def list_views(entity: str, project: str) -> list[tuple[str, str]]:
+    query = """
         query Views($entity: String!, $project: String!) {
           project(name: $project, entityName: $entity) {
             allViews(viewType: "project-view") { edges { node { name displayName } } }
           }
         }
-        """
-    )
-    res = wandb.Api().client.execute(query, variable_values={"entity": entity, "project": project})
+    """
+    res = wandb.Api()._service_api.execute_graphql(query, {"entity": entity, "project": project})
```

That's it. The `_service_api` attribute exists in wandb SDK v0.27.0+ (earlier versions had `client`). Since v0.27.1 is required for the vendored `wandb_gql` removal to be a problem, this is always available.

### Verified

- Python 3.12, wandb 0.28.1 (latest)
- `WandbMonitor` imports successfully
- `list_views` imports successfully  
- Full `rl @ config.toml --dry-run` passes
- No dependency pins or workarounds needed

## Workaround (temporary)

Until this fix lands upstream, pin `wandb<0.27.1`:
```
uv pip install "wandb<0.27.1"
```

## Context

This is the same issue that affected `wandb-workspaces` (fixed in v0.4.2) and the W&B MCP server (temporarily worked around with `wandb<0.27.1` cap, then resolved by upgrading `wandb-workspaces`).

## References

- [wandb PR #11818: Route Public API GraphQL through wandb-core](https://github.com/wandb/wandb/pull/11818)
- [wandb-workspaces#173: Importing reports fails with wandb>=0.27.1](https://github.com/wandb/wandb-workspaces/issues/173)
- [wandb-mcp-server#93: fix: avoid broken wandb-workspaces resolver combo](https://github.com/wandb/wandb-mcp-server/pull/93)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow compatibility swap in W&B overview view listing; no auth, training, or data-path changes.
> 
> **Overview**
> Restores **W&B monitor import and startup** on `wandb>=0.27.1`, where the vendored `wandb_gql` module was removed.
> 
> `list_views` now sends a plain GraphQL string through `wandb.Api()._service_api.execute_graphql()` instead of `gql()` plus `wandb.Api().client.execute()`. The `wandb_gql` import is dropped. Behavior for listing saved project views (used by `ensure_overview_view`) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f4f65398f988f30b6536bb2bd8284bededad0fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->