### PR TITLE
chore: bump research-environments submodule to latest main

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4632,7 +4632,7 @@ requires-dist = [
 
 [[package]]
 name = "openswe-v1"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "deps/research-environments/environments/swe/openswe_v1" }
 dependencies = [
     { name = "datasets" },
@@ -4774,7 +4774,7 @@ wheels = [
 
 [[package]]
 name = "openthoughts-tblite-v1"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "deps/research-environments/environments/terminal/openthoughts_tblite_v1" }
 dependencies = [
     { name = "verifiers" },
@@ -6446,7 +6446,7 @@ wheels = [
 
 [[package]]
 name = "senior-swe-bench-v1"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "deps/research-environments/environments/swe/senior_swe_bench_v1" }
 dependencies = [
     { name = "verifiers", extra = ["harbor"] },
@@ -7091,7 +7091,7 @@ requires-dist = [{ name = "verifiers", specifier = ">=0.2.1" }]
 
 [[package]]
 name = "terminal-lego-v1"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "deps/research-environments/environments/terminal/terminal_lego_v1" }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
Bumps `deps/research-environments` `e40d32690` → `f5d423c32` (latest main).

Picks up the registry ref-cleanup wave: the platform image-naming convention changes (openswe_v1, terminal_lego_v1, openthoughts_tblite_v1, senior_swe_bench_v1 switched to org-less platform refs; multiswe_v1's REGISTRY mapping removed) plus the eval-CLI test-harness fix (#707). All six affected tasksets were smoke-verified post-merge with one prime sandbox boot each (validate --only-setup).

Note: research-environments#708 (tmax Harbor registry pointer) is still open — once it merges, this PR should get one more bump commit so tmax-v1 resolves the renamed `tmax/…` refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Registry/image ref changes can break sandbox image resolution for eval runs; impact is limited to dependency alignment rather than in-repo application logic.
> 
> **Overview**
> Updates **`deps/research-environments`** to latest main so this repo picks up the registry ref-cleanup (org-less platform image refs for several SWE/terminal tasksets, plus related registry mapping changes) and the eval-CLI test-harness fix from upstream.
> 
> The only visible diff here is **`uv.lock`** reflecting bumped editable package versions for **`openswe-v1`** (0.1.2→0.1.3), **`openthoughts-tblite-v1`**, **`senior-swe-bench-v1`**, and **`terminal-lego-v1`** (0.1.0→0.1.1 each), all sourced from paths under the submodule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e613b61d59f17946d900ad10c09f78e2e194dba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->