### PR TITLE
chore: strip -v1 suffix from environment ids in configs and docs

### DIFF
--- a/configs/basic/alphabet-sort/rl.toml
+++ b/configs/basic/alphabet-sort/rl.toml
@@ -34,7 +34,7 @@ max_completion_tokens = 768
 
 [[orchestrator.train.env]]
 name = "alphabet-sort"
-taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
+taskset = { id = "alphabet-sort", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [ckpt] # Checkpoint at the end of training

--- a/configs/basic/hendrycks-sanity/rl.toml
+++ b/configs/basic/hendrycks-sanity/rl.toml
@@ -21,7 +21,7 @@ seq_len = 8192
 
 [[orchestrator.train.env]]
 name = "hendrycks-math"
-taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
+taskset = { id = "math-env", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.model]

--- a/configs/basic/reverse-text/rl.toml
+++ b/configs/basic/reverse-text/rl.toml
@@ -24,7 +24,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]

--- a/configs/basic/wiki-search/rl.toml
+++ b/configs/basic/wiki-search/rl.toml
@@ -42,7 +42,7 @@ max_completion_tokens = 512
 
 [[orchestrator.train.env]]
 name = "wiki-search"
-taskset = { id = "wiki-search-v1" }
+taskset = { id = "wiki-search" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [ckpt] # Checkpoint at the end of training

--- a/configs/basic/wordle/rl.toml
+++ b/configs/basic/wordle/rl.toml
@@ -23,7 +23,7 @@ group_size = 8
 
 [[orchestrator.train.env]]
 name = "wordle"
-taskset = { id = "wordle-v1" }
+taskset = { id = "wordle" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.train.sampling]

--- a/configs/ci/integration/alphabet_sort.toml
+++ b/configs/ci/integration/alphabet_sort.toml
@@ -24,7 +24,7 @@ max_completion_tokens = 384
 
 [[orchestrator.train.env]]
 name = "alphabet-sort"
-taskset = { id = "alphabet-sort-v1", min_turns = 2, max_turns = 2, min_names_per_turn = 1, max_names_per_turn = 3, task = { similarity_power = 4, power_per_turn = false } }
+taskset = { id = "alphabet-sort", min_turns = 2, max_turns = 2, min_names_per_turn = 1, max_names_per_turn = 3, task = { similarity_power = 4, power_per_turn = false } }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference]

--- a/configs/ci/integration/reverse-text-lora/resume.toml
+++ b/configs/ci/integration/reverse-text-lora/resume.toml
@@ -28,7 +28,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference]

--- a/configs/ci/integration/reverse-text-lora/start.toml
+++ b/configs/ci/integration/reverse-text-lora/start.toml
@@ -27,7 +27,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference]

--- a/configs/ci/integration/reverse-text-moe/start.toml
+++ b/configs/ci/integration/reverse-text-moe/start.toml
@@ -27,7 +27,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference]

--- a/configs/ci/integration/reverse-text-multi-run/orchestrator.toml
+++ b/configs/ci/integration/reverse-text-multi-run/orchestrator.toml
@@ -16,7 +16,7 @@ max_completion_tokens = 128
 
 [[train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [ckpt]

--- a/configs/ci/integration/reverse-text-rl-opd/start.toml
+++ b/configs/ci/integration/reverse-text-rl-opd/start.toml
@@ -39,7 +39,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
@@ -51,7 +51,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]

--- a/configs/ci/integration/reverse-text-rl-sft/start.toml
+++ b/configs/ci/integration/reverse-text-rl-sft/start.toml
@@ -45,7 +45,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
@@ -57,7 +57,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]

--- a/configs/ci/integration/reverse-text/resume.toml
+++ b/configs/ci/integration/reverse-text/resume.toml
@@ -25,7 +25,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference]

--- a/configs/ci/integration/reverse-text/start.toml
+++ b/configs/ci/integration/reverse-text/start.toml
@@ -24,7 +24,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference]

--- a/configs/ci/nightly/multimodal_color_codeword.toml
+++ b/configs/ci/nightly/multimodal_color_codeword.toml
@@ -22,7 +22,7 @@ max_completion_tokens = 64
 
 [[orchestrator.train.env]]
 name = "color-codeword"
