### PR TITLE
fix: avoid redundant device-to-device copy in NCCL weight-transfer receiver

### DIFF
--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -48,15 +48,16 @@ def receive_state_dict(communicator: PyNcclCommunicator) -> Generator[tuple[str,
         concatenated = torch.empty(total_elements, dtype=dtype, device=communicator.device)
         communicator.broadcast(concatenated, src=0)
 
-        # Split concatenated tensor back into individual tensors
+        # Split concatenated tensor back into individual tensors. A view is
+        # enough: consumers (`load_weights_kernel` and vLLM's `load_weights`)
+        # copy each tensor into its destination parameter before pulling the
+        # next, and `concatenated` stays alive for the whole dtype group, so we
+        # avoid a redundant device-to-device copy of every parameter.
         offset = 0
         for key, shape, numel in tensor_info_list:
-            tensor = concatenated[offset : offset + numel].view(shape).clone()
+            tensor = concatenated[offset : offset + numel].view(shape)
             offset += numel
-            try:
-                yield key, tensor
-            finally:
-                del tensor
+            yield key, tensor
 
         del concatenated
 


### PR DESCRIPTION
## Summary

- `receive_state_dict` (`src/prime_rl/inference/vllm/worker/nccl.py`) does `concatenated[...].view(shape).clone()` before yielding each tensor, and every consumer then copies that tensor straight into its destination parameter. So each weight is copied twice on-device on every sync.
- Both consumers copy eagerly: `load_weights_kernel` calls `param.copy_(tensor)`, and vLLM's `load_weights` uses `default_weight_loader` (`param.data.copy_(...)`). `concatenated` stays alive for the whole dtype group, so a plain view is valid until the consumer has copied from it and the clone is pure overhead.
- Fix: yield `concatenated[offset : offset + numel].view(shape)` without `.clone()`.

## Verification

Microbenchmark of the split-and-consume pattern on an RTX 3090 (torch 2.8, CUDA 12.8), a 4 GB bf16 group in 2000 tensors:

```
clone + copy:  54.8 ms   ( 73 GB/s)
view + copy:   27.6 ms   (145 GB/s)
```

About 2x on the copy, scaling with checkpoint size (~0.7 s/sync at 100 GB). Peak memory is unchanged — the allocator reuses the transient clone — so this is bandwidth, not memory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path performance change with unchanged copy semantics; views remain valid for the lifetime of the dtype-group buffer.
> 
> **Overview**
> **`receive_state_dict`** in `nccl.py` no longer calls **`.clone()`** on each slice of the per-dtype concatenated broadcast buffer. It yields **`view(shape)`** slices only, with comments noting that **`load_weights_kernel`** and vLLM’s **`load_weights`** already **`copy_`** into destination parameters before the next tensor is consumed, while **`concatenated`** stays alive for the whole dtype group.
> 
> The per-tensor **`try`/`finally`** that deleted each yielded tensor was removed as unnecessary with views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28db8ac632a289ce733146a367f9639f190998fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->