### PR TITLE
fix(nixl): replay strided views on inference

### DIFF
--- a/src/prime_rl/trainer/rl/broadcast/nixl/graph.py
+++ b/src/prime_rl/trainer/rl/broadcast/nixl/graph.py
@@ -92,9 +92,10 @@ def is_view_of(value: torch.Tensor, root: torch.Tensor) -> bool:
 def plan_tensor_replay(shape: tuple[int, ...], dtype: torch.dtype, ops: OperationChain) -> TensorReplayPlan:
     """Resolve a directly transferable source view and local replay suffix.
 
-    The prefix must remain a same-dtype view of the trainer root and can
-    therefore be addressed by RDMA. The first materializing or dtype-changing
-    operation and everything after it is replayed on the receive arena.
+    The prefix must remain a contiguous, same-dtype view of the trainer root
+    and can therefore be transferred in large RDMA runs. The first strided,
+    materializing, or dtype-changing operation and everything after it is
+    replayed on the receive arena.
     """
     root = torch.empty(shape, dtype=dtype, device="meta")
     prefix_len = 0
@@ -105,7 +106,7 @@ def plan_tensor_replay(shape: tuple[int, ...], dtype: torch.dtype, ops: Operatio
         if candidate_len < len(ops) and ops[candidate_len].name == "tuple_getitem":
             continue
         candidate = apply_chain(root, ops[:candidate_len])
-        if candidate.dtype != dtype or not is_view_of(candidate, root):
+        if candidate.dtype != dtype or not is_view_of(candidate, root) or not candidate.is_contiguous():
             break
         prefix_len = candidate_len
         source_view = candidate


### PR DESCRIPTION
## Summary

- require the directly transported replay prefix to remain contiguous
- split replay at the first strided operation
- reproduce the strided view and the remaining operation suffix on inference

## Why

A strided tensor can share the trainer root storage without being a contiguous transfer region. Treating that view as directly transportable fragments the NIXL copy plan and can make synchronization pathologically slow.

## Validation

Validated with the Laguna-XS.2 NIXL + ModelExpress Kubernetes run:

- initial 2 x TP8 pool initialized as 16 ranks
- staggered third TP8 server joined as ranks 16-23
- initial policy transfer completed in about 7.5 seconds
- first 24-rank transfer completed in about 10.7 seconds
- training continued through subsequent synchronized steps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how trainer→inference weight slices are split between RDMA and local replay; incorrect boundaries could corrupt weights, but the fix is narrowly scoped to prefix eligibility in replay planning.
> 
> **Overview**
> **NIXL weight transfer** now treats only **contiguous** same-dtype views of the trainer root as directly RDMA-able; the prefix walk in `plan_tensor_replay` breaks when `is_contiguous()` fails, not only on dtype change or non-view tensors.
> 
> Strided views that still alias root storage are no longer included in the bulk copy plan—those ops move into `replay_ops` and run on the inference receive arena, avoiding fragmented NIXL copy plans and slow sync (as seen with staggered TP pool joins).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c95589c6225c315cfe9dec83352a6d00f3eac11a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->