### PR TITLE
fix(orchestrator): drain after final train batch

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -555,7 +555,7 @@ class Orchestrator:
             if train_batch is not None and not self.draining and not self.stopped.is_set():
                 await self.finalize_train_batch(train_batch)
 
-    async def _start_draining(self) -> None:
+    async def start_draining(self) -> None:
         """Stop train scheduling while allowing in-flight evals to finish."""
         if self.draining:
             return
@@ -582,7 +582,7 @@ class Orchestrator:
         self.last_batch_at = now
 
         if config.max_steps is not None and step > config.max_steps:
-            await self._start_draining()
+            await self.start_draining()
             return
 
         if not batch.samples:
@@ -616,7 +616,7 @@ class Orchestrator:
 
         await self.sender.send(TrainingBatch(examples=batch.samples, step=step))
         if config.max_steps is not None and step == config.max_steps:
-            await self._start_draining()
+            await self.start_draining()
         self.progress.step += 1
         self.update_dispatch_gate()
         # Checkpoint the step we just shipped (resume point: continue at step + 1).

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -555,6 +555,17 @@ class Orchestrator:
             if train_batch is not None and not self.draining and not self.stopped.is_set():
                 await self.finalize_train_batch(train_batch)
 
+    async def _start_draining(self) -> None:
+        """Stop train scheduling while allowing in-flight evals to finish."""
+        if self.draining:
+            return
+        self.draining = True
+        self.dispatcher.disable_train_scheduling()
+        n_cancelled = await self.dispatcher.cancel_inflight_train_rollouts()
+        get_logger().info(
+            f"Draining pipeline (cancelled {n_cancelled} in-flight train rollout(s); any in-flight evals will complete)"
+        )
+
     async def finalize_train_batch(self, batch: TrainBatch) -> None:
         """Ship one ``TrainBatch`` out to the trainer and handle the I/O
         side-effects (ckpt, save_rollouts, reference scoring, sender.send,
@@ -571,13 +582,7 @@ class Orchestrator:
         self.last_batch_at = now
 
         if config.max_steps is not None and step > config.max_steps:
-            self.draining = True
-            self.dispatcher.disable_train_scheduling()
-            n_cancelled = await self.dispatcher.cancel_inflight_train_rollouts()
-            get_logger().info(
-                f"Draining pipeline (cancelled {n_cancelled} in-flight train rollout(s); "
-                f"any in-flight evals will complete)"
-            )
+            await self._start_draining()
             return
 
         if not batch.samples:
@@ -610,6 +615,8 @@ class Orchestrator:
         await asyncio.to_thread(save_rollouts, records, get_trace_path(config.output_dir, step, "train", "effective"))
 
         await self.sender.send(TrainingBatch(examples=batch.samples, step=step))
+        if config.max_steps is not None and step == config.max_steps:
+            await self._start_draining()
         self.progress.step += 1
         self.update_dispatch_gate()
         # Checkpoint the step we just shipped (resume point: continue at step + 1).

--- a/tests/unit/orchestrator/test_orchestrator_lifecycle.py
+++ b/tests/unit/orchestrator/test_orchestrator_lifecycle.py
@@ -1,0 +1,120 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from prime_rl.orchestrator.orchestrator import Orchestrator
+from prime_rl.transport import TrainingSample
+
+
+class _Metrics:
+    def to_wandb(self, **_kwargs) -> dict[str, float]:
+        return {}
+
+
+class _Rollout:
+    is_trainable = True
+    num_total_tokens = 1
+    num_input_tokens = 1
+    num_output_tokens = 0
+    group_id = "group"
+    reward = 1.0
+
+    def to_record(self) -> dict:
+        return {}
+
+    def scalar_advantage(self) -> float:
+        return 1.0
+
+
+class _Rollouts(list[_Rollout]):
+    @property
+    def effective(self) -> "_Rollouts":
+        return self
+
+    @property
+    def rollouts(self) -> list[_Rollout]:
+        return list(self)
+
+    @property
+    def metrics(self) -> _Metrics:
+        return _Metrics()
+
+    def by_env(self) -> dict[str, "_Rollouts"]:
+        return {"test": self}
+
+
+def _make_orchestrator(output_dir: Path, *, max_steps: int, step: int) -> Orchestrator:
+    orchestrator = Orchestrator.__new__(Orchestrator)
+    orchestrator.config = SimpleNamespace(max_steps=max_steps, output_dir=output_dir)
+    orchestrator.progress = SimpleNamespace(step=step, total_tokens=0, total_samples=0, total_problems=0)
+    orchestrator.last_batch_at = None
+    orchestrator.consecutive_empty_batches = 0
+    orchestrator.draining = False
+    orchestrator.dispatcher = SimpleNamespace(
+        disable_train_scheduling=MagicMock(),
+        cancel_inflight_train_rollouts=AsyncMock(return_value=3),
+    )
+    orchestrator.sender = SimpleNamespace(send=AsyncMock())
+    orchestrator.maybe_save_ckpt = AsyncMock(return_value=0.0)
+    orchestrator.update_dispatch_gate = MagicMock()
+    orchestrator.monitor = MagicMock()
+    orchestrator.wait_for_policy_time = 0.0
+    orchestrator.train_sink = SimpleNamespace(pre_filter_seen=0, reset_pre_filter_stats=MagicMock())
+    orchestrator.usage_reporter = None
+    orchestrator.heart = None
+    orchestrator.log_train_batch = MagicMock()
+    orchestrator.maybe_trigger_eval = MagicMock()
+    return orchestrator
+
+
+def _make_batch(*, with_samples: bool = True) -> SimpleNamespace:
+    samples = (
+        [TrainingSample(token_ids=[1], mask=[True], logprobs=[0.0], temperatures=[1.0], env_name="test")]
+        if with_samples
+        else []
+    )
+    return SimpleNamespace(rollouts=_Rollouts([_Rollout()]), samples=samples)
+
+
+def test_final_train_batch_starts_draining_immediately(tmp_path: Path) -> None:
+    orchestrator = _make_orchestrator(tmp_path, max_steps=1, step=1)
+
+    with (
+        patch("prime_rl.orchestrator.orchestrator.save_rollouts"),
+        patch("prime_rl.orchestrator.orchestrator.trim_process_memory"),
+    ):
+        asyncio.run(orchestrator.finalize_train_batch(_make_batch()))
+
+    assert orchestrator.draining
+    orchestrator.sender.send.assert_awaited_once()
+    orchestrator.dispatcher.disable_train_scheduling.assert_called_once_with()
+    orchestrator.dispatcher.cancel_inflight_train_rollouts.assert_awaited_once_with()
+    assert orchestrator.progress.step == 2
+    orchestrator.maybe_trigger_eval.assert_called_once_with(2)
+
+
+def test_non_final_train_batch_keeps_dispatching(tmp_path: Path) -> None:
+    orchestrator = _make_orchestrator(tmp_path, max_steps=2, step=1)
+
+    with (
+        patch("prime_rl.orchestrator.orchestrator.save_rollouts"),
+        patch("prime_rl.orchestrator.orchestrator.trim_process_memory"),
+    ):
+        asyncio.run(orchestrator.finalize_train_batch(_make_batch()))
+
+    assert not orchestrator.draining
+    orchestrator.dispatcher.disable_train_scheduling.assert_not_called()
+    orchestrator.dispatcher.cancel_inflight_train_rollouts.assert_not_awaited()
+
+
+def test_empty_final_train_batch_keeps_dispatching(tmp_path: Path) -> None:
+    orchestrator = _make_orchestrator(tmp_path, max_steps=1, step=1)
+
+    asyncio.run(orchestrator.finalize_train_batch(_make_batch(with_samples=False)))
+
+    assert not orchestrator.draining
+    orchestrator.sender.send.assert_not_awaited()
+    orchestrator.dispatcher.disable_train_scheduling.assert_not_called()
+    orchestrator.dispatcher.cancel_inflight_train_rollouts.assert_not_awaited()
+    assert orchestrator.progress.step == 1

--- a/tests/unit/orchestrator/test_orchestrator_lifecycle.py
+++ b/tests/unit/orchestrator/test_orchestrator_lifecycle.py
@@ -7,47 +7,32 @@ from prime_rl.orchestrator.orchestrator import Orchestrator
 from prime_rl.transport import TrainingSample
 
 
-class _Metrics:
-    def to_wandb(self, **_kwargs) -> dict[str, float]:
-        return {}
+def test_final_train_batch_starts_draining_immediately(tmp_path: Path) -> None:
+    rollout = SimpleNamespace(
+        is_trainable=True,
+        num_total_tokens=1,
+        num_input_tokens=1,
+        num_output_tokens=0,
+        group_id="group",
+        reward=1.0,
+        to_record=MagicMock(return_value={}),
+        scalar_advantage=MagicMock(return_value=1.0),
+    )
+    rollouts = MagicMock()
+    rollouts.__len__.return_value = 1
+    rollouts.__iter__.side_effect = lambda: iter([rollout])
+    rollouts.effective = rollouts
+    rollouts.rollouts = [rollout]
+    rollouts.metrics = SimpleNamespace(to_wandb=MagicMock(return_value={}))
+    rollouts.by_env.return_value = {"test": rollouts}
+    batch = SimpleNamespace(
+        rollouts=rollouts,
+        samples=[TrainingSample(token_ids=[1], mask=[True], logprobs=[0.0], temperatures=[1.0], env_name="test")],
+    )
 
-
-class _Rollout:
-    is_trainable = True
-    num_total_tokens = 1
-    num_input_tokens = 1
-    num_output_tokens = 0
-    group_id = "group"
-    reward = 1.0
-
-    def to_record(self) -> dict:
-        return {}
-
-    def scalar_advantage(self) -> float:
-        return 1.0
-
-
-class _Rollouts(list[_Rollout]):
-    @property
-    def effective(self) -> "_Rollouts":
-        return self
-
-    @property
-    def rollouts(self) -> list[_Rollout]:
-        return list(self)
-
-    @property
-    def metrics(self) -> _Metrics:
-        return _Metrics()
-
-    def by_env(self) -> dict[str, "_Rollouts"]:
-        return {"test": self}
-
-
-def _make_orchestrator(output_dir: Path, *, max_steps: int, step: int) -> Orchestrator:
     orchestrator = Orchestrator.__new__(Orchestrator)
-    orchestrator.config = SimpleNamespace(max_steps=max_steps, output_dir=output_dir)
-    orchestrator.progress = SimpleNamespace(step=step, total_tokens=0, total_samples=0, total_problems=0)
+    orchestrator.config = SimpleNamespace(max_steps=1, output_dir=tmp_path)
+    orchestrator.progress = SimpleNamespace(step=1, total_tokens=0, total_samples=0, total_problems=0)
     orchestrator.last_batch_at = None
     orchestrator.consecutive_empty_batches = 0
     orchestrator.draining = False
@@ -65,26 +50,12 @@ def _make_orchestrator(output_dir: Path, *, max_steps: int, step: int) -> Orches
     orchestrator.heart = None
     orchestrator.log_train_batch = MagicMock()
     orchestrator.maybe_trigger_eval = MagicMock()
-    return orchestrator
-
-
-def _make_batch(*, with_samples: bool = True) -> SimpleNamespace:
-    samples = (
-        [TrainingSample(token_ids=[1], mask=[True], logprobs=[0.0], temperatures=[1.0], env_name="test")]
-        if with_samples
-        else []
-    )
-    return SimpleNamespace(rollouts=_Rollouts([_Rollout()]), samples=samples)
-
-
-def test_final_train_batch_starts_draining_immediately(tmp_path: Path) -> None:
-    orchestrator = _make_orchestrator(tmp_path, max_steps=1, step=1)
 
     with (
         patch("prime_rl.orchestrator.orchestrator.save_rollouts"),
         patch("prime_rl.orchestrator.orchestrator.trim_process_memory"),
     ):
-        asyncio.run(orchestrator.finalize_train_batch(_make_batch()))
+        asyncio.run(orchestrator.finalize_train_batch(batch))
 
     assert orchestrator.draining
     orchestrator.sender.send.assert_awaited_once()
@@ -92,29 +63,3 @@ def test_final_train_batch_starts_draining_immediately(tmp_path: Path) -> None:
     orchestrator.dispatcher.cancel_inflight_train_rollouts.assert_awaited_once_with()
     assert orchestrator.progress.step == 2
     orchestrator.maybe_trigger_eval.assert_called_once_with(2)
-
-
-def test_non_final_train_batch_keeps_dispatching(tmp_path: Path) -> None:
-    orchestrator = _make_orchestrator(tmp_path, max_steps=2, step=1)
-
-    with (
-        patch("prime_rl.orchestrator.orchestrator.save_rollouts"),
-        patch("prime_rl.orchestrator.orchestrator.trim_process_memory"),
-    ):
-        asyncio.run(orchestrator.finalize_train_batch(_make_batch()))
-
-    assert not orchestrator.draining
-    orchestrator.dispatcher.disable_train_scheduling.assert_not_called()
-    orchestrator.dispatcher.cancel_inflight_train_rollouts.assert_not_awaited()
-
-
-def test_empty_final_train_batch_keeps_dispatching(tmp_path: Path) -> None:
-    orchestrator = _make_orchestrator(tmp_path, max_steps=1, step=1)
-
-    asyncio.run(orchestrator.finalize_train_batch(_make_batch(with_samples=False)))
-
-    assert not orchestrator.draining
-    orchestrator.sender.send.assert_not_awaited()
-    orchestrator.dispatcher.disable_train_scheduling.assert_not_called()
-    orchestrator.dispatcher.cancel_inflight_train_rollouts.assert_not_awaited()
-    assert orchestrator.progress.step == 1


### PR DESCRIPTION
## Summary

Enter drain mode immediately after successfully sending the final configured training batch, rather than waiting for an unused overflow batch to complete.

## Problem

The orchestrator currently starts draining only when:

`step > max_steps`

After sending the valid batch at `step == max_steps`, it advances the step but continues scheduling rollouts. Another complete `TrainBatch` must reach `finalize_train_batch()` before the existing overflow guard stops training.

That batch is discarded and cannot serve as a fallback. This wastes rollout work and makes shutdown depend on an unnecessary batch
completing. A slow or unhealthy rollout tail can therefore delay shutdown.

## Change

After `sender.send()` successfully sends the final valid batch, the orchestrator now:

- enters drain mode;
- disables further train scheduling;
- cancels in-flight train rollouts;
- leaves eval rollouts untouched so final evaluations can finish.

The existing `step > max_steps` check remains as a defensive guard.

Draining starts only after a valid batch is sent. Empty or fully filtered final-batch candidates continue to be retried.

## Tests

Added one CPU-only regression test verifying that a valid final batch:

- is sent;
- immediately starts draining;
- advances progress normally;
- still triggers final-step evaluation.

```
uv run pytest -q tests/unit/orchestrator -m "not gpu"
95 passed, 1 skipped
```

Ruff lint and formatting checks also pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestrator shutdown timing and train rollout cancellation at `max_steps`; behavior change is intentional but affects when the pipeline stops scheduling work.
> 
> **Overview**
> **Starts pipeline drain right after the last configured training batch is sent**, instead of waiting for a later batch to hit the `step > max_steps` guard (which was discarded anyway).
> 
> Drain behavior is centralized in **`start_draining()`**: disable train scheduling, cancel in-flight train rollouts, leave evals running. It runs immediately after a successful `sender.send()` when `step == max_steps`; the overflow path still calls the same helper. Empty or fully filtered final batches are unchanged—they do not trigger drain until a valid batch ships.
> 
> Adds a **unit test** that the final valid batch is sent, draining starts at once, progress advances, and final-step eval is still triggered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 237f511608045343d0ad84cff140d792efaac77b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->