### PR TITLE
fix: sync docs to public-docs on stable release only

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -2,10 +2,10 @@ name: Sync Docs to Public Docs
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
+    tags:
+      # Sync docs on stable releases only, not on every commit to main.
+      - 'v*'
+      - '!v*dev*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,11 +1,9 @@
 name: Sync Docs to Public Docs
 
 on:
-  push:
-    tags:
-      # Sync docs on stable releases only, not on every commit to main.
-      - 'v*'
-      - '!v*dev*'
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Change the `Sync Docs to Public Docs` workflow to trigger when a stable GitHub release is **published** instead of every commit to `main` that touches `docs/`, so the public docs only update on actual stable releases.
- Uses the `release` event with `types: [published]` — dev tags (`v*dev*`) are created via `GITHUB_TOKEN` (which doesn't retrigger workflows) and don't have GitHub Releases, so they are naturally excluded.
- Keep `workflow_dispatch` for manual syncs.

On a release publish, `github.sha` resolves to the tagged commit, so the `ref` sent to public-docs remains correct.

Inspired by [PrimeIntellect-ai/verifiers#2108](https://github.com/PrimeIntellect-ai/verifiers/pull/2108).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change for documentation sync; no application or runtime behavior is affected.
> 
> **Overview**
> **Public docs sync is tied to releases instead of every docs commit on `main`.**
> 
> The **Sync Docs to Public Docs** workflow no longer runs on `push` to `main` with `docs/**` path filters. It now triggers on **`release` → `published`**, so public-docs updates align with shipping a release rather than intermediate doc edits on main. **`workflow_dispatch`** is unchanged for on-demand syncs.
> 
> The job steps (mint.json validation and `repository-dispatch` to public-docs with `ref: github.sha`) are the same; only the event that starts the workflow changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03245d1a83a077f66d478b5218ab8dd5b49997b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->