### PR TITLE
feat(cp): context parallelism for hybrid + VLM SFT

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -318,8 +318,8 @@ class SFTConfig(BaseConfig):
             raise ValueError(
                 "VLM models must use optimization_dtype='bfloat16' and reduce_dtype='bfloat16' to match vLLM inference."
             )
-        if self.model.cp > 1:
-            raise ValueError("VLM SFT does not support context parallelism yet.")
+        if self.model.cp > 1 and self.model.cp_style != "ulysses":
+            raise ValueError("VLM models require cp_style='ulysses' for context parallelism")
         if self.data.micro_batch_size != 1:
             raise ValueError("VLM SFT requires data.micro_batch_size = 1.")
         if self.val is not None and self.val.data.micro_batch_size != 1:

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -242,21 +242,13 @@ class ModelConfig(BaseModelConfig):
         return self
 
     @model_validator(mode="after")
-    def cp_only_with_flash_attn(self):
+    def validate_cp(self):
         if self.cp > 1 and self.attn not in ["flash_attention_2", "flash_attention_3", "flash_attention_4", "auto"]:
             raise ValueError("CP is only supported with flash attention 2, 3, or 4")
-        if (
-            self.cp > 1
-            and self.attn in ("flash_attention_3", "flash_attention_4", "auto")
-            and self.impl not in ("custom", "auto")
-        ):
-            # Both ring and ulysses route FA3/FA4 through our custom FlashAttention class:
-            # ring patches `_compute_attention` with the ring kernel, ulysses patches it with
-            # the all-to-all wrapper around the FA3/FA4 kernel. The HF path patches
-            # `_flash_attention_forward` which only wraps FA2.
+        if self.cp > 1 and self.impl not in ("custom", "auto"):
             raise ValueError(
-                f"CP with {self.attn} requires model.impl='custom' or 'auto' "
-                "(FA3/FA4 paths are only implemented for the custom model attention class)"
+                "Context parallelism requires model.impl='custom' or 'auto' "
+                "(resolved to a custom PrimeRL implementation)"
             )
         return self
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1386,7 +1386,7 @@ def forward(
     mm_token_type_ids: Int[Tensor, "batch seq"] | None = None,
     # True when seq_lens holds the full pre-CP-shard document boundaries
     # (kept global because documents can straddle the shard cut).
-    seq_lens_are_global: bool = False,
+    seq_lens_are_pre_shard: bool = False,
 ) -> PrimeLmOutput:
     kwargs = {
         "input_ids": input_ids,
@@ -1408,7 +1408,7 @@ def forward(
 
     if isinstance(model, PreTrainedModelPrimeRL):
         kwargs["seq_lens"] = seq_lens
-        kwargs["seq_lens_are_global"] = seq_lens_are_global
+        kwargs["seq_lens_are_pre_shard"] = seq_lens_are_pre_shard
 
     if routed_experts is not None:
         kwargs["routed_experts"] = routed_experts

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -679,10 +679,10 @@ def get_model(
             f"but model.impl resolved to 'hf'. Set model.impl='custom' explicitly."
         )
 
-    if config.cp > 1 and impl_to_use != "custom":
+    if config.cp > 1 and config.impl == "auto" and impl_to_use != "custom":
         raise ValueError(
-            "Context parallelism requires model.impl='custom' "
-            "(or model.impl='auto' selecting a custom PrimeRL implementation)."
+            "Context parallelism with model.impl='auto' requires a supported custom PrimeRL implementation, "
+            "but this architecture resolved to model.impl='hf'."
         )
 
     if config.vlm is not None and not (is_vlm_arch and custom_vlm_cls):

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -153,10 +153,37 @@ def _patch_qwen3_5_linear_attn_varlen():
         apply_mask_to_padding_states,
     )
 
+    try:
+        from fla.modules.convolution import causal_conv1d as fla_causal_conv1d
+        from fla.ops.cp import build_cp_context
+    except ImportError:
+        build_cp_context = None
+        fla_causal_conv1d = None
+
+    if fla_causal_conv1d is not None:
+        # The CP boundary-state exchange inside fla's conv is not dynamo-traceable;
+        # graph-break deliberately so the rest of the layer still compiles.
+        fla_causal_conv1d = torch.compiler.disable(fla_causal_conv1d)
+
     if getattr(Qwen3_5GatedDeltaNet.forward, "_prl_varlen_patched", False):
         return
 
     _gdn_orig = Qwen3_5GatedDeltaNet.forward
+
+    def _build_cp_context(self, local_seq_len: int, device: torch.device, cu_seqlens=None):
+        cp_group = getattr(self, "cp_group", None)
+        if cp_group is None or build_cp_context is None:
+            return None
+        global_seq_len = local_seq_len * self.cp_world_size
+        if cu_seqlens is not None and int(cu_seqlens[-1].item()) == global_seq_len:
+            global_cu_seqlens = cu_seqlens.to(device=device, dtype=torch.int32)
+        else:
+            global_cu_seqlens = torch.tensor([0, global_seq_len], dtype=torch.int32, device=device)
+        return build_cp_context(
+            cu_seqlens=global_cu_seqlens,
+            group=cp_group,
+            conv1d_kernel_size=self.conv_kernel_size,
+        )
 
     def _gdn_forward(self, hidden_states, cache_params=None, attention_mask=None, cu_seqlens=None):
         if cu_seqlens is None or cache_params is not None:
@@ -170,7 +197,18 @@ def _patch_qwen3_5_linear_attn_varlen():
         b = self.in_proj_b(hidden_states)
         a = self.in_proj_a(hidden_states)
 
-        if self.causal_conv1d_fn is not None:
+        cp_context = _build_cp_context(self, seq_len, hidden_states.device, cu_seqlens)
+
+        if cp_context is not None and fla_causal_conv1d is not None:
+            mixed_qkv, _ = fla_causal_conv1d(
+                x=mixed_qkv.transpose(1, 2),
+                weight=self.conv1d.weight.squeeze(1),
+                bias=self.conv1d.bias,
+                activation=self.activation,
+                cp_context=cp_context,
+            )
+            mixed_qkv = mixed_qkv.transpose(1, 2)
+        elif self.causal_conv1d_fn is not None:
             seg_lens = cu_seqlens[1:] - cu_seqlens[:-1]
             seq_idx = torch.repeat_interleave(
                 torch.arange(seg_lens.numel(), dtype=torch.int32, device=hidden_states.device),
@@ -206,17 +244,29 @@ def _patch_qwen3_5_linear_attn_varlen():
             query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 
-        core_attn_out, _ = self.chunk_gated_delta_rule(
-            query,
-            key,
-            value,
-            g=g,
-            beta=beta,
-            initial_state=None,
-            output_final_state=False,
-            use_qk_l2norm_in_kernel=True,
-            cu_seqlens=cu_seqlens,
-        )
+        if cp_context is not None:
+            core_attn_out, _ = self.chunk_gated_delta_rule(
+                query,
+                key,
+                value,
+                g=g,
+                beta=beta,
+                use_qk_l2norm_in_kernel=True,
+                cu_seqlens=cp_context.cu_seqlens,
+                cp_context=cp_context,
+            )
+        else:
+            core_attn_out, _ = self.chunk_gated_delta_rule(
+                query,
+                key,
+                value,
+                g=g,
+                beta=beta,
+                initial_state=None,
+                output_final_state=False,
+                use_qk_l2norm_in_kernel=True,
+                cu_seqlens=cu_seqlens,
+            )
 
         core_attn_out = core_attn_out.reshape(-1, self.head_v_dim)
         z = z.reshape(-1, self.head_v_dim)
@@ -478,6 +528,12 @@ def get_load_balance_stats(
     }
 
 
+def _is_qwen3_5_config(model_config: PretrainedConfig) -> bool:
+    model_type = getattr(model_config, "model_type", "")
+    text_model_type = getattr(getattr(model_config, "text_config", None), "model_type", "")
+    return model_type.startswith("qwen3_5") or text_model_type.startswith("qwen3_5")
+
+
 def get_model(
     config: ModelConfig, device: torch.device = torch.device("cpu"), dtype: torch.dtype = torch.bfloat16
 ) -> nn.Module:
@@ -528,6 +584,13 @@ def get_model(
         _patch_qwen3_5_text_position_ids()
         _patch_qwen3_5_moe_conversion_mapping()
         _patch_qwen3_5_linear_attn_varlen()
+    if is_vlm_arch and config.cp > 1 and config.cp_style == "ulysses":
+        vision_config = getattr(model_config, "vision_config", None)
+        if vision_config is not None:
+            logger.info("Using SDPA for VLM vision encoder under CP")
+            vision_config._attn_implementation = "sdpa"
+            if hasattr(vision_config, "_attn_implementation_internal"):
+                vision_config._attn_implementation_internal = "sdpa"
     for subconfig_key in getattr(model_config, "sub_configs", {}):
         subconfig = getattr(model_config, subconfig_key, None)
         if subconfig is not None and hasattr(subconfig, "use_cache"):
@@ -620,6 +683,13 @@ def get_model(
         raise ValueError(
             f"{config.attn} requires model.impl='custom' or 'auto' (resolved to 'custom'), "
             f"but model.impl resolved to 'hf'. Set model.impl='custom' explicitly."
+        )
+
+    if config.cp > 1 and _is_qwen3_5_config(model_config) and impl_to_use != "custom":
+        raise ValueError(
+            "Qwen3.5 context parallelism requires model.impl='custom' "
+            "(or model.impl='auto' selecting the custom PrimeRL implementation); "
+            "the HuggingFace implementation does not expose set_context_parallel_attributes."
         )
 
     if config.vlm is not None and not (is_vlm_arch and custom_vlm_cls):
@@ -1314,6 +1384,9 @@ def forward(
     # is split out because it comes from the renderer rather than the processor.
     mm_kwargs: dict[str, Tensor] | None = None,
     mm_token_type_ids: Int[Tensor, "batch seq"] | None = None,
+    # True when seq_lens holds the full pre-CP-shard document boundaries
+    # (kept global because documents can straddle the shard cut).
+    seq_lens_are_global: bool = False,
 ) -> PrimeLmOutput:
     kwargs = {
         "input_ids": input_ids,
@@ -1335,6 +1408,7 @@ def forward(
 
     if isinstance(model, PreTrainedModelPrimeRL):
         kwargs["seq_lens"] = seq_lens
+        kwargs["seq_lens_are_global"] = seq_lens_are_global
 
     if routed_experts is not None:
         kwargs["routed_experts"] = routed_experts

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -528,12 +528,6 @@ def get_load_balance_stats(
     }
 
 
-def _is_qwen3_5_config(model_config: PretrainedConfig) -> bool:
-    model_type = getattr(model_config, "model_type", "")
-    text_model_type = getattr(getattr(model_config, "text_config", None), "model_type", "")
-    return model_type.startswith("qwen3_5") or text_model_type.startswith("qwen3_5")
-
-
 def get_model(
     config: ModelConfig, device: torch.device = torch.device("cpu"), dtype: torch.dtype = torch.bfloat16
 ) -> nn.Module:
@@ -685,11 +679,10 @@ def get_model(
             f"but model.impl resolved to 'hf'. Set model.impl='custom' explicitly."
         )
 
-    if config.cp > 1 and _is_qwen3_5_config(model_config) and impl_to_use != "custom":
+    if config.cp > 1 and impl_to_use != "custom":
         raise ValueError(
-            "Qwen3.5 context parallelism requires model.impl='custom' "
-            "(or model.impl='auto' selecting the custom PrimeRL implementation); "
-            "the HuggingFace implementation does not expose set_context_parallel_attributes."
+            "Context parallelism requires model.impl='custom' "
+            "(or model.impl='auto' selecting a custom PrimeRL implementation)."
         )
 
     if config.vlm is not None and not (is_vlm_arch and custom_vlm_cls):

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -386,7 +386,7 @@ class AfmoeModel(AfmoePreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
     ) -> MoeModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
@@ -480,7 +480,7 @@ class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
@@ -502,7 +502,7 @@ class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
-            seq_lens_are_global=seq_lens_are_global,
+            seq_lens_are_pre_shard=seq_lens_are_pre_shard,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -386,6 +386,7 @@ class AfmoeModel(AfmoePreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
     ) -> MoeModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
@@ -479,6 +480,7 @@ class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
@@ -500,6 +502,7 @@ class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
+            seq_lens_are_global=seq_lens_are_global,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -401,36 +401,12 @@ class AfmoeModel(AfmoePreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        use_flash = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens.numel() > 1 and not use_flash:
-            # SDPA/eager attention has no varlen support and would attend across
-            # packed document boundaries.
-            raise ValueError("Packed Afmoe batches require flash attention")
-
-        if use_flash:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                seq_lens.to(device=inputs_embeds.device),
-                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
-            )
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-            causal_mask_mapping = None
-        else:
-            cu_seqlens = None
-            max_seqlen = None
-            cache_position = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device)
-            if not isinstance(causal_mask_mapping := attention_mask, dict):
-                mask_kwargs = {
-                    "config": self.config,
-                    "inputs_embeds": inputs_embeds,
-                    "attention_mask": attention_mask,
-                    "cache_position": cache_position,
-                    "past_key_values": None,
-                    "position_ids": position_ids,
-                }
-                causal_mask_mapping = {
-                    "full_attention": create_causal_mask(**mask_kwargs),
-                    "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
-                }
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device),
+            total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        causal_mask_mapping = None
 
         hidden_states = inputs_embeds
 

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -401,11 +401,36 @@ class AfmoeModel(AfmoePreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-        )
-        torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        causal_mask_mapping = None
+        use_flash = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens.numel() > 1 and not use_flash:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Afmoe batches require flash attention")
+
+        if use_flash:
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device),
+                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+            )
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+            causal_mask_mapping = None
+        else:
+            cu_seqlens = None
+            max_seqlen = None
+            cache_position = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device)
+            if not isinstance(causal_mask_mapping := attention_mask, dict):
+                mask_kwargs = {
+                    "config": self.config,
+                    "inputs_embeds": inputs_embeds,
+                    "attention_mask": attention_mask,
+                    "cache_position": cache_position,
+                    "past_key_values": None,
+                    "position_ids": position_ids,
+                }
+                causal_mask_mapping = {
+                    "full_attention": create_causal_mask(**mask_kwargs),
+                    "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
+                }
 
         hidden_states = inputs_embeds
 

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -223,20 +223,11 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
-        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens.numel() > 1 and not flash_attn_enabled:
-            # SDPA/eager attention has no varlen support and would attend across
-            # packed document boundaries.
-            raise ValueError("Packed Glm4Moe batches require flash attention")
-        if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                seq_lens.to(device=inputs_embeds.device),
-                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
-            )
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            max_seqlen = None
-            cu_seqlens = None
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device),
+            total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -207,14 +207,14 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
-        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -279,13 +279,13 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
-        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
@@ -330,7 +330,7 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
-            seq_lens_are_global=seq_lens_are_global,
+            seq_lens_are_pre_shard=seq_lens_are_pre_shard,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -223,10 +223,20 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
-        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-        )
-        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Glm4Moe batches require flash attention")
+        if flash_attn_enabled:
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device),
+                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+            )
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        else:
+            max_seqlen = None
+            cu_seqlens = None
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -207,12 +207,15 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -276,11 +279,14 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -324,6 +330,7 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
+            seq_lens_are_global=seq_lens_are_global,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -313,11 +313,14 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
         # trainer's universal contract.
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -313,13 +313,13 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
         # trainer's universal contract.
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
-        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API

