### PR TITLE
feat: adopt the multi-agent verifiers format

### DIFF
--- a/configs/basic/alphabet-sort/rl.toml
+++ b/configs/basic/alphabet-sort/rl.toml
@@ -34,8 +34,8 @@ max_completion_tokens = 768
 
 [[orchestrator.train.env]]
 name = "alphabet-sort"
-taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [ckpt] # Checkpoint at the end of training
 

--- a/configs/basic/hendrycks-sanity/rl.toml
+++ b/configs/basic/hendrycks-sanity/rl.toml
@@ -21,8 +21,8 @@ seq_len = 8192
 
 [[orchestrator.train.env]]
 name = "hendrycks-math"
-taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.model]
 seq_len = 16384

--- a/configs/basic/reverse-text/rl.toml
+++ b/configs/basic/reverse-text/rl.toml
@@ -24,8 +24,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/basic/wiki-search/rl.toml
+++ b/configs/basic/wiki-search/rl.toml
@@ -42,8 +42,8 @@ max_completion_tokens = 512
 
 [[orchestrator.train.env]]
 name = "wiki-search"
-taskset = { id = "wiki-search-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "wiki-search-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [ckpt] # Checkpoint at the end of training
 

--- a/configs/basic/wordle/rl.toml
+++ b/configs/basic/wordle/rl.toml
@@ -23,8 +23,8 @@ group_size = 8
 
 [[orchestrator.train.env]]
 name = "wordle"
-taskset = { id = "wordle-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "wordle-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.train.sampling]
 max_completion_tokens = 1024

--- a/configs/ci/integration/alphabet_sort.toml
+++ b/configs/ci/integration/alphabet_sort.toml
@@ -24,8 +24,8 @@ max_completion_tokens = 384
 
 [[orchestrator.train.env]]
 name = "alphabet-sort"
-taskset = { id = "alphabet-sort-v1", min_turns = 2, max_turns = 2, min_names_per_turn = 1, max_names_per_turn = 3, task = { similarity_power = 4, power_per_turn = false } }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "alphabet-sort-v1", min_turns = 2, max_turns = 2, min_names_per_turn = 1, max_names_per_turn = 3, task = { similarity_power = 4, power_per_turn = false } }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference]
 

--- a/configs/ci/integration/reverse-text-lora/resume.toml
+++ b/configs/ci/integration/reverse-text-lora/resume.toml
@@ -28,8 +28,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference]
 enable_lora = true

--- a/configs/ci/integration/reverse-text-lora/start.toml
+++ b/configs/ci/integration/reverse-text-lora/start.toml
@@ -27,8 +27,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference]
 enable_lora = true

--- a/configs/ci/integration/reverse-text-moe/start.toml
+++ b/configs/ci/integration/reverse-text-moe/start.toml
@@ -27,8 +27,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference]
 gpu_memory_utilization = 0.7

--- a/configs/ci/integration/reverse-text-multi-run/orchestrator.toml
+++ b/configs/ci/integration/reverse-text-multi-run/orchestrator.toml
@@ -16,8 +16,8 @@ max_completion_tokens = 128
 
 [[train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [ckpt]
 interval = 10

--- a/configs/ci/integration/reverse-text-rl-opd/start.toml
+++ b/configs/ci/integration/reverse-text-rl-opd/start.toml
@@ -39,8 +39,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -51,8 +51,8 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/ci/integration/reverse-text-rl-sft/start.toml
+++ b/configs/ci/integration/reverse-text-rl-sft/start.toml
@@ -45,8 +45,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -57,8 +57,8 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/ci/integration/reverse-text/resume.toml
+++ b/configs/ci/integration/reverse-text/resume.toml
@@ -25,8 +25,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference]
 

--- a/configs/ci/integration/reverse-text/start.toml
+++ b/configs/ci/integration/reverse-text/start.toml
@@ -24,8 +24,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference]
 

--- a/configs/ci/nightly/multimodal_color_codeword.toml
+++ b/configs/ci/nightly/multimodal_color_codeword.toml
@@ -22,8 +22,8 @@ max_completion_tokens = 64
 
 [[orchestrator.train.env]]
 name = "color-codeword"
-taskset = { id = "color-codeword-v1", images_per_turn = 1 }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "color-codeword-v1", images_per_turn = 1 }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer]
 

--- a/configs/debug/algo/echo.toml
+++ b/configs/debug/algo/echo.toml
@@ -26,8 +26,8 @@ alpha = 0.1
 
 [[orchestrator.train.env]]
 name = "alphabet-sort"
-taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.train.sampling]
 max_completion_tokens = 512

--- a/configs/debug/algo/grpo.toml
+++ b/configs/debug/algo/grpo.toml
@@ -23,8 +23,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -35,8 +35,8 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/max_rl.toml
+++ b/configs/debug/algo/max_rl.toml
@@ -23,8 +23,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -35,8 +35,8 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/mixed_grpo_opd.toml
+++ b/configs/debug/algo/mixed_grpo_opd.toml
@@ -33,13 +33,13 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text-grpo"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [[orchestrator.train.env]]
 name = "reverse-text-opd"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.train.env.algo]
 type = "opd"
@@ -57,8 +57,8 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/opd.toml
+++ b/configs/debug/algo/opd.toml
@@ -35,8 +35,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -47,8 +47,8 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/opd_lora.toml
+++ b/configs/debug/algo/opd_lora.toml
@@ -35,8 +35,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -47,8 +47,8 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]
 lr = 1e-4

--- a/configs/debug/algo/self_distill.toml
+++ b/configs/debug/algo/self_distill.toml
@@ -31,8 +31,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -43,8 +43,8 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/sft_distill.toml
+++ b/configs/debug/algo/sft_distill.toml
@@ -40,8 +40,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -52,8 +52,8 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/sft_distill_lora.toml
+++ b/configs/debug/algo/sft_distill_lora.toml
@@ -40,8 +40,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -52,8 +52,8 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]
 lr = 1e-4

--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -95,12 +95,12 @@ num_turns_weight = 0.0
 # the plugged BC-style prompt is replaced by the reference judge's stock prompt).
 [[orchestrator.train.env]]
 name = "openseeker"
-harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] } }
+env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] } }
 
-[orchestrator.train.env.taskset]
+[orchestrator.train.env.env.taskset]
 id = "openseeker-v1"
 
-[[orchestrator.train.env.taskset.task.judges]]
+[[orchestrator.train.env.env.taskset.task.judges]]
 id = "reference"
 name = "correct"
 model = "Qwen/Qwen3-235B-A22B-Instruct-2507"
