### PR TITLE
fix: reject train-sampling temperature=0 (produces NaN logprobs)

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -50,8 +50,9 @@ class ModelConfig(BaseModelConfig):
 
 
 class TrainSamplingConfig(BaseConfig):
-    temperature: float = Field(1.0, ge=0, le=2.0)
-    """Sampling temperature."""
+    temperature: float = Field(1.0, gt=0, le=2.0)
+    """Sampling temperature. Strictly positive: it is reused to rescale trainer
+    logits (``logits / temperature``), so 0 yields non-finite log-probabilities."""
 
     max_completion_tokens: int | None = Field(
         None, validation_alias=AliasChoices("max_completion_tokens", "max_tokens")


### PR DESCRIPTION
## Summary

- `TrainSamplingConfig.temperature` is `Field(1.0, ge=0, le=2.0)`, so 0 is accepted. To a sampler 0 means greedy decoding, so it looks like a valid request, yet it silently corrupts training.
- The rollout temperature is recorded per token (`orchestrator/train_sink.py`) and reused by the trainer to rescale logits: `scaled_logits = logits / temperatures` (`trainer/rl/train.py`). At 0 that divide is `x / 0` → inf → `selective_log_softmax` → NaN loss. Nothing raises; the run just stops learning.
- Fix: `temperature: float = Field(1.0, gt=0, le=2.0)`, matching the guards already on neighbouring fields (e.g. `dp: int = Field(1, ge=1)`).

## Verification

With the new bound, a config with `temperature=0` fails Pydantic validation before the run starts. Reproducing the trainer's divide gives all-NaN logprobs at 0 and finite values at any positive temperature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Pydantic bound and docstring on training config; prevents a silent training failure mode with no runtime behavior change for valid configs.
> 
> **Overview**
> **`TrainSamplingConfig.temperature`** validation changes from `ge=0` to **`gt=0`**, so `temperature=0` is rejected at config load time instead of being accepted.
> 
> That value is not only a rollout sampling knob: it is stored per token and reused in the trainer as **`logits / temperature`**. Zero temperature caused division by zero and non-finite log-probs/loss with no clear error. The field docstring now documents that constraint.
> 
> **`EvalSamplingConfig`** is unchanged and may still allow 0 for inference-only eval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecc4d8a53278e4aea3e01b276f597fd6b0b3d2f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->