### PR TITLE
fix: Advertise inference URL to external env servers

### DIFF
--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -1,6 +1,7 @@
 import json
 import os
 import signal
+import socket
 import subprocess
 import sys
 import time
@@ -8,6 +9,7 @@ import uuid
 from pathlib import Path
 from subprocess import Popen
 from threading import Event, Thread
+from urllib.parse import urlsplit, urlunsplit
 
 import pynvml
 import tomli_w
@@ -43,6 +45,8 @@ TRAINER_TOML = "trainer.toml"
 ORCHESTRATOR_TOML = "orchestrator.toml"
 INFERENCE_TOML = "inference.toml"
 
+LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
 
 def get_physical_gpu_ids() -> list[int]:
     """Return physical GPU IDs visible to the launcher."""
@@ -77,6 +81,55 @@ def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
             tomli_w.dump(to_toml_dict(config.inference, exclude=exclude_inference), f)
 
 
+def _replace_loopback_host(url: str, advertised_host: str) -> str:
+    """Replace a loopback URL host while preserving all other URL components."""
+    parsed = urlsplit(url)
+    if parsed.hostname not in LOOPBACK_HOSTS:
+        return url
+
+    host = f"[{advertised_host}]" if ":" in advertised_host else advertised_host
+    userinfo = ""
+    if parsed.username is not None:
+        userinfo = parsed.username
+        if parsed.password is not None:
+            userinfo += f":{parsed.password}"
+        userinfo += "@"
+    port = f":{parsed.port}" if parsed.port is not None else ""
+    return urlunsplit(parsed._replace(netloc=f"{userinfo}{host}{port}"))
+
+
+def advertise_inference_to_external_envs(config: RLConfig, advertised_host: str | None = None) -> bool:
+    """Expose launcher-managed inference to external v1 environment servers.
+
+    V1 environment workers execute the serialized model client themselves. A
+    loopback URL therefore resolves on the environment node, not on the node
+    where this launcher starts inference. Keep loopback URLs for colocated
+    administrative traffic and advertise this node for rollout traffic.
+
+    Returns whether the model client was changed.
+    """
+    if config.inference is None:
+        return False
+
+    envs = list(config.orchestrator.train.env)
+    if config.orchestrator.eval is not None:
+        envs.extend(config.orchestrator.eval.env)
+    if not any(env.address is not None for env in envs):
+        return False
+
+    client = config.orchestrator.model.client
+    original_urls = list(client.base_url)
+    host = advertised_host or socket.gethostname()
+    advertised_urls = [_replace_loopback_host(url, host) for url in original_urls]
+    if advertised_urls == original_urls:
+        return False
+
+    if client.admin_base_url is None:
+        client.admin_base_url = original_urls
+    client.base_url = advertised_urls
+    return True
+
+
 def rl_local(config: RLConfig):
     assert config.deployment.type == "single_node"
 
@@ -84,6 +137,11 @@ def rl_local(config: RLConfig):
         config.log.level or os.environ.get("PRIME_LOG_LEVEL", "info"),
         json_logging=config.log.json_logging,
     )
+
+    if advertise_inference_to_external_envs(config):
+        logger.info(
+            f"Advertising inference to external env servers at {', '.join(config.orchestrator.model.client.base_url)}"
+        )
 
     config_dir = config.output_dir / "configs"
     write_subconfigs(config, config_dir)

