### PR TITLE
fix: sync docs to public-docs on release tags only

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -2,10 +2,13 @@ name: Sync Docs to Public Docs
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
+    tags:
+      # Sync docs on stable releases only, not on every commit to main.
+      # `.dev` tags are created by `devx_tag.yaml` via GITHUB_TOKEN (which
+      # does not retrigger workflows), so they would not arrive here anyway —
+      # the exclusion is defensive for manual pushes.
+      - 'v*'
+      - '!v*dev*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Change the `Sync Docs to Public Docs` workflow to trigger on stable `v*` tag pushes instead of every commit to `main` that touches `docs/`, so the public docs only update on releases.
- Exclude `v*dev*` tags (matching `tag-and-release.yaml`) — `.dev` tags from `devx_tag.yaml` are created via `GITHUB_TOKEN` and wouldn't retrigger workflows anyway, so the exclusion is defensive for manual pushes.
- Keep `workflow_dispatch` for manual syncs.

On a tag push `github.sha` resolves to the tagged commit, so the `ref` sent to public-docs remains correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change for documentation publishing; no runtime application or auth logic is modified.
> 
> **Overview**
> **Docs sync no longer runs on every `main` push under `docs/`.** The `Sync Docs to Public Docs` workflow now runs when stable **`v*`** tags are pushed, with **`!v*dev*`** so dev-style tags are skipped (comments note `.dev` tags from automation typically would not retrigger anyway).
> 
> **Manual sync is unchanged** via `workflow_dispatch`. The dispatch to `public-docs` still passes `github.sha` as `ref`, which still points at the tagged commit on tag pushes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 603601da6569938b6bc6439a8d10e7945e3c4839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->