### PR TITLE
feat(weight-transfer): support router-discovered NIXL autoscaling

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -425,6 +425,9 @@ class NIXLWeightBroadcastConfig(InMemoryWeightBroadcastConfig):
     session_id: str = "default"
     """ModelExpress session ID."""
 
+    router_url: str | None = None
+    """Inference router URL whose workers are initialized by the trainer."""
+
 
 WeightBroadcastConfig: TypeAlias = Annotated[
     FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig | NIXLWeightBroadcastConfig,

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -146,6 +146,9 @@ class SharedNIXLWeightBroadcastConfig(SharedInMemoryWeightBroadcastConfig):
     session_id: str = "default"
     """ModelExpress session ID."""
 
+    router_url: str | None = None
+    """Inference router URL used to discover NIXL transfer workers."""
+
 
 class SharedFileSystemWeightBroadcastConfig(BaseConfig):
     type: Literal["filesystem"] = "filesystem"
@@ -400,7 +403,10 @@ class RLConfig(BaseConfig):
                 trainer_config_type = TrainerNCCLWeightBroadcastConfig
                 orchestrator_config_type = OrchestratorNCCLWeightBroadcastConfig
             else:
-                transport_config = dict(session_id=self.weight_broadcast.session_id)
+                transport_config = dict(
+                    session_id=self.weight_broadcast.session_id,
+                    router_url=self.weight_broadcast.router_url,
+                )
                 trainer_config_type = TrainerNIXLWeightBroadcastConfig
                 orchestrator_config_type = OrchestratorNIXLWeightBroadcastConfig
             self.trainer.weight_broadcast = trainer_config_type(**common_config, **transport_config)

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -548,6 +548,9 @@ class NIXLWeightBroadcastConfig(InMemoryWeightBroadcastConfig):
     session_id: str = "default"
     """ModelExpress session ID."""
 
+    router_url: str | None = None
+    """Inference router URL used to discover NIXL transfer workers."""
+
 
 WeightBroadcastConfig: TypeAlias = Annotated[
     FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig | NIXLWeightBroadcastConfig,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -313,14 +313,15 @@ class Orchestrator:
                 quantize_in_weight_transfer=config.weight_broadcast.quantize_in_weight_transfer,
             )
         elif config.weight_broadcast.type == "nixl":
-            await init_nixl_broadcast(
-                self.policy_inference.admin_clients,
-                config.weight_broadcast.host,
-                config.weight_broadcast.port,
-                config.weight_broadcast.timeout,
-                config.weight_broadcast.inference_world_size,
-                config.weight_broadcast.session_id,
-            )
+            if config.weight_broadcast.router_url is None:
+                await init_nixl_broadcast(
+                    self.policy_inference.admin_clients,
+                    config.weight_broadcast.host,
+                    config.weight_broadcast.port,
+                    config.weight_broadcast.timeout,
+                    config.weight_broadcast.inference_world_size,
+                    config.weight_broadcast.session_id,
+                )
             self.model_express = ModelExpressSession(
                 client=MxClient(server_url=f"{config.weight_broadcast.host}:{config.weight_broadcast.port}"),
                 role="orchestrator",
@@ -361,6 +362,14 @@ class Orchestrator:
                 )
             if self.model_express is not None:
                 await asyncio.to_thread(self.model_express.set_status, p2p_pb2.SOURCE_STATUS_READY)
+                if config.weight_broadcast.type == "nixl" and config.weight_broadcast.router_url is not None:
+                    await asyncio.to_thread(
+                        self.model_express.wait_for,
+                        "trainer",
+                        count=1,
+                        status=p2p_pb2.SOURCE_STATUS_READY,
+                        timeout=config.weight_broadcast.timeout,
+                    )
             await self.policy_inference.update_weights(weights_path, lora_name=self.lora_name, step=sync_version)
             if self.model_express is not None:
                 await asyncio.to_thread(self.model_express.set_status, p2p_pb2.SOURCE_STATUS_INITIALIZING)

--- a/src/prime_rl/trainer/rl/broadcast/nixl/graph.py
+++ b/src/prime_rl/trainer/rl/broadcast/nixl/graph.py
@@ -92,9 +92,10 @@ def is_view_of(value: torch.Tensor, root: torch.Tensor) -> bool:
 def plan_tensor_replay(shape: tuple[int, ...], dtype: torch.dtype, ops: OperationChain) -> TensorReplayPlan:
     """Resolve a directly transferable source view and local replay suffix.
 
-    The prefix must remain a same-dtype view of the trainer root and can
-    therefore be addressed by RDMA. The first materializing or dtype-changing
-    operation and everything after it is replayed on the receive arena.
+    The prefix must remain a contiguous, same-dtype view of the trainer root
+    and can therefore be transferred in large RDMA runs. The first strided,
+    materializing, or dtype-changing operation and everything after it is
+    replayed on the receive arena.
     """
     root = torch.empty(shape, dtype=dtype, device="meta")
     prefix_len = 0
@@ -105,7 +106,7 @@ def plan_tensor_replay(shape: tuple[int, ...], dtype: torch.dtype, ops: Operatio
         if candidate_len < len(ops) and ops[candidate_len].name == "tuple_getitem":
             continue
         candidate = apply_chain(root, ops[:candidate_len])
-        if candidate.dtype != dtype or not is_view_of(candidate, root):
+        if candidate.dtype != dtype or not is_view_of(candidate, root) or not candidate.is_contiguous():
             break
         prefix_len = candidate_len
         source_view = candidate

--- a/src/prime_rl/trainer/rl/broadcast/nixl/nixl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nixl/nixl.py
@@ -11,6 +11,7 @@ from math import prod
 from pathlib import Path
 from typing import cast
 
+import httpx
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -42,6 +43,7 @@ from prime_rl.trainer.utils import get_world
 LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?=\.|$)")
 BUFFER_POLL_INTERVAL = 0.01
 MAX_STAGING_BUFFER_COUNT = 8
+WORKER_DISCOVERY_POLL_INTERVAL = 1.0
 
 
 @dataclass
@@ -338,6 +340,78 @@ class NIXLWeightBroadcast(WeightBroadcast):
             ],
         )
 