--- a/tests/unit/test_rl_entrypoint.py
+++ b/tests/unit/test_rl_entrypoint.py
@@ -1,0 +1,103 @@
+import tomllib
+from types import SimpleNamespace
+
+from prime_rl.configs.rl import RLConfig
+from prime_rl.entrypoints.rl import advertise_inference_to_external_envs, rl_local
+
+
+def _config(
+    *,
+    address: str | None,
+    base_url: list[str],
+    admin_base_url: list[str] | None = None,
+    managed_inference: bool = True,
+):
+    client = SimpleNamespace(base_url=base_url, admin_base_url=admin_base_url)
+    env = SimpleNamespace(address=address)
+    orchestrator = SimpleNamespace(
+        model=SimpleNamespace(client=client),
+        train=SimpleNamespace(env=[env]),
+        eval=None,
+    )
+    return SimpleNamespace(
+        inference=object() if managed_inference else None,
+        orchestrator=orchestrator,
+    )
+
+
+def test_advertises_loopback_inference_to_external_envs():
+    config = _config(
+        address="tcp://env-node:5000",
+        base_url=["http://localhost:8000/v1", "http://inference-b:8000/v1"],
+    )
+
+    changed = advertise_inference_to_external_envs(config, "inference-a")
+
+    assert changed
+    assert config.orchestrator.model.client.base_url == [
+        "http://inference-a:8000/v1",
+        "http://inference-b:8000/v1",
+    ]
+    assert config.orchestrator.model.client.admin_base_url == [
+        "http://localhost:8000/v1",
+        "http://inference-b:8000/v1",
+    ]
+
+
+def test_does_not_change_local_env_launches():
+    config = _config(address=None, base_url=["http://localhost:8000/v1"])
+
+    assert not advertise_inference_to_external_envs(config, "inference-a")
+    assert config.orchestrator.model.client.base_url == ["http://localhost:8000/v1"]
+    assert config.orchestrator.model.client.admin_base_url is None
+
+
+def test_preserves_explicit_admin_urls():
+    config = _config(
+        address="tcp://env-node:5000",
+        base_url=["http://127.0.0.1:8000/v1"],
+        admin_base_url=["http://admin:9000/v1"],
+    )
+
+    assert advertise_inference_to_external_envs(config, "inference-a")
+    assert config.orchestrator.model.client.admin_base_url == ["http://admin:9000/v1"]
+
+
+def test_does_not_change_external_inference_config():
+    config = _config(
+        address="tcp://env-node:5000",
+        base_url=["http://localhost:8000/v1"],
+        managed_inference=False,
+    )
+
+    assert not advertise_inference_to_external_envs(config, "inference-a")
+    assert config.orchestrator.model.client.base_url == ["http://localhost:8000/v1"]
+
+
+def test_local_launcher_serializes_allocated_host_for_external_envs(tmp_path, monkeypatch):
+    config = RLConfig.model_validate(
+        {
+            "output_dir": tmp_path,
+            "dry_run": True,
+            "trainer": {},
+            "orchestrator": {
+                "train": {"env": [{"id": "dummy", "address": "tcp://env-node:5000"}]},
+            },
+            "inference": {},
+            "deployment": {
+                "type": "single_node",
+                "gpus_per_node": 2,
+                "num_train_gpus": 1,
+                "num_infer_gpus": 1,
+            },
+        }
+    )
+    monkeypatch.setattr("prime_rl.entrypoints.rl.socket.gethostname", lambda: "inference-a")
+
+    rl_local(config)
+
+    with (tmp_path / "configs" / "orchestrator.toml").open("rb") as f:
+        orchestrator = tomllib.load(f)
+    client = orchestrator["model"]["client"]
+    assert client["base_url"] == ["http://inference-a:8000/v1"]
+    assert client["admin_base_url"] == ["http://localhost:8000/v1"]


### PR DESCRIPTION
As we have our external fleet running on a separate node as the inference server, the env servers cant communicate with the inference server by requesting a localhost URL. We need to dynamically replace this by the URL of the respective node. This PR introduces a new config variable that can be set to activate such a behavior and automatically advertise the address of our inference server for each env server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestrator model client URLs at launch time; wrong hostname or DNS could break rollouts on multi-node setups, though behavior is gated on external env addresses and managed inference.
> 
> **Overview**
> Fixes remote v1 environment workers failing to reach launcher-managed inference when `orchestrator.model.client.base_url` uses loopback hosts.
> 
> **`rl_local`** now calls **`advertise_inference_to_external_envs`** before writing subconfigs when managed inference is enabled and any train/eval env has a remote **`address`**. Loopback entries in **`base_url`** (`localhost`, `127.0.0.1`, `::1`) are rewritten to the launcher hostname (or an optional override); non-loopback URLs are left alone. If **`admin_base_url`** was unset, the original URLs are copied there so colocated admin traffic can keep using loopback.
> 
> Unit tests cover the rewrite rules, no-op cases (local envs, external-only inference config, explicit admin URLs), and that **`orchestrator.toml`** gets the advertised **`base_url`** on dry-run launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f451295b821006574329b33e18d605c95e9345d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->