-taskset = { id = "color-codeword-v1", images_per_turn = 1 }
+taskset = { id = "color-codeword", images_per_turn = 1 }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer]

--- a/configs/debug/algo/echo.toml
+++ b/configs/debug/algo/echo.toml
@@ -26,7 +26,7 @@ alpha = 0.1
 
 [[orchestrator.train.env]]
 name = "alphabet-sort"
-taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
+taskset = { id = "alphabet-sort", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.train.sampling]

--- a/configs/debug/algo/grpo.toml
+++ b/configs/debug/algo/grpo.toml
@@ -23,7 +23,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
@@ -35,7 +35,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]

--- a/configs/debug/algo/max_rl.toml
+++ b/configs/debug/algo/max_rl.toml
@@ -23,7 +23,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
@@ -35,7 +35,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]

--- a/configs/debug/algo/mixed_grpo_opd.toml
+++ b/configs/debug/algo/mixed_grpo_opd.toml
@@ -33,12 +33,12 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text-grpo"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [[orchestrator.train.env]]
 name = "reverse-text-opd"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.train.env.algo]
@@ -57,7 +57,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]

--- a/configs/debug/algo/opd.toml
+++ b/configs/debug/algo/opd.toml
@@ -35,7 +35,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
@@ -47,7 +47,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]

--- a/configs/debug/algo/opd_lora.toml
+++ b/configs/debug/algo/opd_lora.toml
@@ -35,7 +35,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
@@ -47,7 +47,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]

--- a/configs/debug/algo/self_distill.toml
+++ b/configs/debug/algo/self_distill.toml
@@ -31,7 +31,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
@@ -43,7 +43,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]

--- a/configs/debug/algo/sft_distill.toml
+++ b/configs/debug/algo/sft_distill.toml
@@ -40,7 +40,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
@@ -52,7 +52,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]

--- a/configs/debug/algo/sft_distill_lora.toml
+++ b/configs/debug/algo/sft_distill_lora.toml
@@ -40,7 +40,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
@@ -52,7 +52,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,19 +149,19 @@ Training environments are an array of tables — set one per env, optionally wit
 ```toml
 [[orchestrator.train.env]]
 name = "gsm8k"
-taskset = { id = "gsm8k-v1", split = "train" }
+taskset = { id = "gsm8k", split = "train" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 ratio = 3  # 75% of batches
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 ratio = 1  # default — 25% of batches
 
 [[orchestrator.eval.env]]
 name = "gsm8k-eval"
-taskset = { id = "gsm8k-v1", split = "test" }
+taskset = { id = "gsm8k", split = "test" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 ```
 

--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -98,7 +98,7 @@ name = "openseeker"
 harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] } }
 
 [orchestrator.train.env.taskset]
-id = "openseeker-v1"
+id = "openseeker"
 
 [[orchestrator.train.env.taskset.task.judges]]
 id = "reference"
@@ -120,7 +120,7 @@ name = "redsearcher"
 harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] } }
 
 [orchestrator.train.env.taskset]
-id = "redsearcher-v1" # optional `difficulty` filter (easy/medium/hard)
+id = "redsearcher" # optional `difficulty` filter (easy/medium/hard)
 
 [[orchestrator.train.env.taskset.task.judges]]
 id = "reference"
@@ -149,7 +149,7 @@ harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], s
 timeout = { rollout = 3600 }
 
 [orchestrator.eval.env.taskset]
-id = "browsecomp-v1"
+id = "browsecomp"
 task = { judge = { model = "Qwen/Qwen3-235B-A22B-Instruct-2507" } }
 
 # # Metric-only monitor (weight 0): rlm harness-mechanics rubric, judged by GLM-5.2.

--- a/examples/advanced/glm-4.5-air/swe.toml
+++ b/examples/advanced/glm-4.5-air/swe.toml
@@ -1,4 +1,4 @@
-# v1 RL: GLM-4.5-Air (100B MoE) on the v1 `scaleswe-v1` SWE taskset, rlm harness on a prime sandbox
+# v1 RL: GLM-4.5-Air (100B MoE) on the v1 `scaleswe` SWE taskset, rlm harness on a prime sandbox
 # runtime; eval on SWE-Bench Verified. Router replay is enabled (trainer.enable_router_replay replays
 # the routed-expert decisions returned by inference via enable_return_routed_experts) — GLM-4.5-Air is
 # a glm4_moe model, which supports routed_experts.