@@ -108,7 +108,7 @@ question_field = "question"
 choices = ["A", "B"]
 
 # # Metric-only monitor (weight 0): rlm harness-mechanics rubric, judged by GLM-5.2.
-# [[orchestrator.train.env.taskset.task.judges]]
+# [[orchestrator.train.env.env.taskset.task.judges]]
 # id = "rubric"
 # name = "rlm"
 # path = "deps/research-environments/rubrics/rlm.toml"
@@ -117,12 +117,12 @@ choices = ["A", "B"]
 
 [[orchestrator.train.env]]
 name = "redsearcher"
-harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] } }
+env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] } }
 
-[orchestrator.train.env.taskset]
+[orchestrator.train.env.env.taskset]
 id = "redsearcher-v1" # optional `difficulty` filter (easy/medium/hard)
 
-[[orchestrator.train.env.taskset.task.judges]]
+[[orchestrator.train.env.env.taskset.task.judges]]
 id = "reference"
 name = "correct"
 model = "Qwen/Qwen3-235B-A22B-Instruct-2507"
@@ -130,7 +130,7 @@ question_field = "question"
 choices = ["A", "B"]
 
 # # Metric-only monitor (weight 0): rlm harness-mechanics rubric, judged by GLM-5.2.
-# [[orchestrator.train.env.taskset.task.judges]]
+# [[orchestrator.train.env.env.taskset.task.judges]]
 # id = "rubric"
 # name = "rlm"
 # path = "deps/research-environments/rubrics/rlm.toml"
@@ -145,15 +145,15 @@ interval = 20
 [[orchestrator.eval.env]]
 name = "browsecomp"
 num_examples = 500 # full set is 1266; cap eval at 500
-harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] } }
-timeout = { rollout = 3600 }
+env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] } }
+env.agent.timeout = { rollout = 3600 }
 
-[orchestrator.eval.env.taskset]
+[orchestrator.eval.env.env.taskset]
 id = "browsecomp-v1"
 task = { judge = { model = "Qwen/Qwen3-235B-A22B-Instruct-2507" } }
 
 # # Metric-only monitor (weight 0): rlm harness-mechanics rubric, judged by GLM-5.2.
-# [[orchestrator.eval.env.taskset.task.judges]]
+# [[orchestrator.eval.env.env.taskset.task.judges]]
 # id = "rubric"
 # name = "rlm"
 # path = "deps/research-environments/rubrics/rlm.toml"

--- a/examples/advanced/glm-4.5-air/swe.toml
+++ b/examples/advanced/glm-4.5-air/swe.toml
@@ -99,8 +99,8 @@ thinking_retention = "all"
 
 [[orchestrator.train.env]]
 name = "scaleswe"
-taskset = { id = "scaleswe-v1" }
-harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe"] } }
+env.taskset = { id = "scaleswe-v1" }
+env.agent.harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe"] } }
 
 [orchestrator.prime_monitor]
 
@@ -111,9 +111,9 @@ interval = 20
 
 [[orchestrator.eval.env]]
 name = "swebench-verified"
-taskset = { id = "swebench-verified-v1" }
-harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe"] } }
-timeout = { rollout = 3600 }
+env.taskset = { id = "swebench-verified-v1" }
+env.agent.harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe"] } }
+env.agent.timeout = { rollout = 3600 }
 
 # --- Inference ---
 

--- a/examples/advanced/glm-4.5-air/terminal.toml
+++ b/examples/advanced/glm-4.5-air/terminal.toml
@@ -93,20 +93,20 @@ num_turns_weight = 0.1
 
 [[orchestrator.train.env]]
 name = "tmax"
-harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] } }
+env.agent.harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] } }
 
-[orchestrator.train.env.taskset]
+[orchestrator.train.env.env.taskset]
 id = "tmax-v1"
 
 # # Metric-only monitors (weight 0): rlm harness-mechanics + swe code-usage rubrics, judged by GLM-5.2.
-# [[orchestrator.train.env.taskset.judges]]
+# [[orchestrator.train.env.env.taskset.judges]]
 # id = "rubric"
 # name = "rlm"
 # path = "deps/research-environments/rubrics/rlm.toml"
 # model = "zai-org/GLM-5.2"
 # weight = 0.0
 
-# [[orchestrator.train.env.taskset.judges]]
+# [[orchestrator.train.env.env.taskset.judges]]
 # id = "rubric"
 # name = "swe"
 # path = "deps/research-environments/rubrics/swe.toml"
@@ -120,20 +120,20 @@ interval = 20
 
 [[orchestrator.eval.env]]
 name = "swebench-verified"
-harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] } }
-timeout = { rollout = 3600 }
+env.agent.harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] } }
+env.agent.timeout = { rollout = 3600 }
 
-[orchestrator.eval.env.taskset]
+[orchestrator.eval.env.env.taskset]
 id = "swebench-verified-v1"
 
-# [[orchestrator.eval.env.taskset.judges]]
+# [[orchestrator.eval.env.env.taskset.judges]]
 # id = "rubric"
 # name = "rlm"
 # path = "deps/research-environments/rubrics/rlm.toml"
 # model = "zai-org/GLM-5.2"
 # weight = 0.0
 
-# [[orchestrator.eval.env.taskset.judges]]
+# [[orchestrator.eval.env.env.taskset.judges]]
 # id = "rubric"
 # name = "swe"
 # path = "deps/research-environments/rubrics/swe.toml"
@@ -143,20 +143,20 @@ id = "swebench-verified-v1"
 [[orchestrator.eval.env]]
 name = "terminal-bench-2"
 group_size = 4 # avg@4
-harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] } }
-timeout = { rollout = 3600 }
+env.agent.harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] } }
+env.agent.timeout = { rollout = 3600 }
 
-[orchestrator.eval.env.taskset]
+[orchestrator.eval.env.env.taskset]
 id = "terminal-bench-2-v1"
 
-# [[orchestrator.eval.env.taskset.judges]]
+# [[orchestrator.eval.env.env.taskset.judges]]
 # id = "rubric"
 # name = "rlm"
 # path = "deps/research-environments/rubrics/rlm.toml"
 # model = "zai-org/GLM-5.2"
 # weight = 0.0
 
-# [[orchestrator.eval.env.taskset.judges]]
+# [[orchestrator.eval.env.env.taskset.judges]]
 # id = "rubric"
 # name = "swe"
 # path = "deps/research-environments/rubrics/swe.toml"

--- a/examples/advanced/glm-5.2/swe-llmd.toml
+++ b/examples/advanced/glm-5.2/swe-llmd.toml
@@ -98,8 +98,8 @@ extra_body = {chat_template_kwargs = {clear_thinking = false}}
 
 [[orchestrator.train.env]]
 name = "r2e"