+    @staticmethod
+    def worker_admin_url(url: str) -> str:
+        return re.sub(r"@\d+$", "", url.rstrip("/")).removesuffix("/v1")
+
+    def discover_inference_workers(self) -> list[str]:
+        router_url = self.worker_admin_url(cast(str, self.config.router_url))
+        deadline = time.monotonic() + self.config.timeout
+        last_error: httpx.HTTPError | None = None
+        while True:
+            try:
+                response = httpx.get(f"{router_url}/workers", timeout=10.0)
+                response.raise_for_status()
+            except httpx.HTTPStatusError as error:
+                if error.response.is_client_error:
+                    raise
+                last_error = error
+            except httpx.TransportError as error:
+                last_error = error
+            else:
+                workers = response.json()["workers"]
+                urls = sorted({self.worker_admin_url(worker["url"]) for worker in workers if worker["is_healthy"]})
+                if urls:
+                    return urls
+
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"timed out waiting for inference workers at {router_url}/workers") from last_error
+            time.sleep(WORKER_DISCOVERY_POLL_INTERVAL)
+
+    def initialize_inference_workers(self) -> None:
+        worker_urls = self.discover_inference_workers()
+        workers_per_server = self.config.inference_world_size // len(worker_urls)
+        timeout = httpx.Timeout(connect=10.0, read=self.config.timeout, write=60.0, pool=10.0)
+        deadline = time.monotonic() + self.config.timeout
+        pending = {worker_url: index * workers_per_server for index, worker_url in enumerate(worker_urls)}
+        last_errors: dict[str, httpx.HTTPError] = {}
+        with httpx.Client(timeout=timeout) as client:
+            while pending:
+                for worker_url, rank_offset in list(pending.items()):
+                    try:
+                        response = client.post(
+                            f"{worker_url}/init_broadcaster",
+                            json={
+                                "host": self.config.host,
+                                "port": self.config.port,
+                                "rank_offset": rank_offset,
+                                "inference_world_size": self.config.inference_world_size,
+                                "timeout": self.config.timeout,
+                                "quantize_in_weight_transfer": False,
+                                "session_id": self.config.session_id,
+                            },
+                        )
+                        response.raise_for_status()
+                    except httpx.HTTPStatusError as error:
+                        if error.response.is_client_error:
+                            raise
+                        last_errors[worker_url] = error
+                    except httpx.TransportError as error:
+                        last_errors[worker_url] = error
+                    else:
+                        del pending[worker_url]
+
+                if pending:
+                    if time.monotonic() >= deadline:
+                        pending_urls = ", ".join(pending)
+                        raise TimeoutError(f"timed out initializing inference workers: {pending_urls}") from next(
+                            iter(last_errors.values()), None
+                        )
+                    time.sleep(WORKER_DISCOVERY_POLL_INTERVAL)
+        self.logger.info(
+            f"Initialized NIXL transfer on {len(worker_urls)} inference servers from {self.config.router_url}"
+        )
+
     def initialize_transfer(self, model: nn.Module) -> None:
         if self.initialized:
             return