@@ -99,7 +99,7 @@ thinking_retention = "all"
 
 [[orchestrator.train.env]]
 name = "scaleswe"
-taskset = { id = "scaleswe-v1" }
+taskset = { id = "scaleswe" }
 harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe"] } }
 
 [orchestrator.prime_monitor]
@@ -111,7 +111,7 @@ interval = 20
 
 [[orchestrator.eval.env]]
 name = "swebench-verified"
-taskset = { id = "swebench-verified-v1" }
+taskset = { id = "swebench-verified" }
 harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe"] } }
 timeout = { rollout = 3600 }
 

--- a/examples/advanced/glm-4.5-air/terminal.toml
+++ b/examples/advanced/glm-4.5-air/terminal.toml
@@ -96,7 +96,7 @@ name = "tmax"
 harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] } }
 
 [orchestrator.train.env.taskset]
-id = "tmax-v1"
+id = "tmax"
 
 # # Metric-only monitors (weight 0): rlm harness-mechanics + swe code-usage rubrics, judged by GLM-5.2.
 # [[orchestrator.train.env.taskset.judges]]
@@ -124,7 +124,7 @@ harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime",
 timeout = { rollout = 3600 }
 
 [orchestrator.eval.env.taskset]
-id = "swebench-verified-v1"
+id = "swebench-verified"
 
 # [[orchestrator.eval.env.taskset.judges]]
 # id = "rubric"
@@ -147,7 +147,7 @@ harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime",
 timeout = { rollout = 3600 }
 
 [orchestrator.eval.env.taskset]
-id = "terminal-bench-2-v1"
+id = "terminal-bench-2"
 
 # [[orchestrator.eval.env.taskset.judges]]
 # id = "rubric"

--- a/examples/advanced/glm-5.2/swe-llmd.toml
+++ b/examples/advanced/glm-5.2/swe-llmd.toml
@@ -98,7 +98,7 @@ extra_body = {chat_template_kwargs = {clear_thinking = false}}
 
 [[orchestrator.train.env]]
 name = "r2e"
-taskset = { id = "r2e-gym-v1" }
+taskset = { id = "r2e-gym" }
 harness = { id = "rlm", runtime = { type = "prime", labels = ["glm5-llmd"] } }
 
 [inference]

--- a/examples/advanced/glm-5.2/swe.toml
+++ b/examples/advanced/glm-5.2/swe.toml
@@ -73,7 +73,7 @@ interval = 20
 
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
-taskset = { id = "swebench-verified-v1" }
+taskset = { id = "swebench-verified" }
 harness = { id = "bash", runtime = { type = "prime", labels = ["glm5-pd-disag", "swe-bench-verified"] } }
 
 [[orchestrator.post_batch_filters]]

--- a/examples/advanced/intellect-3.1/rl.toml
+++ b/examples/advanced/intellect-3.1/rl.toml
@@ -50,31 +50,31 @@ oversampling_factor = 2
 [[orchestrator.train.env]]
 name = "swe"
 ratio = 0.3
-taskset = { id = "r2e-gym-v1" }
+taskset = { id = "r2e-gym" }
 harness = { id = "bash", runtime = { type = "prime", labels = ["intellect-3.1", "swe"] } }
 
 [[orchestrator.train.env]]
 name = "deepdive"
 ratio = 0.2
-taskset = { id = "deepdive-v1" }
+taskset = { id = "deepdive" }
 harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], runtime = { type = "prime", labels = ["intellect-3.1", "deepdive"] } }
 
 [[orchestrator.train.env]]
 name = "math"
 ratio = 0.3
