### PR TITLE
fix(ci): increase GPU integration test timeouts to reduce flakiness

### DIFF
--- a/tests/integration/test_alphabet_sort.py
+++ b/tests/integration/test_alphabet_sort.py
@@ -15,7 +15,8 @@ from tests.utils import (
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
 
-TIMEOUT = 900  # 15 minutes
+TIMEOUT = 1200  # 20 minutes (was 900s — alphabet-sort steps can take 2+ min
+# each on contended CI GPU runners, and vLLM warm-up eats ~2 min)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_reverse_text.py
+++ b/tests/integration/test_reverse_text.py
@@ -15,7 +15,8 @@ from tests.utils import (
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
 
-TIMEOUT = 600  # 10 minutes
+TIMEOUT = 900  # 15 minutes (was 600s — can be tight on contended CI runners
+# after verifiers per-call tracing overhead was added)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_reverse_text_multi_run.py
+++ b/tests/integration/test_reverse_text_multi_run.py
@@ -15,13 +15,14 @@ from tests.utils import check_reward_goes_up, check_reward_in_range, strip_escap
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
-TIMEOUT = 300  # 5 minutes
+TIMEOUT = 600  # 10 minutes (was 300s — too tight when 3 concurrent orchestrators
+# contend for 2 inference GPUs; verifiers per-call tracing added overhead)
 ORCHESTRATOR_NAMES = ["alpha", "beta", "gamma"]
 
 
 def wait_for_file(
     file_path: Path,
-    timeout: int = 300,
+    timeout: int = 600,
     poll_interval: float = 1.0,
 ) -> None:
     """Wait for file to exist.
@@ -46,7 +47,7 @@ def wait_for_log(
     log_file: Path,
     conditions: list[str],
     proc: subprocess.Popen,
-    timeout: int = 300,
+    timeout: int = 600,
     poll_interval: float = 0.1,
     sigterm: bool = False,
     kill: bool = False,

--- a/tests/integration/test_reverse_text_rl_opd.py
+++ b/tests/integration/test_reverse_text_rl_opd.py
@@ -14,7 +14,8 @@ from tests.utils import check_final_eval_reward_above, check_no_error, strip_esc
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
-TIMEOUT = 600  # 10 minutes
+TIMEOUT = 900  # 15 minutes (was 600s — the OPD orchestrator finishes in ~8m but
+# the rl entrypoint cleanup phase can push total wall-clock past the old limit)
 REF_PORT = 8001
 REF_READY_TIMEOUT_S = 300
 

--- a/tests/integration/test_reverse_text_rl_sft.py
+++ b/tests/integration/test_reverse_text_rl_sft.py
@@ -14,7 +14,7 @@ from tests.utils import check_final_eval_reward_above, check_no_error, strip_esc
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
-TIMEOUT = 600  # 10 minutes
+TIMEOUT = 900  # 15 minutes (was 600s — same overhead as reverse_text)
 REF_PORT = 8001
 REF_READY_TIMEOUT_S = 300
 


### PR DESCRIPTION
## Problem

GPU integration tests have been failing intermittently on `main` since commit `d085605b` (verifiers re-pin for per-call trace records). Different tests fail in different runs — the CI is flaky, not deterministically broken.

## Root Cause

The verifiers update (`d085605b`) added per-call model call metadata tracing and split generation time into model vs harness phases. This added overhead that pushed several integration tests past their tight timeouts on contended CI GPU runners:

- **`reverse_text_multi_run`** (most frequent failure): `TimeoutError: Timed out waiting for conditions ["Step 11", "Step 12", "Step 13"] in orchestrator.log after 300s` — 3 concurrent orchestrators contending for 2 inference GPUs can take >5 min to reach step 11
- **`alphabet_sort`**: RL process exits with code 1 after the 900s timeout — individual steps can take 2+ min on contended runners
- **`reverse_text_rl_opd`**: Orchestrator completes in ~8m but the `rl` entrypoint cleanup phase pushes total wall-clock past the 600s timeout

## Fix

Increase the `TIMEOUT` constants in the affected integration tests:

| Test | Old timeout | New timeout |
|------|------------|-------------|
| `reverse_text_multi_run` | 300s (5 min) | 600s (10 min) |
| `alphabet_sort` | 900s (15 min) | 1200s (20 min) |
| `reverse_text_rl_opd` | 600s (10 min) | 900s (15 min) |
| `reverse_text` | 600s (10 min) | 900s (15 min) |
| `reverse_text_rl_sft` | 600s (10 min) | 900s (15 min) |

All remain well within the 60-minute workflow-level timeout.

## Evidence

- Last green run on main: `3da69fde` (Jul 18 00:58 UTC)
- First failure: `d085605b` (Jul 18 03:05 UTC) — `reverse_text` failed
- Subsequent runs: different tests fail each time (flaky)
- Failure log from `0af55062`: `TimeoutError: Timed out waiting for conditions ["Step 11", "Step 12", "Step 13"] in /tmp/outputs/run_alpha/logs/orchestrator.log after 300s`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout changes; no production logic, auth, or data paths affected.
> 
> **Overview**
> Raises wall-clock limits on slow GPU integration tests after verifiers per-call tracing and heavier CI GPU contention made the previous caps too tight.
> 
> **`test_reverse_text_multi_run`**: module `TIMEOUT` 300s → 600s, and `wait_for_file` / `wait_for_log` defaults match (600s) so log/step waits no longer fail before the orchestrator reaches step 11.
> 
> **Single-process RL tests**: `TIMEOUT` for `alphabet_sort` 900s → 1200s; `reverse_text`, `reverse_text_rl_opd`, and `reverse_text_rl_sft` 600s → 900s, passed through `run_process(..., timeout=TIMEOUT)`.
> 
> Comments in each file document why (tracing overhead, multi-orchestrator GPU sharing, vLLM warm-up, rl cleanup after OPD).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733c4f29557b0393c86ca965361cbe89ced9edd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->