### PR TITLE
fix(trainer): don't resolve Hub envs when parsing orchestrator configs

### DIFF
--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -236,8 +236,9 @@ class MultiRunManager:
             with open(config_path, "rb") as f:
                 config_dict = tomli.load(f)
 
-            from prime_rl.configs.orchestrator import OrchestratorConfig
             from verifiers.v1.loaders import skip_plugin_install
+
+            from prime_rl.configs.orchestrator import OrchestratorConfig
 
             # The trainer only reads training-relevant fields (model, lora, seq_len, buffers,
             # env names) and never runs the env, so skip resolving/installing taskset/harness

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -237,8 +237,18 @@ class MultiRunManager:
                 config_dict = tomli.load(f)
 
             from prime_rl.configs.orchestrator import OrchestratorConfig
+            from verifiers.v1.loaders import skip_plugin_install
 
-            config = OrchestratorConfig(**config_dict)
+            # The trainer only reads training-relevant fields (model, lora, seq_len, buffers,
+            # env names) and never runs the env, so skip resolving/installing taskset/harness
+            # plugins from the Environments Hub while parsing. Otherwise a private v1 hub env
+            # (`taskset.id = owner/name@version`) 404s here — the trainer has no Hub creds — and
+            # the run is silently skipped. The env server still installs the plugin at runtime.
+            token = skip_plugin_install.set(True)
+            try:
+                config = OrchestratorConfig(**config_dict)
+            finally:
+                skip_plugin_install.reset(token)
         except Exception as e:
             if error_path.parent.exists():
                 with open(error_path, "w") as f:


### PR DESCRIPTION


## Problem

`discover_runs()` builds `OrchestratorConfig` to read training-relevant fields (model, lora, seq_len, buffers, env names), but constructing a v1 env config eagerly resolves (imports/installs) its taskset/harness plugins from the Environments Hub. On the trainer that 404s for private hub envs (`taskset.id = owner/name@version`) — the trainer has no Hub credentials — so `get_orchestrator_config()` returns `None` and the run is silently skipped.

## Fix

Parse under verifiers' `skip_plugin_install` contextvar so the trainer never touches the Hub while reading the config. The env server still installs the plugin at runtime.

## Dependency / sequencing

1. Merge the verifiers PR: PrimeIntellect-ai/verifiers#2084
2. Bump `deps/verifiers` to a commit that includes `skip_plugin_install` (separate PR)
3. Mark this ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to config-load path only; does not alter training or env execution, but adds a hard dependency on the new verifiers API until the submodule is bumped.
> 
> **Overview**
> **Fixes runs with private v1 Environments Hub tasksets being silently dropped during trainer run discovery.**
> 
> `get_orchestrator_config()` now parses `OrchestratorConfig` under verifiers’ `skip_plugin_install` context so construction does not resolve or install taskset/harness plugins from the Hub. The trainer only needs training fields from the TOML and never executes the env; without this, private hub refs (`taskset.id = owner/name@version`) 404 when the trainer has no Hub credentials and `discover_runs()` skips the run. Hub plugin install still happens on the env server at runtime.
> 
> **Note:** Depends on a verifiers release that exports `skip_plugin_install` (separate submodule bump).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c29313ee9c46691bb89139ae321e5cd7f64f126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->