-taskset = { id = "r2e-gym-v1" }
-harness = { id = "rlm", runtime = { type = "prime", labels = ["glm5-llmd"] } }
+env.taskset = { id = "r2e-gym-v1" }
+env.agent.harness = { id = "rlm", runtime = { type = "prime", labels = ["glm5-llmd"] } }
 
 [inference]
 enable_expert_parallel = true

--- a/examples/advanced/glm-5.2/swe.toml
+++ b/examples/advanced/glm-5.2/swe.toml
@@ -73,8 +73,8 @@ interval = 20
 
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
-taskset = { id = "swebench-verified-v1" }
-harness = { id = "bash", runtime = { type = "prime", labels = ["glm5-pd-disag", "swe-bench-verified"] } }
+env.taskset = { id = "swebench-verified-v1" }
+env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["glm5-pd-disag", "swe-bench-verified"] } }
 
 [[orchestrator.post_batch_filters]]
 type = "gibberish"

--- a/examples/advanced/intellect-3.1/rl.toml
+++ b/examples/advanced/intellect-3.1/rl.toml
@@ -50,32 +50,32 @@ oversampling_factor = 2
 [[orchestrator.train.env]]
 name = "swe"
 ratio = 0.3
-taskset = { id = "r2e-gym-v1" }
-harness = { id = "bash", runtime = { type = "prime", labels = ["intellect-3.1", "swe"] } }
+env.taskset = { id = "r2e-gym-v1" }
+env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["intellect-3.1", "swe"] } }
 
 [[orchestrator.train.env]]
 name = "deepdive"
 ratio = 0.2
-taskset = { id = "deepdive-v1" }
-harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], runtime = { type = "prime", labels = ["intellect-3.1", "deepdive"] } }
+env.taskset = { id = "deepdive-v1" }
+env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], runtime = { type = "prime", labels = ["intellect-3.1", "deepdive"] } }
 
 [[orchestrator.train.env]]
 name = "math"
 ratio = 0.3
-taskset = { id = "i3_math_v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "i3_math_v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [[orchestrator.train.env]]
 name = "logic"
 ratio = 0.2
-taskset = { id = "i3_logic_v1", filter = { max = 0.874 } }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "i3_logic_v1", filter = { max = 0.874 } }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [[orchestrator.train.env]]
 name = "code"
 ratio = 0.2
-taskset = { id = "i3_code_v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "i3_code_v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [[orchestrator.pre_batch_filters]]
 type = "zero_advantage"
@@ -86,13 +86,13 @@ interval = 25
 
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
-taskset = { id = "swebench-verified-v1" }
-harness = { id = "bash", runtime = { type = "prime", labels = ["intellect-3.1", "swe-bench-verified"] } }
+env.taskset = { id = "swebench-verified-v1" }
+env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["intellect-3.1", "swe-bench-verified"] } }
 
 [[orchestrator.eval.env]]
 name = "aime2025"
-taskset = { id = "aime25-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "aime25-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference.parallel]
 tp = 8

--- a/examples/advanced/minimax-m2.5/swe.toml
+++ b/examples/advanced/minimax-m2.5/swe.toml
@@ -51,16 +51,16 @@ max_off_policy_steps = 16
 
 [[orchestrator.train.env]]
 name = "swe"
-taskset = { id = "r2e-gym-v1" }
-harness = { id = "bash", runtime = { type = "prime", labels = ["minimax-swe", "swe"] } }
+env.taskset = { id = "r2e-gym-v1" }
+env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["minimax-swe", "swe"] } }
 
 [orchestrator.eval]
 interval = 25
 
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
-taskset = { id = "swebench-verified-v1" }
-harness = { id = "bash", runtime = { type = "prime", labels = ["minimax-swe", "swe-bench-verified"] } }
+env.taskset = { id = "swebench-verified-v1" }
+env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["minimax-swe", "swe-bench-verified"] } }
 
 [inference.parallel]
 tp = 8

--- a/examples/advanced/nemotron-3-super/swe.toml
+++ b/examples/advanced/nemotron-3-super/swe.toml
@@ -83,8 +83,8 @@ truncate_history_thinking = false
 
 [[orchestrator.train.env]]
 name = "scaleswe"
-taskset = { id = "scaleswe-v1" }
-harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["nemotron-3-super-swe"] } }
+env.taskset = { id = "scaleswe-v1" }
+env.agent.harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["nemotron-3-super-swe"] } }
 
 [orchestrator.prime_monitor]
 
@@ -93,9 +93,9 @@ interval = 20
 
 [[orchestrator.eval.env]]
 name = "swebench-verified"
-taskset = { id = "swebench-verified-v1" }
-harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["nemotron-3-super-swe"] } }
-timeout = { rollout = 3600 }
+env.taskset = { id = "swebench-verified-v1" }
+env.agent.harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["nemotron-3-super-swe"] } }
+env.agent.timeout = { rollout = 3600 }
 
 [inference]
 enable_expert_parallel = true

--- a/examples/advanced/qwen3-30b-a3b/math.toml
+++ b/examples/advanced/qwen3-30b-a3b/math.toml
@@ -50,16 +50,16 @@ max_completion_tokens = 32768
 
 [[orchestrator.train.env]]
 name = "math"
-taskset = { id = "i3_math_v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "i3_math_v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 25
 
 [[orchestrator.eval.env]]
 name = "aime2025"
-taskset = { id = "aime25-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "aime25-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference.parallel]
 tp = 8

--- a/examples/advanced/qwen3-30b-a3b/swe.toml
+++ b/examples/advanced/qwen3-30b-a3b/swe.toml
@@ -48,16 +48,16 @@ max_off_policy_steps = 16
 
 [[orchestrator.train.env]]
 name = "swe"
-taskset = { id = "r2e-gym-v1" }
-harness = { id = "bash", runtime = { type = "prime", labels = ["qwen30b-swe", "swe"] } }
+env.taskset = { id = "r2e-gym-v1" }
+env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["qwen30b-swe", "swe"] } }
 
 [orchestrator.eval]
 interval = 25
 
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
-taskset = { id = "swebench-verified-v1" }
-harness = { id = "bash", runtime = { type = "prime", labels = ["qwen30b-swe", "swe-bench-verified"] } }
+env.taskset = { id = "swebench-verified-v1" }
+env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["qwen30b-swe", "swe-bench-verified"] } }
 
 [inference.parallel]
 tp = 8

--- a/examples/advanced/qwen3-30b-a3b/tool.toml
+++ b/examples/advanced/qwen3-30b-a3b/tool.toml
@@ -36,8 +36,8 @@ group_size = 16
 max_off_policy_steps = 32
 
 [[orchestrator.train.env]]
