### PR TITLE
feat(monitor): add local file monitor for JSONL metrics

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -14,6 +14,7 @@ from prime_rl.configs.shared import (
     BaseModelConfig,
     ClientConfig,
     EnvVars,
+    FileMonitorConfig,
     FileSystemTransportConfig,
     HeartbeatConfig,
     LogConfig,
@@ -492,6 +493,9 @@ class OrchestratorConfig(BaseConfig):
     wandb: WandbWithExtrasConfig | None = None
 
     prime_monitor: PrimeMonitorConfig | None = None
+
+    file_monitor: FileMonitorConfig | None = None
+    """Local JSONL metric sink. If set, orchestrator metrics are appended to ``<output_dir>/metrics.jsonl``."""
 
     collect_inference_metrics: bool = True
     """Collect inference-server metrics (requires wandb)."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -20,6 +20,7 @@ from prime_rl.configs.orchestrator import (
 )
 from prime_rl.configs.shared import (
     EnvVars,
+    FileMonitorConfig,
     SlurmConfig,
     VLMConfig,
 )
@@ -241,6 +242,9 @@ class RLConfig(BaseConfig):
 
     wandb: SharedWandbConfig | None = None
     """Shared W&B config. If None, falls back to the sub-config W&B settings."""
+
+    file_monitor: FileMonitorConfig | None = None
+    """Shared local JSONL metric sink. If set, enables ``<output_dir>/metrics.jsonl`` on both trainer and orchestrator. If None, falls back to the sub-config settings."""
 
     model: SharedModelConfig | None = None
     """Shared model config. If None, falls back to the sub-config model settings."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -8,6 +8,7 @@ from renderers.base import MODEL_RENDERER_MAP
 
 from prime_rl.configs.shared import (
     EnvVars,
+    FileMonitorConfig,
     HeartbeatConfig,
     SlurmConfig,
     TrainerLogConfig,
@@ -190,6 +191,9 @@ class SFTConfig(BaseConfig):
     log: TrainerLogConfig = TrainerLogConfig()
 
     wandb: WandbConfig | None = None
+
+    file_monitor: FileMonitorConfig | None = None
+    """Local JSONL metric sink. If set, metrics are appended to ``<output_dir>/metrics.jsonl``."""
 
     output_dir: Path = Path("outputs")
     """Directory to write outputs to — checkpoints and logs are written as subdirectories. Should be a persistent directory with enough disk space and unique per experiment running on a single node."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -221,6 +221,18 @@ class WandbWithExtrasConfig(WandbConfig):
     """Extras logging configuration. If None, no extras are logged."""
 
 
+class FileMonitorConfig(BaseConfig):
+    """Enable the local JSONL metric sink (``<output_dir>/metrics.jsonl``).
+
+    Present (non-None) enables it, mirroring the ``prime_monitor`` pattern. Metrics
+    are the same scalars sent to W&B; useful for self-hosted dashboards or when W&B
+    is disabled.
+    """
+
+    filename: str = "metrics.jsonl"
+    """Name of the JSONL file written under the component's ``output_dir``."""
+
+
 class PrimeMonitorConfig(BaseConfig):
     base_url: str = "https://api.primeintellect.ai/api/v1/rft"
     """Base URL for the Prime Intellect monitoring API."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -7,6 +7,7 @@ from pydantic import Field, model_validator
 from prime_rl.configs.shared import (
     BaseModelConfig,
     EnvVars,
+    FileMonitorConfig,
     FileSystemTransportConfig,
     HeartbeatConfig,
     MetricsServerConfig,
@@ -581,6 +582,9 @@ class TrainerConfig(BaseConfig):
     log: TrainerLogConfig = TrainerLogConfig()
 
     wandb: WandbConfig | None = None
+
+    file_monitor: FileMonitorConfig | None = None
+    """Local JSONL metric sink. If set, trainer metrics are appended to ``<output_dir>/metrics.jsonl``."""
 
     output_dir: Path = Path("outputs")
     """Directory to write outputs to — checkpoints, weights, rollouts, and logs are written as subdirectories. Should be a persistent directory with enough disk space and unique per experiment running on a single node."""

--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -106,6 +106,9 @@ def propagate_shared_fields(data: Any) -> Any:
     propagate("wandb.tags", "trainer.wandb.tags", "orchestrator.wandb.tags")
     propagate("wandb.offline", "trainer.wandb.offline", "orchestrator.wandb.offline")
 
+    # [file_monitor] leaf. (Bare empty ``[file_monitor]`` block enablement is at the end.)
+    propagate("file_monitor.filename", "trainer.file_monitor.filename", "orchestrator.file_monitor.filename")
+
     # [tokenizer]. ``chat_template`` also flows to ``inference.model`` (vLLM's
     # ``--chat-template``); ``name`` and ``trust_remote_code`` can legitimately
     # differ between sub-configs (auto-derived from model names, which may
@@ -172,7 +175,7 @@ def propagate_shared_fields(data: Any) -> Any:
     # (not ``is not None``) is what makes CLI ``--no-wandb`` / ``--no-ckpt``
     # work — those land as the *string* ``"None"`` until ``BaseConfig``'s
     # parent-class validator converts it, which happens after this one.
-    for key in ("ckpt", "wandb"):
+    for key in ("ckpt", "wandb", "file_monitor"):
         if isinstance(get(key), dict):
             fill(f"trainer.{key}", {})
             fill(f"orchestrator.{key}", {})

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -231,6 +231,7 @@ class Orchestrator:
         self.monitor = setup_monitor(
             wandb_config=config.wandb,
             prime_config=config.prime_monitor,
+            file_config=config.file_monitor,
             output_dir=config.output_dir,
             tokenizer=self.tokenizer,
             run_config=config,

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -86,7 +86,9 @@ def train(config: TrainerConfig):
 
     # Setup the monitor
     logger.info(f"Initializing monitor ({config.wandb})")
-    monitor = setup_monitor(config.wandb, output_dir=config.output_dir, run_config=config)
+    monitor = setup_monitor(
+        config.wandb, file_config=config.file_monitor, output_dir=config.output_dir, run_config=config
+    )
 
     # Setup heartbeat (only on rank 0)
     heart = None

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -73,7 +73,9 @@ def train(config: SFTConfig):
 
     # Setup the monitor
     logger.info(f"Initializing monitor ({config.wandb})")
-    monitor = setup_monitor(config.wandb, output_dir=config.output_dir, run_config=config)
+    monitor = setup_monitor(
+        config.wandb, file_config=config.file_monitor, output_dir=config.output_dir, run_config=config
+    )
 
     # Setup heartbeat (only on rank 0)
     heart = None

--- a/src/prime_rl/utils/monitor/__init__.py
+++ b/src/prime_rl/utils/monitor/__init__.py
@@ -2,9 +2,10 @@ from pathlib import Path
 
 from transformers.tokenization_utils import PreTrainedTokenizer
 
-from prime_rl.configs.shared import PrimeMonitorConfig, WandbWithExtrasConfig
+from prime_rl.configs.shared import FileMonitorConfig, PrimeMonitorConfig, WandbWithExtrasConfig
 from prime_rl.utils.config import BaseConfig
 from prime_rl.utils.monitor.base import Monitor, NoOpMonitor
+from prime_rl.utils.monitor.file import FileMonitor
 from prime_rl.utils.monitor.multi import MultiMonitor
 from prime_rl.utils.monitor.prime import PrimeMonitor
 from prime_rl.utils.monitor.wandb import WandbMonitor
@@ -13,6 +14,7 @@ __all__ = [
     "Monitor",
     "WandbMonitor",
     "PrimeMonitor",
+    "FileMonitor",
     "MultiMonitor",
     "NoOpMonitor",
     "setup_monitor",
@@ -37,6 +39,7 @@ def setup_monitor(
     run_config: BaseConfig | None = None,
     *,
     prime_config: PrimeMonitorConfig | None = None,
+    file_config: FileMonitorConfig | None = None,
     keep_full_history: bool = True,
     train_env_names: list[str] = [],
     eval_env_names: list[str] = [],
@@ -78,6 +81,16 @@ def setup_monitor(
                 config=prime_config,
                 output_dir=output_dir,
                 tokenizer=tokenizer,
+                run_config=run_config,
+                keep_full_history=keep_full_history,
+            )
+        )
+
+    if file_config is not None:
+        monitors.append(
+            FileMonitor(
+                config=file_config,
+                output_dir=output_dir,
                 run_config=run_config,
                 keep_full_history=keep_full_history,
             )

--- a/src/prime_rl/utils/monitor/base.py
+++ b/src/prime_rl/utils/monitor/base.py
@@ -1,11 +1,51 @@
 from __future__ import annotations
 
+import math
 import random
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from prime_rl.orchestrator.types import Rollout
+
+
+_DROPPED_JSON_VALUE = object()
+
+
+def drop_non_finite_json_values(value: Any, dropped_paths: list[str], path: str = "") -> Any:
+    """Recursively drop non-finite floats (NaN/inf) from a JSON-serializable value.
+
+    Appends the dotted path of each dropped value to `dropped_paths`. Used before
+    serializing metric payloads that must be strict JSON (the public Prime API and
+    the local `metrics.jsonl` sink), since NaN/Infinity are not valid JSON.
+    """
+    if isinstance(value, float) and not math.isfinite(value):
+        dropped_paths.append(path)
+        return _DROPPED_JSON_VALUE
+
+    if isinstance(value, dict):
+        return {
+            key: sanitized_item
+            for key, item in value.items()
+            if (
+                sanitized_item := drop_non_finite_json_values(
+                    item,
+                    dropped_paths,
+                    f"{path}.{key}" if path else str(key),
+                )
+            )
+            is not _DROPPED_JSON_VALUE
+        }
+
+    if isinstance(value, list):
+        return [
+            sanitized_item
+            for idx, item in enumerate(value)
+            if (sanitized_item := drop_non_finite_json_values(item, dropped_paths, f"{path}[{idx}]"))
+            is not _DROPPED_JSON_VALUE
+        ]
+
+    return value
 
 
 def sample_items_for_logging(items: list[Any], sample_ratio: float | None) -> list[Any]:

--- a/src/prime_rl/utils/monitor/file.py
+++ b/src/prime_rl/utils/monitor/file.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from prime_rl.configs.shared import FileMonitorConfig
+from prime_rl.utils.config import BaseConfig
+from prime_rl.utils.logger import get_logger
+from prime_rl.utils.monitor.base import Monitor, drop_non_finite_json_values
+
+if TYPE_CHECKING:
+    from prime_rl.orchestrator.types import Rollout
+
+
+class FileMonitor(Monitor):
+    """Appends logged metrics to a local ``metrics.jsonl`` file.
+
+    A self-hosted, dependency-free mirror of what ``WandbMonitor.log`` sees: one
+    JSON object per line, ``{"step": step, "time": <wall>, **metrics}``. The file is
+    flushed after every write so an in-progress run can be read (e.g. to build a
+    static dashboard snapshot mid-run). Only rank 0 writes. Samples and
+    distributions are not persisted here (scalars only).
+    """
+
+    def __init__(
+        self,
+        config: FileMonitorConfig | None,
+        output_dir: Path | None = None,
+        run_config: BaseConfig | None = None,
+        keep_full_history: bool = True,
+    ):
+        self.config = config
+        self.logger = get_logger()
+        self.history: list[dict[str, Any]] = []
+        self._keep_full_history = keep_full_history
+        self.output_dir = output_dir
+        self._file = None
+
+        rank = int(os.environ.get("RANK", os.environ.get("DP_RANK", "0")))
+        self.enabled = self.config is not None
+        self.is_master = rank == 0
+        if not self.enabled or not self.is_master:
+            if not self.is_master:
+                self.logger.warning(f"Skipping {self.__class__.__name__} initialization from non-master rank ({rank})")
+            return
+
+        if output_dir is None:
+            self.logger.warning("FileMonitor requires an output_dir; disabling.")
+            self.enabled = False
+            return
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        self._path = output_dir / config.filename
+        # Line-buffered append so a concurrently-running dashboard can tail the file.
+        self._file = open(self._path, "a", buffering=1)  # noqa: SIM115
+        self.logger.info(f"Logging metrics to {self._path}")
+
+    def log(self, metrics: dict[str, Any], step: int) -> None:
+        if self._keep_full_history:
+            self.history.append(metrics)
+        else:
+            self.history = [metrics]
+        if not self.is_master or not self.enabled or self._file is None:
+            return
+
+        dropped_paths: list[str] = []
+        sanitized = drop_non_finite_json_values(metrics, dropped_paths)
+        if dropped_paths:
+            preview = ", ".join(dropped_paths[:5])
+            suffix = " ..." if len(dropped_paths) > 5 else ""
+            self.logger.debug(
+                f"Dropping {len(dropped_paths)} non-finite value(s) from metrics.jsonl: {preview}{suffix}"
+            )
+
+        row = {"step": step, "time": time.time(), **sanitized}
+        self._file.write(json.dumps(row))
+        self._file.write("\n")
+
+    def log_samples(self, rollouts: list[Rollout], step: int) -> None:
+        pass
+
+    def log_eval_samples(self, rollouts: list[Rollout], env_name: str, step: int) -> None:
+        pass
+
+    def log_distributions(self, distributions: dict[str, list[float]], step: int) -> None:
+        pass
+
+    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+        if not self.is_master or not self.enabled or self.output_dir is None:
+            return
+        summary = self.history[-1] if self.history else {}
+        dropped_paths: list[str] = []
+        sanitized = drop_non_finite_json_values(summary, dropped_paths)
+        with open(self.output_dir / filename, "w") as f:
+            json.dump(sanitized, f)
+
+    def close(self) -> None:
+        if self._file is not None:
+            self._file.close()
+            self._file = None

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import io
 import json
-import math
 import os
 import time
 from datetime import datetime, timezone
@@ -21,7 +20,7 @@ from verifiers.v1.push import trace_to_sample
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.configs.shared import PrimeMonitorConfig
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.monitor.base import Monitor, sample_items_for_logging
+from prime_rl.utils.monitor.base import Monitor, drop_non_finite_json_values, sample_items_for_logging
 
 if TYPE_CHECKING:
     from prime_rl.orchestrator.types import Rollout
@@ -52,46 +51,13 @@ _SAMPLE_SCHEMA = pa.schema(
 )
 
 
-_DROPPED_JSON_VALUE = object()
-
-
-def _drop_non_finite_json_values(value: Any, dropped_paths: list[str], path: str = "") -> Any:
-    if isinstance(value, float) and not math.isfinite(value):
-        dropped_paths.append(path)
-        return _DROPPED_JSON_VALUE
-
-    if isinstance(value, dict):
-        return {
-            key: sanitized_item
-            for key, item in value.items()
-            if (
-                sanitized_item := _drop_non_finite_json_values(
-                    item,
-                    dropped_paths,
-                    f"{path}.{key}" if path else str(key),
-                )
-            )
-            is not _DROPPED_JSON_VALUE
-        }
-
-    if isinstance(value, list):
-        return [
-            sanitized_item
-            for idx, item in enumerate(value)
-            if (sanitized_item := _drop_non_finite_json_values(item, dropped_paths, f"{path}[{idx}]"))
-            is not _DROPPED_JSON_VALUE
-        ]
-
-    return value
-
-
 class PrimeMonitor(Monitor):
     """Logs to Prime Intellect API."""
 
     def _sanitize_json_payload(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         """Drop non-finite floats before sending JSON payloads to the public API."""
         dropped_paths: list[str] = []
-        sanitized_payload = _drop_non_finite_json_values(payload, dropped_paths)
+        sanitized_payload = drop_non_finite_json_values(payload, dropped_paths)
         if not dropped_paths:
             return payload
 


### PR DESCRIPTION
## Summary

- Add a `FileMonitor` that appends every logged metrics dict to a local JSONL file (`<output_dir>/metrics.jsonl`, one `{"step": ..., "time": ..., **metrics}` object per line) for offline analysis — a dependency-free mirror of what `WandbMonitor.log` sees. The file is line-buffered/flushed per write so an in-progress run can be tailed; only rank 0 writes; scalars only (samples and distributions are not persisted).
- New optional `FileMonitorConfig` (`filename`, default `metrics.jsonl`) wired as `file_monitor` on trainer, orchestrator, SFT, and shared RL configs, following the `prime_monitor` presence-enables pattern, including shared-config propagation in `validation.py` (leaf `file_monitor.filename` plus bare `[file_monitor]` block enablement).
- Move the NaN/inf JSON sanitizer out of `PrimeMonitor` into `monitor/base.py` as `drop_non_finite_json_values` and reuse it for the JSONL sink, since NaN/Infinity are not valid JSON.

## Verification

- `tests/unit/test_configs.py` passes (98 passed), covering the shared-config propagation change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in observability only; no changes to training, auth, or weight paths when `file_monitor` is unset.
> 
> **Overview**
> Adds an optional **local JSONL metric sink** so scalar training metrics can be recorded without W&B or Prime API.
> 
> Enable via **`file_monitor`** on trainer, orchestrator, SFT, and shared RL configs (presence enables it, like `prime_monitor`). **`FileMonitor`** appends one JSON object per `log()` call to `<output_dir>/metrics.jsonl` (configurable filename), line-buffered for tailing mid-run; rank 0 only; samples and distributions are not written.
> 
> **`setup_monitor`** composes `FileMonitor` alongside W&B and Prime monitors. **`drop_non_finite_json_values`** is moved from `PrimeMonitor` into `monitor/base.py` and reused for JSONL and Prime API payloads so NaN/inf are stripped before strict JSON serialization.
> 
> Shared RL config propagation covers `file_monitor.filename` and bare `[file_monitor]` block enablement on trainer and orchestrator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae61eda3e21949133232c641bc892b692255da2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->