@@ -379,6 +453,8 @@ class NIXLWeightBroadcast(WeightBroadcast):
             )
             self.model_express.publish(nixl_metadata=table.encode())
             self.model_express.set_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
+            if self.config.router_url is not None:
+                self.initialize_inference_workers()
             tensor_count = sum(len(group.tensors) for group in table.groups)
             self.logger.info(
                 f"Published {tensor_count} trainer tensors in {len(table.groups)} groups "

--- a/src/prime_rl/trainer/rl/broadcast/nixl/nixl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nixl/nixl.py
@@ -86,6 +86,9 @@ class NIXLWeightBroadcast(WeightBroadcast):
         self.staged_shards_by_group: dict[int, list[StagedTensorShard]] = {}
         self.staging_arenas: dict[torch.dtype, torch.Tensor] = {}
         self.staging_buffer_count: int
+        self.inference_worker_rank_offsets: dict[str, int] = {}
+        self.ranks_per_inference_worker: int | None = None
+        self.inference_rank_count = config.inference_world_size
 
     @property
     def is_serving_rank(self) -> bool:
@@ -360,7 +363,16 @@ class NIXLWeightBroadcast(WeightBroadcast):
                 last_error = error
             else:
                 workers = response.json()["workers"]
-                urls = sorted({self.worker_admin_url(worker["url"]) for worker in workers if worker["is_healthy"]})
+                if self.ranks_per_inference_worker is None:
+                    initial_workers = [worker for worker in workers if worker["is_usable"]]
+                    healthy_workers = (
+                        initial_workers
+                        if initial_workers and all(worker["is_healthy"] for worker in initial_workers)
+                        else []
+                    )
+                else:
+                    healthy_workers = [worker for worker in workers if worker["is_healthy"]]
+                urls = sorted({self.worker_admin_url(worker["url"]) for worker in healthy_workers})
                 if urls:
                     return urls
 
@@ -370,10 +382,23 @@ class NIXLWeightBroadcast(WeightBroadcast):
 
     def initialize_inference_workers(self) -> None:
         worker_urls = self.discover_inference_workers()
-        workers_per_server = self.config.inference_world_size // len(worker_urls)
+        if self.ranks_per_inference_worker is None:
+            self.ranks_per_inference_worker = self.config.inference_world_size // len(worker_urls)
+
+        new_worker_urls = [url for url in worker_urls if url not in self.inference_worker_rank_offsets]
+        next_rank_offset = len(self.inference_worker_rank_offsets) * self.ranks_per_inference_worker
+        new_workers = {
+            worker_url: next_rank_offset + index * self.ranks_per_inference_worker
+            for index, worker_url in enumerate(new_worker_urls)
+        }
+        current_rank_count = len(worker_urls) * self.ranks_per_inference_worker
+        if not new_workers:
+            self.inference_rank_count = current_rank_count
+            return
+
         timeout = httpx.Timeout(connect=10.0, read=self.config.timeout, write=60.0, pool=10.0)
         deadline = time.monotonic() + self.config.timeout
-        pending = {worker_url: index * workers_per_server for index, worker_url in enumerate(worker_urls)}
+        pending = dict(new_workers)
         last_errors: dict[str, httpx.HTTPError] = {}
         with httpx.Client(timeout=timeout) as client:
             while pending:
@@ -385,7 +410,7 @@ class NIXLWeightBroadcast(WeightBroadcast):
                                 "host": self.config.host,
                                 "port": self.config.port,
                                 "rank_offset": rank_offset,
-                                "inference_world_size": self.config.inference_world_size,
+                                "inference_world_size": current_rank_count,
                                 "timeout": self.config.timeout,
                                 "quantize_in_weight_transfer": False,
                                 "session_id": self.config.session_id,
@@ -408,8 +433,11 @@ class NIXLWeightBroadcast(WeightBroadcast):
                             iter(last_errors.values()), None
                         )
                     time.sleep(WORKER_DISCOVERY_POLL_INTERVAL)
+        self.inference_worker_rank_offsets.update(new_workers)
+        self.inference_rank_count = current_rank_count
         self.logger.info(
-            f"Initialized NIXL transfer on {len(worker_urls)} inference servers from {self.config.router_url}"
+            f"Initialized NIXL transfer on {len(new_workers)} new inference servers; "
+            f"{len(worker_urls)} servers and {self.inference_rank_count} ranks now participate"
         )
 
     def initialize_transfer(self, model: nn.Module) -> None:
