### PR TITLE
fix: reject scheduler min_lr greater than optimizer lr

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -679,6 +679,16 @@ class TrainerConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def validate_scheduler_min_lr(self):
+        if (
+            self.max_concurrent_runs == 1
+            and self.scheduler.type in ("linear", "cosine")
+            and self.scheduler.min_lr > self.optim.lr
+        ):
+            raise ValueError(f"scheduler.min_lr ({self.scheduler.min_lr}) must be <= optim.lr ({self.optim.lr})")
+        return self
+
+    @model_validator(mode="after")
     def validate_optim_cpu_offload_single_run(self):
         if self.model.optim_cpu_offload and self.max_concurrent_runs > 1:
             raise ValueError("Optimizer CPU offload is not supported with max_concurrent_runs > 1")

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -96,6 +96,9 @@ def setup_scheduler(
 
     Handles CPUOffloadOptimizer by extracting the base optimizer for the scheduler.
     """
+    if scheduler_config.type in ("linear", "cosine") and scheduler_config.min_lr > lr:
+        raise ValueError(f"scheduler.min_lr ({scheduler_config.min_lr}) must be <= optim.lr ({lr})")
+
     base_optimizer = _get_base_optimizer(optimizer)
 
     match scheduler_config.type:

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import ConstantLR, CosineAnnealingLR, LinearLR, LRScheduler, SequentialLR
 
+from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.configs.trainer import SchedulerConfig
 from prime_rl.trainer.optim import CPUOffloadOptimizer, MultiLoRAOptimizer
 from prime_rl.trainer.runs import get_multi_run_manager
@@ -186,6 +187,17 @@ def setup_multi_scheduler(
 ) -> MultiLoRAScheduler:
     """Create a MultiLoRAScheduler for managing per-run schedulers."""
     scheduler = MultiLoRAScheduler(scheduler_config, max_steps)
+    if scheduler.multi_run_manager.world.is_master and scheduler_config.type in ("linear", "cosine"):
+
+        def validate_scheduler_min_lr(orch_config: OrchestratorConfig) -> tuple[bool, str]:
+            if orch_config.optim.lr < scheduler_config.min_lr:
+                return (
+                    False,
+                    f"scheduler.min_lr ({scheduler_config.min_lr}) must be <= optim.lr ({orch_config.optim.lr})",
+                )
+            return True, ""
+
+        scheduler.multi_run_manager.register_config_validation_hook(validate_scheduler_min_lr)
     # Register callback at index 0 so schedulers are created before other callbacks
     optimizer.register_post_creation_callback(scheduler.scheduler_creation_hook, index=0)
     return scheduler


### PR DESCRIPTION
## Summary

- `scheduler.min_lr` is bounded `ge=0` but never checked against `optim.lr`. When `min_lr > lr`, `CosineAnnealingLR(eta_min=min_lr)` interpolates upward, so the "minimum" LR becomes the peak and the run trains above its configured `lr` for the whole schedule. Nothing raises.
- Example with `lr=1e-3`, `min_lr=1e-2`: the LR climbs from 0.001 to 0.010 across the decay. The linear path already errors on `LinearLR(start_factor=min_lr/lr)`, but only from deep inside torch.
- Fix: check the relation where both values are visible.
  - Single-run: a `TrainerConfig` validator fails fast at config load.
  - Multi-run RL: a config-validation hook (registered in `setup_multi_scheduler`, master-rank only, alongside `validate_lora_rank`) rejects a run whose per-run `optim.lr < scheduler.min_lr` through the normal `config_validation_error.txt` path, so one bad run is skipped instead of crashing the shared trainer.
  - `setup_scheduler` keeps a defensive `ValueError` as a last line. The constant scheduler has no `min_lr` and is untouched.

## Verification

A single-run cosine config with `min_lr > optim.lr` raises `ValueError` at construction. The multi-run hook returns `(False, ...)` for a per-run `optim.lr` below `min_lr` and `(True, "")` otherwise. `min_lr <= lr` is accepted.