--- a/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
@@ -309,11 +309,14 @@ class GptOssForCausalLM(GptOssPreTrainedModel, GenerationMixin):
         # seq_lens is accepted to satisfy the trainer's universal contract.
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Per-token temperatures for logprobs/entropy computation when `labels` are provided.
         """

--- a/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
@@ -309,13 +309,13 @@ class GptOssForCausalLM(GptOssPreTrainedModel, GenerationMixin):
         # seq_lens is accepted to satisfy the trainer's universal contract.
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
-        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Per-token temperatures for logprobs/entropy computation when `labels` are provided.

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -302,11 +302,35 @@ class LagunaModel(LagunaPreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-        )
-        torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        causal_mask_mapping = dict.fromkeys(set(self.config.layer_types), None)
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Laguna batches require flash attention")
+        if flash_attn_enabled:
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device),
+                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+            )
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+            causal_mask_mapping = dict.fromkeys(set(self.config.layer_types), None)
+        else:
+            cu_seqlens = None
+            max_seqlen = None
+            if isinstance(attention_mask, dict):
+                causal_mask_mapping = attention_mask
+            else:
+                mask_kwargs = {
+                    "config": self.config,
+                    "inputs_embeds": inputs_embeds,
+                    "attention_mask": attention_mask,
+                    "past_key_values": None,
+                    "position_ids": position_ids,
+                }
+                causal_mask_mapping = {
+                    "full_attention": create_causal_mask(**mask_kwargs),
+                    "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
+                }
 
         hidden_states = inputs_embeds
         position_embeddings = {

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -292,7 +292,7 @@ class LagunaModel(LagunaPreTrainedModel):
         routed_experts: torch.LongTensor | None = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
     ) -> MoeModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -367,7 +367,7 @@ class LagunaForCausalLM(LagunaPreTrainedModel, GenerationMixin):
         routed_experts: torch.LongTensor | None = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom Laguna"
@@ -380,7 +380,7 @@ class LagunaForCausalLM(LagunaPreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
-            seq_lens_are_global=seq_lens_are_global,
+            seq_lens_are_pre_shard=seq_lens_are_pre_shard,
         )
         hidden_states = outputs.last_hidden_state
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -292,6 +292,7 @@ class LagunaModel(LagunaPreTrainedModel):
         routed_experts: torch.LongTensor | None = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
     ) -> MoeModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -366,6 +367,7 @@ class LagunaForCausalLM(LagunaPreTrainedModel, GenerationMixin):
         routed_experts: torch.LongTensor | None = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom Laguna"
@@ -378,6 +380,7 @@ class LagunaForCausalLM(LagunaPreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
+            seq_lens_are_global=seq_lens_are_global,
         )
         hidden_states = outputs.last_hidden_state
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -302,35 +302,12 @@ class LagunaModel(LagunaPreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens.numel() > 1 and not flash_attn_enabled:
-            # SDPA/eager attention has no varlen support and would attend across
-            # packed document boundaries.
-            raise ValueError("Packed Laguna batches require flash attention")
-        if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                seq_lens.to(device=inputs_embeds.device),
-                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
-            )
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-            causal_mask_mapping = dict.fromkeys(set(self.config.layer_types), None)
-        else:
-            cu_seqlens = None
-            max_seqlen = None
-            if isinstance(attention_mask, dict):
-                causal_mask_mapping = attention_mask
-            else:
-                mask_kwargs = {
-                    "config": self.config,
-                    "inputs_embeds": inputs_embeds,
-                    "attention_mask": attention_mask,
-                    "past_key_values": None,
-                    "position_ids": position_ids,
-                }
-                causal_mask_mapping = {
-                    "full_attention": create_causal_mask(**mask_kwargs),
-                    "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
-                }
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device),
+            total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        causal_mask_mapping = dict.fromkeys(set(self.config.layer_types), None)
 
         hidden_states = inputs_embeds
         position_embeddings = {

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -183,12 +183,12 @@ class LlamaModel(LlamaPreTrainedModel):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
     ) -> BaseModelOutputWithPast:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
-        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -250,13 +250,13 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
         temperature: Optional[torch.Tensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
-        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
@@ -298,7 +298,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             seq_lens=seq_lens,
-            seq_lens_are_global=seq_lens_are_global,
+            seq_lens_are_pre_shard=seq_lens_are_pre_shard,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -197,20 +197,11 @@ class LlamaModel(LlamaPreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
-        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens.numel() > 1 and not flash_attn_enabled:
-            # SDPA/eager attention has no varlen support and would attend across
-            # packed document boundaries.
-            raise ValueError("Packed Llama batches require flash attention")
-        if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                seq_lens.to(device=inputs_embeds.device),
-                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
-            )
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            max_seqlen = None
-            cu_seqlens = None
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device),
+            total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -197,10 +197,20 @@ class LlamaModel(LlamaPreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
-        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-        )
-        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Llama batches require flash attention")
+        if flash_attn_enabled:
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device),
+                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+            )
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        else:
+            max_seqlen = None
+            cu_seqlens = None
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -183,10 +183,13 @@ class LlamaModel(LlamaPreTrainedModel):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
     ) -> BaseModelOutputWithPast:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -247,11 +250,14 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
         temperature: Optional[torch.Tensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -292,6 +298,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             seq_lens=seq_lens,
+            seq_lens_are_global=seq_lens_are_global,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -184,10 +184,20 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-        )
-        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed MiniMaxM2 batches require flash attention")
+        if flash_attn_enabled:
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device),
+                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+            )
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        else:
+            max_seqlen = None
+            cu_seqlens = None
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -168,12 +168,15 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -234,11 +237,14 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -265,6 +271,7 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
+            seq_lens_are_global=seq_lens_are_global,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -184,20 +184,11 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens.numel() > 1 and not flash_attn_enabled:
-            # SDPA/eager attention has no varlen support and would attend across
-            # packed document boundaries.
-            raise ValueError("Packed MiniMaxM2 batches require flash attention")
-        if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                seq_lens.to(device=inputs_embeds.device),
-                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
-            )
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            max_seqlen = None
-            cu_seqlens = None
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device),
+            total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -168,14 +168,14 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
-        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -237,13 +237,13 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
-        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
@@ -271,7 +271,7 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
-            seq_lens_are_global=seq_lens_are_global,
+            seq_lens_are_pre_shard=seq_lens_are_pre_shard,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -537,21 +537,11 @@ class NemotronHModel(NemotronHPreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        # Compute cu_seqlens and max_seqlen for flash attention
-        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens.numel() > 1 and not flash_attn_enabled:
-            # SDPA/eager attention has no varlen support and would attend across
-            # packed document boundaries.
-            raise ValueError("Packed NemotronH batches require flash attention")
-        if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                seq_lens.to(device=inputs_embeds.device),
-                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
-            )
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            max_seqlen = None
-            cu_seqlens = None
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device),
+            total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids) if self.rotary_emb is not None else None

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -225,20 +225,22 @@ class NemotronHMambaLayer(GradientCheckpointingLayer):
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
         routed_experts: torch.Tensor | None = None,
+        cu_seqlens_are_pre_shard: bool = False,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.norm(hidden_states)
 
         if self.cp_enabled:
-            # The local cu_seqlens cover only this shard; conv/scan need the full
-            # pre-shard document boundaries published by setup_cp_params.
+            global_cu_seqlens = (
+                cu_seqlens if cu_seqlens is not None and cu_seqlens_are_pre_shard else ULYSSES_PARAMS["cu_seqlens"]
+            )
             hidden_states = mamba_cp_forward(
                 self.mamba,
                 hidden_states,
                 self._cp_group,
                 self._cp_rank,
                 self._cp_world_size,
-                ULYSSES_PARAMS["cu_seqlens"],
+                global_cu_seqlens,
             )
         else:
             hidden_states = self.mamba(hidden_states, cu_seqlens=cu_seqlens)
@@ -275,6 +277,7 @@ class NemotronHMoELayer(GradientCheckpointingLayer):
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
         routed_experts: torch.Tensor | None = None,
+        cu_seqlens_are_pre_shard: bool = False,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.norm(hidden_states)
@@ -308,6 +311,7 @@ class NemotronHAttentionLayer(GradientCheckpointingLayer):
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
         routed_experts: torch.Tensor | None = None,
+        cu_seqlens_are_pre_shard: bool = False,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.norm(hidden_states)
@@ -533,10 +537,21 @@ class NemotronHModel(NemotronHPreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-        )
-        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        # Compute cu_seqlens and max_seqlen for flash attention
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed NemotronH batches require flash attention")
+        if flash_attn_enabled:
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device),
+                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+            )
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        else:
+            max_seqlen = None
+            cu_seqlens = None
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids) if self.rotary_emb is not None else None
@@ -550,6 +565,7 @@ class NemotronHModel(NemotronHPreTrainedModel):
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
                 routed_experts=routed_experts_layer,
+                cu_seqlens_are_pre_shard=seq_lens_are_pre_shard,
             )
 
         hidden_states = self.norm(hidden_states)

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -503,7 +503,7 @@ class NemotronHModel(NemotronHPreTrainedModel):
         self.post_init()
 
     def set_context_parallel_attributes(self, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
-        for layer in self.layers:
+        for layer in self.layers.modules():
             if isinstance(layer, NemotronHMambaLayer):
                 layer.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
 

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -502,6 +502,11 @@ class NemotronHModel(NemotronHPreTrainedModel):
         self.gradient_checkpointing = False
         self.post_init()
 
+    def set_context_parallel_attributes(self, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
+        for layer in self.layers:
+            if isinstance(layer, NemotronHMambaLayer):
+                layer.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
+
     @auto_docstring
     def forward(
         self,
@@ -511,6 +516,7 @@ class NemotronHModel(NemotronHPreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
@@ -518,6 +524,8 @@ class NemotronHModel(NemotronHPreTrainedModel):
             for non-MoE (Mamba/attention) layers are ignored.
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -562,6 +570,9 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
     def get_decoder(self):
         return self.model
 
+    def set_context_parallel_attributes(self, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
+        self.model.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
+
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
@@ -573,6 +584,7 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
         **kwargs,
     ) -> PrimeLmOutput:
         if position_ids is None:
@@ -587,6 +599,7 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
+            seq_lens_are_global=seq_lens_are_global,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -516,7 +516,7 @@ class NemotronHModel(NemotronHPreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
@@ -524,7 +524,7 @@ class NemotronHModel(NemotronHPreTrainedModel):
             for non-MoE (Mamba/attention) layers are ignored.
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
-        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -584,7 +584,7 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
         **kwargs,
     ) -> PrimeLmOutput:
         if position_ids is None:
@@ -599,7 +599,7 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
-            seq_lens_are_global=seq_lens_are_global,
+            seq_lens_are_pre_shard=seq_lens_are_pre_shard,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
+++ b/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
@@ -156,12 +156,12 @@ class Qwen3Model(Qwen3PreTrainedModel):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
     ) -> BaseModelOutputWithPast:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
-        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -228,13 +228,13 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
         temperature: Optional[torch.Tensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
-        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
@@ -254,7 +254,7 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             seq_lens=seq_lens,
-            seq_lens_are_global=seq_lens_are_global,
+            seq_lens_are_pre_shard=seq_lens_are_pre_shard,
         )
         hidden_states = outputs.last_hidden_state
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep

--- a/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
+++ b/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
@@ -156,10 +156,13 @@ class Qwen3Model(Qwen3PreTrainedModel):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
     ) -> BaseModelOutputWithPast:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -225,11 +228,14 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
         temperature: Optional[torch.Tensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility; prime-rl asserts `use_cache is None` since training does not
@@ -248,6 +254,7 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             seq_lens=seq_lens,
+            seq_lens_are_global=seq_lens_are_global,
         )
         hidden_states = outputs.last_hidden_state
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep

--- a/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
+++ b/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
@@ -172,10 +172,20 @@ class Qwen3Model(Qwen3PreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-        )
-        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Qwen3 batches require flash attention")
+        if flash_attn_enabled:
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device),
+                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+            )
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        else:
+            cu_seqlens = None
+            max_seqlen = None
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)

--- a/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
+++ b/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
@@ -172,20 +172,11 @@ class Qwen3Model(Qwen3PreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens.numel() > 1 and not flash_attn_enabled:
-            # SDPA/eager attention has no varlen support and would attend across
-            # packed document boundaries.
-            raise ValueError("Packed Qwen3 batches require flash attention")
-        if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                seq_lens.to(device=inputs_embeds.device),
-                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
-            )
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            cu_seqlens = None
-            max_seqlen = None
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device),
+            total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -215,7 +215,7 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
     ) -> BaseModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -230,7 +230,7 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
                 seq_lens.to(device=inputs_embeds.device),
-                total_tokens=None if seq_lens_are_global else inputs_embeds.shape[1],
+                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
             )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -239,12 +239,12 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
                 raise ValueError("Packed Qwen3.5 batches with full_attention layers require flash attention")
             cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
                 seq_lens,
-                total_tokens=None if seq_lens_are_global else inputs_embeds.shape[1],
+                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
             )
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
-        cu_seqlens_are_global = seq_lens_are_global
+        cu_seqlens_are_global = seq_lens_are_pre_shard
 
         for decoder_layer in self.layers:
             hidden_states = decoder_layer(
@@ -338,7 +338,7 @@ class Qwen3_5VLMModel(nn.Module):
         mm_token_type_ids: torch.LongTensor | None = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
     ) -> BaseModelOutputWithPast:
         inputs_embeds, position_ids = self.prepare_inputs_embeds_and_position_ids(
             input_ids=input_ids,
@@ -356,13 +356,13 @@ class Qwen3_5VLMModel(nn.Module):
             setup_cp_attention_params(position_ids, cp_group=cp_group, cp_style="ulysses", seq_lens=seq_lens)
             inputs_embeds = shard_for_cp(inputs_embeds, cp_rank=cp_rank, cp_world_size=cp_world_size)
             position_ids = shard_position_ids_for_cp(position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
-            seq_lens_are_global = True
+            seq_lens_are_pre_shard = True
 
         return self.language_model(
             inputs_embeds=inputs_embeds,
             position_ids=position_ids,
             seq_lens=seq_lens,
-            seq_lens_are_global=seq_lens_are_global,
+            seq_lens_are_pre_shard=seq_lens_are_pre_shard,
         )
 
 
@@ -421,7 +421,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         mm_token_type_ids: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom qwen3_5 for now"
@@ -435,7 +435,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
                 image_grid_thw=image_grid_thw,
                 mm_token_type_ids=mm_token_type_ids,
                 seq_lens=seq_lens,
-                seq_lens_are_global=seq_lens_are_global,
+                seq_lens_are_pre_shard=seq_lens_are_pre_shard,
             )
         else:
             outputs = self.model(
@@ -443,7 +443,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
                 position_ids=position_ids,
                 inputs_embeds=inputs_embeds,
                 seq_lens=seq_lens,
-                seq_lens_are_global=seq_lens_are_global,
+                seq_lens_are_pre_shard=seq_lens_are_pre_shard,
             )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -100,14 +100,14 @@ class Qwen3_5DecoderLayer(GradientCheckpointingLayer):
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
-        cu_seqlens_are_global: bool = False,
+        cu_seqlens_are_pre_shard: bool = False,
     ) -> torch.FloatTensor:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
 
         if self.layer_type == "linear_attention":
             hidden_states = self.linear_attn(
-                hidden_states, cu_seqlens=cu_seqlens, cu_seqlens_are_global=cu_seqlens_are_global
+                hidden_states, cu_seqlens=cu_seqlens, cu_seqlens_are_pre_shard=cu_seqlens_are_pre_shard
             )
         else:
             hidden_states, _ = self.self_attn(
@@ -202,7 +202,7 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         self._cp_group = cp_group
         self._cp_rank = cp_rank
         self._cp_world_size = cp_world_size
-        for layer in self.layers:
+        for layer in self.layers.modules():
             if getattr(layer, "layer_type", None) == "linear_attention":
                 layer.linear_attn.cp_group = cp_group
                 layer.linear_attn.cp_rank = cp_rank
@@ -244,7 +244,7 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
-        cu_seqlens_are_global = seq_lens_are_pre_shard
+        cu_seqlens_are_pre_shard = seq_lens_are_pre_shard
 
         for decoder_layer in self.layers:
             hidden_states = decoder_layer(
@@ -252,7 +252,7 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
                 position_embeddings=position_embeddings,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
-                cu_seqlens_are_global=cu_seqlens_are_global,
+                cu_seqlens_are_pre_shard=cu_seqlens_are_pre_shard,
             )
 
         hidden_states = self.norm(hidden_states)

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -226,21 +226,11 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                seq_lens.to(device=inputs_embeds.device),
-                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
-            )
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            seq_lens = seq_lens.to(device=inputs_embeds.device)
-            if seq_lens.numel() > 1 and "full_attention" in self.config.layer_types:
-                raise ValueError("Packed Qwen3.5 batches with full_attention layers require flash attention")
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                seq_lens,
-                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
-            )
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device),
+            total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 

--- a/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/prime_rl/trainer/models/qwen3_5/modeling_qwen3_5.py
@@ -28,6 +28,7 @@ from prime_rl.trainer.models.qwen3_5_moe.modeling_qwen3_5_moe import (
     normalize_qwen3_5_attn_implementation,
 )
 from prime_rl.trainer.models.qwen3_5_moe.mrope import build_qwen3_5_mrope_position_ids
+from prime_rl.utils.cp import setup_cp_attention_params, shard_for_cp, shard_position_ids_for_cp
 from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 
@@ -99,12 +100,15 @@ class Qwen3_5DecoderLayer(GradientCheckpointingLayer):
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
+        cu_seqlens_are_global: bool = False,
     ) -> torch.FloatTensor:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
 
         if self.layer_type == "linear_attention":
-            hidden_states = self.linear_attn(hidden_states, cu_seqlens=cu_seqlens)
+            hidden_states = self.linear_attn(
+                hidden_states, cu_seqlens=cu_seqlens, cu_seqlens_are_global=cu_seqlens_are_global
+            )
         else:
             hidden_states, _ = self.self_attn(
                 hidden_states=hidden_states,
@@ -194,6 +198,16 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
     def set_input_embeddings(self, value):
         self.embed_tokens = value
 
+    def set_context_parallel_attributes(self, cp_group, cp_rank: int, cp_world_size: int) -> None:
+        self._cp_group = cp_group
+        self._cp_rank = cp_rank
+        self._cp_world_size = cp_world_size
+        for layer in self.layers:
+            if getattr(layer, "layer_type", None) == "linear_attention":
+                layer.linear_attn.cp_group = cp_group
+                layer.linear_attn.cp_rank = cp_rank
+                layer.linear_attn.cp_world_size = cp_world_size
+
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
@@ -201,6 +215,7 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
     ) -> BaseModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -211,12 +226,25 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-        )
-        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if flash_attn_enabled:
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device),
+                total_tokens=None if seq_lens_are_global else inputs_embeds.shape[1],
+            )
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        else:
+            seq_lens = seq_lens.to(device=inputs_embeds.device)
+            if seq_lens.numel() > 1 and "full_attention" in self.config.layer_types:
+                raise ValueError("Packed Qwen3.5 batches with full_attention layers require flash attention")
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens,
+                total_tokens=None if seq_lens_are_global else inputs_embeds.shape[1],
+            )
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        cu_seqlens_are_global = seq_lens_are_global
 
         for decoder_layer in self.layers:
             hidden_states = decoder_layer(
@@ -224,6 +252,7 @@ class Qwen3_5Model(Qwen3_5PreTrainedModel):
                 position_embeddings=position_embeddings,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
+                cu_seqlens_are_global=cu_seqlens_are_global,
             )
 
         hidden_states = self.norm(hidden_states)
@@ -244,6 +273,9 @@ class Qwen3_5VLMModel(nn.Module):
 
     def set_input_embeddings(self, value):
         self.language_model.set_input_embeddings(value)
+
+    def set_context_parallel_attributes(self, cp_group, cp_rank: int, cp_world_size: int) -> None:
+        self.language_model.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
 
     def _dummy_vision_inputs(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
         vcfg = self.config.vision_config
@@ -306,6 +338,7 @@ class Qwen3_5VLMModel(nn.Module):
         mm_token_type_ids: torch.LongTensor | None = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
     ) -> BaseModelOutputWithPast:
         inputs_embeds, position_ids = self.prepare_inputs_embeds_and_position_ids(
             input_ids=input_ids,
@@ -316,10 +349,20 @@ class Qwen3_5VLMModel(nn.Module):
             seq_lens=seq_lens,
         )
 
+        cp_group = getattr(self.language_model, "_cp_group", None)
+        if image_grid_thw is not None and cp_group is not None:
+            cp_rank = self.language_model._cp_rank
+            cp_world_size = self.language_model._cp_world_size
+            setup_cp_attention_params(position_ids, cp_group=cp_group, cp_style="ulysses", seq_lens=seq_lens)
+            inputs_embeds = shard_for_cp(inputs_embeds, cp_rank=cp_rank, cp_world_size=cp_world_size)
+            position_ids = shard_position_ids_for_cp(position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
+            seq_lens_are_global = True
+
         return self.language_model(
             inputs_embeds=inputs_embeds,
             position_ids=position_ids,
             seq_lens=seq_lens,
+            seq_lens_are_global=seq_lens_are_global,
         )
 
 
@@ -359,6 +402,9 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
     def get_decoder(self):
         return self.model
 
+    def set_context_parallel_attributes(self, cp_group, cp_rank: int, cp_world_size: int) -> None:
+        self.model.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
+
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
@@ -375,6 +421,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         mm_token_type_ids: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom qwen3_5 for now"
@@ -388,6 +435,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
                 image_grid_thw=image_grid_thw,
                 mm_token_type_ids=mm_token_type_ids,
                 seq_lens=seq_lens,
+                seq_lens_are_global=seq_lens_are_global,
             )
         else:
             outputs = self.model(
@@ -395,6 +443,7 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
                 position_ids=position_ids,
                 inputs_embeds=inputs_embeds,
                 seq_lens=seq_lens,
+                seq_lens_are_global=seq_lens_are_global,
             )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -133,21 +133,17 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
 
     def _build_cp_context(
         self,
-        local_seq_len: int,
         device: torch.device,
         cu_seqlens: torch.LongTensor | None = None,
         cu_seqlens_are_pre_shard: bool = False,
     ) -> "FLACPContext | None":
-        """Build fla CP context from the local (sharded) sequence length."""
+        """Build the FLA CP context from full pre-shard sequence boundaries."""
         cp_group = getattr(self, "cp_group", None)
         if cp_group is None:
             return None
-        # Provenance flag rather than reading cu_seqlens back (per-layer CPU-GPU sync).
-        if cu_seqlens is not None and cu_seqlens_are_pre_shard:
-            global_cu_seqlens = cu_seqlens.to(device=device, dtype=torch.int32)
-        else:
-            global_seq_len = local_seq_len * self.cp_world_size
-            global_cu_seqlens = torch.tensor([0, global_seq_len], dtype=torch.int32, device=device)
+        if cu_seqlens is None or not cu_seqlens_are_pre_shard:
+            raise ValueError("Qwen3.5 context parallelism requires full pre-shard sequence boundaries")
+        global_cu_seqlens = cu_seqlens.to(device=device, dtype=torch.int32)
         return build_cp_context(
             cu_seqlens=global_cu_seqlens,
             group=cp_group,
@@ -167,7 +163,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         b = self.in_proj_b(hidden_states)
         a = self.in_proj_a(hidden_states)
 
-        cp_context = self._build_cp_context(seq_len, hidden_states.device, cu_seqlens, cu_seqlens_are_pre_shard)
+        cp_context = self._build_cp_context(hidden_states.device, cu_seqlens, cu_seqlens_are_pre_shard)
 
         # Causal conv1d — must reset at sequence boundaries for packed batches,
         # otherwise the kernel-1 left pad leaks state across sequences.

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -118,14 +118,14 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         local_seq_len: int,
         device: torch.device,
         cu_seqlens: torch.LongTensor | None = None,
-        cu_seqlens_are_global: bool = False,
+        cu_seqlens_are_pre_shard: bool = False,
     ) -> "FLACPContext | None":
         """Build fla CP context from the local (sharded) sequence length."""
         cp_group = getattr(self, "cp_group", None)
         if cp_group is None:
             return None
         # Provenance flag rather than reading cu_seqlens back (per-layer CPU-GPU sync).
-        if cu_seqlens is not None and cu_seqlens_are_global:
+        if cu_seqlens is not None and cu_seqlens_are_pre_shard:
             global_cu_seqlens = cu_seqlens.to(device=device, dtype=torch.int32)
         else:
             global_seq_len = local_seq_len * self.cp_world_size
@@ -140,7 +140,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         self,
         hidden_states: torch.Tensor,
         cu_seqlens: torch.LongTensor | None = None,
-        cu_seqlens_are_global: bool = False,
+        cu_seqlens_are_pre_shard: bool = False,
     ) -> torch.Tensor:
         batch_size, seq_len, _ = hidden_states.shape
 
@@ -149,7 +149,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         b = self.in_proj_b(hidden_states)
         a = self.in_proj_a(hidden_states)
 
-        cp_context = self._build_cp_context(seq_len, hidden_states.device, cu_seqlens, cu_seqlens_are_global)
+        cp_context = self._build_cp_context(seq_len, hidden_states.device, cu_seqlens, cu_seqlens_are_pre_shard)
 
         # Causal conv1d — must reset at sequence boundaries for packed batches,
         # otherwise the kernel-1 left pad leaks state across sequences.
@@ -444,7 +444,7 @@ class Qwen3_5MoeDecoderLayer(GradientCheckpointingLayer):
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        cu_seqlens_are_global: bool = False,
+        cu_seqlens_are_pre_shard: bool = False,
     ) -> torch.FloatTensor:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
@@ -452,7 +452,7 @@ class Qwen3_5MoeDecoderLayer(GradientCheckpointingLayer):
         # Token mixer
         if self.layer_type == "linear_attention":
             hidden_states = self.linear_attn(
-                hidden_states, cu_seqlens=cu_seqlens, cu_seqlens_are_global=cu_seqlens_are_global
+                hidden_states, cu_seqlens=cu_seqlens, cu_seqlens_are_pre_shard=cu_seqlens_are_pre_shard
             )
         elif self.layer_type == "full_attention":
             hidden_states, _ = self.self_attn(
@@ -679,7 +679,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
         self._cp_group = cp_group
         self._cp_rank = cp_rank
         self._cp_world_size = cp_world_size
-        for layer in self.layers:
+        for layer in self.layers.modules():
             if getattr(layer, "layer_type", None) == "linear_attention":
                 layer.linear_attn.cp_group = cp_group
                 layer.linear_attn.cp_rank = cp_rank
@@ -722,7 +722,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
-        cu_seqlens_are_global = seq_lens_are_pre_shard
+        cu_seqlens_are_pre_shard = seq_lens_are_pre_shard
 
         for layer_idx, decoder_layer in enumerate(self.layers):
             routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
@@ -732,7 +732,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
                 routed_experts=routed_experts_layer,
-                cu_seqlens_are_global=cu_seqlens_are_global,
+                cu_seqlens_are_pre_shard=cu_seqlens_are_pre_shard,
             )
 
         hidden_states = self.norm(hidden_states)

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -43,6 +43,24 @@ from .mrope import build_qwen3_5_mrope_position_ids
 logger = logging.get_logger(__name__)
 
 
+@torch.compiler.disable
+def _fla_causal_conv1d_cp(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    activation: str,
+    cp_context: FLACPContext,
+) -> torch.Tensor:
+    output, _ = fla_causal_conv1d(
+        x=x,
+        weight=weight,
+        bias=bias,
+        activation=activation,
+        cp_context=cp_context,
+    )
+    return output
+
+
 # ---------------------------------------------------------------------------
 # RMSNorm variants
 # ---------------------------------------------------------------------------
@@ -153,14 +171,24 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
 
         # Causal conv1d — must reset at sequence boundaries for packed batches,
         # otherwise the kernel-1 left pad leaks state across sequences.
-        mixed_qkv, _ = fla_causal_conv1d(
-            x=mixed_qkv.transpose(1, 2),
-            weight=self.conv1d.weight.squeeze(1),
-            bias=self.conv1d.bias,
-            activation=self.activation,
-            cu_seqlens=cu_seqlens if cp_context is None else None,
-            cp_context=cp_context,
-        )
+        conv_input = mixed_qkv.transpose(1, 2)
+        conv_weight = self.conv1d.weight.squeeze(1)
+        if cp_context is None:
+            mixed_qkv, _ = fla_causal_conv1d(
+                x=conv_input,
+                weight=conv_weight,
+                bias=self.conv1d.bias,
+                activation=self.activation,
+                cu_seqlens=cu_seqlens,
+            )
+        else:
+            mixed_qkv = _fla_causal_conv1d_cp(
+                x=conv_input,
+                weight=conv_weight,
+                bias=self.conv1d.bias,
+                activation=self.activation,
+                cp_context=cp_context,
+            )
         query, key, value = torch.split(mixed_qkv, [self.key_dim, self.key_dim, self.value_dim], dim=-1)
 
         query = query.reshape(batch_size, seq_len, -1, self.head_k_dim)

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -732,21 +732,11 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                seq_lens.to(device=inputs_embeds.device),
-                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
-            )
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            seq_lens = seq_lens.to(device=inputs_embeds.device)
-            if seq_lens.numel() > 1 and "full_attention" in self.config.layer_types:
-                raise ValueError("Packed Qwen3.5 batches with full_attention layers require flash attention")
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                seq_lens,
-                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
-            )
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device),
+            total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -693,7 +693,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
     ) -> MoeModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -708,7 +708,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
         if flash_attn_enabled:
             cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
                 seq_lens.to(device=inputs_embeds.device),
-                total_tokens=None if seq_lens_are_global else inputs_embeds.shape[1],
+                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
             )
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
@@ -717,12 +717,12 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
                 raise ValueError("Packed Qwen3.5 batches with full_attention layers require flash attention")
             cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
                 seq_lens,
-                total_tokens=None if seq_lens_are_global else inputs_embeds.shape[1],
+                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
             )
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
-        cu_seqlens_are_global = seq_lens_are_global
+        cu_seqlens_are_global = seq_lens_are_pre_shard
 
         for layer_idx, decoder_layer in enumerate(self.layers):
             routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
@@ -844,7 +844,7 @@ class Qwen3_5MoeVLMModel(nn.Module):
         routed_experts: torch.LongTensor | None = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
     ) -> MoeModelOutputWithPast:
         inputs_embeds, position_ids = self.prepare_inputs_embeds_and_position_ids(
             input_ids=input_ids,
@@ -864,14 +864,14 @@ class Qwen3_5MoeVLMModel(nn.Module):
             position_ids = shard_position_ids_for_cp(position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
             if routed_experts is not None:
                 routed_experts = shard_for_cp(routed_experts, cp_rank=cp_rank, cp_world_size=cp_world_size)
-            seq_lens_are_global = True
+            seq_lens_are_pre_shard = True
 
         return self.language_model(
             inputs_embeds=inputs_embeds,
             position_ids=position_ids,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
-            seq_lens_are_global=seq_lens_are_global,
+            seq_lens_are_pre_shard=seq_lens_are_pre_shard,
         )
 
 
@@ -1019,7 +1019,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
         mm_token_type_ids: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom qwen3_5_moe for now"
@@ -1034,7 +1034,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
                 mm_token_type_ids=mm_token_type_ids,
                 routed_experts=routed_experts,
                 seq_lens=seq_lens,
-                seq_lens_are_global=seq_lens_are_global,
+                seq_lens_are_pre_shard=seq_lens_are_pre_shard,
             )
         else:
             outputs = self.model(
@@ -1043,7 +1043,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
                 inputs_embeds=inputs_embeds,
                 routed_experts=routed_experts,
                 seq_lens=seq_lens,
-                seq_lens_are_global=seq_lens_are_global,
+                seq_lens_are_pre_shard=seq_lens_are_pre_shard,
             )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -28,7 +28,7 @@ from prime_rl.trainer.models.layers.attn import (
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.moe import FeedForward, MoE, MoEArgs
 from prime_rl.trainer.models.layers.rotary_emb import apply_rotary_pos_emb
-from prime_rl.trainer.models.layers.ulysses_attn import ULYSSES_PARAMS
+from prime_rl.utils.cp import setup_cp_attention_params, shard_for_cp, shard_position_ids_for_cp
 from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 from .configuration_qwen3_5_moe import Qwen3_5MoeConfig
@@ -113,16 +113,25 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         self.in_proj_b = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)
         self.in_proj_a = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)
 
-    def _build_cp_context(self) -> "FLACPContext | None":
-        """Build fla CP context from the full pre-shard document boundaries."""
+    def _build_cp_context(
+        self,
+        local_seq_len: int,
+        device: torch.device,
+        cu_seqlens: torch.LongTensor | None = None,
+        cu_seqlens_are_global: bool = False,
+    ) -> "FLACPContext | None":
+        """Build fla CP context from the local (sharded) sequence length."""
         cp_group = getattr(self, "cp_group", None)
         if cp_group is None:
             return None
-        # Local cu_seqlens cannot describe documents straddling shard boundaries;
-        # use the full (un-sharded) cu_seqlens published by setup_cp_params. fla
-        # derives per-rank boundaries and document-aware state passing from them.
+        # Provenance flag rather than reading cu_seqlens back (per-layer CPU-GPU sync).
+        if cu_seqlens is not None and cu_seqlens_are_global:
+            global_cu_seqlens = cu_seqlens.to(device=device, dtype=torch.int32)
+        else:
+            global_seq_len = local_seq_len * self.cp_world_size
+            global_cu_seqlens = torch.tensor([0, global_seq_len], dtype=torch.int32, device=device)
         return build_cp_context(
-            cu_seqlens=ULYSSES_PARAMS["cu_seqlens"],
+            cu_seqlens=global_cu_seqlens,
             group=cp_group,
             conv1d_kernel_size=self.conv_kernel_size,
         )
@@ -131,6 +140,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         self,
         hidden_states: torch.Tensor,
         cu_seqlens: torch.LongTensor | None = None,
+        cu_seqlens_are_global: bool = False,
     ) -> torch.Tensor:
         batch_size, seq_len, _ = hidden_states.shape
 
@@ -139,7 +149,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         b = self.in_proj_b(hidden_states)
         a = self.in_proj_a(hidden_states)
 
-        cp_context = self._build_cp_context()
+        cp_context = self._build_cp_context(seq_len, hidden_states.device, cu_seqlens, cu_seqlens_are_global)
 
         # Causal conv1d — must reset at sequence boundaries for packed batches,
         # otherwise the kernel-1 left pad leaks state across sequences.
@@ -434,13 +444,16 @@ class Qwen3_5MoeDecoderLayer(GradientCheckpointingLayer):
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        cu_seqlens_are_global: bool = False,
     ) -> torch.FloatTensor:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
 
         # Token mixer
         if self.layer_type == "linear_attention":
-            hidden_states = self.linear_attn(hidden_states, cu_seqlens=cu_seqlens)
+            hidden_states = self.linear_attn(
+                hidden_states, cu_seqlens=cu_seqlens, cu_seqlens_are_global=cu_seqlens_are_global
+            )
         elif self.layer_type == "full_attention":
             hidden_states, _ = self.self_attn(
                 hidden_states=hidden_states,
@@ -662,6 +675,16 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
     def set_input_embeddings(self, value):
         self.embed_tokens = value
 
+    def set_context_parallel_attributes(self, cp_group, cp_rank: int, cp_world_size: int) -> None:
+        self._cp_group = cp_group
+        self._cp_rank = cp_rank
+        self._cp_world_size = cp_world_size
+        for layer in self.layers:
+            if getattr(layer, "layer_type", None) == "linear_attention":
+                layer.linear_attn.cp_group = cp_group
+                layer.linear_attn.cp_rank = cp_rank
+                layer.linear_attn.cp_world_size = cp_world_size
+
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
@@ -670,6 +693,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
     ) -> MoeModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -680,12 +704,25 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
         if position_ids is None:
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
-        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-        )
-        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if flash_attn_enabled:
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device),
+                total_tokens=None if seq_lens_are_global else inputs_embeds.shape[1],
+            )
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        else:
+            seq_lens = seq_lens.to(device=inputs_embeds.device)
+            if seq_lens.numel() > 1 and "full_attention" in self.config.layer_types:
+                raise ValueError("Packed Qwen3.5 batches with full_attention layers require flash attention")
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens,
+                total_tokens=None if seq_lens_are_global else inputs_embeds.shape[1],
+            )
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        cu_seqlens_are_global = seq_lens_are_global
 
         for layer_idx, decoder_layer in enumerate(self.layers):
             routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
@@ -695,6 +732,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
                 routed_experts=routed_experts_layer,
+                cu_seqlens_are_global=cu_seqlens_are_global,
             )
 
         hidden_states = self.norm(hidden_states)
@@ -734,6 +772,9 @@ class Qwen3_5MoeVLMModel(nn.Module):
 
     def set_input_embeddings(self, value):
         self.language_model.set_input_embeddings(value)
+
+    def set_context_parallel_attributes(self, cp_group, cp_rank: int, cp_world_size: int) -> None:
+        self.language_model.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
 
     def _dummy_vision_inputs(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
         """Smallest valid vision input: a single merged token (grid [1, m, m])."""
@@ -803,6 +844,7 @@ class Qwen3_5MoeVLMModel(nn.Module):
         routed_experts: torch.LongTensor | None = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
     ) -> MoeModelOutputWithPast:
         inputs_embeds, position_ids = self.prepare_inputs_embeds_and_position_ids(
             input_ids=input_ids,
@@ -813,11 +855,23 @@ class Qwen3_5MoeVLMModel(nn.Module):
             seq_lens=seq_lens,
         )
 
+        cp_group = getattr(self.language_model, "_cp_group", None)
+        if image_grid_thw is not None and cp_group is not None:
+            cp_rank = self.language_model._cp_rank
+            cp_world_size = self.language_model._cp_world_size
+            setup_cp_attention_params(position_ids, cp_group=cp_group, cp_style="ulysses", seq_lens=seq_lens)
+            inputs_embeds = shard_for_cp(inputs_embeds, cp_rank=cp_rank, cp_world_size=cp_world_size)
+            position_ids = shard_position_ids_for_cp(position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
+            if routed_experts is not None:
+                routed_experts = shard_for_cp(routed_experts, cp_rank=cp_rank, cp_world_size=cp_world_size)
+            seq_lens_are_global = True
+
         return self.language_model(
             inputs_embeds=inputs_embeds,
             position_ids=position_ids,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
+            seq_lens_are_global=seq_lens_are_global,
         )
 
 
@@ -883,6 +937,9 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
 
     def get_decoder(self):
         return self.model
+
+    def set_context_parallel_attributes(self, cp_group, cp_rank: int, cp_world_size: int) -> None:
+        self.model.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
 
     # ------------------------------------------------------------------
     # State dict detection & conversion (handles both text-only and VLM)
@@ -962,6 +1019,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
         mm_token_type_ids: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom qwen3_5_moe for now"
@@ -976,6 +1034,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
                 mm_token_type_ids=mm_token_type_ids,
                 routed_experts=routed_experts,
                 seq_lens=seq_lens,
+                seq_lens_are_global=seq_lens_are_global,
             )
         else:
             outputs = self.model(
@@ -984,6 +1043,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
                 inputs_embeds=inputs_embeds,
                 routed_experts=routed_experts,
                 seq_lens=seq_lens,
+                seq_lens_are_global=seq_lens_are_global,
             )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -224,20 +224,11 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
-        if seq_lens.numel() > 1 and not flash_attn_enabled:
-            # SDPA/eager attention has no varlen support and would attend across
-            # packed document boundaries.
-            raise ValueError("Packed Qwen3Moe batches require flash attention")
-        if flash_attn_enabled:
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-                seq_lens.to(device=inputs_embeds.device),
-                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
-            )
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            max_seqlen = None
-            cu_seqlens = None
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device),
+            total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+        )
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -208,12 +208,15 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
     ) -> MoeModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -286,11 +289,14 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
+        seq_lens_are_global: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
+        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
             compatibility — prime-rl asserts `use_cache is None` since training does not
@@ -339,6 +345,7 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
+            seq_lens_are_global=seq_lens_are_global,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -224,10 +224,20 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
-            seq_lens.to(device=inputs_embeds.device), total_tokens=inputs_embeds.shape[1]
-        )
-        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        flash_attn_enabled = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
+        if seq_lens.numel() > 1 and not flash_attn_enabled:
+            # SDPA/eager attention has no varlen support and would attend across
+            # packed document boundaries.
+            raise ValueError("Packed Qwen3Moe batches require flash attention")
+        if flash_attn_enabled:
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=inputs_embeds.device),
+                total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+            )
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        else:
+            max_seqlen = None
+            cu_seqlens = None
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -208,14 +208,14 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
     ) -> MoeModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
-        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -289,13 +289,13 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
         routed_experts: Optional[torch.LongTensor] = None,
         *,
         seq_lens: torch.LongTensor,
-        seq_lens_are_global: bool = False,
+        seq_lens_are_pre_shard: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
-        seq_lens_are_global (`bool`, *optional*, defaults to `False`):
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
         cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
             Indices of input tokens in the KV cache. Accepted only for HuggingFace API
@@ -345,7 +345,7 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
-            seq_lens_are_global=seq_lens_are_global,
+            seq_lens_are_pre_shard=seq_lens_are_pre_shard,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -65,7 +65,6 @@ from prime_rl.utils.metrics_server import HealthServer, MetricsServer, RunStats
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.config import cli
 from prime_rl.utils.process import set_proc_title
-from prime_rl.utils.sequence import get_cp_local_seq_lens
 from prime_rl.utils.utils import clean_exit, resolve_latest_ckpt_step, to_col_format
 from ring_flash_attn import substitute_hf_flash_attn
 from torchtitan.distributed.utils import clip_grad_norm_
@@ -205,8 +204,7 @@ def train(config: TrainerConfig):
             substitute_ulysses_attn(cp_group, attn_impl=config.model.attn)
         from prime_rl.utils.cp import (
             assert_cp_style_supports_model,
-            setup_hybrid_cp,
-            setup_nemotron_h_cp,
+            setup_model_cp,
             setup_sparse_mla_cp,
         )
 
@@ -216,8 +214,7 @@ def train(config: TrainerConfig):
         # Linear-attn / Mamba layers are only configured under ulysses; with ring
         # we'd have already raised above.
         if config.model.cp_style == "ulysses":
-            setup_hybrid_cp(model, cp_group, cp_rank, parallel_dims.cp)
-            setup_nemotron_h_cp(model, cp_group, cp_rank, parallel_dims.cp)
+            setup_model_cp(model, cp_group, cp_rank, parallel_dims.cp)
 
     # Optionally, resume training from a checkpoint
     progress = Progress()
@@ -379,7 +376,6 @@ def train(config: TrainerConfig):
                 raise NotImplementedError("Context parallelism is not supported with VLM/multimodal training")
 
             if cp_enabled:
-                total_tokens = input_ids.shape[1]
                 input_ids, forward_position_ids = setup_cp_params(
                     input_ids,
                     position_ids,
@@ -389,7 +385,6 @@ def train(config: TrainerConfig):
                     seq_lens=seq_lens,
                     cp_style=config.model.cp_style,
                 )
-                seq_lens = get_cp_local_seq_lens(seq_lens, total_tokens, cp_rank, cp_size)
                 labels = shard_for_cp(labels, cp_rank=cp_rank, cp_world_size=cp_size)
                 if routed_experts is not None:
                     routed_experts = shard_for_cp(routed_experts, cp_rank=cp_rank, cp_world_size=cp_size)
@@ -425,6 +420,7 @@ def train(config: TrainerConfig):
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_token_type_ids,
                     seq_lens=seq_lens,
+                    seq_lens_are_global=cp_enabled,
                     routed_experts=routed_experts,
                 )
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -420,7 +420,7 @@ def train(config: TrainerConfig):
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_token_type_ids,
                     seq_lens=seq_lens,
-                    seq_lens_are_global=cp_enabled,
+                    seq_lens_are_pre_shard=cp_enabled,
                     routed_experts=routed_experts,
                 )
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -51,7 +51,6 @@ from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.config import cli
 from prime_rl.utils.process import set_proc_title
-from prime_rl.utils.sequence import get_cp_local_seq_lens
 from prime_rl.utils.utils import clean_exit, to_col_format
 import torch.distributed as dist
 
@@ -126,7 +125,7 @@ def train(config: SFTConfig):
 
             substitute_hf_ulysses_attn(cp_group)
             substitute_ulysses_attn(cp_group, attn_impl=config.model.attn)
-        from prime_rl.utils.cp import setup_hybrid_cp, setup_nemotron_h_cp, setup_sparse_mla_cp
+        from prime_rl.utils.cp import setup_model_cp, setup_sparse_mla_cp
 
     # Set up checkpoint manager
     logger.info(f"Initializing checkpoint managers ({config.ckpt})")
@@ -153,8 +152,7 @@ def train(config: SFTConfig):
         # Linear-attn / Mamba layers are only configured under ulysses; with ring
         # we'd have already raised above.
         if config.model.cp_style == "ulysses":
-            setup_hybrid_cp(model, cp_group, cp_rank, parallel_dims.cp)
-            setup_nemotron_h_cp(model, cp_group, cp_rank, parallel_dims.cp)
+            setup_model_cp(model, cp_group, cp_rank, parallel_dims.cp)
 
     if config.model.lora is not None:
         multi_run_manager = get_multi_run_manager()
@@ -244,23 +242,30 @@ def train(config: SFTConfig):
         mm_kwargs = micro_batch.get("mm_kwargs")
         mm_type_ids = micro_batch.get("mm_token_type_ids")
 
+        seq_lens_are_global = False
+
         if cp_enabled:
-            total_tokens = input_ids.shape[1]
-            input_ids, position_ids = setup_cp_params(
-                input_ids,
-                position_ids,
-                cp_rank,
-                cp_size,
-                cp_group,
-                seq_lens=seq_lens,
-                cp_style=config.model.cp_style,
+            # CP requires the sequence length to be divisible by cp_size. CatDataset
+            # pads every pack to seq_len; shard_for_cp raises on violations.
+            defer_vlm_cp_to_model = (
+                mm_kwargs is not None and "image_grid_thw" in mm_kwargs and config.model.cp_style == "ulysses"
             )
-            seq_lens = get_cp_local_seq_lens(seq_lens, total_tokens, cp_rank, cp_size)
+            if not defer_vlm_cp_to_model:
+                input_ids, position_ids = setup_cp_params(
+                    input_ids,
+                    position_ids,
+                    cp_rank,
+                    cp_size,
+                    cp_group,
+                    seq_lens=seq_lens,
+                    cp_style=config.model.cp_style,
+                )
+            seq_lens_are_global = True
             target_ids = shard_for_cp(target_ids, cp_rank=cp_rank, cp_world_size=cp_size)
             loss_mask = shard_for_cp(loss_mask, cp_rank=cp_rank, cp_world_size=cp_size)
 
         if config.model.lora is not None:
-            set_lora_num_tokens(torch.full((1,), input_ids.numel(), dtype=torch.int32, device="cuda"))
+            set_lora_num_tokens(torch.full((1,), loss_mask.numel(), dtype=torch.int32, device="cuda"))
 
         token_count = loss_mask.sum(dtype=torch.int64)
 
@@ -279,6 +284,7 @@ def train(config: SFTConfig):
                     temperature=temperature,
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_type_ids,
+                    seq_lens_are_global=seq_lens_are_global,
                 )
                 loss_sum = -out["logprobs"][loss_mask].sum()
             else:
@@ -289,6 +295,7 @@ def train(config: SFTConfig):
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_type_ids,
                     seq_lens=seq_lens,
+                    seq_lens_are_global=seq_lens_are_global,
                 )
                 logits = out["logits"]
                 B, L, V = logits.shape

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -242,7 +242,7 @@ def train(config: SFTConfig):
         mm_kwargs = micro_batch.get("mm_kwargs")
         mm_type_ids = micro_batch.get("mm_token_type_ids")
 
-        seq_lens_are_global = False
+        seq_lens_are_pre_shard = False
 
         if cp_enabled:
             # CP requires the sequence length to be divisible by cp_size. CatDataset
@@ -260,7 +260,7 @@ def train(config: SFTConfig):
                     seq_lens=seq_lens,
                     cp_style=config.model.cp_style,
                 )
-            seq_lens_are_global = True
+            seq_lens_are_pre_shard = True
             target_ids = shard_for_cp(target_ids, cp_rank=cp_rank, cp_world_size=cp_size)
             loss_mask = shard_for_cp(loss_mask, cp_rank=cp_rank, cp_world_size=cp_size)
 
@@ -284,7 +284,7 @@ def train(config: SFTConfig):
                     temperature=temperature,
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_type_ids,
-                    seq_lens_are_global=seq_lens_are_global,
+                    seq_lens_are_pre_shard=seq_lens_are_pre_shard,
                 )
                 loss_sum = -out["logprobs"][loss_mask].sum()
             else:
@@ -295,7 +295,7 @@ def train(config: SFTConfig):
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_type_ids,
                     seq_lens=seq_lens,
-                    seq_lens_are_global=seq_lens_are_global,
+                    seq_lens_are_pre_shard=seq_lens_are_pre_shard,
                 )
                 logits = out["logits"]
                 B, L, V = logits.shape

--- a/src/prime_rl/utils/cp.py
+++ b/src/prime_rl/utils/cp.py
@@ -52,54 +52,22 @@ def assert_cp_style_supports_model(cp_style: CPStyle, model: nn.Module) -> None:
         )
 
 
-def setup_hybrid_cp(model: nn.Module, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
-    """Configure DeltaNet modules in Qwen3.5 hybrid models for ulysses-style CP."""
-    layers = None
-    if hasattr(model, "model"):
-        inner = model.model
-        if hasattr(inner, "language_model"):
-            inner = inner.language_model
-        if hasattr(inner, "layers"):
-            layers = inner.layers
+def setup_model_cp(model: nn.Module, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
+    """Hand the CP topology to models whose layers need it (DeltaNet, Mamba).
 