-taskset = { id = "i3_math_v1" }
+taskset = { id = "i3_math" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [[orchestrator.train.env]]
 name = "logic"
 ratio = 0.2
-taskset = { id = "i3_logic_v1", filter = { max = 0.874 } }
+taskset = { id = "i3_logic", filter = { max = 0.874 } }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [[orchestrator.train.env]]
 name = "code"
 ratio = 0.2
-taskset = { id = "i3_code_v1" }
+taskset = { id = "i3_code" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [[orchestrator.pre_batch_filters]]
@@ -86,12 +86,12 @@ interval = 25
 
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
-taskset = { id = "swebench-verified-v1" }
+taskset = { id = "swebench-verified" }
 harness = { id = "bash", runtime = { type = "prime", labels = ["intellect-3.1", "swe-bench-verified"] } }
 
 [[orchestrator.eval.env]]
 name = "aime2025"
-taskset = { id = "aime25-v1" }
+taskset = { id = "aime25" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference.parallel]

--- a/examples/advanced/minimax-m2.5/swe.toml
+++ b/examples/advanced/minimax-m2.5/swe.toml
@@ -51,7 +51,7 @@ max_off_policy_steps = 16
 
 [[orchestrator.train.env]]
 name = "swe"
-taskset = { id = "r2e-gym-v1" }
+taskset = { id = "r2e-gym" }
 harness = { id = "bash", runtime = { type = "prime", labels = ["minimax-swe", "swe"] } }
 
 [orchestrator.eval]
@@ -59,7 +59,7 @@ interval = 25
 
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
-taskset = { id = "swebench-verified-v1" }
+taskset = { id = "swebench-verified" }
 harness = { id = "bash", runtime = { type = "prime", labels = ["minimax-swe", "swe-bench-verified"] } }
 
 [inference.parallel]

--- a/examples/advanced/nemotron-3-super/swe.toml
+++ b/examples/advanced/nemotron-3-super/swe.toml
@@ -83,7 +83,7 @@ truncate_history_thinking = false
 
 [[orchestrator.train.env]]
 name = "scaleswe"
-taskset = { id = "scaleswe-v1" }
+taskset = { id = "scaleswe" }
 harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["nemotron-3-super-swe"] } }
 
 [orchestrator.prime_monitor]
@@ -93,7 +93,7 @@ interval = 20
 
 [[orchestrator.eval.env]]
 name = "swebench-verified"
-taskset = { id = "swebench-verified-v1" }
+taskset = { id = "swebench-verified" }
 harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["nemotron-3-super-swe"] } }
 timeout = { rollout = 3600 }
 

--- a/examples/advanced/qwen3-30b-a3b/math.toml
+++ b/examples/advanced/qwen3-30b-a3b/math.toml
@@ -50,7 +50,7 @@ max_completion_tokens = 32768
 
 [[orchestrator.train.env]]
 name = "math"