-taskset = { id = "general-agent-v1", task = { tools = { colocated = true } }, min_tier = 1 }
-harness = { id = "null", runtime = { type = "modal" } }
+env.taskset = { id = "general-agent-v1", task = { tools = { colocated = true } }, min_tier = 1 }
+env.agent.harness = { id = "null", runtime = { type = "modal" } }
 
 [inference]
 gpu_memory_utilization = 0.85

--- a/examples/basic/alphabet-sort/rl.toml
+++ b/examples/basic/alphabet-sort/rl.toml
@@ -33,7 +33,7 @@ max_completion_tokens = 768
 
 [[orchestrator.train.env]]
 name = "alphabet-sort"
-taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference] # Default inference config

--- a/examples/basic/hendrycks-sanity/rl.toml
+++ b/examples/basic/hendrycks-sanity/rl.toml
@@ -18,16 +18,16 @@ seq_len = 8192
 
 [[orchestrator.train.env]]
 name = "hendrycks-math"
-taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 50
 
 [[orchestrator.eval.env]]
 name = "aime2024"
-taskset = { id = "aime24-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "aime24-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 group_size = 32
 
 [trainer.model]

--- a/examples/basic/reverse-text/rl.toml
+++ b/examples/basic/reverse-text/rl.toml
@@ -17,8 +17,8 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "reverse-text-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]
 lr = 3e-6

--- a/examples/basic/wiki-search/rl.toml
+++ b/examples/basic/wiki-search/rl.toml
@@ -46,8 +46,8 @@ enforce = true
 
 [[orchestrator.train.env]]
 name = "wiki-search"
-taskset = { id = "wiki-search-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "wiki-search-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [ckpt] # Checkpoint at the end of training
 

--- a/examples/basic/wordle/rl.toml
+++ b/examples/basic/wordle/rl.toml
@@ -20,8 +20,8 @@ group_size = 16
 
 [[orchestrator.train.env]]
 name = "wordle"
-taskset = { id = "wordle-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "wordle-v1" }
+env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.train.sampling]
 max_completion_tokens = 1024

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -173,23 +173,16 @@ class EnvConfig(vf.EnvServerConfig):
         return data
 
     @property
-    def is_legacy(self) -> bool:
-        """A v0/legacy env (run via the bridge): an ``id`` is set and no v1 ``taskset`` is."""
-        return not self.taskset.id
-
-    @property
-    def env_id(self) -> str:
-        """The env identifier — the v1 taskset id (v1) or the legacy env id (v0)."""
-        return self.taskset.id or self.id or ""
-
-    @property
     def resolved_name(self) -> str:
         return self.name or self.env_id
 
     @model_validator(mode="after")
     def validate_env(self):
-        if not self.taskset.id and not self.id:
-            raise ValueError('no env configured — set taskset = { id = "<id>" } (v1) or id = "<id>" (v0/legacy)')
+        taskset = self.env.taskset
+        if (taskset is None or not taskset.id) and not self.id:
+            raise ValueError(
+                'no env configured — set env = { taskset = { id = "<id>" } } (v1) or id = "<id>" (v0/legacy)'
+            )
         if self.resolved_name == "agg":
             raise ValueError(
                 'Environment name "agg" is reserved for cross-env metric aggregation. Use a different name or id.'
@@ -200,13 +193,16 @@ class EnvConfig(vf.EnvServerConfig):
     def resolve_legacy_env_kwargs(self):
         """For a v0/legacy env, surface the v1 knobs the legacy bridge applies via
         ``extra_env_kwargs`` (``env.set_kwargs(...)``): the per-rollout wall-clock timeout and
-        the multi-turn completion-token budget. (``max_seq_len`` is added per train run in
+        the multi-turn completion-token budget — read off the default single-agent block, the
+        only per-run cap site. (``max_seq_len`` is added per train run in
         ``OrchestratorConfig.resolve_env_config``, which knows ``seq_len``.)"""
         if self.is_legacy:
-            if self.timeout.rollout is not None:
-                self.extra_env_kwargs["timeout_seconds"] = self.timeout.rollout
-            if self.max_output_tokens is not None:
-                self.extra_env_kwargs["max_total_completion_tokens"] = self.max_output_tokens
+            agent = getattr(self.env, "agent", None)
+            if agent is not None:
+                if agent.timeout.rollout is not None:
+                    self.extra_env_kwargs["timeout_seconds"] = agent.timeout.rollout
+                if agent.max_output_tokens is not None:
+                    self.extra_env_kwargs["max_total_completion_tokens"] = agent.max_output_tokens
         return self
 
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -178,8 +178,7 @@ class EnvConfig(vf.EnvServerConfig):
 
     @model_validator(mode="after")
     def validate_env(self):
-        taskset = self.env.taskset
-        if (taskset is None or not taskset.id) and not self.id:
+        if not self.env.taskset.id and not self.id:
             raise ValueError(
                 'no env configured — set env = { taskset = { id = "<id>" } } (v1) or id = "<id>" (v0/legacy)'
             )

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -3,10 +3,11 @@
 - Capacity (``max_inflight_rollouts``) is shared across train + eval.
   A group-scoring task that runs N rollouts in one call reserves N permits.
 - Optional rate limiting via ``AsyncLimiter(tasks_per_minute, 60)``.
-- Emit-everything invariant: every dispatched rollout eventually reaches
-  ``out_q`` exactly once as a ``Rollout``. Failures
-  (env error, empty trajectory, task exception, off-policy cancel) carry
-  ``trace.error`` set; sinks decide drop / partial-train policy.
+- Emit-everything invariant: every dispatched env-rollout eventually reaches
+  ``out_q`` exactly once, as one episode — a ``list[Rollout]`` (one trace for a
+  single-agent env, several for a multi-agent one). Failures (env error, empty
+  trajectory, task exception, off-policy cancel) carry ``trace.error`` set;
+  sinks decide drop / partial-train policy.
 - ``DispatcherMode.PREFER_TRAIN`` / ``PREFER_EVAL`` controls which kind to
   schedule next. Transitions are level-triggered (driven by the eval
   source's emptiness), so in-flight rollouts of the opposite kind drain
@@ -153,7 +154,9 @@ class RolloutDispatcher:
         self.groups: dict[uuid.UUID, GroupState] = {}
 
         # Bounded so the dispatcher backpressures on a slow sink
-        self.out_q: asyncio.Queue[Rollout] = asyncio.Queue(maxsize=max(8, self.max_inflight))
+        # One entry per episode: the traces of one env-rollout travel together, so
+        # the sinks' group accounting counts episodes, never loose traces.
+        self.out_q: asyncio.Queue[list[Rollout]] = asyncio.Queue(maxsize=max(8, self.max_inflight))
 
         self.mode: DispatcherMode = DispatcherMode.PREFER_TRAIN
         # Set by the orchestrator after the final train step; pipeline then
@@ -393,7 +396,7 @@ class RolloutDispatcher:
         )
 
     async def schedule_group_rollout(self, group_id: uuid.UUID, group: GroupState) -> bool:
-        """Dispatch one ``run_rollout`` / ``run_group`` task for this group.
+        """Dispatch one ``run`` / ``run_group`` task for this group.
 
         Returns False only if we couldn't even schedule one rollout (no clients
         ready, no permits). Returns True after issuing one task — the caller
@@ -454,7 +457,7 @@ class RolloutDispatcher:
             group.rollouts_to_schedule -= 1
             await self.acquire(permits)
             task = asyncio.create_task(
-                env.run_rollout(
+                env.run(
                     client=client,
                     task_idx=group.task_idx,
                     model_name=model_name,
@@ -485,12 +488,14 @@ class RolloutDispatcher:
         self.inflight_permits -= n
 
     async def handle_completed_rollout(self, task: asyncio.Task) -> None:
-        """Emit every dispatched rollout exactly once to ``out_q``. Task
-        exceptions synthesize ``meta.rollout_count`` error markers so the
-        sink's count-to-``group_size`` finalization still triggers.
-        Cancelled tasks (popped by ``drop_group``) raise ``CancelledError``
-        and are discarded — ``drop_group`` already emitted their markers.
-        """
+        """Emit every dispatched env-rollout exactly once to ``out_q``. A ``run``
+        task's result is one episode (its traces emitted together); a legacy
+        ``run_group`` task's result is ``rollout_count`` single-trace episodes.
+        Task exceptions (and zero-trace episodes) synthesize ``rollout_count``
+        error-marker episodes so the sink's count-to-``group_size`` finalization
+        still triggers. Cancelled tasks (popped by ``drop_group``) raise
+        ``CancelledError`` and are discarded — ``drop_group`` already emitted
+        their markers."""
         meta = self.inflight.pop(task, None)
         if meta is None:
             return  # already handled by drop_group / cancel_inflight_rollouts
@@ -501,6 +506,8 @@ class RolloutDispatcher:
         try:
             result = task.result()
             rollouts: list[Rollout] = result if isinstance(result, list) else [result]
+            if not rollouts:
+                raise RuntimeError("env run returned an empty episode (no traces)")
         except asyncio.CancelledError:
             return
         except Exception as exc:
@@ -526,11 +533,19 @@ class RolloutDispatcher:
                     get_logger().warning(
                         f"Rollout failed in group {meta.group_id} ({meta.env_name}) — {r.error.type}: {r.error.message}"
                     )
-            await self.emit_rollout(meta, group, r)
+        if meta.rollout_count == 1:
+            # A `run` task: the whole result is one episode.
+            await self.emit_episode(meta, group, rollouts)
+        else:
+            # A legacy `run_group` task (or its error markers): each trace is
+            # its own single-trace episode.
+            for r in rollouts:
+                await self.emit_episode(meta, group, [r])
 
-    async def emit_rollout(self, meta: InflightRollout, group: GroupState | None, rollout: Rollout) -> None:
-        """Stamp prime-rl metadata onto the completed rollout and put it on ``out_q``.
-        Pops the group from ``self.groups`` once every member has been emitted."""
+    async def emit_episode(self, meta: InflightRollout, group: GroupState | None, rollouts: list[Rollout]) -> None:
+        """Stamp prime-rl metadata onto one completed episode's traces and put it
+        on ``out_q``. Pops the group from ``self.groups`` once every owed episode
+        has been emitted."""
         eval_step = meta.eval_step
         policy_version = meta.policy_version
         if group is not None:
@@ -540,15 +555,16 @@ class RolloutDispatcher:
             if group.emitted >= group.target_rollouts:
                 self.groups.pop(meta.group_id, None)
 
-        rollout.kind = meta.kind
-        rollout.env_name = meta.env_name
-        rollout.group_id = meta.group_id
-        rollout.policy_version = policy_version
-        rollout.off_policy_steps = meta.off_policy_steps
-        if meta.kind == "eval":
-            assert eval_step is not None, "eval rollout missing eval_step"
-            rollout.eval_step = eval_step
-        await self.out_q.put(rollout)
+        for rollout in rollouts:
+            rollout.kind = meta.kind
+            rollout.env_name = meta.env_name
+            rollout.group_id = meta.group_id
+            rollout.policy_version = policy_version
+            rollout.off_policy_steps = meta.off_policy_steps
+            if meta.kind == "eval":
+                assert eval_step is not None, "eval rollout missing eval_step"
+                rollout.eval_step = eval_step
+        await self.out_q.put(rollouts)
 
     async def drop_group(self, group_id: uuid.UUID) -> int:
         """Cancel remaining in-flight tasks for this group and emit a
@@ -581,7 +597,7 @@ class RolloutDispatcher:
                     errors=[vf.Error(type="Cancelled", message="Off-policy cancel")],
                     stop_condition="error",
                 )
-                await self.emit_rollout(meta, group, trace)
+                await self.emit_episode(meta, group, [trace])
 
         # For non-group-scoring envs, the group may have rollouts that
         # were never dispatched (``rollouts_to_schedule > 0``). Emit
@@ -607,7 +623,7 @@ class RolloutDispatcher:
                     errors=[vf.Error(type="Cancelled", message="Off-policy cancel")],
                     stop_condition="error",
                 )
-                await self.emit_rollout(fallback_meta, group, trace)
+                await self.emit_episode(fallback_meta, group, [trace])
 
         cancelled = inflight_cancelled + unscheduled_cancelled
         if cancelled > 0:

--- a/src/prime_rl/orchestrator/env_server/env_server.py
+++ b/src/prime_rl/orchestrator/env_server/env_server.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from verifiers.v1 import pool_serve_kwargs
-from verifiers.v1.serve import serve_env
+from verifiers.v1.serve import env_config_data, serve_env
 
 from prime_rl.configs.env_server import EnvServerConfig
 from prime_rl.orchestrator.utils import setup_env_server_logging
@@ -21,7 +21,7 @@ def run_server(config: EnvServerConfig):
     server_kwargs = (
         {"env_id": env.env_id, "env_args": env.args, "extra_env_kwargs": env.extra_env_kwargs}
         if env.is_legacy
-        else {"config": env}
+        else {"config_data": env_config_data(env.env)}
     )
     serve_env(
         **pool_serve_kwargs(env.pool),

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Generic, TypeVar
 
 import verifiers.v1 as vf
-from verifiers.v1.serve import EnvClient
+from verifiers.v1.serve import PROTOCOL_VERSION, EnvClient, env_config_data
 
 from prime_rl.configs.orchestrator import EnvConfig, EvalEnvConfig, TrainEnvConfig
 from prime_rl.orchestrator.algo import Algorithm, build_algorithm
@@ -111,6 +111,11 @@ class Env:
         if external:
             await self.env_client.wait_for_server_startup()
         info = await self.env_client.info()
+        if info.protocol != PROTOCOL_VERSION:
+            raise RuntimeError(
+                f"Env server {self.name} speaks serve protocol {info.protocol}, but this "
+                f"orchestrator expects {PROTOCOL_VERSION} — align the verifiers versions"
+            )
         self.num_tasks = info.num_tasks
         self.requires_group_scoring = info.requires_group_scoring
         num_tasks = self.num_tasks if self.num_tasks is not None else "infinite"
@@ -135,7 +140,9 @@ class Env:
                 extra_env_kwargs=self.config.extra_env_kwargs,
             )
             if self.config.is_legacy
-            else dict(legacy=False, config=self.config)
+            # The env block only — and as a picklable dict: the narrowed config
+            # class doesn't survive the spawn.
+            else dict(legacy=False, config_data=env_config_data(self.config.env))
         )
         process = ctx.Process(
             target=_run_env_server,
@@ -168,17 +175,19 @@ class Env:
             sampling["extra_body"] = {**sampling.get("extra_body", {}), "cache_salt": cache_salt}
         return vf.SamplingConfig(**sampling)
 
-    async def run_rollout(
+    async def run(
         self, client: vf.ClientConfig, task_idx: int, model_name: str, cache_salt: str | None
-    ) -> Rollout:
-        """Run a single rollout for ``task_idx``; return a typed Trace."""
-        wire = await self.env_client.run_rollout(
+    ) -> list[Rollout]:
+        """Run one env-rollout (episode) for ``task_idx``; return its typed Traces —
+        one for a single-agent env, several for a multi-agent one, linked through
+        each trace's ``episode`` stamp."""
+        wires = await self.env_client.run(
             task_idx=task_idx,
             client=client,
             model=model_name,
             sampling=self._sampling(cache_salt),
         )
-        return ROLLOUT_TYPE.model_construct(**dict(wire))
+        return [ROLLOUT_TYPE.model_construct(**dict(wire)) for wire in wires]
 
     async def run_group(
         self, client: vf.ClientConfig, task_idx: int, model_name: str, group_size: int, cache_salt: str | None

--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -3,12 +3,14 @@
 Same shape as ``TrainSink``, but no tokenization / advantages / filters:
 
 1. ``process_rollout`` — no-op.
-2. ``process_group`` — at ``group_size`` arrivals, move the rollouts
+2. ``process_group`` — at ``group_size`` episodes, move the rollouts
    (errored ones included) into the ``(env, eval_step)`` bucket.
-3. ``process_batch`` — at ``num_examples × group_size`` arrivals, return an
+3. ``process_batch`` — at ``num_examples × group_size`` episodes, return an
    ``EvalBatch`` with the full returned cohort (metrics are computed downstream).
 
-``add()`` returns ``EvalBatch | None``.
+``add()`` takes one episode (``list[Rollout]`` — the traces of one env-rollout,
+arriving atomically) and returns ``EvalBatch | None``; all accounting counts
+episodes, never loose traces.
 """
 
 from __future__ import annotations
@@ -28,20 +30,25 @@ class EvalSink:
     def __init__(self, *, eval_envs: EvalEnvs) -> None:
         self.eval_envs = eval_envs
         self.pending_groups: dict[uuid.UUID, list[Rollout]] = defaultdict(list)
-        # Bucket size IS the arrival count — ``process_group`` flushes
-        # everything in without filtering
+        # Episodes arrived per group / per batch bucket — the finalization
+        # counts. A multi-agent episode adds several traces but one count.
+        self.pending_group_episodes: dict[uuid.UUID, int] = defaultdict(int)
         self.pending_batches: dict[tuple[str, int], list[Rollout]] = defaultdict(list)
+        self.pending_batch_episodes: dict[tuple[str, int], int] = defaultdict(int)
 
-    def add(self, rollout: Rollout) -> EvalBatch | None:
-        """Process one arrival; finalize the group on the ``group_size``-th
-        arrival and the per-env epoch on the ``num_examples × group_size``-th."""
-        env_name = rollout.env_name
-        self.process_rollout(rollout)
-        bkey = (env_name, rollout.eval_step)
-        self.pending_groups[rollout.group_id].append(rollout)
-        if len(self.pending_groups[rollout.group_id]) >= self.group_size_for(env_name):
-            self.process_group(rollout.group_id)
-        if len(self.pending_batches[bkey]) >= self.batch_size_for(env_name):
+    def add(self, episode: list[Rollout]) -> EvalBatch | None:
+        """Process one episode arrival; finalize the group on the ``group_size``-th
+        episode and the per-env epoch on the ``num_examples × group_size``-th."""
+        env_name = episode[0].env_name
+        group_id = episode[0].group_id
+        for rollout in episode:
+            self.process_rollout(rollout)
+        bkey = (env_name, episode[0].eval_step)
+        self.pending_groups[group_id].extend(episode)
+        self.pending_group_episodes[group_id] += 1
+        if self.pending_group_episodes[group_id] >= self.group_size_for(env_name):
+            self.process_group(group_id)
+        if self.pending_batch_episodes[bkey] >= self.batch_size_for(env_name):
             return self.process_batch(bkey)
         return None
 
@@ -49,7 +56,7 @@ class EvalSink:
         return self.eval_envs.get(env_name).config.group_size
 
     def batch_size_for(self, env_name: str) -> int:
-        """``num_examples × group_size`` — total rollouts expected for one
+        """``num_examples × group_size`` — total episodes expected for one
         epoch of ``env_name``."""
         env = self.eval_envs.get(env_name)
         return len(env.examples) * env.config.group_size
@@ -59,7 +66,7 @@ class EvalSink:
         ``(env_name, eval_step, batch_count, expected, buffered)``.
         ``batch_count`` is finalized-group survivors in ``pending_batches``;
         ``buffered`` is partial-group arrivals from non-group-scoring envs."""
-        batch_counts: dict[tuple[str, int], int] = {bkey: len(bucket) for bkey, bucket in self.pending_batches.items()}
+        batch_counts: dict[tuple[str, int], int] = dict(self.pending_batch_episodes)
         buffered: dict[tuple[str, int], int] = {}
         for rollouts in self.pending_groups.values():
             if not rollouts:
@@ -93,6 +100,7 @@ class EvalSink:
 
     def process_group(self, group_id: uuid.UUID) -> None:
         group = self.pending_groups.pop(group_id, [])
+        episodes = self.pending_group_episodes.pop(group_id, 0)
         if not group:
             return
         env_name = group[0].env_name
@@ -100,6 +108,7 @@ class EvalSink:
         eval_step = group[0].eval_step
         bucket = self.pending_batches[(env_name, eval_step)]
         bucket.extend(group)
+        self.pending_batch_episodes[(env_name, eval_step)] += episodes
 
         survivors = [r for r in group if not r.has_error]
         num_errored = len(group) - len(survivors)
@@ -117,4 +126,5 @@ class EvalSink:
         does no aggregation."""
         env_name, step = key
         rollouts = self.pending_batches.pop(key, [])
+        self.pending_batch_episodes.pop(key, None)
         return EvalBatch(env_name=env_name, step=step, rollouts=EvalRollouts(rollouts))

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -466,7 +466,7 @@ class Orchestrator:
             trim_process_memory()
 
     async def main_loop(self) -> None:
-        """Consume ``Rollout``\\ s from the dispatcher and route them
+        """Consume episodes (``list[Rollout]``) from the dispatcher and route them
         to the train / eval sink. Both sinks return a finalized batch (or
         ``None``) from ``add()``; we just dispatch on the result."""
         while not self.stopped.is_set():
@@ -476,7 +476,7 @@ class Orchestrator:
                 break
 
             try:
-                rollout: Rollout = await asyncio.wait_for(self.dispatcher.out_q.get(), timeout=0.5)
+                episode: list[Rollout] = await asyncio.wait_for(self.dispatcher.out_q.get(), timeout=0.5)
             except asyncio.TimeoutError:
                 continue
 
@@ -484,33 +484,35 @@ class Orchestrator:
             # ``all`` trace file the moment it arrives, so it survives crashes and drains.
             # Train rollouts belong to the batch window currently collecting (``progress.step``),
             # eval rollouts to the step whose eval triggered them.
-            step = rollout.eval_step if rollout.kind == "eval" else self.progress.step
+            kind = episode[0].kind
+            step = episode[0].eval_step if kind == "eval" else self.progress.step
             assert step is not None
             run: vf.RunInfo = (
                 vf.EvalRunInfo(id=self.monitor.run_id, step=step)
-                if rollout.kind == "eval"
+                if kind == "eval"
                 else vf.TrainRunInfo(id=self.monitor.run_id, step=step)
             )
-            rollout.stamp(
-                run,
-                env_name=rollout.env_name,
-                group_id=str(rollout.group_id),
-                policy_version=rollout.policy_version,
-            )
+            for rollout in episode:
+                rollout.stamp(
+                    run,
+                    env_name=rollout.env_name,
+                    group_id=str(rollout.group_id),
+                    policy_version=rollout.policy_version,
+                )
             await asyncio.to_thread(
                 save_rollouts,
-                [rollout.to_record()],
-                get_trace_path(self.config.output_dir, step, rollout.kind, "all"),
+                [rollout.to_record() for rollout in episode],
+                get_trace_path(self.config.output_dir, step, kind, "all"),
             )
 
-            if rollout.kind == "eval":
+            if kind == "eval":
                 assert self.eval_sink is not None  # eval rollouts only emitted when eval is configured
-                eval_batch = self.eval_sink.add(rollout)
+                eval_batch = self.eval_sink.add(episode)
                 if eval_batch is not None:
                     await self.finalize_eval_batch(eval_batch)
                 continue
 
-            train_batch = await self.train_sink.add(rollout)
+            train_batch = await self.train_sink.add(episode)
             # In drain mode any late-arriving train batch is dropped — we
             # don't want to ship past ``max_steps``
             if train_batch is not None and not self.draining and not self.stopped.is_set():

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -3,15 +3,18 @@
 1. ``process_rollout`` — eager per-rollout tokenization (overlaps with
    dispatcher producing more rollouts), then the env algorithm's
    ``finalize_rollout`` (rollout-local scoring + any reference I/O). Errored
-   rollouts skip this.
-2. ``process_group`` — filters errored rollouts, hands survivors to the env
-   algorithm's ``finalize_group`` (advantages + per-sample wire stamping),
-   runs the pre-batch filter pass.
+   and untrainable rollouts (a multi-agent env's frozen agents) skip this —
+   only the trainable subset becomes training samples.
+2. ``process_group`` — filters errored rollouts, hands the trainable
+   survivors to the env algorithm's ``finalize_group`` (advantages +
+   per-sample wire stamping), runs the pre-batch filter pass.
 3. ``process_batch`` — applies post-batch filter annotations and assembles
    the trainer-bound ``TrainingSample`` list. Returns a ``TrainBatch``.
 
-``add()`` returns ``TrainBatch | None``. I/O concerns (ship to trainer,
-save_rollouts, monitor.log) live on the orchestrator.
+``add()`` takes one episode (``list[Rollout]`` — the traces of one
+env-rollout, arriving atomically) and returns ``TrainBatch | None``; group
+accounting counts episodes, never loose traces. I/O concerns (ship to
+trainer, save_rollouts, monitor.log) live on the orchestrator.
 """
 
 from __future__ import annotations
@@ -78,6 +81,9 @@ class TrainSink:
         # isn't unique — the same task can be re-sampled while an
         # earlier group is still in flight
         self.pending_groups: dict[uuid.UUID, list[Rollout]] = defaultdict(list)
+        # Episodes arrived per group — the finalization count. A multi-agent
+        # episode adds several traces to ``pending_groups`` but one here.
+        self.pending_group_episodes: dict[uuid.UUID, int] = defaultdict(int)
         self.pending_batch: list[Rollout] = []
         # Running payload-token total of ``pending_batch`` (token-batched
         # runs), kept in sync on append/pop so the readiness check never
@@ -131,17 +137,20 @@ class TrainSink:
             counts[r.env_name] += 1
         return dict(counts)
 
-    async def add(self, rollout: Rollout) -> TrainBatch | None:
-        """Process one arrival; finalize the group on the ``group_size``-th
-        arrival; return a ``TrainBatch`` if the finalization pushed (or left)
-        the batch over its threshold. Arrivals into still-incomplete groups
-        never ship a batch."""
-        await self.process_rollout(rollout)
-        env_name = rollout.env_name
-        self.pending_groups[rollout.group_id].append(rollout)
-        if len(self.pending_groups[rollout.group_id]) < self.group_size_for(env_name):
+    async def add(self, episode: list[Rollout]) -> TrainBatch | None:
+        """Process one episode arrival (the traces of one env-rollout, together);
+        finalize the group on the ``group_size``-th episode; return a
+        ``TrainBatch`` if the finalization pushed (or left) the batch over its
+        threshold. Arrivals into still-incomplete groups never ship a batch."""
+        group_id = episode[0].group_id
+        env_name = episode[0].env_name
+        for rollout in episode:
+            await self.process_rollout(rollout)
+        self.pending_groups[group_id].extend(episode)
+        self.pending_group_episodes[group_id] += 1
+        if self.pending_group_episodes[group_id] < self.group_size_for(env_name):
             return None
-        await self.process_group(rollout.group_id)
+        await self.process_group(group_id)
         # ``pending_batch`` only grows on group finalization, so readiness is
         # only re-checked here — the window of a shipped batch then always
         # contains at least the group that finalized it.
@@ -158,8 +167,9 @@ class TrainSink:
         """Build training samples from the rollout's Trace (one per branch), walking the
         message graph. Training is renderer-only across all modes (RL/OPD student, SFT teacher),
         so every node already carries its tokens. Errored rollouts are dropped at the group
-        level, so skip them here."""
-        if rollout.has_error:
+        level, so skip them here; untrainable traces (a multi-agent env's frozen agents —
+        ``trace.agent.trainable`` is False) never become training data."""
+        if rollout.has_error or not rollout.trainable:
             return
         samples = await asyncio.to_thread(
             trace_to_samples,
@@ -178,6 +188,7 @@ class TrainSink:
         when ``requires_group_scoring`` and any failed), assign advantages,
         run pre-batch filters, append survivors to ``pending_batch``."""
         group = self.pending_groups.pop(group_id, [])
+        self.pending_group_episodes.pop(group_id, None)
         if not group:
             return
         # Window membership follows group finalization, not arrival: a rollout
@@ -200,10 +211,14 @@ class TrainSink:
                 f"rollouts={len(group)} (errored={num_errored}) | dropped: group-scored partial"
             )
             return
+        # The training signal comes from the trainable subset only: a
+        # multi-agent env's frozen agents (a grader, a pinned user sim) carry
+        # no samples and must not skew the group baseline.
+        survivors = [r for r in survivors if r.trainable]
         if not survivors:
             get_logger().debug(
                 f"Finished group | env={env_name} task_idx={task_idx} | "
-                f"rollouts={len(group)} (errored={num_errored}) | dropped: all failed"
+                f"rollouts={len(group)} (errored={num_errored}) | dropped: no trainable survivors"
             )
             return
 

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -41,7 +41,7 @@ RolloutKind = Literal["train", "eval"]
 @dataclass
 class InflightRollout:
     """Per-task scheduling state in the dispatcher; one entry per in-flight
-    ``run_rollout`` / ``run_group`` task."""
+    ``run`` / ``run_group`` task."""
 
     kind: RolloutKind
     env_name: str

--- a/uv.lock
+++ b/uv.lock
@@ -94,6 +94,7 @@ members = [
     "prime-rl",
     "programbench-v1",
     "prolog-v1",
+    "proposer-solver-v1",
     "r2e-gym-v1",
     "redsearcher-v1",
     "reverse-text-v1",
@@ -5454,6 +5455,17 @@ wheels = [
 ]
 
 [[package]]
+name = "proposer-solver-v1"
+version = "0.1.0"
+source = { editable = "deps/verifiers/environments/proposer_solver_v1" }
+dependencies = [
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -7893,6 +7905,7 @@ examples = [
     { name = "glossary-v1", editable = "deps/verifiers/environments/glossary_v1" },
     { name = "gsm8k-v1", editable = "deps/verifiers/environments/gsm8k_v1" },
     { name = "openenv-wordle-v1", editable = "deps/verifiers/environments/openenv_wordle_v1" },
+    { name = "proposer-solver-v1", editable = "deps/verifiers/environments/proposer_solver_v1" },
     { name = "reverse-text-v1", editable = "deps/verifiers/environments/reverse_text_v1" },
     { name = "scratchpad-v1", editable = "deps/verifiers/environments/scratchpad_v1" },
     { name = "wiki-search-v1", editable = "deps/verifiers/environments/wiki_search_v1" },


### PR DESCRIPTION
## Summary

Companion to PrimeIntellect-ai/verifiers#2086 (multi-agent: the Agent as a first-class primitive, envs as control flow, trace-native episodes). Re-pins `deps/verifiers` and adopts the new serve protocol and config shape.

- **Serve protocol 2**: the env server route `run_rollout` -> `run`, answering one episode as `list[Trace]` (one trace for a single-agent env, several for a multi-agent one, linked by each trace's `episode` stamp). `Env.run` returns `list[Rollout]`; the orchestrator refuses a protocol-mismatched server at startup.
- **The episode is the pipeline currency**: the dispatcher emits one episode (`list[Rollout]`) per completed task onto `out_q` (a legacy `run_group` result emits its traces as single-trace episodes), and both sinks count **episodes** — never loose traces — toward `group_size` and eval epoch sizes. Error markers and off-policy cancels stay per owed episode.
- **Only the trainable subset becomes training samples**: a trace stamped untrainable (a multi-agent env's frozen agent — a grader, a pinned user sim) is never tokenized, never enters the group's advantage computation, and never ships; it still lands in the trace files and observation window.
- **Config shape**: prime-rl's `EnvConfig` follows the new `vf.EnvServerConfig` — everything env lives under the `env` block. Checked-in TOMLs migrated: `taskset = {...}` -> `env.taskset = {...}`, `harness = {...}` -> `env.agent.harness = {...}` (per-run caps are per-agent: `env.agent.max_turns`, `env.agent.timeout`). The spawned env server now receives the picklable env block (`env_config_data`).

## Verification

- `uv run rl @ examples/basic/reverse-text/rl.toml --max-steps 3` runs e2e in single-agent mode on 2 GPUs: env server handshakes protocol 2, rollouts flow through the new `run` route, groups finalize, batches ship at 0% errors, and every saved trace in `rollouts/step_*/train/all/traces.jsonl` carries the `episode` stamp and `agent.name="agent"`.
- `tests/unit` green; `ruff` clean.

## Breaking

- Env TOML shape: `taskset` / `harness` / per-run caps move under the `env` block (`env.taskset`, `env.agent.harness`, `env.agent.max_turns`, `env.agent.timeout`, `env.retries`, `env.max_concurrent`); all checked-in configs migrated.
- `Env.run_rollout` -> `Env.run` returning `list[Rollout]`; `Dispatcher.out_q` carries `list[Rollout]` (one episode) per entry; `TrainSink.add` / `EvalSink.add` take an episode.
- Requires a verifiers env server speaking serve protocol 2 (the re-pinned submodule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