-    if layers is None:
-        return
-
-    count = 0
-    for layer in layers:
-        if getattr(layer, "layer_type", None) == "linear_attention":
-            attn = getattr(layer, "linear_attn", None)
-            if attn is not None:
-                attn.cp_group = cp_group
-                attn.cp_rank = cp_rank
-                attn.cp_world_size = cp_world_size
-                count += 1
-
-    if count > 0:
+    Such models expose ``set_context_parallel_attributes`` at the top level and
+    own their layer wiring; softmax-only models don't and need nothing.
+    """
+    if hasattr(model, "set_context_parallel_attributes"):
+        model.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
         from prime_rl.utils.logger import get_logger
 
-        get_logger().info(f"Configured hybrid CP on {count} DeltaNet modules (fla native state passing)")
-
-
-def setup_nemotron_h_cp(model: nn.Module, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
-    """Configure NemotronH Mamba layers for ulysses-style all-to-all head partitioning."""
-    layers = None
-    if hasattr(model, "model") and hasattr(model.model, "layers"):
-        layers = model.model.layers
-
-    if layers is None:
-        return
-
-    count = 0
-    for layer in layers:
-        if hasattr(layer, "mamba") and hasattr(layer, "set_context_parallel_attributes"):
-            layer.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
-            count += 1
-
-    if count > 0:
-        from prime_rl.utils.logger import get_logger
-
-        get_logger().info(f"Configured NemotronH CP on {count} Mamba layers (all-to-all head partitioning)")
+        get_logger().info("Configured model CP attributes")
+    elif _has_linear_attn_layer(model):
+        raise ValueError(
+            "Model has linear-attention/Mamba layers but does not implement "
+            "set_context_parallel_attributes; CP would silently misconfigure them"
+        )
 
 
 def setup_sparse_mla_cp(model: nn.Module, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
@@ -125,7 +93,7 @@ def setup_sparse_mla_cp(model: nn.Module, cp_group: dist.ProcessGroup, cp_rank: 
         get_logger().info(f"Configured sparse MLA CP on {count} DSA layers")
 
 
-def shard_for_cp(t: torch.Tensor, cp_rank: int, cp_world_size: int) -> torch.Tensor:
+def shard_for_cp(t: torch.Tensor, cp_rank: int, cp_world_size: int, seq_dim: int = 1) -> torch.Tensor:
     """
     Shard a tensor for context parallelism.
     Args:
@@ -136,11 +104,24 @@ def shard_for_cp(t: torch.Tensor, cp_rank: int, cp_world_size: int) -> torch.Ten
         The shard of the tensor for the current rank.
     """
 
-    assert t.shape[0] == 1, "For CP, tensor must have batch dimension of 1"
+    if seq_dim == 1 and t.shape[0] != 1:
+        raise ValueError(f"For CP, tensor must have batch dimension 1, got shape={tuple(t.shape)}")
+    if t.shape[seq_dim] % cp_world_size != 0:
+        raise ValueError(
+            f"CP requires sequence dimension {seq_dim} to be divisible by cp size: "
+            f"shape={tuple(t.shape)}, cp_size={cp_world_size}; "
+            "uneven shards deadlock CP collectives (e.g. ulysses all-to-all)"
+        )
 
-    chunked_t = torch.chunk(t, cp_world_size, dim=1)
+    chunked_t = torch.chunk(t, cp_world_size, dim=seq_dim)
 
     return chunked_t[cp_rank]
+
+
+def shard_position_ids_for_cp(position_ids: torch.Tensor, cp_rank: int, cp_world_size: int) -> torch.Tensor:
+    if position_ids.ndim == 3:
+        return shard_for_cp(position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size, seq_dim=2)
+    return shard_for_cp(position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
 
 
 def gather_for_cp(t: torch.Tensor, cp_group: dist.ProcessGroup) -> torch.Tensor:
@@ -176,6 +157,20 @@ def setup_cp_params(
     Returns the sequence-sharded input_ids and position_ids — the rest of the
     model still runs sequence-sharded; only attention sees the full sequence.
     """