@@ -453,8 +481,6 @@ class NIXLWeightBroadcast(WeightBroadcast):
             )
             self.model_express.publish(nixl_metadata=table.encode())
             self.model_express.set_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
-            if self.config.router_url is not None:
-                self.initialize_inference_workers()
             tensor_count = sum(len(group.tensors) for group in table.groups)
             self.logger.info(
                 f"Published {tensor_count} trainer tensors in {len(table.groups)} groups "
@@ -467,7 +493,7 @@ class NIXLWeightBroadcast(WeightBroadcast):
             session = self.buffer_sessions[buffer_index]
             session.wait_for(
                 "inference",
-                count=self.config.inference_world_size,
+                count=self.inference_rank_count,
                 status=p2p_pb2.SOURCE_STATUS_READY,
                 timeout=self.config.timeout,
                 poll_interval=BUFFER_POLL_INTERVAL,
@@ -475,7 +501,7 @@ class NIXLWeightBroadcast(WeightBroadcast):
             session.set_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
             session.wait_for(
                 "inference",
-                count=self.config.inference_world_size,
+                count=self.inference_rank_count,
                 status=p2p_pb2.SOURCE_STATUS_INITIALIZING,
                 timeout=self.config.timeout,
                 poll_interval=BUFFER_POLL_INTERVAL,
@@ -489,6 +515,8 @@ class NIXLWeightBroadcast(WeightBroadcast):
         start = time.perf_counter()
 
         if self.world.is_master:
+            if self.config.router_url is not None:
+                self.initialize_inference_workers()
             self.model_express.set_status(p2p_pb2.SOURCE_STATUS_READY)
             self.model_express.wait_for(
                 "orchestrator",
@@ -498,7 +526,7 @@ class NIXLWeightBroadcast(WeightBroadcast):
             )
             self.model_express.wait_for(
                 "inference",
-                count=self.config.inference_world_size,
+                count=self.inference_rank_count,
                 status=p2p_pb2.SOURCE_STATUS_INITIALIZING,
                 timeout=self.config.timeout,
             )
@@ -529,7 +557,7 @@ class NIXLWeightBroadcast(WeightBroadcast):
         if self.world.is_master:
             self.model_express.wait_for(
                 "inference",
-                count=self.config.inference_world_size,
+                count=self.inference_rank_count,
                 status=p2p_pb2.SOURCE_STATUS_READY,
                 timeout=self.config.timeout,
             )


### PR DESCRIPTION
## Summary

PoC support for adding inference replicas to a running NIXL + ModelExpress RL job through the inference router.

- adds `router_url` to the shared trainer/orchestrator NIXL configuration
- moves inference-worker discovery and `/init_broadcaster` setup to the trainer
- discovers backend admin URLs through the router's `/workers` endpoint
- assigns stable rank ranges to newly discovered inference servers
- updates ModelExpress participant counts as the inference pool grows
- keeps orchestrator pause/update/resume traffic on the router endpoint

## Validated topology

Validated on the H200 E2E Kubernetes cluster with:

- two trainer nodes, 16 trainer ranks, EP=8
- two initial TP=8 inference replicas
- one additional TP=8 inference replica started about 90 seconds later
- Laguna-XS.2, 100-step math run, NIXL + ModelExpress

The third replica registered as unavailable for rollout traffic, joined the next weight update as inference ranks 16–23, became routable after that update, and the job continued with 24 participating inference ranks.

## Stack

- Includes the now-merged strided-view replay prerequisite: https://github.com/PrimeIntellect-ai/prime-rl/pull/3113
- Router companion: https://github.com/PrimeIntellect-ai/router/pull/48
- Kubernetes/FFT companion and runnable example: https://github.com/PrimeIntellect-ai/fft/pull/27
- Full Jannik handoff: https://github.com/PrimeIntellect-ai/fft/blob/exp/router-autoscaling-poc/charts/prime-rl-fft/examples/NIXL_AUTOSCALING_HANDOFF.md
- Builds on merged NIXL + ModelExpress support: https://github.com/PrimeIntellect-ai/prime-rl/pull/3060

## Current PoC limitations

- only homogeneous inference servers are supported; ranks per server are fixed from the initial pool
- scale-up was validated; arbitrary shrink/grow churn and stable-URL pod replacement still need lifecycle work
- rank assignments and membership are process-local and are not restored after trainer/router restart
- a worker failure during an in-flight synchronization remains fail-stop

## Checks

- `ruff format --check` on changed Python files
- `ruff check` on changed Python files
- end-to-end staggered 2×TP8 → 3×TP8 H200 run
