### PR TITLE
fix: dp=1 EP replicas launch dense-style (vLLM rejects external-LB args at dp=1)

### DIFF
--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -367,12 +367,15 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     for ((d=0; d<INFERENCE_DP_LOCAL; d++)); do
         RANK_GPUS=$(seq -s, $((d * INFERENCE_TP)) $((d * INFERENCE_TP + INFERENCE_TP - 1)))
         RANK_LOG=$(rank_log "$INFER_NODE_RANK" "$d")
-        if [ "$INFERENCE_ENABLE_EXPERT_PARALLEL" -eq 1 ]; then
+        if [ "$INFERENCE_ENABLE_EXPERT_PARALLEL" -eq 1 ] && [ "$INFER_GROUP_DP" -gt 1 ]; then
             GLOBAL_DP_RANK=$((RANK_IN_REPLICA * INFERENCE_DP_LOCAL + d))
             RANK_EXTRA="{\"data_parallel_rank\": $GLOBAL_DP_RANK, \"data_parallel_address\": \"$DP_ADDR\"}"
             launch_inference_rank "$((BACKEND_PORT + d))" "$RANK_GPUS" "$INFER_GROUP_DP" "$INFERENCE_DATA_PARALLEL_RPC_PORT" "$RANK_EXTRA" "" "$RANK_LOG"
         else
-            # Dense: independent single-engine servers (no DP linkage).
+            # Dense or single-DP-rank EP (dp=1, e.g. EP within one tp=8 group):
+            # independent single-engine servers. vLLM rejects the external-LB DP
+            # args when data_parallel_size == 1; enable_expert_parallel in the
+            # inference config alone shards experts across the TP group.
             launch_inference_rank "$((BACKEND_PORT + d))" "$RANK_GPUS" 1 "" "" "" "$RANK_LOG"
         fi
     done


### PR DESCRIPTION
## Problem
Multi-node inference with `enable_expert_parallel` and per-node data-parallel size 1 (e.g. `tp=8` on 8-GPU nodes → `dp_local=1`; the "etp8" shape: experts EP-sharded across the node's 8 GPUs, attention at full tp=8) fails to launch. The EP branch in `multi_node_rl.sbatch.j2` unconditionally passes vLLM's external-LB DP args, which vLLM rejects when `data_parallel_size == 1`:

```
pydantic_core.ValidationError: data_parallel_external_lb can only be set when data_parallel_size > 1
```

## Fix
Guard the external-LB EP launch on `INFER_GROUP_DP > 1`; for dp=1 EP replicas, launch dense-style (independent single-engine server). `enable_expert_parallel` in the engine config alone still shards experts across the TP group — no external-LB coordination needed within a single DP rank.

Split out of #3067 as an independent bug fix (the global-router change there is separate and still under evaluation). Validated: etp8 launches and serves cleanly on 8 nodes with this fix; without it, launch crashes at engine init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow SLURM launcher branch change for dp=1 EP; multi-DP EP behavior unchanged when `INFER_GROUP_DP > 1`.
> 
> **Overview**
> Fixes **multi-node RL inference launch** when `enable_expert_parallel` is on but the replica’s effective data-parallel size is **1** (e.g. one node with `tp=8` → `INFER_GROUP_DP=1`).
> 
> The EP branch in `multi_node_rl.sbatch.j2` now requires **`INFERENCE_ENABLE_EXPERT_PARALLEL` and `INFER_GROUP_DP > 1`** before passing external load-balancer DP fields (`data_parallel_rank`, `data_parallel_address`, RPC port, `INFER_GROUP_DP`). Otherwise it uses the **dense-style** `launch_inference_rank` path (`dp=1`, no DP coordinator args), because vLLM rejects `data_parallel_external_lb` when `data_parallel_size == 1`.
> 
> Expert sharding within a single TP group still comes from **`enable_expert_parallel` in the inference config**; only cross-rank external-LB coordination is skipped for dp=1 EP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0aa31dd799425cdd32694aead160ce064eb92b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->