### PR TITLE
chore(rl): add message to multimodal packing assert

### DIFF
--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -270,7 +270,7 @@ class _MicroBatchBin:
         if existing_mm_sample is not None and sample_is_mm:
             dst = existing_mm_sample.mm_kwargs
             src = sample.mm_kwargs
-            assert dst is not None and src is not None
+            assert dst is not None and src is not None, "multimodal samples must carry mm_kwargs"
             return set(dst) == set(src) and all(
                 dst[key].dtype == src[key].dtype
                 and len(dst[key].shape) > 0


### PR DESCRIPTION
## Summary
- Follow-up to [#3103](https://github.com/PrimeIntellect-ai/prime-rl/pull/3103) review feedback from samsja: give the multimodal `mm_kwargs` invariant assert an error message.

## Test plan
- [ ] CI / unit tests pass
- [ ] Confirm assert site in `src/prime_rl/trainer/batch.py` matches the review request


Made with [Cursor](https://cursor.com)