### PR TITLE
fix(trainer): use UE8M0 FP8 scales only on SM100

### DIFF
--- a/src/prime_rl/trainer/models/kernels/fp8_utils.py
+++ b/src/prime_rl/trainer/models/kernels/fp8_utils.py
@@ -15,6 +15,13 @@ def ceil_div(x: int, y: int) -> int:
     return (x + y - 1) // y
 
 
+def ue8m0_for_device(device: torch.device | None = None) -> bool:
+    """DeepGEMM requires UE8M0 (power-of-2) scales on SM100; SM90 supports exact float
+    scales, and UE8M0 there is a pure precision loss (it measurably raises the
+    trainer/inference mismatch KL)."""
+    return torch.cuda.get_device_capability(device)[0] >= 10
+
+
 # ---------------------------------------------------------------------------
 # Layout building
 # ---------------------------------------------------------------------------

--- a/src/prime_rl/trainer/models/layers/fp8_grouped_gemm.py
+++ b/src/prime_rl/trainer/models/layers/fp8_grouped_gemm.py
@@ -16,6 +16,7 @@ from prime_rl.trainer.models.kernels.fp8_utils import (
     grouped_per_channel_cast_to_fp8_rowmajor_triton,
     grouped_per_channel_cast_to_fp8_sm90_kmajor_triton,
     grouped_per_token_cast_to_fp8_triton,
+    ue8m0_for_device,
     unpack_rows_triton,
 )
 
@@ -66,7 +67,7 @@ def _compute_grad_weight(
             actual_ms_tensor,
             ks_tensor,
             block_starts_tensor,
-            True,
+            False,
             GROUP_ALIGNMENT,
         )
         dy_fp8 = grouped_per_channel_cast_to_fp8_sm90_kmajor_triton(
@@ -77,7 +78,7 @@ def _compute_grad_weight(
             actual_ms_tensor,
             ks_tensor,
             block_starts_tensor,
-            True,
+            False,
             GROUP_ALIGNMENT,
         )
         grouped_weight_grad = deep_gemm.k_grouped_fp8_gemm_nt_contiguous
@@ -113,6 +114,7 @@ class _GroupedFP8Gemm(torch.autograd.Function):
             block_starts_tensor,
         ) = build_grouped_layout(offs, total_m=x.size(0))
 
+        use_ue8m0 = ue8m0_for_device(x.device)
         x_fp8 = grouped_per_token_cast_to_fp8_triton(
             x,
             padded_total_m,
@@ -120,12 +122,12 @@ class _GroupedFP8Gemm(torch.autograd.Function):
             starts_tensor,
             actual_ms_tensor,
             block_starts_tensor,
-            True,
+            use_ue8m0,
             GROUP_ALIGNMENT,
         )
         weight_fp8 = grouped_per_block_cast_to_fp8_triton(
             weight.transpose(1, 2),
-            True,
+            use_ue8m0,
             GROUP_ALIGNMENT,
         )
 
@@ -197,6 +199,7 @@ class _GroupedFP8Gemm(torch.autograd.Function):
             )
 
         if ctx.needs_input_grad[0]:
+            use_ue8m0 = ue8m0_for_device(grad_output.device)
             dy_fp8 = grouped_per_token_cast_to_fp8_triton(
                 grad_output,
                 padded_total_m,
@@ -204,12 +207,12 @@ class _GroupedFP8Gemm(torch.autograd.Function):
                 starts_tensor,
                 actual_ms_tensor,
                 block_starts_tensor,
-                True,
+                use_ue8m0,
                 GROUP_ALIGNMENT,
             )
             weight_dx_fp8 = grouped_per_block_cast_to_fp8_triton(
                 weight,
-                True,
+                use_ue8m0,
                 GROUP_ALIGNMENT,
             )
             grad_x_padded = torch.empty(

--- a/src/prime_rl/trainer/models/layers/fp8_linear.py
+++ b/src/prime_rl/trainer/models/layers/fp8_linear.py
@@ -17,6 +17,7 @@ from prime_rl.trainer.models.kernels.fp8_utils import (
     per_block_cast_to_fp8_triton,
     per_token_cast_to_fp8_tp_triton,
     per_token_cast_to_fp8_triton,
+    ue8m0_for_device,
 )
 from prime_rl.utils.logger import get_logger
 
@@ -26,8 +27,9 @@ class _FP8BlockwiseMM(torch.autograd.Function):
     def forward(ctx, x, weight, block_size, out_dtype=torch.bfloat16):
         x_shape = x.shape
         x_2d = x.reshape(-1, x_shape[-1]).contiguous()
-        x_fp8 = per_token_cast_to_fp8_triton(x_2d, True, block_size)
-        weight_fp8 = per_block_cast_to_fp8_triton(weight, True, block_size)
+        use_ue8m0 = ue8m0_for_device(x.device)
+        x_fp8 = per_token_cast_to_fp8_triton(x_2d, use_ue8m0, block_size)
+        weight_fp8 = per_block_cast_to_fp8_triton(weight, use_ue8m0, block_size)
 
         out = torch.empty((x_2d.size(0), weight.size(0)), device=x.device, dtype=out_dtype)
         deep_gemm.fp8_gemm_nt(x_fp8, weight_fp8, out)
@@ -42,11 +44,12 @@ class _FP8BlockwiseMM(torch.autograd.Function):
         x_2d, weight = ctx.saved_tensors
         block_size = ctx.block_size
         grad_output_2d = grad_output.reshape(-1, grad_output.shape[-1]).contiguous()
+        use_ue8m0 = ue8m0_for_device(grad_output.device)
 
         grad_x = grad_weight = None
         if ctx.needs_input_grad[0]:
-            grad_output_fp8 = per_token_cast_to_fp8_triton(grad_output_2d, True, block_size)
-            weight_dx_fp8 = per_block_cast_to_fp8_tp_triton(weight, True, block_size)
+            grad_output_fp8 = per_token_cast_to_fp8_triton(grad_output_2d, use_ue8m0, block_size)
+            weight_dx_fp8 = per_block_cast_to_fp8_tp_triton(weight, use_ue8m0, block_size)
             grad_x_2d = torch.empty_like(x_2d)
             deep_gemm.fp8_gemm_nt(grad_output_fp8, weight_dx_fp8, grad_x_2d)
             grad_x = grad_x_2d.reshape(ctx.x_shape)
@@ -64,8 +67,8 @@ class _FP8BlockwiseMM(torch.autograd.Function):
             else:
                 grad_output_2d_padded = grad_output_2d
                 x_2d_padded = x_2d
-            grad_output_t_fp8 = per_token_cast_to_fp8_tp_triton(grad_output_2d_padded, True, block_size)
-            x_t_fp8 = per_token_cast_to_fp8_tp_triton(x_2d_padded, True, block_size)
+            grad_output_t_fp8 = per_token_cast_to_fp8_tp_triton(grad_output_2d_padded, use_ue8m0, block_size)
+            x_t_fp8 = per_token_cast_to_fp8_tp_triton(x_2d_padded, use_ue8m0, block_size)
             grad_weight_fp32 = torch.zeros_like(weight, dtype=torch.float32)
             deep_gemm.fp8_gemm_nt(
                 grad_output_t_fp8,


### PR DESCRIPTION
## Problem

#3022 flipped `use_ue8m0` from `False` to `True` unconditionally in the trainer's FP8 casts (`fp8_linear.py` dense linears + `fp8_grouped_gemm.py` MoE expert GEMMs, forward and backward). UE8M0 (power-of-2-rounded scale factors) is required by DeepGEMM on SM100, but on SM90 it is strictly coarser quantization than the exact float scales used before — a silent numerics regression on Hopper.

## Impact observed

On the GLM-5.2 SWE-rebench RL prod run (H200s, cp8/ep8/fp8), trainer/inference `mismatch_kl/all/mean` jumped from ~0.0038 to ~0.0059–0.0069 at the first training step after the flip, and stayed ~1.8× elevated for ~300 steps. Verified by direct A/B on an **identical batch** (same tokens, same recorded inference logprobs, base weights):

| trainer FP8 scales | step-1 mismatch KL |
|---|---|
| UE8M0 (post-#3022) | 0.0059 |
| float (this PR) | **0.0038** |

## Fix

Add `ue8m0_for_device()` (compute capability ≥ 10) and derive the flag from the tensor's device at every cast site: SM100 keeps the UE8M0 recipe DeepGEMM requires there; SM90 returns to exact float scales. The SM100-only row-major cast paths keep `True` hardcoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FP8 quantization numerics on the training hot path (dense and MoE GEMMs); scope is limited to scale-format selection by GPU generation with clear SM100 vs SM90 split.
> 
> **Overview**
> Reverts the unconditional **UE8M0** (power-of-2) FP8 scale quantization on Hopper (SM90) while keeping it on Blackwell (SM100+), where DeepGEMM requires it.
> 
> Adds **`ue8m0_for_device()`** in `fp8_utils.py` (enabled when `get_device_capability()[0] >= 10`) and wires it into every per-token/per-block cast in **`fp8_linear.py`** and **`fp8_grouped_gemm.py`** forward and backward instead of hardcoded `True`. On SM90, **`grouped_per_channel_cast_to_fp8_sm90_kmajor_triton`** in the weight-gradient path is set back to **`False`** so exact float scales are used; SM100 row-major grad paths still pass **`True`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc81164b49770a609a8b775ee060b3a66abd969c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->