### PR TITLE
fix: validate tensor and context parallel degrees are positive

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -24,7 +24,7 @@ class ServerConfig(BaseConfig):
 
 
 class ParallelConfig(BaseConfig):
-    tp: int = 1
+    tp: int = Field(1, ge=1)
     """Tensor parallel size. Forwarded to vLLM as ``--tensor-parallel-size``."""
 
     dp: int = Field(1, ge=1)

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -189,7 +189,7 @@ class ModelConfig(BaseModelConfig):
     deepep_token_chunk_size: int | None = Field(None, ge=1)
     """Token chunk size for DeepEP MoE pipelining. When set, DeepEP dispatch for chunk i+1 is launched while experts compute chunk i. Only used when ``ep_comm_backend='deepep'``."""
 
-    cp: int = 1
+    cp: int = Field(1, ge=1)
     """Context parallelism degree. 1 disables CP."""
 
     cp_style: Literal["ring", "ulysses"] = "ring"


### PR DESCRIPTION
## Summary

- `ParallelConfig.tp` (inference) and `ModelConfig.cp` (trainer) are plain `int = 1` with no lower bound, even though the neighbouring `dp` is already `Field(1, ge=1)`.
- `auto_setup_deployment` divides by both (`num_infer_gpus // tp`, `num_train_gpus // cp`), so `tp=0` or `cp=0` crashes with a bare `ZeroDivisionError` during config resolution, with nothing in the traceback pointing back to the field. The existing `cp` validator only runs when `cp > 1`, so it misses 0.
- Fix: `tp: int = Field(1, ge=1)` and `cp: int = Field(1, ge=1)`.

## Verification

`ParallelConfig(tp=0)` and the trainer model config with `cp=0` now raise a Pydantic `ValidationError` naming the field; `1` is accepted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only validation on two integer defaults; no runtime behavior change for valid configs.
> 
> **Overview**
> Adds Pydantic **`ge=1`** validation on inference **`parallel.tp`** and trainer **`model.cp`**, matching how **`parallel.dp`** is already constrained.
> 
> Invalid values like **`0`** now fail at config parse time with a **`ValidationError`** on the field instead of surfacing later as a **`ZeroDivisionError`** in deployment auto-setup (e.g. GPU counts divided by **`tp`** or **`cp`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d0450f7900e73d19dcba050cb0578af6f9ffaee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->