### PR TITLE
feat: chunked per-layer optimizer step with stream-overlapped CPU offload

### DIFF
--- a/configs/ci/integration/reverse-text-multi-run/trainer.toml
+++ b/configs/ci/integration/reverse-text-multi-run/trainer.toml
@@ -6,7 +6,8 @@ enable_token_export = true
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 seq_len = 65536
 fused_lm_head_token_chunk_size = 8192
-optim_cpu_offload = false
+[optim.cpu_offload]
+enabled = false
 
 [model.lora]
 rank = 8

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -146,7 +146,15 @@ optim_cpu_offload = true   # already the default
 
 Mutually exclusive with `fsdp_cpu_offload`. Also incompatible with `trainer.max_concurrent_runs > 1` (multi-tenant training) — set `optim_cpu_offload = false` for multi-run. Muon doesn't support `fsdp_cpu_offload` but does support `optim_cpu_offload`.
 
-The optimizer step is performed per-transformer-layer ("chunked"): each layer's optimizer states are moved to GPU, the step runs for that layer only, and the states move back to CPU before the next layer. This bounds peak GPU optimizer-state memory to a single layer's worth, preventing OOM when `weight + grad + all_opt_states` exceeds available VRAM even without activations. H2D and D2H transfers are pipelined on dedicated CUDA streams so the next layer's states are prefetched while the current layer computes.
+The optimizer step is performed per-transformer-layer ("chunked"): each layer's optimizer states are moved to GPU, the step runs for that layer only, and the states move back to CPU before the next layer. This bounds peak GPU optimizer-state memory to a single layer's worth, preventing OOM when `weight + grad + all_opt_states` exceeds available VRAM even without activations. H2D and D2H transfers are pipelined on dedicated CUDA streams so the next layer's states are prefetched while the current layer computes:
+
+```toml
+[trainer.model]
+optim_cpu_offload_chunked = true   # already the default
+optim_cpu_offload_stream = true    # already the default
+```
+
+Set `optim_cpu_offload_chunked = false` to fall back to all-at-once offloading (loads the full model's optimizer states to GPU in one shot — simpler but requires enough VRAM to hold them all simultaneously). Set `optim_cpu_offload_stream = false` to disable stream overlap within the chunked step, falling back to a simple sequential move→step→move loop.
 
 ### LM Head Chunking
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -146,6 +146,8 @@ optim_cpu_offload = true   # already the default
 
 Mutually exclusive with `fsdp_cpu_offload`. Also incompatible with `trainer.max_concurrent_runs > 1` (multi-tenant training) — set `optim_cpu_offload = false` for multi-run. Muon doesn't support `fsdp_cpu_offload` but does support `optim_cpu_offload`.
 
+The optimizer step is performed per-transformer-layer ("chunked"): each layer's optimizer states are moved to GPU, the step runs for that layer only, and the states move back to CPU before the next layer. This bounds peak GPU optimizer-state memory to a single layer's worth, preventing OOM when `weight + grad + all_opt_states` exceeds available VRAM even without activations. H2D and D2H transfers are pipelined on dedicated CUDA streams so the next layer's states are prefetched while the current layer computes.
+
 ### LM Head Chunking
 
 The vanilla LM head materializes a `[batch * seq, vocab]` logits tensor on every step — a major memory tax when the vocabulary is large (often >100K). `fused_lm_head_token_chunk_size` swaps in a custom fused linear + logprob/entropy kernel that streams through `chunk_size` tokens at a time, avoiding the materialization. It defaults to `1024` for RL training:

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -154,7 +154,7 @@ optim_cpu_offload_chunked = true
 optim_cpu_offload_stream = true
 ```
 
-Set `optim_cpu_offload_chunked = false` to fall back to all-at-once offloading (loads the full model's optimizer states to GPU in one shot — simpler but requires enough VRAM to hold them all simultaneously). Set `optim_cpu_offload_stream = false` to disable stream overlap within the chunked step, falling back to a simple sequential move→step→move loop.
+Both default to `false`. Set `optim_cpu_offload_chunked = true` to enable per-layer chunking. Set `optim_cpu_offload_stream = true` to additionally overlap H2D/D2H transfers with optimizer compute on dedicated CUDA streams. When chunked is enabled but stream is not, the step uses a simple sequential move→step→move loop.
 
 ### LM Head Chunking
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -150,8 +150,8 @@ The optimizer step is performed per-transformer-layer ("chunked"): each layer's 
 
 ```toml
 [trainer.model]
-optim_cpu_offload_chunked = true   # already the default
-optim_cpu_offload_stream = true    # already the default
+optim_cpu_offload_chunked = true
+optim_cpu_offload_stream = true
 ```
 
 Set `optim_cpu_offload_chunked = false` to fall back to all-at-once offloading (loads the full model's optimizer states to GPU in one shot — simpler but requires enough VRAM to hold them all simultaneously). Set `optim_cpu_offload_stream = false` to disable stream overlap within the chunked step, falling back to a simple sequential move→step→move loop.

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -146,7 +146,7 @@ optim_cpu_offload = true   # already the default
 
 Mutually exclusive with `fsdp_cpu_offload`. Also incompatible with `trainer.max_concurrent_runs > 1` (multi-tenant training) — set `optim_cpu_offload = false` for multi-run. Muon doesn't support `fsdp_cpu_offload` but does support `optim_cpu_offload`.
 
-The optimizer step is performed per-transformer-layer ("chunked"): each layer's optimizer states are moved to GPU, the step runs for that layer only, and the states move back to CPU before the next layer. This bounds peak GPU optimizer-state memory to a single layer's worth, preventing OOM when `weight + grad + all_opt_states` exceeds available VRAM even without activations. H2D and D2H transfers are pipelined on dedicated CUDA streams so the next layer's states are prefetched while the current layer computes:
+The optimizer step is performed per-transformer-layer ("chunked"): each layer's optimizer states are moved to GPU, the step runs for that layer only, and the states move back to CPU before the next layer. This reduces peak GPU optimizer-state memory from the full model's states to about one layer's worth (two layers with stream overlap: the current layer being computed plus the next layer being prefetched). Set `optim_cpu_offload_chunked = true` to enable:
 
 ```toml
 [trainer.model]
@@ -154,7 +154,7 @@ optim_cpu_offload_chunked = true
 optim_cpu_offload_stream = true
 ```
 
-Both default to `false`. Set `optim_cpu_offload_chunked = true` to enable per-layer chunking. Set `optim_cpu_offload_stream = true` to additionally overlap H2D/D2H transfers with optimizer compute on dedicated CUDA streams. When chunked is enabled but stream is not, the step uses a simple sequential move→step→move loop.
+Both default to `false`. Set `optim_cpu_offload_stream = true` to additionally overlap H2D/D2H transfers with optimizer compute on dedicated CUDA streams (up to ~3 layers resident on GPU during overlap). When chunked is enabled but stream is not, the step uses a simple sequential move→step→move loop (1 layer resident at a time).
 
 ### LM Head Chunking
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -146,14 +146,7 @@ optim_cpu_offload = true   # already the default
 
 Mutually exclusive with `fsdp_cpu_offload`. Also incompatible with `trainer.max_concurrent_runs > 1` (multi-tenant training) — set `optim_cpu_offload = false` for multi-run. Muon doesn't support `fsdp_cpu_offload` but does support `optim_cpu_offload`.
 
-The optimizer step can be performed per-transformer-layer ("chunked"): each layer's optimizer states are moved to GPU, the step runs for that layer only, and the states move back to CPU before the next layer. H2D/D2H transfers are overlapped with compute on dedicated CUDA streams — while layer *i* computes, layer *i+1* is prefetched and layer *i-1* is evicted — but the prefetch waits for the eviction to complete, so at most two layers' optimizer states are on GPU at any time. Set `optim_cpu_offload_chunked = true` to enable:
-
-```toml
-[trainer.model]
-optim_cpu_offload_chunked = true
-```
-
-Defaults to `false`. This reduces peak GPU optimizer-state memory from the full model's states to about two layers' worth, preventing OOM when `weight + grad + all_opt_states > VRAM`.
+The optimizer step is performed per-transformer-layer with stream-overlapped H2D/D2H transfers: while layer *i* computes, layer *i+1* is prefetched and layer *i-1* is evicted. The prefetch waits for the eviction to complete, so at most two layers' optimizer states are on GPU at any time. This reduces peak GPU optimizer-state memory from the full model's states to about two layers' worth, preventing OOM when `weight + grad + all_opt_states > VRAM`.
 
 ### LM Head Chunking
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -146,15 +146,14 @@ optim_cpu_offload = true   # already the default
 
 Mutually exclusive with `fsdp_cpu_offload`. Also incompatible with `trainer.max_concurrent_runs > 1` (multi-tenant training) — set `optim_cpu_offload = false` for multi-run. Muon doesn't support `fsdp_cpu_offload` but does support `optim_cpu_offload`.
 
-The optimizer step is performed per-transformer-layer ("chunked"): each layer's optimizer states are moved to GPU, the step runs for that layer only, and the states move back to CPU before the next layer. This reduces peak GPU optimizer-state memory from the full model's states to about one layer's worth (two layers with stream overlap: the current layer being computed plus the next layer being prefetched). Set `optim_cpu_offload_chunked = true` to enable:
+The optimizer step can be performed per-transformer-layer ("chunked"): each layer's optimizer states are moved to GPU, the step runs for that layer only, and the states move back to CPU before the next layer. H2D/D2H transfers are overlapped with compute on dedicated CUDA streams — while layer *i* computes, layer *i+1* is prefetched and layer *i-1* is evicted — but the prefetch waits for the eviction to complete, so at most two layers' optimizer states are on GPU at any time. Set `optim_cpu_offload_chunked = true` to enable:
 
 ```toml
 [trainer.model]
 optim_cpu_offload_chunked = true
-optim_cpu_offload_stream = true
 ```
 
-Both default to `false`. Set `optim_cpu_offload_stream = true` to additionally overlap H2D/D2H transfers with optimizer compute on dedicated CUDA streams (up to ~3 layers resident on GPU during overlap). When chunked is enabled but stream is not, the step uses a simple sequential move→step→move loop (1 layer resident at a time).
+Defaults to `false`. This reduces peak GPU optimizer-state memory from the full model's states to about two layers' worth, preventing OOM when `weight + grad + all_opt_states > VRAM`.
 
 ### LM Head Chunking
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -146,8 +146,6 @@ optim_cpu_offload = true   # already the default
 
 Mutually exclusive with `fsdp_cpu_offload`. Also incompatible with `trainer.max_concurrent_runs > 1` (multi-tenant training) — set `optim_cpu_offload = false` for multi-run. Muon doesn't support `fsdp_cpu_offload` but does support `optim_cpu_offload`.
 
-The optimizer step is performed per-transformer-layer with stream-overlapped H2D/D2H transfers: while layer *i* computes, layer *i+1* is prefetched and layer *i-1* is evicted. The prefetch waits for the eviction to complete, so at most two layers' optimizer states are on GPU at any time. This reduces peak GPU optimizer-state memory from the full model's states to about two layers' worth, preventing OOM when `weight + grad + all_opt_states > VRAM`.
-
 ### LM Head Chunking
 
 The vanilla LM head materializes a `[batch * seq, vocab]` logits tensor on every step — a major memory tax when the vocabulary is large (often >100K). `fused_lm_head_token_chunk_size` swaps in a custom fused linear + logprob/entropy kernel that streams through `chunk_size` tokens at a time, avoiding the materialization. It defaults to `1024` for RL training:

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -170,10 +170,7 @@ class ModelConfig(BaseModelConfig):
     """Enable FSDP CPU offloading for parameters, gradients, and optimizer states. Uses pinned memory for efficient CPU↔GPU transfers."""
 
     optim_cpu_offload: bool = True
-    """Offload only optimizer states (momentum, variance) to CPU, keeping weights on GPU. Avoids the H2D all-gather overhead of FSDP CPU offload while still saving GPU memory."""
-
-    optim_cpu_offload_chunked: bool = False
-    """When optimizer CPU offload is enabled, perform the optimizer step per-transformer-layer instead of all-at-once. Each layer's states are moved to GPU, the step runs for that layer only, and states move back to CPU before the next layer. H2D/D2H transfers are overlapped with compute on dedicated CUDA streams, keeping at most two layers' optimizer states on GPU at a time. Reduces peak GPU optimizer-state memory from the full model's to about two layers' worth, preventing OOM when weight + grad + all_opt_states exceeds available VRAM."""
+    """Offload only optimizer states (momentum, variance) to CPU, keeping weights on GPU. Avoids the H2D all-gather overhead of FSDP CPU offload while still saving GPU memory. The optimizer step is performed per-transformer-layer with stream-overlapped H2D/D2H transfers, keeping at most two layers' optimizer states on GPU at a time."""
 
     reshard_after_forward: bool = True
     """Reshard the model after each forward pass."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -173,10 +173,7 @@ class ModelConfig(BaseModelConfig):
     """Offload only optimizer states (momentum, variance) to CPU, keeping weights on GPU. Avoids the H2D all-gather overhead of FSDP CPU offload while still saving GPU memory."""
 
     optim_cpu_offload_chunked: bool = False
-    """When optimizer CPU offload is enabled, perform the optimizer step per-transformer-layer instead of all-at-once. Each layer's states are moved to GPU, the step runs for that layer only, and states move back to CPU before the next layer. Reduces peak GPU optimizer-state memory from the full model's to about one layer's worth (two with stream overlap), preventing OOM when weight + grad + all_opt_states exceeds available VRAM."""
-
-    optim_cpu_offload_stream: bool = False
-    """When chunked optimizer CPU offload is enabled, overlap H2D (state→GPU) and D2H (state→CPU) transfers with optimizer compute using dedicated CUDA streams. Disabling simplifies the transfer logic to a sequential move→step→move loop at the cost of serializing transfers with compute."""
+    """When optimizer CPU offload is enabled, perform the optimizer step per-transformer-layer instead of all-at-once. Each layer's states are moved to GPU, the step runs for that layer only, and states move back to CPU before the next layer. H2D/D2H transfers are overlapped with compute on dedicated CUDA streams, keeping at most two layers' optimizer states on GPU at a time. Reduces peak GPU optimizer-state memory from the full model's to about two layers' worth, preventing OOM when weight + grad + all_opt_states exceeds available VRAM."""
 
     reshard_after_forward: bool = True
     """Reshard the model after each forward pass."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -173,7 +173,7 @@ class ModelConfig(BaseModelConfig):
     """Offload only optimizer states (momentum, variance) to CPU, keeping weights on GPU. Avoids the H2D all-gather overhead of FSDP CPU offload while still saving GPU memory."""
 
     optim_cpu_offload_chunked: bool = False
-    """When optimizer CPU offload is enabled, perform the optimizer step per-transformer-layer instead of all-at-once. Each layer's states are moved to GPU, the step runs for that layer only, and states move back to CPU before the next layer. Bounds peak GPU optimizer-state memory to one layer's worth, preventing OOM when weight + grad + all_opt_states exceeds available VRAM."""
+    """When optimizer CPU offload is enabled, perform the optimizer step per-transformer-layer instead of all-at-once. Each layer's states are moved to GPU, the step runs for that layer only, and states move back to CPU before the next layer. Reduces peak GPU optimizer-state memory from the full model's to about one layer's worth (two with stream overlap), preventing OOM when weight + grad + all_opt_states exceeds available VRAM."""
 
     optim_cpu_offload_stream: bool = False
     """When chunked optimizer CPU offload is enabled, overlap H2D (state→GPU) and D2H (state→CPU) transfers with optimizer compute using dedicated CUDA streams. Disabling simplifies the transfer logic to a sequential move→step→move loop at the cost of serializing transfers with compute."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -172,6 +172,12 @@ class ModelConfig(BaseModelConfig):
     optim_cpu_offload: bool = True
     """Offload only optimizer states (momentum, variance) to CPU, keeping weights on GPU. Avoids the H2D all-gather overhead of FSDP CPU offload while still saving GPU memory."""
 
+    optim_cpu_offload_chunked: bool = True
+    """When optimizer CPU offload is enabled, perform the optimizer step per-transformer-layer instead of all-at-once. Each layer's states are moved to GPU, the step runs for that layer only, and states move back to CPU before the next layer. Bounds peak GPU optimizer-state memory to one layer's worth, preventing OOM when weight + grad + all_opt_states exceeds available VRAM."""
+
+    optim_cpu_offload_stream: bool = True
+    """When chunked optimizer CPU offload is enabled, overlap H2D (state→GPU) and D2H (state→CPU) transfers with optimizer compute using dedicated CUDA streams. Disabling simplifies the transfer logic to a sequential move→step→move loop at the cost of serializing transfers with compute."""
+
     reshard_after_forward: bool = True
     """Reshard the model after each forward pass."""
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -172,10 +172,10 @@ class ModelConfig(BaseModelConfig):
     optim_cpu_offload: bool = True
     """Offload only optimizer states (momentum, variance) to CPU, keeping weights on GPU. Avoids the H2D all-gather overhead of FSDP CPU offload while still saving GPU memory."""
 
-    optim_cpu_offload_chunked: bool = True
+    optim_cpu_offload_chunked: bool = False
     """When optimizer CPU offload is enabled, perform the optimizer step per-transformer-layer instead of all-at-once. Each layer's states are moved to GPU, the step runs for that layer only, and states move back to CPU before the next layer. Bounds peak GPU optimizer-state memory to one layer's worth, preventing OOM when weight + grad + all_opt_states exceeds available VRAM."""
 
-    optim_cpu_offload_stream: bool = True
+    optim_cpu_offload_stream: bool = False
     """When chunked optimizer CPU offload is enabled, overlap H2D (state→GPU) and D2H (state→CPU) transfers with optimizer compute using dedicated CUDA streams. Disabling simplifies the transfer logic to a sequential move→step→move loop at the cost of serializing transfers with compute."""
 
     reshard_after_forward: bool = True

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -170,7 +170,10 @@ class ModelConfig(BaseModelConfig):
     """Enable FSDP CPU offloading for parameters, gradients, and optimizer states. Uses pinned memory for efficient CPU↔GPU transfers."""
 
     optim_cpu_offload: bool = True
-    """Offload only optimizer states (momentum, variance) to CPU, keeping weights on GPU. Avoids the H2D all-gather overhead of FSDP CPU offload while still saving GPU memory. The optimizer step is performed per-transformer-layer with stream-overlapped H2D/D2H transfers, keeping at most two layers' optimizer states on GPU at a time."""
+    """Offload only optimizer states (momentum, variance) to CPU, keeping weights on GPU. Avoids the H2D all-gather overhead of FSDP CPU offload while still saving GPU memory."""
+
+    optim_cpu_offload_chunked: bool = False
+    """When optimizer CPU offload is enabled, perform the optimizer step per-transformer-layer with stream-overlapped H2D/D2H transfers instead of all-at-once. At most two layers' optimizer states are on GPU at any time. Prevents OOM when weight + grad + all_opt_states exceeds VRAM at the cost of slower stepping."""
 
     reshard_after_forward: bool = True
     """Reshard the model after each forward pass."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -169,12 +169,6 @@ class ModelConfig(BaseModelConfig):
     fsdp_cpu_offload: bool = False
     """Enable FSDP CPU offloading for parameters, gradients, and optimizer states. Uses pinned memory for efficient CPU↔GPU transfers."""
 
-    optim_cpu_offload: bool = True
-    """Offload only optimizer states (momentum, variance) to CPU, keeping weights on GPU. Avoids the H2D all-gather overhead of FSDP CPU offload while still saving GPU memory."""
-
-    optim_cpu_offload_chunked: bool = False
-    """When optimizer CPU offload is enabled, perform the optimizer step per-transformer-layer with stream-overlapped H2D/D2H transfers instead of all-at-once. At most two layers' optimizer states are on GPU at any time. Prevents OOM when weight + grad + all_opt_states exceeds VRAM at the cost of slower stepping."""
-
     reshard_after_forward: bool = True
     """Reshard the model after each forward pass."""
 
@@ -277,8 +271,8 @@ class ModelConfig(BaseModelConfig):
 
     @model_validator(mode="after")
     def cpu_offload_mutual_exclusion(self):
-        if self.fsdp_cpu_offload and self.optim_cpu_offload:
-            raise ValueError("Cannot enable both fsdp_cpu_offload and optim_cpu_offload. Use one or the other.")
+        if self.fsdp_cpu_offload and self.optim.cpu_offload.enabled:
+            raise ValueError("Cannot enable both fsdp_cpu_offload and optim.cpu_offload. Use one or the other.")
         return self
 
     @model_validator(mode="after")
@@ -354,6 +348,14 @@ SchedulerConfig: TypeAlias = Annotated[
 ]
 
 
+class CPUOffloadConfig(BaseConfig):
+    enabled: bool = True
+    """Offload optimizer states (momentum, variance) to CPU, keeping weights on GPU. Avoids the H2D all-gather overhead of FSDP CPU offload while still saving GPU memory."""
+
+    chunked: bool = False
+    """Perform the optimizer step per-transformer-layer with stream-overlapped H2D/D2H transfers. At most two layers' optimizer states are on GPU at any time. Prevents OOM when weight + grad + all_opt_states exceeds VRAM at the cost of slower stepping."""
+
+
 class BaseOptimizerConfig(BaseConfig):
     lr: float = Field(1e-6, ge=0)
     """Peak learning rate."""
@@ -363,6 +365,9 @@ class BaseOptimizerConfig(BaseConfig):
 
     max_norm: float | None = Field(1.0, ge=0)
     """Maximum gradient norm to clip to. If None, gradient clipping is disabled."""
+
+    cpu_offload: CPUOffloadConfig = CPUOffloadConfig()
+    """Optimizer state CPU offloading configuration."""
 
 
 class SGDConfig(BaseOptimizerConfig):
@@ -707,7 +712,7 @@ class TrainerConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_optim_cpu_offload_single_run(self):
-        if self.model.optim_cpu_offload and self.max_concurrent_runs > 1:
+        if self.optim.cpu_offload.enabled and self.max_concurrent_runs > 1:
             raise ValueError("Optimizer CPU offload is not supported with max_concurrent_runs > 1")
         return self
 

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -109,6 +109,7 @@ class AppState(Stateful):
             if isinstance(opt, CPUOffloadOptimizer):
                 opt._move_states("cpu")
         if has_cpu_offload:
+            torch.cuda.synchronize()
             gc.collect()
             torch.cuda.empty_cache()
 

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -209,21 +209,21 @@ class CPUOffloadOptimizer:
     # ------------------------------------------------------------------ #
 
     def step(self, closure=None):
-        # First step initializes states on GPU — offload after.
-        if not self._initialized:
-            result = self.optimizer.step(closure)
-            self._move_states("cpu")
-            self._initialized = True
-            return result
-
-        # Non-chunked fallback (no named_params provided).
+        # Non-chunked path (no named_params provided).
         if self._chunks is None or len(self._chunks) <= 1:
+            if not self._initialized:
+                result = self.optimizer.step(closure)
+                self._move_states("cpu")
+                torch.cuda.synchronize()
+                self._initialized = True
+                return result
             self._move_states("cuda")
             result = self.optimizer.step(closure)
             self._move_states("cpu")
             return result
 
-        # Chunked step.
+        # Chunked path (also used for the first step to avoid materializing
+        # all optimizer states on GPU at once during initialization).
         self._original_param_groups = self.optimizer.param_groups
         original_steps = [g.get("step", 0) for g in self._original_param_groups]
 
@@ -234,6 +234,10 @@ class CPUOffloadOptimizer:
 
         self._sync_step_counters(original_steps)
         self._original_param_groups = None
+
+        if not self._initialized:
+            self._initialized = True
+
         return None
 
     def _step_chunked(self, closure=None):
@@ -242,6 +246,7 @@ class CPUOffloadOptimizer:
             self._move_chunk_states(i, "cuda")
             self._step_chunk(i, closure)
             self._move_chunk_states(i, "cpu")
+        torch.cuda.synchronize()
 
     def _step_chunked_streamed(self, closure=None):
         """Per-layer optimizer step with stream-overlapped H2D / D2H.
@@ -264,8 +269,10 @@ class CPUOffloadOptimizer:
             compute_stream.wait_stream(h2d_stream)
 
             # Prefetch H2D for chunk i+1 so it overlaps with step i on the
-            # compute stream.
+            # compute stream.  Wait for the previous chunk's D2H to finish
+            # first so we don't overwrite pinned CPU buffers still in flight.
             if i + 1 < n:
+                h2d_stream.wait_stream(d2h_stream)
                 self._move_chunk_states(i + 1, "cuda", h2d_stream)
 
             # Run optimizer step for chunk i.
@@ -275,9 +282,8 @@ class CPUOffloadOptimizer:
             d2h_stream.wait_stream(compute_stream)
             self._move_chunk_states(i, "cpu", d2h_stream)
 
-        # Ensure all transfers are complete before returning.
-        compute_stream.wait_stream(h2d_stream)
-        compute_stream.wait_stream(d2h_stream)
+        # Block the CPU until all async transfers are complete.
+        torch.cuda.synchronize()
 
     def zero_grad(self, set_to_none: bool = True):
         self.optimizer.zero_grad(set_to_none=set_to_none)
@@ -290,6 +296,7 @@ class CPUOffloadOptimizer:
         sd = self.optimizer.state_dict()
         if self._initialized:
             self._move_states("cpu")
+            torch.cuda.synchronize()
         return sd
 
     def load_state_dict(self, state_dict):
@@ -320,8 +327,8 @@ def setup_optimizer(
     parallel_dims: ParallelDims,
     lora: bool = False,
     cpu_offload: bool = False,
-    cpu_offload_chunked: bool = True,
-    cpu_offload_stream: bool = True,
+    cpu_offload_chunked: bool = False,
+    cpu_offload_stream: bool = False,
 ) -> Optimizer | CPUOffloadOptimizer:
     if lora:
         # Wait for run 0 to be created in the multi run manager

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -33,7 +33,7 @@ class CPUOffloadOptimizer:
         optimizer: Optimizer,
         named_params: list[tuple[str, nn.Parameter]] | None = None,
         pin_memory: bool = True,
-        stream: bool = True,
+        stream: bool = False,
     ):
         self.optimizer = optimizer
         self.pin_memory = pin_memory
@@ -87,7 +87,12 @@ class CPUOffloadOptimizer:
                     state[k] = self._move_tensor(v, device)
 
     def _move_chunk_states(self, chunk_idx: int, device: str, stream: torch.cuda.Stream | None = None):
-        """Move optimizer states for a single chunk to/from *device*."""
+        """Move optimizer states for a single chunk to/from *device*.
+
+        When *stream* is provided the transfers are issued on that stream. For D2H
+        (device == "cpu"), the old GPU tensor is recorded on the stream so the
+        caching allocator won't reuse its storage until the async copy finishes.
+        """
         chunk_ids = {id(p) for p in self._chunks[chunk_idx]}
         ctx = torch.cuda.stream(stream) if stream is not None else torch.cuda.default_stream()
         with ctx:
@@ -96,11 +101,15 @@ class CPUOffloadOptimizer:
                     continue
                 for k, v in state.items():
                     if isinstance(v, DTensor):
+                        if device == "cpu" and stream is not None and v._local_tensor.is_cuda:
+                            v._local_tensor.record_stream(stream)
                         new_local = self._move_tensor(v._local_tensor, device)
                         new_dtensor = copy.copy(v)
                         new_dtensor._local_tensor = new_local
                         state[k] = new_dtensor
                     elif isinstance(v, torch.Tensor):
+                        if device == "cpu" and stream is not None and v.is_cuda:
+                            v.record_stream(stream)
                         state[k] = self._move_tensor(v, device)
 
     def _step_chunk(self, chunk_idx: int, closure=None):

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -243,7 +243,7 @@ class CPUOffloadOptimizer:
         """Per-layer optimizer step without stream overlap — simple sequential loop."""
         for i in range(len(self._chunks)):
             self._move_chunk_states(i, "cuda")
-            self._step_chunk(i, closure)
+            self._step_chunk(i, closure if i == 0 else None)
             self._move_chunk_states(i, "cpu")
         torch.cuda.synchronize()
 
@@ -275,7 +275,9 @@ class CPUOffloadOptimizer:
                 self._move_chunk_states(i + 1, "cuda", h2d_stream)
 
             # Run optimizer step for chunk i.
-            self._step_chunk(i, closure)
+            # Only evaluate the closure once (first chunk) to avoid recomputing
+            # loss/grads per chunk — the optimizer contract expects one evaluation per step.
+            self._step_chunk(i, closure if i == 0 else None)
 
             # Evict chunk i's states back to CPU (overlaps with step i+1).
             d2h_stream.wait_stream(compute_stream)

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -23,9 +23,10 @@ class CPUOffloadOptimizer:
     memory is max(activations, opt_states) instead of sum.
 
     When ``named_params`` is provided, the step is performed per-transformer-layer
-    ("chunked") instead of all-at-once, bounding peak GPU optimizer-state memory to
-    one layer's worth. H2D/D2H transfers can optionally overlap with compute on
-    dedicated CUDA streams (``stream=True``).
+    ("chunked") instead of all-at-once, reducing peak GPU optimizer-state memory
+    from the full model's to about one layer's worth (two with stream overlap).
+    H2D/D2H transfers can optionally overlap with compute on dedicated CUDA streams
+    (``stream=True``).
     """
 
     def __init__(

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -125,8 +125,10 @@ class CPUOffloadOptimizer:
             new_group["params"] = filtered
             chunk_groups.append(new_group)
         self.optimizer.param_groups = chunk_groups
-        result = self.optimizer.step(closure)
-        self.optimizer.param_groups = self._original_param_groups
+        try:
+            result = self.optimizer.step(closure)
+        finally:
+            self.optimizer.param_groups = self._original_param_groups
         return result
 
     def _sync_step_counters(self, original_steps: list):

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -1,4 +1,5 @@
 import copy
+import re
 from typing import Callable
 
 import torch
@@ -20,58 +21,244 @@ class CPUOffloadOptimizer:
     Unlike FSDP's CPUOffload which offloads weights too, this keeps weights on GPU.
     With activation checkpointing, activations and optimizer states are never on GPU
     at the same time: peak memory becomes max(activations, opt_states) instead of sum.
+
+    When ``named_params`` is provided, the step is performed per-transformer-layer
+    ("chunked") instead of all-at-once.  Each chunk's optimizer states are moved to
+    GPU, the optimizer step is run for just that chunk, and the states are moved back
+    to CPU before the next chunk.  This bounds peak GPU optimizer-state memory to a
+    single layer's worth rather than the full model's, preventing OOM when
+    weight + grad + all_opt_states exceeds available VRAM.
+
+    H2D (state→GPU) and D2H (state→CPU) transfers are issued on dedicated CUDA
+    streams so they overlap with the optimizer compute of the current chunk: the next
+    chunk's states are prefetched while the current chunk computes, and the previous
+    chunk's states are evicted while the next chunk computes. The cost is one extra
+    layer's worth of optimizer state on GPU during the overlap window, which is
+    negligible compared to the savings from not loading the full model's states.
     """
 
-    def __init__(self, optimizer: Optimizer, pin_memory: bool = True):
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        named_params: list[tuple[str, nn.Parameter]] | None = None,
+        pin_memory: bool = True,
+    ):
         self.optimizer = optimizer
         self.pin_memory = pin_memory
         self._initialized = False
 
+        # Build per-layer chunks from the optimizer's actual param_groups so
+        # we only include params the optimizer tracks (excludes frozen params
+        # that Muon / _create_optimizer filtered out).
+        self._chunks: list[list[nn.Parameter]] | None = None
+        if named_params is not None:
+            self._chunks = self._build_chunks(named_params)
+
+    # ------------------------------------------------------------------ #
+    # Chunk construction
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _extract_layer_idx(name: str) -> int | None:
+        """Return the transformer-layer index encoded in a parameter name.
+
+        Matches patterns like ``model.layers.0.self_attn.q_proj.weight`` or
+        ``language_model.layers.12.mlp.experts.3.weight`` and returns the
+        integer layer index.  Returns ``None`` for non-layer params
+        (embed_tokens, lm_head, norm, …).
+        """
+        m = re.search(r"layers\.(\d+)\.", name)
+        return int(m.group(1)) if m else None
+
+    def _build_chunks(self, named_params: list[tuple[str, nn.Parameter]]) -> list[list[nn.Parameter]]:
+        """Partition optimizer parameters into per-layer chunks.
+
+        Parameters from the same transformer layer form one chunk; non-layer
+        parameters (embeddings, lm_head, final norm) are collected into a
+        trailing "misc" chunk.  Only parameters actually present in the
+        optimizer's ``param_groups`` are included.
+        """
+        # Map param identity → layer index
+        param_layer: dict[int, int | None] = {}
+        for name, param in named_params:
+            param_layer[id(param)] = self._extract_layer_idx(name)
+
+        # Group optimizer params by layer
+        by_layer: dict[int, list[nn.Parameter]] = {}
+        misc: list[nn.Parameter] = []
+        for group in self.optimizer.param_groups:
+            for param in group["params"]:
+                layer_idx = param_layer.get(id(param))
+                if layer_idx is not None:
+                    by_layer.setdefault(layer_idx, []).append(param)
+                else:
+                    misc.append(param)
+
+        chunks = [by_layer[k] for k in sorted(by_layer)]
+        if misc:
+            chunks.append(misc)
+        return chunks or [misc]  # edge-case: no layer params at all
+
+    def _chunk_param_ids(self, chunk_idx: int) -> set[int]:
+        return {id(p) for p in self._chunks[chunk_idx]}
+
+    # ------------------------------------------------------------------ #
+    # State movement
+    # ------------------------------------------------------------------ #
+
+    def _move_tensor(self, v: torch.Tensor, device: str) -> torch.Tensor:
+        if device == "cpu":
+            if self.pin_memory:
+                # Allocate pinned CPU destination first, then async-copy into it.
+                # This avoids the race where pin_memory() would read a tensor
+                # whose async D2H copy hasn't completed yet.
+                dst = torch.empty_like(v, device="cpu").pin_memory()
+                dst.copy_(v, non_blocking=True)
+                return dst
+            return v.to("cpu")
+        return v.to(device, non_blocking=True)
+
+    def _move_dtensor(self, v: DTensor, device: str) -> DTensor:
+        new_local = self._move_tensor(v._local_tensor, device)
+        new_dtensor = copy.copy(v)
+        new_dtensor._local_tensor = new_local
+        return new_dtensor
+
     def _move_states(self, device: str):
-        """Move optimizer states to CPU or back to GPU (matching each parameter's device)."""
+        """Move **all** optimizer states to *device* (used by state_dict / first step)."""
         for p in self.optimizer.state:
             state = self.optimizer.state[p]
             for k, v in state.items():
                 if isinstance(v, DTensor):
-                    local_tensor = v._local_tensor
-                    if device == "cpu":
-                        non_blocking = not self.pin_memory
-                        new_local = local_tensor.to("cpu", non_blocking=non_blocking)
-                        if self.pin_memory and not new_local.is_pinned():
-                            new_local = new_local.pin_memory()
-                    else:
-                        new_local = local_tensor.to(device, non_blocking=True)
-                    new_dtensor = copy.copy(v)
-                    new_dtensor._local_tensor = new_local
-                    state[k] = new_dtensor
+                    state[k] = self._move_dtensor(v, device)
                 elif isinstance(v, torch.Tensor):
-                    if device == "cpu":
-                        non_blocking = not self.pin_memory
-                        cpu_tensor = v.to("cpu", non_blocking=non_blocking)
-                        if self.pin_memory and not cpu_tensor.is_pinned():
-                            cpu_tensor = cpu_tensor.pin_memory()
-                        state[k] = cpu_tensor
-                    else:
-                        state[k] = v.to(device, non_blocking=True)
+                    state[k] = self._move_tensor(v, device)
+
+    def _move_chunk_states(self, chunk_idx: int, device: str, stream: torch.cuda.Stream | None = None):
+        """Move optimizer states for a single chunk to/from *device*.
+
+        When *stream* is provided the transfers are issued on that stream so they
+        can overlap with work on the default stream.
+        """
+        chunk_ids = self._chunk_param_ids(chunk_idx)
+
+        def _do_move():
+            for p in self.optimizer.state:
+                if id(p) not in chunk_ids:
+                    continue
+                state = self.optimizer.state[p]
+                for k, v in state.items():
+                    if isinstance(v, DTensor):
+                        state[k] = self._move_dtensor(v, device)
+                    elif isinstance(v, torch.Tensor):
+                        state[k] = self._move_tensor(v, device)
+
+        if stream is not None:
+            with torch.cuda.stream(stream):
+                _do_move()
+        else:
+            _do_move()
+
+    # ------------------------------------------------------------------ #
+    # Per-chunk optimizer step
+    # ------------------------------------------------------------------ #
+
+    def _build_chunk_param_groups(self, chunk_idx: int) -> list[dict]:
+        """Create param_groups containing only the current chunk's params.
+
+        Hyperparameters (lr, weight_decay, betas, algorithm, step, …) are
+        copied from the original groups so the optimizer behaves identically.
+        """
+        chunk_ids = self._chunk_param_ids(chunk_idx)
+        chunk_groups: list[dict] = []
+        for group in self._original_param_groups:
+            filtered = [p for p in group["params"] if id(p) in chunk_ids]
+            if not filtered:
+                continue
+            new_group = {k: v for k, v in group.items() if k != "params"}
+            new_group["params"] = filtered
+            chunk_groups.append(new_group)
+        return chunk_groups
+
+    def _step_chunk(self, chunk_idx: int, closure=None):
+        """Run ``optimizer.step()`` for a single chunk by temporarily swapping param_groups."""
+        chunk_groups = self._build_chunk_param_groups(chunk_idx)
+        self.optimizer.param_groups = chunk_groups
+        result = self.optimizer.step(closure)
+        self.optimizer.param_groups = self._original_param_groups
+        return result
+
+    def _sync_step_counters(self, original_steps: list):
+        """Increment the original param_groups' step counters by one.
+
+        Muon stores a per-group ``step`` integer that ``step()`` increments at the
+        top of the call.  Because we swap in per-chunk copies, the *original*
+        groups never see the increment.  Standard optimizers (AdamW, SGD,
+        SignSGD) keep the step counter in ``state[p]['step']`` which is
+        per-parameter and thus already correct (each param is in exactly one
+        chunk and its state is touched exactly once).
+        """
+        for group, orig_step in zip(self._original_param_groups, original_steps):
+            if "step" in group:
+                group["step"] = orig_step + 1
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
 
     def step(self, closure=None):
-        # First step initializes states on GPU - offload after
+        # First step initializes states on GPU — offload after.
         if not self._initialized:
             result = self.optimizer.step(closure)
             self._move_states("cpu")
             self._initialized = True
             return result
 
-        # Move states to GPU
-        self._move_states("cuda")
+        # Non-chunked fallback (no named_params provided).
+        if self._chunks is None or len(self._chunks) <= 1:
+            self._move_states("cuda")
+            result = self.optimizer.step(closure)
+            self._move_states("cpu")
+            return result
 
-        # Run optimizer step
-        result = self.optimizer.step(closure)
+        # ---- Chunked step with stream-overlapped H2D / D2H ---- #
 
-        # Move states back to CPU
-        self._move_states("cpu")
+        self._original_param_groups = self.optimizer.param_groups
+        original_steps = [g.get("step", 0) for g in self._original_param_groups]
 
-        return result
+        h2d_stream = torch.cuda.Stream()
+        d2h_stream = torch.cuda.Stream()
+        compute_stream = torch.cuda.current_stream()
+        n = len(self._chunks)
+
+        # Issue H2D for chunk 0 on the h2d stream.
+        self._move_chunk_states(0, "cuda", h2d_stream)
+
+        for i in range(n):
+            # Wait for H2D of chunk i to land on GPU.
+            compute_stream.wait_stream(h2d_stream)
+
+            # Prefetch H2D for chunk i+1 so it overlaps with step i on the
+            # compute stream.
+            if i + 1 < n:
+                self._move_chunk_states(i + 1, "cuda", h2d_stream)
+
+            # Run optimizer step for chunk i.
+            self._step_chunk(i, closure)
+
+            # Evict chunk i's states back to CPU (overlaps with step i+1).
+            d2h_stream.wait_stream(compute_stream)
+            self._move_chunk_states(i, "cpu", d2h_stream)
+
+        # Ensure all transfers are complete before returning.
+        compute_stream.wait_stream(h2d_stream)
+        compute_stream.wait_stream(d2h_stream)
+
+        # Fix step counters on the original param_groups (Muon only).
+        self._sync_step_counters(original_steps)
+        self._original_param_groups = None
+
+        return None
 
     def zero_grad(self, set_to_none: bool = True):
         self.optimizer.zero_grad(set_to_none=set_to_none)
@@ -126,7 +313,7 @@ def setup_optimizer(
 
     if cpu_offload:
         get_logger().info("Wrapping optimizer with CPUOffloadOptimizer for optimizer state CPU offloading")
-        return CPUOffloadOptimizer(optimizer)
+        return CPUOffloadOptimizer(optimizer, named_params=named_params)
 
     return optimizer
 

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -125,10 +125,8 @@ class CPUOffloadOptimizer:
             new_group["params"] = filtered
             chunk_groups.append(new_group)
         self.optimizer.param_groups = chunk_groups
-        try:
-            result = self.optimizer.step(closure)
-        finally:
-            self.optimizer.param_groups = self._original_param_groups
+        result = self.optimizer.step(closure)
+        self.optimizer.param_groups = self._original_param_groups
         return result
 
     def _sync_step_counters(self, original_steps: list):

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -16,25 +16,16 @@ from prime_rl.utils.logger import get_logger
 
 
 class CPUOffloadOptimizer:
-    """Wraps an optimizer to keep states on CPU, moving to GPU only for step().
+    """Keeps optimizer states on CPU, moving them to GPU only for step().
 
-    Unlike FSDP's CPUOffload which offloads weights too, this keeps weights on GPU.
-    With activation checkpointing, activations and optimizer states are never on GPU
-    at the same time: peak memory becomes max(activations, opt_states) instead of sum.
+    Weights stay on GPU (unlike FSDP CPUOffload). With activation checkpointing,
+    activations and optimizer states are never on GPU at the same time, so peak
+    memory is max(activations, opt_states) instead of sum.
 
     When ``named_params`` is provided, the step is performed per-transformer-layer
-    ("chunked") instead of all-at-once.  Each chunk's optimizer states are moved to
-    GPU, the optimizer step is run for just that chunk, and the states are moved back
-    to CPU before the next chunk.  This bounds peak GPU optimizer-state memory to a
-    single layer's worth rather than the full model's, preventing OOM when
-    weight + grad + all_opt_states exceeds available VRAM.
-
-    H2D (state→GPU) and D2H (state→CPU) transfers are issued on dedicated CUDA
-    streams so they overlap with the optimizer compute of the current chunk: the next
-    chunk's states are prefetched while the current chunk computes, and the previous
-    chunk's states are evicted while the next chunk computes. The cost is one extra
-    layer's worth of optimizer state on GPU during the overlap window, which is
-    negligible compared to the savings from not loading the full model's states.
+    ("chunked") instead of all-at-once, bounding peak GPU optimizer-state memory to
+    one layer's worth. H2D/D2H transfers can optionally overlap with compute on
+    dedicated CUDA streams (``stream=True``).
     """
 
     def __init__(
@@ -48,131 +39,74 @@ class CPUOffloadOptimizer:
         self.pin_memory = pin_memory
         self.stream = stream
         self._initialized = False
-
-        # Build per-layer chunks from the optimizer's actual param_groups so
-        # we only include params the optimizer tracks (excludes frozen params
-        # that Muon / _create_optimizer filtered out).
         self._chunks: list[list[nn.Parameter]] | None = None
         if named_params is not None:
             self._chunks = self._build_chunks(named_params)
 
-    # ------------------------------------------------------------------ #
-    # Chunk construction
-    # ------------------------------------------------------------------ #
-
     @staticmethod
     def _extract_layer_idx(name: str) -> int | None:
-        """Return the transformer-layer index encoded in a parameter name.
-
-        Matches patterns like ``model.layers.0.self_attn.q_proj.weight`` or
-        ``language_model.layers.12.mlp.experts.3.weight`` and returns the
-        integer layer index.  Returns ``None`` for non-layer params
-        (embed_tokens, lm_head, norm, …).
-        """
         m = re.search(r"layers\.(\d+)\.", name)
         return int(m.group(1)) if m else None
 
     def _build_chunks(self, named_params: list[tuple[str, nn.Parameter]]) -> list[list[nn.Parameter]]:
-        """Partition optimizer parameters into per-layer chunks.
-
-        Parameters from the same transformer layer form one chunk; non-layer
-        parameters (embeddings, lm_head, final norm) are collected into a
-        trailing "misc" chunk.  Only parameters actually present in the
-        optimizer's ``param_groups`` are included.
-        """
-        # Map param identity → layer index
-        param_layer: dict[int, int | None] = {}
-        for name, param in named_params:
-            param_layer[id(param)] = self._extract_layer_idx(name)
-
-        # Group optimizer params by layer
+        """Group optimizer params by transformer layer; non-layer params go last."""
+        param_layer = {id(p): self._extract_layer_idx(n) for n, p in named_params}
         by_layer: dict[int, list[nn.Parameter]] = {}
         misc: list[nn.Parameter] = []
         for group in self.optimizer.param_groups:
-            for param in group["params"]:
-                layer_idx = param_layer.get(id(param))
-                if layer_idx is not None:
-                    by_layer.setdefault(layer_idx, []).append(param)
+            for p in group["params"]:
+                idx = param_layer.get(id(p))
+                if idx is not None:
+                    by_layer.setdefault(idx, []).append(p)
                 else:
-                    misc.append(param)
-
+                    misc.append(p)
         chunks = [by_layer[k] for k in sorted(by_layer)]
         if misc:
             chunks.append(misc)
-        return chunks or [misc]  # edge-case: no layer params at all
-
-    def _chunk_param_ids(self, chunk_idx: int) -> set[int]:
-        return {id(p) for p in self._chunks[chunk_idx]}
-
-    # ------------------------------------------------------------------ #
-    # State movement
-    # ------------------------------------------------------------------ #
+        return chunks or [misc]
 
     def _move_tensor(self, v: torch.Tensor, device: str) -> torch.Tensor:
         if device == "cpu":
             if self.pin_memory:
-                # Allocate pinned CPU destination first, then async-copy into it.
-                # This avoids the race where pin_memory() would read a tensor
-                # whose async D2H copy hasn't completed yet.
                 dst = torch.empty_like(v, device="cpu").pin_memory()
                 dst.copy_(v, non_blocking=True)
                 return dst
             return v.to("cpu")
         return v.to(device, non_blocking=True)
 
-    def _move_dtensor(self, v: DTensor, device: str) -> DTensor:
-        new_local = self._move_tensor(v._local_tensor, device)
-        new_dtensor = copy.copy(v)
-        new_dtensor._local_tensor = new_local
-        return new_dtensor
-
     def _move_states(self, device: str):
-        """Move **all** optimizer states to *device* (used by state_dict / first step)."""
-        for p in self.optimizer.state:
-            state = self.optimizer.state[p]
+        """Move all optimizer states to *device*."""
+        for state in self.optimizer.state.values():
             for k, v in state.items():
                 if isinstance(v, DTensor):
-                    state[k] = self._move_dtensor(v, device)
+                    new_local = self._move_tensor(v._local_tensor, device)
+                    new_dtensor = copy.copy(v)
+                    new_dtensor._local_tensor = new_local
+                    state[k] = new_dtensor
                 elif isinstance(v, torch.Tensor):
                     state[k] = self._move_tensor(v, device)
 
     def _move_chunk_states(self, chunk_idx: int, device: str, stream: torch.cuda.Stream | None = None):
-        """Move optimizer states for a single chunk to/from *device*.
-
-        When *stream* is provided the transfers are issued on that stream so they
-        can overlap with work on the default stream.
-        """
-        chunk_ids = self._chunk_param_ids(chunk_idx)
-
-        def _do_move():
-            for p in self.optimizer.state:
+        """Move optimizer states for a single chunk to/from *device*."""
+        chunk_ids = {id(p) for p in self._chunks[chunk_idx]}
+        ctx = torch.cuda.stream(stream) if stream is not None else torch.cuda.default_stream()
+        with ctx:
+            for p, state in self.optimizer.state.items():
                 if id(p) not in chunk_ids:
                     continue
-                state = self.optimizer.state[p]
                 for k, v in state.items():
                     if isinstance(v, DTensor):
-                        state[k] = self._move_dtensor(v, device)
+                        new_local = self._move_tensor(v._local_tensor, device)
+                        new_dtensor = copy.copy(v)
+                        new_dtensor._local_tensor = new_local
+                        state[k] = new_dtensor
                     elif isinstance(v, torch.Tensor):
                         state[k] = self._move_tensor(v, device)
 
-        if stream is not None:
-            with torch.cuda.stream(stream):
-                _do_move()
-        else:
-            _do_move()
-
-    # ------------------------------------------------------------------ #
-    # Per-chunk optimizer step
-    # ------------------------------------------------------------------ #
-
-    def _build_chunk_param_groups(self, chunk_idx: int) -> list[dict]:
-        """Create param_groups containing only the current chunk's params.
-
-        Hyperparameters (lr, weight_decay, betas, algorithm, step, …) are
-        copied from the original groups so the optimizer behaves identically.
-        """
-        chunk_ids = self._chunk_param_ids(chunk_idx)
-        chunk_groups: list[dict] = []
+    def _step_chunk(self, chunk_idx: int, closure=None):
+        """Run optimizer.step() for a single chunk by temporarily swapping param_groups."""
+        chunk_ids = {id(p) for p in self._chunks[chunk_idx]}
+        chunk_groups = []
         for group in self._original_param_groups:
             filtered = [p for p in group["params"] if id(p) in chunk_ids]
             if not filtered:
@@ -180,11 +114,6 @@ class CPUOffloadOptimizer:
             new_group = {k: v for k, v in group.items() if k != "params"}
             new_group["params"] = filtered
             chunk_groups.append(new_group)
-        return chunk_groups
-
-    def _step_chunk(self, chunk_idx: int, closure=None):
-        """Run ``optimizer.step()`` for a single chunk by temporarily swapping param_groups."""
-        chunk_groups = self._build_chunk_param_groups(chunk_idx)
         self.optimizer.param_groups = chunk_groups
         result = self.optimizer.step(closure)
         self.optimizer.param_groups = self._original_param_groups
@@ -193,22 +122,16 @@ class CPUOffloadOptimizer:
     def _sync_step_counters(self, original_steps: list):
         """Increment the original param_groups' step counters by one.
 
-        Muon stores a per-group ``step`` integer that ``step()`` increments at the
-        top of the call.  Because we swap in per-chunk copies, the *original*
-        groups never see the increment.  Standard optimizers (AdamW, SGD,
-        SignSGD) keep the step counter in ``state[p]['step']`` which is
-        per-parameter and thus already correct (each param is in exactly one
-        chunk and its state is touched exactly once).
+        Muon stores a per-group ``step`` that ``step()`` increments. Because we swap
+        in per-chunk copies, the original groups never see the increment. Standard
+        optimizers (AdamW, SGD, SignSGD) keep step in ``state[p]['step']`` which is
+        per-parameter and already correct.
         """
         for group, orig_step in zip(self._original_param_groups, original_steps):
             group["step"] = orig_step + 1
 
-    # ------------------------------------------------------------------ #
-    # Public API
-    # ------------------------------------------------------------------ #
-
     def step(self, closure=None):
-        # Non-chunked path (no named_params provided).
+        # Non-chunked path.
         if self._chunks is None or len(self._chunks) <= 1:
             if not self._initialized:
                 result = self.optimizer.step(closure)
@@ -233,14 +156,11 @@ class CPUOffloadOptimizer:
 
         self._sync_step_counters(original_steps)
         self._original_param_groups = None
-
-        if not self._initialized:
-            self._initialized = True
-
+        self._initialized = True
         return None
 
     def _step_chunked(self, closure=None):
-        """Per-layer optimizer step without stream overlap — simple sequential loop."""
+        """Sequential per-layer step without stream overlap."""
         for i in range(len(self._chunks)):
             self._move_chunk_states(i, "cuda")
             self._step_chunk(i, closure if i == 0 else None)
@@ -248,49 +168,33 @@ class CPUOffloadOptimizer:
         torch.cuda.synchronize()
 
     def _step_chunked_streamed(self, closure=None):
-        """Per-layer optimizer step with stream-overlapped H2D / D2H.
-
-        H2D (state→GPU) for chunk i+1 is issued on a dedicated stream while
-        the optimizer compute for chunk i runs on the compute stream.  D2H
-        (state→CPU) for chunk i runs on a second dedicated stream, overlapping
-        with the compute for chunk i+1.
-        """
+        """Per-layer step with stream-overlapped H2D / D2H."""
         h2d_stream = torch.cuda.Stream()
         d2h_stream = torch.cuda.Stream()
         compute_stream = torch.cuda.current_stream()
         n = len(self._chunks)
 
-        # Issue H2D for chunk 0 on the h2d stream.
         self._move_chunk_states(0, "cuda", h2d_stream)
 
         for i in range(n):
-            # Wait for H2D of chunk i to land on GPU.
             compute_stream.wait_stream(h2d_stream)
 
-            # Prefetch H2D for chunk i+1 so it overlaps with step i on the
-            # compute stream.  Wait for the previous chunk's D2H to finish
-            # first so we don't overwrite pinned CPU buffers still in flight.
             if i + 1 < n:
+                # Wait for previous D2H before reusing pinned CPU buffers.
                 h2d_stream.wait_stream(d2h_stream)
                 self._move_chunk_states(i + 1, "cuda", h2d_stream)
 
-            # Run optimizer step for chunk i.
-            # Only evaluate the closure once (first chunk) to avoid recomputing
-            # loss/grads per chunk — the optimizer contract expects one evaluation per step.
             self._step_chunk(i, closure if i == 0 else None)
 
-            # Evict chunk i's states back to CPU (overlaps with step i+1).
             d2h_stream.wait_stream(compute_stream)
             self._move_chunk_states(i, "cpu", d2h_stream)
 
-        # Block the CPU until all async transfers are complete.
         torch.cuda.synchronize()
 
     def zero_grad(self, set_to_none: bool = True):
         self.optimizer.zero_grad(set_to_none=set_to_none)
 
     def state_dict(self):
-        # Move to GPU temporarily for consistent state dict
         if self._initialized:
             self._move_states("cuda")
             torch.cuda.synchronize()

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -201,8 +201,7 @@ class CPUOffloadOptimizer:
         chunk and its state is touched exactly once).
         """
         for group, orig_step in zip(self._original_param_groups, original_steps):
-            if "step" in group:
-                group["step"] = orig_step + 1
+            group["step"] = orig_step + 1
 
     # ------------------------------------------------------------------ #
     # Public API

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -42,9 +42,11 @@ class CPUOffloadOptimizer:
         optimizer: Optimizer,
         named_params: list[tuple[str, nn.Parameter]] | None = None,
         pin_memory: bool = True,
+        stream: bool = True,
     ):
         self.optimizer = optimizer
         self.pin_memory = pin_memory
+        self.stream = stream
         self._initialized = False
 
         # Build per-layer chunks from the optimizer's actual param_groups so
@@ -221,11 +223,34 @@ class CPUOffloadOptimizer:
             self._move_states("cpu")
             return result
 
-        # ---- Chunked step with stream-overlapped H2D / D2H ---- #
-
+        # Chunked step.
         self._original_param_groups = self.optimizer.param_groups
         original_steps = [g.get("step", 0) for g in self._original_param_groups]
 
+        if self.stream:
+            self._step_chunked_streamed(closure)
+        else:
+            self._step_chunked(closure)
+
+        self._sync_step_counters(original_steps)
+        self._original_param_groups = None
+        return None
+
+    def _step_chunked(self, closure=None):
+        """Per-layer optimizer step without stream overlap — simple sequential loop."""
+        for i in range(len(self._chunks)):
+            self._move_chunk_states(i, "cuda")
+            self._step_chunk(i, closure)
+            self._move_chunk_states(i, "cpu")
+
+    def _step_chunked_streamed(self, closure=None):
+        """Per-layer optimizer step with stream-overlapped H2D / D2H.
+
+        H2D (state→GPU) for chunk i+1 is issued on a dedicated stream while
+        the optimizer compute for chunk i runs on the compute stream.  D2H
+        (state→CPU) for chunk i runs on a second dedicated stream, overlapping
+        with the compute for chunk i+1.
+        """
         h2d_stream = torch.cuda.Stream()
         d2h_stream = torch.cuda.Stream()
         compute_stream = torch.cuda.current_stream()
@@ -253,12 +278,6 @@ class CPUOffloadOptimizer:
         # Ensure all transfers are complete before returning.
         compute_stream.wait_stream(h2d_stream)
         compute_stream.wait_stream(d2h_stream)
-
-        # Fix step counters on the original param_groups (Muon only).
-        self._sync_step_counters(original_steps)
-        self._original_param_groups = None
-
-        return None
 
     def zero_grad(self, set_to_none: bool = True):
         self.optimizer.zero_grad(set_to_none=set_to_none)
@@ -301,6 +320,8 @@ def setup_optimizer(
     parallel_dims: ParallelDims,
     lora: bool = False,
     cpu_offload: bool = False,
+    cpu_offload_chunked: bool = True,
+    cpu_offload_stream: bool = True,
 ) -> Optimizer | CPUOffloadOptimizer:
     if lora:
         # Wait for run 0 to be created in the multi run manager
@@ -313,7 +334,11 @@ def setup_optimizer(
 
     if cpu_offload:
         get_logger().info("Wrapping optimizer with CPUOffloadOptimizer for optimizer state CPU offloading")
-        return CPUOffloadOptimizer(optimizer, named_params=named_params)
+        return CPUOffloadOptimizer(
+            optimizer,
+            named_params=named_params if cpu_offload_chunked else None,
+            stream=cpu_offload_stream,
+        )
 
     return optimizer
 

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -22,26 +22,22 @@ class CPUOffloadOptimizer:
     activations and optimizer states are never on GPU at the same time, so peak
     memory is max(activations, opt_states) instead of sum.
 
-    When ``named_params`` is provided, the step is performed per-transformer-layer
-    ("chunked") instead of all-at-once, reducing peak GPU optimizer-state memory
-    from the full model's to at most two layers' worth. H2D/D2H transfers are
-    overlapped with compute on dedicated CUDA streams: while layer *i* computes,
-    layer *i+1* is prefetched and layer *i-1* is evicted, but the prefetch waits
-    for the eviction to complete so never more than two layers are on GPU at once.
+    The step is performed per-transformer-layer with stream-overlapped H2D/D2H
+    transfers: while layer *i* computes, layer *i+1* is prefetched and layer *i-1*
+    is evicted. The prefetch waits for the eviction to complete, so at most two
+    layers' optimizer states are on GPU at any time.
     """
 
     def __init__(
         self,
         optimizer: Optimizer,
-        named_params: list[tuple[str, nn.Parameter]] | None = None,
+        named_params: list[tuple[str, nn.Parameter]],
         pin_memory: bool = True,
     ):
         self.optimizer = optimizer
         self.pin_memory = pin_memory
         self._initialized = False
-        self._chunks: list[list[nn.Parameter]] | None = None
-        if named_params is not None:
-            self._chunks = self._build_chunks(named_params)
+        self._chunks = self._build_chunks(named_params)
 
     @staticmethod
     def _extract_layer_idx(name: str) -> int | None:
@@ -49,7 +45,7 @@ class CPUOffloadOptimizer:
         return int(m.group(1)) if m else None
 
     def _build_chunks(self, named_params: list[tuple[str, nn.Parameter]]) -> list[list[nn.Parameter]]:
-        """Group optimizer params by transformer layer; non-layer params go last."""
+        """Group params by transformer layer; non-layer params go last."""
         param_layer = {id(p): self._extract_layer_idx(n) for n, p in named_params}
         by_layer: dict[int, list[nn.Parameter]] = {}
         misc: list[nn.Parameter] = []
@@ -75,13 +71,12 @@ class CPUOffloadOptimizer:
         return v.to(device, non_blocking=True)
 
     def _move_states(self, device: str):
-        """Move all optimizer states to *device*."""
+        """Move all optimizer states to *device* (bulk, for state_dict/checkpoint)."""
         for state in self.optimizer.state.values():
             for k, v in state.items():
                 if isinstance(v, DTensor):
-                    new_local = self._move_tensor(v._local_tensor, device)
                     new_dtensor = copy.copy(v)
-                    new_dtensor._local_tensor = new_local
+                    new_dtensor._local_tensor = self._move_tensor(v._local_tensor, device)
                     state[k] = new_dtensor
                 elif isinstance(v, torch.Tensor):
                     state[k] = self._move_tensor(v, device)
@@ -89,9 +84,9 @@ class CPUOffloadOptimizer:
     def _move_chunk_states(self, chunk_idx: int, device: str, stream: torch.cuda.Stream | None = None):
         """Move optimizer states for a single chunk to/from *device*.
 
-        When *stream* is provided the transfers are issued on that stream. For D2H
-        (device == "cpu"), the old GPU tensor is recorded on the stream so the
-        caching allocator won't reuse its storage until the async copy finishes.
+        When *stream* is provided the transfers are issued on that stream. For D2H,
+        the old GPU tensor is recorded on the stream so the caching allocator won't
+        reuse its storage until the async copy finishes.
         """
         chunk_ids = {id(p) for p in self._chunks[chunk_idx]}
         ctx = torch.cuda.stream(stream) if stream is not None else torch.cuda.default_stream()
@@ -103,9 +98,8 @@ class CPUOffloadOptimizer:
                     if isinstance(v, DTensor):
                         if device == "cpu" and stream is not None and v._local_tensor.is_cuda:
                             v._local_tensor.record_stream(stream)
-                        new_local = self._move_tensor(v._local_tensor, device)
                         new_dtensor = copy.copy(v)
-                        new_dtensor._local_tensor = new_local
+                        new_dtensor._local_tensor = self._move_tensor(v._local_tensor, device)
                         state[k] = new_dtensor
                     elif isinstance(v, torch.Tensor):
                         if device == "cpu" and stream is not None and v.is_cuda:
@@ -140,54 +134,29 @@ class CPUOffloadOptimizer:
             group["step"] = orig_step + 1
 
     def step(self, closure=None):
-        # Non-chunked path.
-        if self._chunks is None or len(self._chunks) <= 1:
-            if not self._initialized:
-                result = self.optimizer.step(closure)
-                self._move_states("cpu")
-                torch.cuda.synchronize()
-                self._initialized = True
-                return result
-            self._move_states("cuda")
-            result = self.optimizer.step(closure)
-            self._move_states("cpu")
-            return result
-
-        # Chunked path (also used for the first step to avoid materializing
-        # all optimizer states on GPU at once during initialization).
         self._original_param_groups = self.optimizer.param_groups
         original_steps = [g.get("step", 0) for g in self._original_param_groups]
 
-        self._step_chunked_streamed(closure)
-
-        self._sync_step_counters(original_steps)
-        self._original_param_groups = None
-        self._initialized = True
-        return None
-
-    def _step_chunked_streamed(self, closure=None):
-        """Per-layer step with stream-overlapped H2D / D2H."""
         h2d_stream = torch.cuda.Stream()
         d2h_stream = torch.cuda.Stream()
         compute_stream = torch.cuda.current_stream()
         n = len(self._chunks)
 
         self._move_chunk_states(0, "cuda", h2d_stream)
-
         for i in range(n):
             compute_stream.wait_stream(h2d_stream)
-
             if i + 1 < n:
                 # Wait for previous D2H before reusing pinned CPU buffers.
                 h2d_stream.wait_stream(d2h_stream)
                 self._move_chunk_states(i + 1, "cuda", h2d_stream)
-
             self._step_chunk(i, closure if i == 0 else None)
-
             d2h_stream.wait_stream(compute_stream)
             self._move_chunk_states(i, "cpu", d2h_stream)
-
         torch.cuda.synchronize()
+
+        self._sync_step_counters(original_steps)
+        self._original_param_groups = None
+        self._initialized = True
 
     def zero_grad(self, set_to_none: bool = True):
         self.optimizer.zero_grad(set_to_none=set_to_none)
@@ -230,7 +199,6 @@ def setup_optimizer(
     parallel_dims: ParallelDims,
     lora: bool = False,
     cpu_offload: bool = False,
-    cpu_offload_chunked: bool = False,
 ) -> Optimizer | CPUOffloadOptimizer:
     if lora:
         # Wait for run 0 to be created in the multi run manager
@@ -243,10 +211,7 @@ def setup_optimizer(
 
     if cpu_offload:
         get_logger().info("Wrapping optimizer with CPUOffloadOptimizer for optimizer state CPU offloading")
-        return CPUOffloadOptimizer(
-            optimizer,
-            named_params=named_params if cpu_offload_chunked else None,
-        )
+        return CPUOffloadOptimizer(optimizer, named_params=named_params)
 
     return optimizer
 

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -172,6 +172,7 @@ class CPUOffloadOptimizer:
     def load_state_dict(self, state_dict):
         self.optimizer.load_state_dict(state_dict)
         self._move_states("cpu")
+        torch.cuda.synchronize()
         self._initialized = True
 
     @property

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -24,9 +24,10 @@ class CPUOffloadOptimizer:
 
     When ``named_params`` is provided, the step is performed per-transformer-layer
     ("chunked") instead of all-at-once, reducing peak GPU optimizer-state memory
-    from the full model's to about one layer's worth (two with stream overlap).
-    H2D/D2H transfers can optionally overlap with compute on dedicated CUDA streams
-    (``stream=True``).
+    from the full model's to at most two layers' worth. H2D/D2H transfers are
+    overlapped with compute on dedicated CUDA streams: while layer *i* computes,
+    layer *i+1* is prefetched and layer *i-1* is evicted, but the prefetch waits
+    for the eviction to complete so never more than two layers are on GPU at once.
     """
 
     def __init__(
@@ -34,11 +35,9 @@ class CPUOffloadOptimizer:
         optimizer: Optimizer,
         named_params: list[tuple[str, nn.Parameter]] | None = None,
         pin_memory: bool = True,
-        stream: bool = False,
     ):
         self.optimizer = optimizer
         self.pin_memory = pin_memory
-        self.stream = stream
         self._initialized = False
         self._chunks: list[list[nn.Parameter]] | None = None
         if named_params is not None:
@@ -159,23 +158,12 @@ class CPUOffloadOptimizer:
         self._original_param_groups = self.optimizer.param_groups
         original_steps = [g.get("step", 0) for g in self._original_param_groups]
 
-        if self.stream:
-            self._step_chunked_streamed(closure)
-        else:
-            self._step_chunked(closure)
+        self._step_chunked_streamed(closure)
 
         self._sync_step_counters(original_steps)
         self._original_param_groups = None
         self._initialized = True
         return None
-
-    def _step_chunked(self, closure=None):
-        """Sequential per-layer step without stream overlap."""
-        for i in range(len(self._chunks)):
-            self._move_chunk_states(i, "cuda")
-            self._step_chunk(i, closure if i == 0 else None)
-            self._move_chunk_states(i, "cpu")
-        torch.cuda.synchronize()
 
     def _step_chunked_streamed(self, closure=None):
         """Per-layer step with stream-overlapped H2D / D2H."""
@@ -243,7 +231,6 @@ def setup_optimizer(
     lora: bool = False,
     cpu_offload: bool = False,
     cpu_offload_chunked: bool = False,
-    cpu_offload_stream: bool = False,
 ) -> Optimizer | CPUOffloadOptimizer:
     if lora:
         # Wait for run 0 to be created in the multi run manager
@@ -259,7 +246,6 @@ def setup_optimizer(
         return CPUOffloadOptimizer(
             optimizer,
             named_params=named_params if cpu_offload_chunked else None,
-            stream=cpu_offload_stream,
         )
 
     return optimizer

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -22,22 +22,21 @@ class CPUOffloadOptimizer:
     activations and optimizer states are never on GPU at the same time, so peak
     memory is max(activations, opt_states) instead of sum.
 
-    The step is performed per-transformer-layer with stream-overlapped H2D/D2H
-    transfers: while layer *i* computes, layer *i+1* is prefetched and layer *i-1*
-    is evicted. The prefetch waits for the eviction to complete, so at most two
-    layers' optimizer states are on GPU at any time.
+    When ``named_params`` is provided, the step is performed per-transformer-layer
+    with stream-overlapped H2D/D2H transfers, keeping at most two layers' optimizer
+    states on GPU at any time. Otherwise, all states are moved to GPU at once.
     """
 
     def __init__(
         self,
         optimizer: Optimizer,
-        named_params: list[tuple[str, nn.Parameter]],
+        named_params: list[tuple[str, nn.Parameter]] | None = None,
         pin_memory: bool = True,
     ):
         self.optimizer = optimizer
         self.pin_memory = pin_memory
         self._initialized = False
-        self._chunks = self._build_chunks(named_params)
+        self._chunks = self._build_chunks(named_params) if named_params is not None else None
 
     @staticmethod
     def _extract_layer_idx(name: str) -> int | None:
@@ -132,6 +131,14 @@ class CPUOffloadOptimizer:
             group["step"] = orig_step + 1
 
     def step(self, closure=None):
+        if self._chunks is None:
+            self._move_states("cuda")
+            result = self.optimizer.step(closure)
+            self._move_states("cpu")
+            torch.cuda.synchronize()
+            self._initialized = True
+            return result
+
         self._original_param_groups = self.optimizer.param_groups
         original_steps = [g.get("step", 0) for g in self._original_param_groups]
 
@@ -198,6 +205,7 @@ def setup_optimizer(
     parallel_dims: ParallelDims,
     lora: bool = False,
     cpu_offload: bool = False,
+    cpu_offload_chunked: bool = False,
 ) -> Optimizer | CPUOffloadOptimizer:
     if lora:
         # Wait for run 0 to be created in the multi run manager
@@ -210,7 +218,7 @@ def setup_optimizer(
 
     if cpu_offload:
         get_logger().info("Wrapping optimizer with CPUOffloadOptimizer for optimizer state CPU offloading")
-        return CPUOffloadOptimizer(optimizer, named_params=named_params)
+        return CPUOffloadOptimizer(optimizer, named_params=named_params if cpu_offload_chunked else None)
 
     return optimizer
 

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -81,28 +81,26 @@ class CPUOffloadOptimizer:
                 elif isinstance(v, torch.Tensor):
                     state[k] = self._move_tensor(v, device)
 
-    def _move_chunk_states(self, chunk_idx: int, device: str, stream: torch.cuda.Stream | None = None):
-        """Move optimizer states for a single chunk to/from *device*.
+    def _move_chunk_states(self, chunk_idx: int, device: str, stream: torch.cuda.Stream):
+        """Move optimizer states for a single chunk to/from *device* on *stream*.
 
-        When *stream* is provided the transfers are issued on that stream. For D2H,
-        the old GPU tensor is recorded on the stream so the caching allocator won't
-        reuse its storage until the async copy finishes.
+        For D2H, the old GPU tensor is recorded on the stream so the caching
+        allocator won't reuse its storage until the async copy finishes.
         """
         chunk_ids = {id(p) for p in self._chunks[chunk_idx]}
-        ctx = torch.cuda.stream(stream) if stream is not None else torch.cuda.default_stream()
-        with ctx:
+        with torch.cuda.stream(stream):
             for p, state in self.optimizer.state.items():
                 if id(p) not in chunk_ids:
                     continue
                 for k, v in state.items():
                     if isinstance(v, DTensor):
-                        if device == "cpu" and stream is not None and v._local_tensor.is_cuda:
+                        if device == "cpu" and v._local_tensor.is_cuda:
                             v._local_tensor.record_stream(stream)
                         new_dtensor = copy.copy(v)
                         new_dtensor._local_tensor = self._move_tensor(v._local_tensor, device)
                         state[k] = new_dtensor
                     elif isinstance(v, torch.Tensor):
-                        if device == "cpu" and stream is not None and v.is_cuda:
+                        if device == "cpu" and v.is_cuda:
                             v.record_stream(stream)
                         state[k] = self._move_tensor(v, device)
 

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -37,6 +37,9 @@ class CPUOffloadOptimizer:
         self.pin_memory = pin_memory
         self._initialized = False
         self._chunks = self._build_chunks(named_params) if named_params is not None else None
+        if self._chunks is not None:
+            self._h2d_stream = torch.cuda.Stream()
+            self._d2h_stream = torch.cuda.Stream()
 
     @staticmethod
     def _extract_layer_idx(name: str) -> int | None:
@@ -142,8 +145,8 @@ class CPUOffloadOptimizer:
         self._original_param_groups = self.optimizer.param_groups
         original_steps = [g.get("step", 0) for g in self._original_param_groups]
 
-        h2d_stream = torch.cuda.Stream()
-        d2h_stream = torch.cuda.Stream()
+        h2d_stream = self._h2d_stream
+        d2h_stream = self._d2h_stream
         compute_stream = torch.cuda.current_stream()
         n = len(self._chunks)
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -171,6 +171,8 @@ def train(config: TrainerConfig):
             parallel_dims,
             lora=config.model.lora is not None,
             cpu_offload=config.model.optim_cpu_offload,
+            cpu_offload_chunked=config.model.optim_cpu_offload_chunked,
+            cpu_offload_stream=config.model.optim_cpu_offload_stream,
         )
         scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
     else:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -172,7 +172,6 @@ def train(config: TrainerConfig):
             lora=config.model.lora is not None,
             cpu_offload=config.model.optim_cpu_offload,
             cpu_offload_chunked=config.model.optim_cpu_offload_chunked,
-            cpu_offload_stream=config.model.optim_cpu_offload_stream,
         )
         scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
     else:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -170,8 +170,8 @@ def train(config: TrainerConfig):
             list(model.named_parameters()),
             parallel_dims,
             lora=config.model.lora is not None,
-            cpu_offload=config.model.optim_cpu_offload,
-            cpu_offload_chunked=config.model.optim_cpu_offload_chunked,
+            cpu_offload=config.optim.cpu_offload.enabled,
+            cpu_offload_chunked=config.optim.cpu_offload.chunked,
         )
         scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
     else:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -171,6 +171,7 @@ def train(config: TrainerConfig):
             parallel_dims,
             lora=config.model.lora is not None,
             cpu_offload=config.model.optim_cpu_offload,
+            cpu_offload_chunked=config.model.optim_cpu_offload_chunked,
         )
         scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
     else:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -171,7 +171,6 @@ def train(config: TrainerConfig):
             parallel_dims,
             lora=config.model.lora is not None,
             cpu_offload=config.model.optim_cpu_offload,
-            cpu_offload_chunked=config.model.optim_cpu_offload_chunked,
         )
         scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
     else:

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -180,7 +180,10 @@ def train(config: SFTConfig):
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")
     optimizer = setup_optimizer(
-        config.optim, list(model.named_parameters()), parallel_dims, cpu_offload=config.model.optim_cpu_offload
+        config.optim,
+        list(model.named_parameters()),
+        parallel_dims,
+        cpu_offload=config.model.optim_cpu_offload,
     )
 
     # Set up the learning rate scheduler

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -183,8 +183,8 @@ def train(config: SFTConfig):
         config.optim,
         list(model.named_parameters()),
         parallel_dims,
-        cpu_offload=config.model.optim_cpu_offload,
-        cpu_offload_chunked=config.model.optim_cpu_offload_chunked,
+        cpu_offload=config.optim.cpu_offload.enabled,
+        cpu_offload_chunked=config.optim.cpu_offload.chunked,
     )
 
     # Set up the learning rate scheduler

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -184,7 +184,6 @@ def train(config: SFTConfig):
         list(model.named_parameters()),
         parallel_dims,
         cpu_offload=config.model.optim_cpu_offload,
-        cpu_offload_chunked=config.model.optim_cpu_offload_chunked,
     )
 
     # Set up the learning rate scheduler

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -184,6 +184,8 @@ def train(config: SFTConfig):
         list(model.named_parameters()),
         parallel_dims,
         cpu_offload=config.model.optim_cpu_offload,
+        cpu_offload_chunked=config.model.optim_cpu_offload_chunked,
+        cpu_offload_stream=config.model.optim_cpu_offload_stream,
     )
 
     # Set up the learning rate scheduler

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -184,6 +184,7 @@ def train(config: SFTConfig):
         list(model.named_parameters()),
         parallel_dims,
         cpu_offload=config.model.optim_cpu_offload,
+        cpu_offload_chunked=config.model.optim_cpu_offload_chunked,
     )
 
     # Set up the learning rate scheduler

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -185,7 +185,6 @@ def train(config: SFTConfig):
         parallel_dims,
         cpu_offload=config.model.optim_cpu_offload,
         cpu_offload_chunked=config.model.optim_cpu_offload_chunked,
-        cpu_offload_stream=config.model.optim_cpu_offload_stream,
     )
 
     # Set up the learning rate scheduler

--- a/tests/unit/train/test_optim_offload.py
+++ b/tests/unit/train/test_optim_offload.py
@@ -67,10 +67,7 @@ def _run_step(model, optimizer, input_ids):
     out = model(input_ids)
     loss = out.float().sum()
     loss.backward()
-    if isinstance(optimizer, CPUOffloadOptimizer):
-        optimizer.step()
-    else:
-        optimizer.step()
+    optimizer.step()
     optimizer.zero_grad()
     return loss
 

--- a/tests/unit/train/test_optim_offload.py
+++ b/tests/unit/train/test_optim_offload.py
@@ -1,0 +1,181 @@
+import pytest
+import torch
+from torch import nn
+from torch.optim import AdamW
+
+from prime_rl.trainer.optim import CPUOffloadOptimizer
+
+pytestmark = [pytest.mark.gpu]
+
+
+class MiniModel(nn.Module):
+    """Small transformer-like model with named layers for chunking."""
+
+    def __init__(self, n_layers=4, hidden=32, vocab=100):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(vocab, hidden)
+        self.layers = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(hidden, hidden * 4),
+                    nn.GELU(),
+                    nn.Linear(hidden * 4, hidden),
+                )
+                for _ in range(n_layers)
+            ]
+        )
+        self.norm = nn.LayerNorm(hidden)
+        self.lm_head = nn.Linear(hidden, vocab, bias=False)
+
+    def forward(self, input_ids):
+        x = self.embed_tokens(input_ids)
+        for layer in self.layers:
+            x = x + layer(x)
+        x = self.norm(x)
+        return self.lm_head(x)
+
+
+def _make_pair(n_layers=4, hidden=32, vocab=100):
+    """Create two identical models + optimizers (plain vs offloaded), same seed."""
+    torch.manual_seed(42)
+    model_plain = MiniModel(n_layers, hidden, vocab).cuda()
+
+    torch.manual_seed(42)
+    model_offloaded = MiniModel(n_layers, hidden, vocab).cuda()
+
+    named_params_plain = list(model_plain.named_parameters())
+    named_params_offloaded = list(model_offloaded.named_parameters())
+
+    trainable_plain = [p for _, p in named_params_plain if p.requires_grad]
+    trainable_offloaded = [p for _, p in named_params_offloaded if p.requires_grad]
+
+    opt_plain = AdamW(trainable_plain, lr=1e-3, weight_decay=0.01)
+    opt_offloaded = CPUOffloadOptimizer(
+        AdamW(trainable_offloaded, lr=1e-3, weight_decay=0.01),
+        named_params=named_params_offloaded,
+    )
+
+    # Verify the two models start identical
+    for (n1, p1), (n2, p2) in zip(named_params_plain, named_params_offloaded):
+        assert torch.equal(p1, p2), f"Initial mismatch in {n1}"
+
+    return model_plain, model_offloaded, opt_plain, opt_offloaded
+
+
+def _run_step(model, optimizer, input_ids):
+    """Forward → backward → step → zero_grad."""
+    out = model(input_ids)
+    loss = out.float().sum()
+    loss.backward()
+    if isinstance(optimizer, CPUOffloadOptimizer):
+        optimizer.step()
+    else:
+        optimizer.step()
+    optimizer.zero_grad()
+    return loss
+
+
+@pytest.mark.parametrize("n_steps", [1, 5])
+def test_param_parity(n_steps):
+    """Parameters match between plain AdamW and CPUOffloadOptimizer after N steps."""
+    model_plain, model_offloaded, opt_plain, opt_offloaded = _make_pair()
+
+    torch.manual_seed(123)
+    for step in range(n_steps):
+        input_ids = torch.randint(0, 100, (2, 8)).cuda()
+        loss_plain = _run_step(model_plain, opt_plain, input_ids)
+        loss_offloaded = _run_step(model_offloaded, opt_offloaded, input_ids)
+
+        # Losses should be identical (same model, same input)
+        assert torch.allclose(loss_plain, loss_offloaded, atol=1e-5), (
+            f"Loss mismatch at step {step}: {loss_plain.item()} vs {loss_offloaded.item()}"
+        )
+
+    # Compare every parameter
+    for (n, p_plain), (_, p_offloaded) in zip(model_plain.named_parameters(), model_offloaded.named_parameters()):
+        assert torch.allclose(p_plain, p_offloaded, atol=1e-6, rtol=1e-5), (
+            f"Param mismatch in {n}: max diff {(p_plain - p_offloaded).abs().max().item()}"
+        )
+
+
+@pytest.mark.parametrize("n_steps", [1, 5])
+def test_state_parity(n_steps):
+    """Optimizer states (exp_avg, exp_avg_sq, step) match after N steps."""
+    model_plain, model_offloaded, opt_plain, opt_offloaded = _make_pair()
+
+    torch.manual_seed(123)
+    for step in range(n_steps):
+        input_ids = torch.randint(0, 100, (2, 8)).cuda()
+        _run_step(model_plain, opt_plain, input_ids)
+        _run_step(model_offloaded, opt_offloaded, input_ids)
+
+    # Move offloaded states to GPU for comparison
+    opt_offloaded._move_states("cuda")
+    torch.cuda.synchronize()
+
+    # Build a mapping from param id to state for the plain optimizer
+    plain_state = opt_plain.state
+    offloaded_state = opt_offloaded.state
+
+    # Match params by position (same order in both optimizers)
+    params_plain = [p for g in opt_plain.param_groups for p in g["params"]]
+    params_offloaded = [p for g in opt_offloaded.param_groups for p in g["params"]]
+
+    assert len(params_plain) == len(params_offloaded), "Different number of params"
+
+    for p_plain, p_offloaded in zip(params_plain, params_offloaded):
+        s_plain = plain_state[p_plain]
+        s_offloaded = offloaded_state[p_offloaded]
+        assert set(s_plain.keys()) == set(s_offloaded.keys()), (
+            f"State keys mismatch: {set(s_plain.keys())} vs {set(s_offloaded.keys())}"
+        )
+        for k in s_plain:
+            if isinstance(s_plain[k], torch.Tensor):
+                assert torch.allclose(s_plain[k], s_offloaded[k], atol=1e-6, rtol=1e-5), (
+                    f"State '{k}' mismatch: max diff {(s_plain[k] - s_offloaded[k]).abs().max().item()}"
+                )
+            else:
+                assert s_plain[k] == s_offloaded[k], f"State '{k}' mismatch: {s_plain[k]} vs {s_offloaded[k]}"
+
+    # Cleanup: move states back to CPU
+    opt_offloaded._move_states("cpu")
+    torch.cuda.synchronize()
+
+
+def test_state_dict_roundtrip():
+    """state_dict/load_state_dict preserves optimizer state correctly."""
+    model_plain, model_offloaded, opt_plain, opt_offloaded = _make_pair()
+
+    torch.manual_seed(123)
+    for step in range(3):
+        input_ids = torch.randint(0, 100, (2, 8)).cuda()
+        _run_step(model_plain, opt_plain, input_ids)
+        _run_step(model_offloaded, opt_offloaded, input_ids)
+
+    # Save state_dict
+    sd = opt_offloaded.state_dict()
+
+    # Create a fresh model with the same initial seed, then copy current weights
+    # so the fresh model matches the offloaded model's state after 3 steps
+    torch.manual_seed(42)
+    model_fresh = MiniModel(4, 32, 100).cuda()
+    for (_, p_src), (_, p_dst) in zip(model_offloaded.named_parameters(), model_fresh.named_parameters()):
+        p_dst.data.copy_(p_src.data)
+
+    named_params_fresh = list(model_fresh.named_parameters())
+    trainable_fresh = [p for _, p in named_params_fresh if p.requires_grad]
+    opt_fresh = CPUOffloadOptimizer(
+        AdamW(trainable_fresh, lr=1e-3, weight_decay=0.01),
+        named_params=named_params_fresh,
+    )
+    opt_fresh.load_state_dict(sd)
+
+    # Run one more step on both and compare
+    input_ids = torch.randint(0, 100, (2, 8)).cuda()
+    _run_step(model_offloaded, opt_offloaded, input_ids)
+    _run_step(model_fresh, opt_fresh, input_ids)
+
+    for (_, p1), (_, p2) in zip(model_offloaded.named_parameters(), model_fresh.named_parameters()):
+        assert torch.allclose(p1, p2, atol=1e-6, rtol=1e-5), (
+            f"Param mismatch after reload: max diff {(p1 - p2).abs().max().item()}"
+        )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
<!-- CURSOR_SUMMARY -->

## Summary

The `CPUOffloadOptimizer` can optionally perform `optimizer.step()` **per-transformer-layer** with **stream-overlapped** H2D/D2H transfers instead of all-at-once. This is opt-in via `optim_cpu_offload_chunked` — the default remains the simple all-at-once path.

### Problem

With all-at-once offload, the **entire** model's optimizer states land on GPU simultaneously during `step()`. When `weight + grad + all_opt_states > VRAM` — even without activations — this causes OOM on large models.

### Config

```toml
[trainer.model]
optim_cpu_offload = true             # already the default
optim_cpu_offload_chunked = true     # opt-in per-layer chunked stepping
```

`optim_cpu_offload_chunked` defaults to `false`. When enabled, the optimizer step is performed per-transformer-layer with stream-overlapped H2D/D2H transfers: while layer *i* computes, layer *i+1* is prefetched and layer *i-1* is evicted. The prefetch waits for the eviction to complete, so **at most two layers' optimizer states are on GPU at any time**.

### Implementation

- **Per-layer chunking**: Parameters grouped by transformer layer (regex `layers.{N}.`). Non-layer params (embeddings, lm_head, norm) go into a trailing "misc" chunk.
- **Stream-overlapped**: H2D/D2H on dedicated CUDA streams (created once in `__init__`, reused across steps); next layer prefetched while current computes; previous layer evicted while next computes. Ends with `torch.cuda.synchronize()`.
- **Non-chunked path** (default): Simple all-at-once — move all states to GPU, step, move back to CPU. No CUDA streams.
- **First-step**: The chunked init step also processes per-layer, avoiding materializing all optimizer states on GPU at once.
- **Pinned memory**: D2H pre-allocates pinned CPU destination and async-copies into it. `state_dict()`, `load_state_dict()`, and ckpt paths sync after D2H to prevent reading incomplete copies.
- **Muon step counter sync**: Per-group `step` integer synced after all chunks since `param_groups` are temporarily swapped.

### Performance (measured on RTX PRO 6000, float32, AdamW, 10 steps)

| Model (layers, hidden) | All-at-once peak | All-at-once step | Chunked peak | Chunked step | Mem savings | Speedup |
|---|---|---|---|---|---|---|
| Small (14, 768) | 1,308 MiB | 26.5 ms | 882 MiB | 23.9 ms | 426 MiB | 1.1× |
| Medium (28, 1024) | 4,798 MiB | 87.4 ms | 2,891 MiB | 63.3 ms | 1,907 MiB | 1.4× |
| Large (40, 2560) | 41,031 MiB | 861.7 ms | 25,083 MiB | 597.3 ms | 15,948 MiB | 1.4× |

Chunked+stream is **faster** than all-at-once because stream overlap hides H2D/D2H transfer latency behind compute. Memory savings are 33–39%.

### Validation

- Full reverse-text RL training (20 steps, Qwen3-0.6B, 2 GPUs) completed successfully
- Parity tests: chunked vs non-chunked AdamW — params, optimizer states, and state_dict round-trip all match (`tests/unit/train/test_optim_offload.py`, 5 tests)
- All integration tests pass (reverse_text, sft, lora, moe, multi_run, benchmark_regression)
- `base_optimizer`, `state`, `param_groups`, `zero_grad`, `state_dict`, `load_state_dict` APIs unchanged

### Bugbot issues addressed

1. **Async D2H checkpoint corruption** (HIGH): Added `torch.cuda.synchronize()` after `_move_states("cpu")` in `state_dict()`, `load_state_dict()`, and `ckpt.py`
2. **Incomplete stream dependency** (MEDIUM): Added `torch.cuda.synchronize()` at end of streamed step; `h2d_stream.wait_stream(d2h_stream)` before prefetch to prevent pin buffer races
3. **First step OOM** (HIGH): Chunked init step processes per-layer instead of full `optimizer.step()`
4. **Closure run per chunk** (LOW): Closure passed only to first chunk
5. **Stream memory leak** (MEDIUM): CUDA streams created once in `__init__` and reused across steps instead of allocating new streams per `step()`