-taskset = { id = "i3_math_v1" }
+taskset = { id = "i3_math" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
@@ -58,7 +58,7 @@ interval = 25
 
 [[orchestrator.eval.env]]
 name = "aime2025"
-taskset = { id = "aime25-v1" }
+taskset = { id = "aime25" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference.parallel]

--- a/examples/advanced/qwen3-30b-a3b/swe.toml
+++ b/examples/advanced/qwen3-30b-a3b/swe.toml
@@ -48,7 +48,7 @@ max_off_policy_steps = 16
 
 [[orchestrator.train.env]]
 name = "swe"
-taskset = { id = "r2e-gym-v1" }
+taskset = { id = "r2e-gym" }
 harness = { id = "bash", runtime = { type = "prime", labels = ["qwen30b-swe", "swe"] } }
 
 [orchestrator.eval]
@@ -56,7 +56,7 @@ interval = 25
 
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
-taskset = { id = "swebench-verified-v1" }
+taskset = { id = "swebench-verified" }
 harness = { id = "bash", runtime = { type = "prime", labels = ["qwen30b-swe", "swe-bench-verified"] } }
 
 [inference.parallel]

--- a/examples/advanced/qwen3-30b-a3b/tool.toml
+++ b/examples/advanced/qwen3-30b-a3b/tool.toml
@@ -36,7 +36,7 @@ group_size = 16
 max_off_policy_steps = 32
 
 [[orchestrator.train.env]]
-taskset = { id = "general-agent-v1", task = { tools = { colocated = true } }, min_tier = 1 }
+taskset = { id = "general-agent", task = { tools = { colocated = true } }, min_tier = 1 }
 harness = { id = "null", runtime = { type = "modal" } }
 
 [inference]

--- a/examples/basic/alphabet-sort/README.md
+++ b/examples/basic/alphabet-sort/README.md
@@ -1,6 +1,6 @@
 # Alphabet Sort
 
-In this example, we demonstrate how to train `Qwen3-4B-Instruct-2507` to sort names alphabetically using LoRA. Unlike other examples, this task doesn't require SFT warmup as the base model already understands the conversation format. We proceed directly to multi-turn RL against the `alphabet-sort-v1` taskset.
+In this example, we demonstrate how to train `Qwen3-4B-Instruct-2507` to sort names alphabetically using LoRA. Unlike other examples, this task doesn't require SFT warmup as the base model already understands the conversation format. We proceed directly to multi-turn RL against the `alphabet-sort` taskset.
 
 > This example runs on a single H100 GPU.
 
@@ -9,7 +9,7 @@ In this example, we demonstrate how to train `Qwen3-4B-Instruct-2507` to sort na
 The taskset is included through the Verifiers workspace. After syncing the repository, verify it with:
 
 ```bash
-uv run python -c "import alphabet_sort_v1"
+uv run python -c "import alphabet_sort"
 ```
 
 Start the tmux session:
@@ -38,7 +38,7 @@ uv run inference --enable-lora --model.name Qwen/Qwen3-4B-Instruct-2507
 Evaluate the base model:
 ```bash
 # In the `Trainer` pane
-uv run eval alphabet-sort-v1 --harness.id null \
+uv run eval alphabet-sort --harness.id null \
   -m Qwen/Qwen3-4B-Instruct-2507 \
   --client.base-url http://localhost:8000/v1 \
   -n 20 \
@@ -115,7 +115,7 @@ uv run inference --enable-lora --model.name PrimeIntellect/Qwen3-4B-Instruct-Alp
 
 ```bash
 # In the `Trainer` pane
-uv run eval alphabet-sort-v1 --harness.id null \
+uv run eval alphabet-sort --harness.id null \
   -m PrimeIntellect/Qwen3-4B-Instruct-AlphabetSort-RL \
   --client.base-url http://localhost:8000/v1 \
   -n 20 \

--- a/examples/basic/alphabet-sort/rl.toml
+++ b/examples/basic/alphabet-sort/rl.toml
@@ -33,7 +33,7 @@ max_completion_tokens = 768
 
 [[orchestrator.train.env]]
 name = "alphabet-sort"
-taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
+taskset = { id = "alphabet-sort", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [inference] # Default inference config

--- a/examples/basic/hendrycks-sanity/rl.toml
+++ b/examples/basic/hendrycks-sanity/rl.toml
@@ -18,7 +18,7 @@ seq_len = 8192
 
 [[orchestrator.train.env]]
 name = "hendrycks-math"
-taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
+taskset = { id = "math-env", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
@@ -26,7 +26,7 @@ interval = 50
 
 [[orchestrator.eval.env]]
 name = "aime2024"
-taskset = { id = "aime24-v1" }
+taskset = { id = "aime24" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 group_size = 32
 

--- a/examples/basic/reverse-text/README.md
+++ b/examples/basic/reverse-text/README.md
@@ -1,15 +1,15 @@
 # Reverse Text
 
-We demonstrate how to train `Qwen3-0.6B` to reverse a small chunk of text. We will use a SFT warmup to learn the skill of text reversal on longer documents and then a quick RL run on the `reverse-text-v1` taskset. We use a similar setup in our CI and for development.
+We demonstrate how to train `Qwen3-0.6B` to reverse a small chunk of text. We will use a SFT warmup to learn the skill of text reversal on longer documents and then a quick RL run on the `reverse-text` taskset. We use a similar setup in our CI and for development.
 
 > The commands in this example were designed to be run on 2 GPUs (one trainer and one inference GPU). It is possible to run on less or more GPUs using different deployment strategies. If you run on a different setup, you may need to adjust the start commands.
 
 ## Setup
 
-The `reverse-text-v1` taskset is included through the Verifiers workspace. After syncing the repository, verify it with:
+The `reverse-text` taskset is included through the Verifiers workspace. After syncing the repository, verify it with:
 
 ```bash
-uv run python -c "import reverse_text_v1"
+uv run python -c "import reverse_text"
 ```
 
 First, let's start a `tmux` session which we will use throughout the experiment.
@@ -27,7 +27,7 @@ uv run inference --model.name Qwen/Qwen3-0.6B
 
 ```bash
 # Run this in the `Trainer` pane
-uv run eval reverse-text-v1 --harness.id null -m Qwen/Qwen3-0.6B --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
+uv run eval reverse-text --harness.id null -m Qwen/Qwen3-0.6B --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
 ```
 
 This is of course just a quick vibe check and no full-fledged evaluation, but we can see that the model struggles with this task. In this specific instance, we got an **average reward of ~0.05** across the 20x3 rollouts. Let's do some training!
@@ -100,7 +100,7 @@ uv run inference --model.name PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL
 
 ```bash
 # Run this in the `Trainer` pane
-uv run eval reverse-text-v1 --harness.id null -m PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
+uv run eval reverse-text --harness.id null -m PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
 ```
 
 Way better! Now we get an **average reward of ~0.8**.
@@ -213,7 +213,7 @@ kubectl exec -it my-exp-inference-0 -- bash
 uv run inference --model.name /data/outputs/weights/step_20
 
 # Back in trainer pod, run evaluation
-uv run eval reverse-text-v1 --harness.id null \
+uv run eval reverse-text --harness.id null \
   -m /data/outputs/weights/step_20 \
   --client.base-url $INFERENCE_URL \
   -n 20 -r 3 --sampling.max-tokens 1024 --no-push

--- a/examples/basic/reverse-text/rl.toml
+++ b/examples/basic/reverse-text/rl.toml
@@ -17,7 +17,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [trainer.optim]

--- a/examples/basic/wiki-search/README.md
+++ b/examples/basic/wiki-search/README.md
@@ -16,7 +16,7 @@ In this example, we demonstrate how to train `Qwen3-4B-Instruct-2507` to answer 
 The taskset is included through the Verifiers workspace. After syncing the repository, verify it with:
 
 ```bash
-uv run python -c "import wiki_search_v1"
+uv run python -c "import wiki_search"
 ```
 
 Set up the credentials for the configured reference judge:
@@ -77,7 +77,7 @@ Evaluate the base model:
 
 ```bash
 # In the `Trainer` pane
-uv run eval wiki-search-v1 --harness.id null \
+uv run eval wiki-search --harness.id null \
   -m Qwen/Qwen3-4B-Instruct-2507 \
   --client.base-url http://localhost:8000/v1 \
   -n 20 \
@@ -119,7 +119,7 @@ uv run inference --enable-lora --model.name <user>/Qwen3-4B-Instruct-WikiSearch-
 
 ```bash
 # In the `Trainer` pane
-uv run eval wiki-search-v1 --harness.id null \
+uv run eval wiki-search --harness.id null \
   -m <user>/Qwen3-4B-Instruct-WikiSearch-RL \
   --client.base-url http://localhost:8000/v1 \
   -n 20 \
@@ -135,7 +135,7 @@ The V1 taskset fixes the question bank and searchable corpus. You can replace it
 ```toml
 [[orchestrator.train.env]]
 name = "wiki-search"
-taskset = { id = "wiki-search-v1", task = { judges = [{ id = "reference", model = "openai/gpt-5.4-nano" }] } }
+taskset = { id = "wiki-search", task = { judges = [{ id = "reference", model = "openai/gpt-5.4-nano" }] } }
 harness = { id = "null", runtime = { type = "subprocess" } }
 ```
 

--- a/examples/basic/wiki-search/rl.toml
+++ b/examples/basic/wiki-search/rl.toml
@@ -46,7 +46,7 @@ enforce = true
 
 [[orchestrator.train.env]]
 name = "wiki-search"
-taskset = { id = "wiki-search-v1" }
+taskset = { id = "wiki-search" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [ckpt] # Checkpoint at the end of training

--- a/examples/basic/wordle/README.md
+++ b/examples/basic/wordle/README.md
@@ -1,6 +1,6 @@
 # Wordle
 
-In this example, we demonstrate how to train `Qwen3-1.7B` to play Wordle. This will require a SFT warmup to learn the format and, finally, multi-turn RL against the `wordle-v1` taskset to improve performance.
+In this example, we demonstrate how to train `Qwen3-1.7B` to play Wordle. This will require a SFT warmup to learn the format and, finally, multi-turn RL against the `wordle` taskset to improve performance.
 
 > The commands in this example were designed to be run on 2 GPUs (one trainer and one inference GPU). It is possible to run on less or more GPUs using different deployment strategies. If you run on a different setup, you may need to adjust the start commands.
 
@@ -9,7 +9,7 @@ In this example, we demonstrate how to train `Qwen3-1.7B` to play Wordle. This w
 The taskset is included through the Verifiers workspace. After syncing the repository, verify it with:
 
 ```bash
-uv run python -c "import wordle_v1"
+uv run python -c "import wordle"
 ```
 
 Start the pre-layouted `tmux` session which we will use to run all experiments and view logs conveniently
@@ -29,7 +29,7 @@ Then, use the `eval` entrypoint to evaluate the model in the `wordle` environmen
 
 ```bash
 # Run this in the `Trainer` pane
-uv run eval wordle-v1 --harness.id null -m Qwen/Qwen3-1.7B --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
+uv run eval wordle --harness.id null -m Qwen/Qwen3-1.7B --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
 ```
 
 We got an **average reward of ~0.2** across the 20x3 rollouts. From the summary, we can see that the most of the reward is coming from format and partial rewards. In fact, the model does not guess the correct word within any game, leading to a win rate of **0%**. Looking at some samples, it is evident repeatedly submitting guesses in the wrong format and is not able to revise its strategy from the environment feedback. Let's do some SFT warmup to get the model to learn the format of the environment.
@@ -103,7 +103,7 @@ uv run inference --model.name PrimeIntellect/Qwen3-1.7B-Wordle-RL
 
 ```bash
 # Run this in the `Trainer` pane
-uv run eval wordle-v1 --harness.id null -m PrimeIntellect/Qwen3-1.7B-Wordle-RL --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
+uv run eval wordle --harness.id null -m PrimeIntellect/Qwen3-1.7B-Wordle-RL --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
 ```
 
 Way better! Our model now wins **~60%** and gets an average reward of **~1.5**.

--- a/examples/basic/wordle/rl.toml
+++ b/examples/basic/wordle/rl.toml
@@ -20,7 +20,7 @@ group_size = 16
 
 [[orchestrator.train.env]]
 name = "wordle"
-taskset = { id = "wordle-v1" }
+taskset = { id = "wordle" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [orchestrator.train.sampling]

--- a/k8s/prime-rl/examples/reverse-text/orch.toml
+++ b/k8s/prime-rl/examples/reverse-text/orch.toml
@@ -15,7 +15,7 @@ max_completion_tokens = 128
 
 [[train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 
 [renderer]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,11 +133,11 @@ members = [
     "deps/research-environments/environments/*/*",
     "deps/verifiers/environments/*",
 ]
-# tau2-synth-v1 and tau3-bench-v1 pin `tau2` forks/revs that conflict with the
-# canonical tau2-bench-v1; a workspace shares one lock, so these can't coexist.
+# tau2-synth and tau3-bench pin `tau2` forks/revs that conflict with the
+# canonical tau2-bench; a workspace shares one lock, so these can't coexist.
 exclude = [
-    "deps/research-environments/environments/tool_use/tau2_synth_v1",
-    "deps/research-environments/environments/tool_use/tau3_bench_v1",
+    "deps/research-environments/environments/tool_use/tau2_synth",
+    "deps/research-environments/environments/tool_use/tau3_bench",
 ]
 
 # ModelExpress 0.3.0 publishes protobuf<6 metadata, but its generated proto is

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -43,11 +43,11 @@ Incompatible combinations (e.g. CP requires flash attention) must raise in a `mo
 ```toml
 [[orchestrator.train.env]]
 name = "reverse-text"
-taskset = { id = "reverse-text-v1" }
+taskset = { id = "reverse-text" }
 harness = { id = "null", runtime = { type = "subprocess" } }
 ```
 
-CLI: `--orchestrator.train.env.0.taskset.id reverse-text-v1`.
+CLI: `--orchestrator.train.env.0.taskset.id reverse-text`.
 
 **Dicts** — TOML uses a section; CLI takes a JSON string: `--vllm-extra '{"key1": "value1"}'`. This works for plain `dict` fields only — nested pydantic-model fields (e.g. `algo`) reject JSON strings; use dotted keys (`--orchestrator.algo.type max_rl`) or a TOML overlay file.
 

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -26,7 +26,7 @@ uv sync                                    # core only
 uv sync --group dev                        # + pytest, ruff, pre-commit
 uv sync --all-extras                       # + extras (flash-attn, flash-attn-cute, …)
 uv sync --all-extras --all-packages        # + all env packages (needed to train on them)
-uv sync --package prime-rl --package gsm8k-v1  # core + just one env
+uv sync --package prime-rl --package gsm8k  # core + just one env
 ```
 
 Environment packages under `deps/research-environments/environments/*/*` and `deps/verifiers/environments/*` are uv **workspace members**, auto-discovered — adding a new env needs no `pyproject.toml` change. They are opt-in: a plain `uv sync` / `--all-extras` does not install them (and would remove them if already present — re-run with `--all-packages`, or `--inexact` to keep them). Install all with `--all-packages`, or a subset with repeated `--package <env>` (include `--package prime-rl` to keep the core). If two envs pin conflicting transitive versions (all members share one lock), add the loser to `[tool.uv.workspace].exclude`.

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -35,7 +35,7 @@ uv run rl @ examples/basic/reverse-text/rl.toml --dry-run                       
 - SLURM: single- and multi-node
 - Environment packages: before launching a config with a non-core verifier env id,
   verify the package imports under `uv run` (for example
-  `uv run python -c "import importlib.util; print(importlib.util.find_spec('r2e_gym_v1'))"`).
+  `uv run python -c "import importlib.util; print(importlib.util.find_spec('r2e_gym'))"`).
   If a local env exists under `deps/research-environments/environments/` or
   `deps/verifiers/environments/` but does not import, install the env workspace
   members with `uv sync --all-packages` (all) or `uv sync --package prime-rl


### PR DESCRIPTION
## Summary

The env repos are dropping the trailing `_v1`/`-v1` suffix from all v1 environment packages, and the hub envs are being republished under the stripped names (e.g. `reverse-text-v1` → `reverse-text`, `i3_math_v1` → `i3_math`, `swebench-verified-v1` → `swebench-verified`). This PR updates every environment-id pointer in prime-rl to the new names:

- **taskset ids** in `configs/` (basic, ci integration + nightly, debug), `examples/` (basic + advanced), and `k8s/` example configs
- **CLI / import examples** in `docs/configuration.md`, `skills/`, and example READMEs (`uv run eval reverse-text-v1` → `uv run eval reverse-text`, `import reverse_text_v1` → `import reverse_text`)
- **workspace exclude paths** in `pyproject.toml` (`tau2_synth_v1`/`tau3_bench_v1` dirs → renamed dirs)

50 files, 98 pointer renames, no logic changes. Only trailing `_v1`/`-v1` is stripped — version-bearing names keep their real suffix (`swerebench-v2-v1` → `swerebench-v2`, `mrcr_v2_v1` → `mrcr_v2`).

## ⚠️ Merge order — do NOT merge yet

This PR only works once ALL of the following have landed:

1. The **research-environments** rename PR (strips `_v1` from its 76 packages) — in flight.
2. An equivalent **verifiers** rename for its example envs (`reverse_text_v1`, `gsm8k_v1`, `wordle_v1`, `alphabet_sort_v1`, `wiki_search_v1`, `color_codeword_v1`, …) — **not yet opened**.
3. The `deps/research-environments` and `deps/verifiers` checkouts here are bumped past those renames (workspace globs auto-discover the renamed packages; `uv.lock` regenerates on sync).
4. The hub republish under the stripped ids completes.

Until then the old ids keep working and this branch would break config resolution.

## Not touched (deliberate)

- `deps/` vendored checkouts and `uv.lock` (regenerate on dep bump)
- `verifiers.v1` framework module paths (unrelated to env package names)
- No config referenced an env id outside the affected 87-package set

🤖 Generated with [Claude Code](https://claude.com/claude-code)