+    setup_cp_attention_params(position_ids, cp_group=cp_group, seq_lens=seq_lens, cp_style=cp_style)
+
+    input_ids = shard_for_cp(input_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
+    position_ids = shard_position_ids_for_cp(position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
+    return input_ids, position_ids
+
+
+def setup_cp_attention_params(
+    position_ids: torch.Tensor,
+    cp_group: dist.ProcessGroup,
+    *,
+    seq_lens: torch.Tensor,
+    cp_style: CPStyle = "ring",
+) -> None:
     cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
         seq_lens.to(device=position_ids.device),
         total_tokens=position_ids.shape[-1],
@@ -191,7 +186,3 @@ def setup_cp_params(
         update_ulysses_params(cu_seqlens, max_seqlen)
     else:
         raise ValueError(f"Unknown cp_style: {cp_style}")
-
-    input_ids = shard_for_cp(input_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
-    position_ids = shard_for_cp(position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
-    return input_ids, position_ids

--- a/src/prime_rl/utils/cp.py
+++ b/src/prime_rl/utils/cp.py
@@ -158,7 +158,7 @@ def setup_cp_params(
     Returns the sequence-sharded input_ids and position_ids — the rest of the
     model still runs sequence-sharded; only attention sees the full sequence.
     """
-    setup_cp_attention_params(position_ids, cp_group=cp_group, seq_lens=seq_lens, cp_style=cp_style)
+    setup_cp_attention_params(position_ids, cp_group=cp_group, cp_style=cp_style, seq_lens=seq_lens)
 
     input_ids = shard_for_cp(input_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
     position_ids = shard_position_ids_for_cp(position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
@@ -172,9 +172,10 @@ def setup_cp_attention_params(
     seq_lens: torch.Tensor,
     cp_style: CPStyle = "ring",
 ) -> None:
+    total_tokens = position_ids.shape[-1]
     cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
         seq_lens.to(device=position_ids.device),
-        total_tokens=position_ids.shape[-1],
+        total_tokens=total_tokens,
     )
 
     if cp_style == "ring":

--- a/src/prime_rl/utils/cp.py
+++ b/src/prime_rl/utils/cp.py
@@ -24,7 +24,8 @@ def _has_linear_attn_layer(model: nn.Module) -> bool:
     layers = getattr(inner, "layers", None)
     if layers is None:
         return False
-    for layer in layers:
+    layer_modules = layers.modules() if isinstance(layers, nn.Module) else layers
+    for layer in layer_modules:
         # Qwen3.5 hybrid DeltaNet
         if getattr(layer, "layer_type", None) == "linear_attention":
             return True

--- a/src/prime_rl/utils/sequence.py
+++ b/src/prime_rl/utils/sequence.py
@@ -50,19 +50,3 @@ def get_cu_seqlens_from_seq_lens(seq_lens: torch.Tensor, total_tokens: int | Non
     cu_seqlens[0] = 0
     cu_seqlens[1:] = seq_lens.cumsum(dim=0, dtype=torch.int32)
     return cu_seqlens, int(seq_lens.max().item())
-
-
-def get_cp_local_seq_lens(
-    seq_lens: torch.Tensor,
-    total_tokens: int,
-    cp_rank: int,
-    cp_world_size: int,
-) -> torch.Tensor:
-    """Intersect global sequence boundaries with one contiguous CP shard."""
-    shard_size = total_tokens // cp_world_size
-    shard_start = seq_lens.new_tensor(cp_rank * shard_size)
-    shard_end = shard_start + shard_size
-    seq_ends = seq_lens.cumsum(dim=0)
-    seq_starts = torch.cat([seq_lens.new_zeros(1), seq_ends[:-1]])
-    overlaps = torch.minimum(seq_ends, shard_end) - torch.maximum(seq_starts, shard_start)
-    return overlaps[overlaps > 0]

--- a/tests/unit/train/models/test_nemotron_h.py
+++ b/tests/unit/train/models/test_nemotron_h.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 import torch
 from transformers.models.nemotron_h.configuration_nemotron_h import NemotronHConfig as HFNemotronHConfig
@@ -10,7 +12,8 @@ from transformers.models.nemotron_h.modeling_nemotron_h import (
 
 from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
 from prime_rl.trainer.models.nemotron_h import NemotronHConfig, NemotronHForCausalLM
-from prime_rl.trainer.models.nemotron_h.modeling_nemotron_h import NemotronHAttentionLayer
+from prime_rl.trainer.models.nemotron_h.modeling_nemotron_h import NemotronHAttentionLayer, NemotronHMambaLayer
+from prime_rl.utils.cp import setup_model_cp
 from prime_rl.utils.utils import default_dtype
 
 pytestmark = [pytest.mark.gpu]
@@ -223,6 +226,27 @@ def test_nemotron_h_hybrid_override_pattern():
     config = NemotronHConfig(**_BASE, hybrid_override_pattern="ME*E")
     assert config.layers_block_type == ["mamba", "moe", "attention", "moe"]
     assert config.num_hidden_layers == 4
+
+
+def test_nemotron_h_context_parallel_setup_finds_wrapped_mamba_layer():
+    config = NemotronHConfig(
+        **(_BASE | {"mamba_n_groups": 2}),
+        layers_block_type=["mamba", "moe", "attention", "moe"],
+        use_grouped_mm=False,
+    )
+    with torch.device("meta"):
+        model = NemotronHForCausalLM(config)
+
+    mamba_layer = model.model.layers[0]
+    assert isinstance(mamba_layer, NemotronHMambaLayer)
+    model.model.layers[0] = torch.nn.Sequential(mamba_layer)
+
+    cp_group = MagicMock()
+    setup_model_cp(model, cp_group, cp_rank=1, cp_world_size=2)
+
+    assert mamba_layer._cp_group is cp_group
+    assert mamba_layer._cp_rank == 1
+    assert mamba_layer._cp_world_size == 2
 
 
 def test_nemotron_h_no_latent_projection():

--- a/tests/unit/train/models/test_qwen3_5.py
+++ b/tests/unit/train/models/test_qwen3_5.py
@@ -134,11 +134,13 @@ def test_qwen3_5_context_parallel_setup_chain_text_and_vlm():
     cp_group = MagicMock()
 
     text_model = Qwen3_5ForCausalLM(_tiny_text_config())
+    linear_layer = text_model.model.layers[0]
+    text_model.model.layers[0] = torch.nn.Sequential(linear_layer)
     setup_model_cp(text_model, cp_group, cp_rank=1, cp_world_size=2)
     assert text_model.model._cp_group is cp_group
     assert text_model.model._cp_rank == 1
     assert text_model.model._cp_world_size == 2
-    assert text_model.model.layers[0].linear_attn.cp_group is cp_group
+    assert linear_layer.linear_attn.cp_group is cp_group
 
     with torch.device("meta"):
         vlm_model = Qwen3_5ForCausalLM(_tiny_vlm_config())
@@ -148,11 +150,11 @@ def test_qwen3_5_context_parallel_setup_chain_text_and_vlm():
 
 
 def test_setup_model_cp_requires_hook_only_for_hybrid_models():
-    class HybridLayer:
+    class HybridLayer(torch.nn.Module):
         layer_type = "linear_attention"
 
     class Inner:
-        layers = [HybridLayer()]
+        layers = torch.nn.Sequential(torch.nn.Sequential(HybridLayer()))
 
     class HybridNoHookModel:
         model = Inner()

--- a/tests/unit/train/models/test_qwen3_5.py
+++ b/tests/unit/train/models/test_qwen3_5.py
@@ -3,13 +3,16 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
-from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
+from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5Config, Qwen3_5TextConfig, Qwen3_5VisionConfig
 from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5ForCausalLM as HFQwen3_5ForCausalLM
 
+from prime_rl.configs.trainer import ModelConfig
+from prime_rl.trainer.model import get_model
 from prime_rl.trainer.models.layers.attn import FlashAttention, substitute_ring_attn
 from prime_rl.trainer.models.qwen3_5 import Qwen3_5ForCausalLM, Qwen3_5Model
 from prime_rl.trainer.models.qwen3_5.modeling_qwen3_5 import Qwen3_5GatedFlashAttention
 from prime_rl.trainer.models.qwen3_5_moe import Qwen3_5MoeConfig
+from prime_rl.utils.cp import setup_model_cp
 
 
 def _tiny_text_config(attn_impl: str = "flash_attention_2") -> Qwen3_5TextConfig:
@@ -30,6 +33,28 @@ def _tiny_text_config(attn_impl: str = "flash_attention_2") -> Qwen3_5TextConfig
         linear_conv_kernel_dim=4,
     )
     config._attn_implementation = attn_impl
+    return config
+
+
+def _tiny_vlm_config(attn_impl: str = "flash_attention_2") -> Qwen3_5Config:
+    text_config = _tiny_text_config(attn_impl)
+    vision_config = Qwen3_5VisionConfig(
+        depth=1,
+        hidden_size=64,
+        intermediate_size=128,
+        num_heads=4,
+        out_hidden_size=text_config.hidden_size,
+    )
+    config = Qwen3_5Config(
+        text_config=text_config,
+        vision_config=vision_config,
+        image_token_id=120,
+        video_token_id=121,
+        vision_start_token_id=122,
+        vision_end_token_id=123,
+    )
+    config._attn_implementation = attn_impl
+    config.text_config._attn_implementation = attn_impl
     return config
 
 
@@ -93,6 +118,52 @@ def test_qwen3_5_moe_full_attention_normalizes_fa3_hub_alias():
 
     assert isinstance(model.layers[1].self_attn, Qwen3_5MoeGatedFlashAttention)
     assert model.config._attn_implementation == "flash_attention_3"
+
+
+@pytest.mark.parametrize("config_factory", [_tiny_text_config, _tiny_vlm_config, _tiny_moe_config])
+def test_qwen3_5_context_parallel_rejects_hf_impl(monkeypatch, config_factory):
+    model_config = config_factory(attn_impl="flash_attention_2")
+    monkeypatch.setattr("prime_rl.trainer.model.AutoConfig.from_pretrained", lambda *args, **kwargs: model_config)
+
+    config = ModelConfig(name="unit-test-model", attn="flash_attention_2", cp=2, impl="hf")
+    with pytest.raises(ValueError, match="Qwen3.5 context parallelism requires model.impl='custom'"):
+        get_model(config, device=torch.device("meta"))
+
+
+def test_qwen3_5_context_parallel_setup_chain_text_and_vlm():
+    cp_group = MagicMock()
+
+    text_model = Qwen3_5ForCausalLM(_tiny_text_config())
+    setup_model_cp(text_model, cp_group, cp_rank=1, cp_world_size=2)
+    assert text_model.model._cp_group is cp_group
+    assert text_model.model._cp_rank == 1
+    assert text_model.model._cp_world_size == 2
+    assert text_model.model.layers[0].linear_attn.cp_group is cp_group
+
+    with torch.device("meta"):
+        vlm_model = Qwen3_5ForCausalLM(_tiny_vlm_config())
+    setup_model_cp(vlm_model, cp_group, cp_rank=0, cp_world_size=2)
+    assert vlm_model.model.language_model._cp_group is cp_group
+    assert vlm_model.model.language_model.layers[0].linear_attn.cp_world_size == 2
+
+
+def test_setup_model_cp_requires_hook_only_for_hybrid_models():
+    class HybridLayer:
+        layer_type = "linear_attention"
+
+    class Inner:
+        layers = [HybridLayer()]
+
+    class HybridNoHookModel:
+        model = Inner()
+
+    with pytest.raises(ValueError, match="set_context_parallel_attributes"):
+        setup_model_cp(HybridNoHookModel(), MagicMock(), cp_rank=0, cp_world_size=2)
+
+    class SoftmaxOnlyModel:
+        pass
+
+    setup_model_cp(SoftmaxOnlyModel(), MagicMock(), cp_rank=0, cp_world_size=2)
 
 
 def test_qwen3_5_ring_patches_dense_flash_attention():

--- a/tests/unit/train/models/test_qwen3_5.py
+++ b/tests/unit/train/models/test_qwen3_5.py
@@ -6,8 +6,6 @@ import torch
 from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5Config, Qwen3_5TextConfig, Qwen3_5VisionConfig
 from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5ForCausalLM as HFQwen3_5ForCausalLM
 
-from prime_rl.configs.trainer import ModelConfig
-from prime_rl.trainer.model import get_model
 from prime_rl.trainer.models.layers.attn import FlashAttention, substitute_ring_attn
 from prime_rl.trainer.models.qwen3_5 import Qwen3_5ForCausalLM, Qwen3_5Model
 from prime_rl.trainer.models.qwen3_5.modeling_qwen3_5 import Qwen3_5GatedFlashAttention
@@ -120,16 +118,6 @@ def test_qwen3_5_moe_full_attention_normalizes_fa3_hub_alias():
     assert model.config._attn_implementation == "flash_attention_3"
 
 
-@pytest.mark.parametrize("config_factory", [_tiny_text_config, _tiny_vlm_config, _tiny_moe_config])
-def test_qwen3_5_context_parallel_rejects_hf_impl(monkeypatch, config_factory):
-    model_config = config_factory(attn_impl="flash_attention_2")
-    monkeypatch.setattr("prime_rl.trainer.model.AutoConfig.from_pretrained", lambda *args, **kwargs: model_config)
-
-    config = ModelConfig(name="unit-test-model", attn="flash_attention_2", cp=2, impl="hf")
-    with pytest.raises(ValueError, match="Qwen3.5 context parallelism requires model.impl='custom'"):
-        get_model(config, device=torch.device("meta"))
-
-
 def test_qwen3_5_context_parallel_setup_chain_text_and_vlm():
     cp_group = MagicMock()
 
@@ -142,8 +130,11 @@ def test_qwen3_5_context_parallel_setup_chain_text_and_vlm():
     assert text_model.model._cp_world_size == 2
     assert linear_layer.linear_attn.cp_group is cp_group
 
+    vlm_config = _tiny_vlm_config()
+    vlm_config.vision_config._attn_implementation = "sdpa"
+    vlm_config.vision_config._attn_implementation_internal = "sdpa"
     with torch.device("meta"):
-        vlm_model = Qwen3_5ForCausalLM(_tiny_vlm_config())
+        vlm_model = Qwen3_5ForCausalLM(vlm_config)
     setup_model_cp(vlm_model, cp_group, cp_rank=0, cp_world_size=2)
     assert vlm_model.model.language_model._cp_group is cp_group
     assert vlm_model.model.language_model.layers[0].linear_attn.cp_world_size == 2

--- a/tests/unit/train/models/test_qwen3_5_moe.py
+++ b/tests/unit/train/models/test_qwen3_5_moe.py
@@ -170,7 +170,7 @@ def test_qwen3_5_moe_context_parallel_setup_hook():
         linear_num_value_heads=8,
         use_grouped_mm=False,
     )
-    config._attn_implementation = "sdpa"
+    config._attn_implementation = "flash_attention_2"
     with torch.device("meta"):
         model = PrimeRLQwen3_5MoeForCausalLM(config)
 

--- a/tests/unit/train/models/test_qwen3_5_moe.py
+++ b/tests/unit/train/models/test_qwen3_5_moe.py
@@ -174,14 +174,16 @@ def test_qwen3_5_moe_context_parallel_setup_hook():
     with torch.device("meta"):
         model = PrimeRLQwen3_5MoeForCausalLM(config)
 
+    linear_layer = model.model.layers[0]
+    model.model.layers[0] = torch.nn.Sequential(linear_layer)
     cp_group = MagicMock()
     setup_model_cp(model, cp_group, cp_rank=1, cp_world_size=2)
 
     assert model.model._cp_group is cp_group
     assert model.model._cp_rank == 1
     assert model.model._cp_world_size == 2
-    assert model.model.layers[0].linear_attn.cp_group is cp_group
-    assert model.model.layers[0].linear_attn.cp_world_size == 2
+    assert linear_layer.linear_attn.cp_group is cp_group
+    assert linear_layer.linear_attn.cp_world_size == 2
 
 
 if __name__ == "__main__":

--- a/tests/unit/train/models/test_qwen3_5_moe.py
+++ b/tests/unit/train/models/test_qwen3_5_moe.py
@@ -5,6 +5,7 @@ from transformers import Qwen3_5MoeForCausalLM as HFQwen3_5MoeForCausalLM
 from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
 from prime_rl.trainer.models.qwen3_5_moe import Qwen3_5MoeConfig
 from prime_rl.trainer.models.qwen3_5_moe import Qwen3_5MoeForCausalLM as PrimeRLQwen3_5MoeForCausalLM
+from prime_rl.utils.cp import setup_model_cp
 from prime_rl.utils.utils import default_dtype
 
 pytestmark = [pytest.mark.gpu]
@@ -144,6 +145,43 @@ def test_qwen3_5_moe_cp_patching():
     finally:
         for cls, method in originals.items():
             cls._compute_attention = method
+
+
+def test_qwen3_5_moe_context_parallel_setup_hook():
+    from unittest.mock import MagicMock
+
+    config = Qwen3_5MoeConfig(
+        vocab_size=128,
+        hidden_size=64,
+        num_hidden_layers=2,
+        layer_types=["linear_attention", "full_attention"],
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        moe_intermediate_size=64,
+        shared_expert_intermediate_size=64,
+        num_experts=4,
+        num_experts_per_tok=2,
+        max_position_embeddings=128,
+        linear_conv_kernel_dim=4,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_num_key_heads=4,
+        linear_num_value_heads=8,
+        use_grouped_mm=False,
+    )
+    config._attn_implementation = "sdpa"
+    with torch.device("meta"):
+        model = PrimeRLQwen3_5MoeForCausalLM(config)
+
+    cp_group = MagicMock()
+    setup_model_cp(model, cp_group, cp_rank=1, cp_world_size=2)
+
+    assert model.model._cp_group is cp_group
+    assert model.model._cp_rank == 1
+    assert model.model._cp_world_size == 2
+    assert model.model.layers[0].linear_attn.cp_group is cp_group
+    assert model.model.layers[0].linear_attn.cp_world_size == 2
 
 
 if __name__ == "__main__":

--- a/tests/unit/utils/test_sequence.py
+++ b/tests/unit/utils/test_sequence.py
@@ -2,7 +2,6 @@ import pytest
 import torch
 
 from prime_rl.utils.sequence import (
-    get_cp_local_seq_lens,
     get_cu_seqlens_from_position_ids,
     get_cu_seqlens_from_seq_lens,
 )
@@ -40,10 +39,3 @@ def test_get_cu_seqlens_from_seq_lens():
 def test_get_cu_seqlens_from_seq_lens_rejects_wrong_total():
     with pytest.raises(ValueError, match="sum must equal"):
         get_cu_seqlens_from_seq_lens(torch.tensor([4, 3]), total_tokens=9)
-
-
-@pytest.mark.parametrize(("cp_rank", "expected"), [(0, [3, 1]), (1, [4])])
-def test_get_cp_local_seq_lens(cp_rank: int, expected: list[int]):
-    local_seq_lens = get_cp_local_seq_lens(torch.tensor([3, 5]), 8, cp_rank, 2)
-
-    assert local_seq_lens.tolist() == expected


### PR DESCRIPTION
## Summary

Rebased successor to #2946, now targeting `main` after #3075 merged. The six context-parallelism commits are unchanged from the reviewed stack (`git range-diff` reports an exact match).

Context parallelism for hybrid linear-attention and VLM models in SFT:

- Unifies model-specific CP setup behind `setup_model_cp`; hybrid models expose `set_context_parallel_attributes`, including through activation-checkpoint wrappers, and unsupported configurations fail during setup.
- Keeps `seq_lens` as global pre-shard boundaries under CP while sharding inputs and positions per rank. Explicit provenance is threaded through custom forwards and into FLA so documents can safely cross shard boundaries without per-layer CPU/GPU synchronization.
- Uses FLA's CP-aware causal convolution for Qwen3.5 DeltaNet and Nemotron-H Mamba, including document-boundary resets, behind a narrow `torch.compiler.disable` helper.
- Keeps custom attention on the canonical Flash Attention path; this stack does not restore removed SDPA/eager/PyTorch attention fallbacks.
- Defers VLM sharding until after the full-sequence vision merge, then shards embeddings and 3D MRoPE positions and configures Ulysses from global sequence boundaries. The vision encoder uses SDPA under CP.
- Validates CP divisibility and requires custom model implementations for CP, with `impl = "auto"` checked after architecture support is resolved.

## Existing E2E evidence

W&B project: [`pr2485`](https://wandb.ai/primeintellect/pr2485)

- cp=2 Ulysses SFT, 10/10 steps in eager and compiled modes: dense text [rdu3ydne](https://wandb.ai/primeintellect/pr2485/runs/rdu3ydne), MoE text [40nwjbkg](https://wandb.ai/primeintellect/pr2485/runs/40nwjbkg), dense multimodal [p5p4e28y](https://wandb.ai/primeintellect/pr2485/runs/p5p4e28y), and MoE multimodal [eqvyrc96](https://wandb.ai/primeintellect/pr2485/runs/eqvyrc96).
- Pre-fix comparison run: [ioqkts7p](https://wandb.ai/primeintellect/pr2485/runs/ioqkts7p).
- Final-stack H100 focused CP boundary suite: 10 passed across DeltaNet/Mamba, Qwen3.5, Nemotron-H, VLM, and forward metadata paths.

## Validation after rebasing onto main

- `git range-diff`: all six CP commits match the pre-rebase stack exactly.
- `git diff --check`: passed.
- Ruff check and format check across all 23 changed files: passed.
- `uv run pytest tests/unit/test_configs.py tests/unit/utils/test_sequence.py -q -k 'not test_load_configs'`: 47 passed, 57 deselected. The deselected cases are the external-environment-plugin config matrix unavailable in this worktree.



## Post-rebase validation (2026-07-21, a212f4ba)

qwen3.5-2B multimodal SFT CP-equivalence on H200s, using an internal multi-turn
tool-use dataset (screenshots in user and tool turns, documents crossing shard
boundaries at 16k): **cp=1 (4 GPUs) vs cp=2 Ulysses (8 GPUs), both dp=4**, so both
runs consume identical global batches — per-step losses and grad norms are
directly comparable.

- cp=1: [nez2rr30](https://wandb.ai/primeintellect/pr2485/runs/nez2rr30) | cp=2: [e0vn8a4p](https://wandb.ai/primeintellect/pr2485/runs/e0vn8a4p)
- eval_on_start over the identical validation set: **0.5004 vs 0.4998** (0.12%)
- 10/10 train steps: losses match to max |d|=0.0024 (typical <=0.001); grad norms within 3% (typical <=1%)
- 0 errors; both runs completed cleanly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes distributed training semantics for hybrid SSM/linear attention and VLM packing across many model forwards; incorrect boundary handling would skew loss without obvious crashes, though new validation and unit tests reduce silent misconfiguration.
> 
> **Overview**
> **Context parallelism** is extended so hybrid models (Qwen3.5 DeltaNet, Nemotron-H Mamba) and **VLM SFT** can train with `cp > 1` under **Ulysses**, not only dense softmax attention.
> 
> **Document boundaries under CP** no longer get converted to per-shard local lengths. Trainers keep **global** `seq_lens` and pass `seq_lens_are_pre_shard=True` into custom forwards; `get_cu_seqlens_from_seq_lens` skips the local-token sum check when that flag is set. Linear-attn layers use **FLA CP context** for conv and gated-delta-rule so sequences that cross shard cuts stay correct.
> 
> **Setup is unified** in `setup_model_cp`, which calls each model’s `set_context_parallel_attributes` (including through checkpoint wrappers). Hybrid models without that hook fail fast instead of misconfiguring silently. `get_cp_local_seq_lens` is removed.
> 
> **VLM + Ulysses SFT** defers input sharding until after full-sequence vision embedding merge: the composite model shards embeddings, MRoPE `position_ids`, and optional `routed_experts`, sets Ulysses attention params from global `seq_lens`, and forces the vision encoder to **SDPA** when CP is on. SFT config allows VLM CP only with `cp_style='ulysses'`.
> 
> **Config and load-time checks** tighten CP: custom/`auto` impl required (with post-resolve error for `auto` → HF), shard divisibility validated in `shard_for_cp`, and attention CP params split into `setup_cp_attention_params` vs sharding in `setup_cp_params`. RL still rejects CP with multimodal batches at the trainer loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a212f4ba8ed2ab819c4be04e3c1402ddac1b3fa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
