### PR TITLE
feat(kernels): add SM100 NVFP4 grouped GEMM

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -40,10 +40,11 @@ The custom path enables you to set EP, CP, selective activation checkpointing, l
 
 ### Low-precision training
 
-Set `[trainer.model.quantization]` to train dense linears and MoE expert GEMMs in low precision. Two backends are available via the `type` discriminator:
+Set `[trainer.model.quantization]` to train dense linears and MoE expert GEMMs in low precision. Three backends are available via the `type` discriminator:
 
 - `type = "fp8"` — DeepGEMM FP8 blockwise (requires SM90+ / Hopper). Options: `enable_grouped_gemm` (FP8 MoE expert GEMM). Both default on.
 - `type = "mxfp8"` — torchao MXFP8 microscaling (requires SM100+ / Blackwell). Options: `enable_grouped_gemm`, `enable_a2a` (MXFP8 expert-parallel all-to-all), and `recipe` (`mxfp8_rceil` default or `mxfp8_rceil_wgrad_with_hp`).
+- `type = "nvfp4"` — experimental NVFP4 grouped GEMM for gated MoE experts (requires SM100+ / Blackwell). Forward uses E2M1 values with E4M3 1-by-16 block scales and one current FP32 scale per expert; backward remains BF16. Dense linears and stored weights remain BF16.
 
 ```toml
 [trainer.model.quantization]

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -44,7 +44,7 @@ Set `[trainer.model.quantization]` to train dense linears and MoE expert GEMMs i
 
 - `type = "fp8"` — DeepGEMM FP8 blockwise (requires SM90+ / Hopper). Options: `enable_grouped_gemm` (FP8 MoE expert GEMM). Both default on.
 - `type = "mxfp8"` — torchao MXFP8 microscaling (requires SM100+ / Blackwell). Options: `enable_grouped_gemm`, `enable_a2a` (MXFP8 expert-parallel all-to-all), and `recipe` (`mxfp8_rceil` default or `mxfp8_rceil_wgrad_with_hp`).
-- `type = "nvfp4"` — experimental NVFP4 grouped GEMM for gated MoE experts (requires SM100+ / Blackwell). Forward uses E2M1 values with E4M3 1-by-16 block scales and one current FP32 scale per expert; backward remains BF16. Dense linears and stored weights remain BF16.
+- `type = "nvfp4"` — experimental NVFP4 grouped GEMM for gated MoE experts (requires SM100+ / Blackwell). Forward uses E2M1 values with E4M3 1-by-16 block scales, a current FP32 scale per token for activations, and a current FP32 scale per expert for weights. `backward` accepts `bf16_dequantized` (default; reconstruct BF16 operands from the forward's saved NVFP4 tensors) or `bf16` (retain the original BF16 operands). Dense linears and stored weights remain BF16.
 
 ```toml
 [trainer.model.quantization]

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -144,7 +144,12 @@ class MXFP8Config(BaseConfig):
     ignore_patterns: list[str] = _DEFAULT_FP8_IGNORE_PATTERNS
 
 
-QuantizationConfig: TypeAlias = Annotated[FP8Config | MXFP8Config, Field(discriminator="type")]
+class NVFP4Config(BaseConfig):
+    type: Literal["nvfp4"] = "nvfp4"
+    """Use experimental NVFP4 for routed-expert grouped GEMMs on Blackwell."""
+
+
+QuantizationConfig: TypeAlias = Annotated[FP8Config | MXFP8Config | NVFP4Config, Field(discriminator="type")]
 
 
 class ModelConfig(BaseModelConfig):
@@ -289,6 +294,12 @@ class ModelConfig(BaseModelConfig):
     def quantization_only_with_custom_impl(self):
         if self.quantization is not None and self.impl not in ("custom", "auto"):
             raise ValueError(f"{self.quantization.type} training is only supported with model.impl='custom' or 'auto'.")
+        return self
+
+    @model_validator(mode="after")
+    def nvfp4_requires_grouped_mm(self):
+        if isinstance(self.quantization, NVFP4Config) and not self.moe_use_grouped_mm:
+            raise ValueError("NVFP4 quantization requires model.moe_use_grouped_mm=true.")
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -112,6 +112,7 @@ class DebugModelConfig(BaseConfig):
 
 
 MXFP8Recipe: TypeAlias = Literal["mxfp8_rceil", "mxfp8_rceil_wgrad_with_hp"]
+NVFP4Backward: TypeAlias = Literal["bf16", "bf16_dequantized"]
 
 _DEFAULT_FP8_IGNORE_PATTERNS: list[str] = [
     "lm_head",
@@ -147,6 +148,9 @@ class MXFP8Config(BaseConfig):
 class NVFP4Config(BaseConfig):
     type: Literal["nvfp4"] = "nvfp4"
     """Use experimental NVFP4 for routed-expert grouped GEMMs on Blackwell."""
+
+    backward: NVFP4Backward = "bf16_dequantized"
+    """Backward recipe. ``bf16`` retains the original operands; ``bf16_dequantized`` reconstructs BF16 operands from the forward's saved NVFP4 tensors."""
 
 
 QuantizationConfig: TypeAlias = Annotated[FP8Config | MXFP8Config | NVFP4Config, Field(discriminator="type")]

--- a/packages/prime-rl-kernels/README.md
+++ b/packages/prime-rl-kernels/README.md
@@ -1,0 +1,86 @@
+# prime-rl-kernels
+
+Standalone GPU kernels used by `prime-rl`.
+
+The initial proof of concept provides grouped NVFP4 matrix multiplication for
+Blackwell GPUs without a Transformer Engine dependency. It combines a Triton
+NVFP4 packer with PyTorch's native grouped scaled-matmul backend and uses BF16
+grouped matmuls for the straight-through backward pass.
+
+## Requirements
+
+- NVIDIA Blackwell (SM100 or newer)
+- CUDA 12.8 or newer
+- PyTorch 2.11 or newer built with NVFP4 grouped-matmul support
+
+## API
+
+```python
+from prime_rl_kernels import grouped_nvfp4_mm
+
+# x:       [total_tokens, in_features], BF16
+# weight:  [num_experts, in_features, out_features], BF16
+# offsets: cumulative token counts, one INT32 value per expert
+output = grouped_nvfp4_mm(x, weight, offsets)
+```
+
+`quantize_nvfp4_activations`, `quantize_nvfp4_weights`, and
+`grouped_nvfp4_mm_quantized` expose the lower-level path for callers that want
+to manage packed-weight caching.
+
+This PoC implements NVFP4 two-level scaling: E2M1 values, E4M3 scales over
+16-value blocks, and one FP32 global scale per expert. This is deliberately not
+yet the same recipe as vLLM's `nvfp4_per_token`, which uses one activation
+global scale per token and jointly quantizes the gate/up projection. The block
+scales are emitted directly in the native 128-by-4 swizzled layout. Ragged and
+empty groups are supported, as is TorchTitan's physically padded token buffer.
+
+## prime-rl integration
+
+Set the trainer model's quantization discriminator to `nvfp4`:
+
+```toml
+[trainer.model.quantization]
+type = "nvfp4"
+```
+
+The integration selects this path for `GroupedExperts` while leaving dense
+linears, BF16 master parameters, checkpoints, optimizer state, and weight
+transfer unchanged. Torch expert parallelism dispatches local packed tokens to
+the same grouped kernel; the DeepEP local-expert path uses the same adapter.
+
+## GB200 snapshot
+
+The following medians were measured with 32 groups, `K=2048`, `N=768`, PyTorch
+2.11, and warm caches. They measure the native grouped GEMM independently from
+packing, then show both cached-weight and repack-both paths.
+
+| Tokens per group | BF16 GEMM | NVFP4 prepacked | Activation pack | Cached-weight total | Repack-both total |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 256 | 0.050 ms | 0.060 ms | 0.262 ms | 0.339 ms | 0.667 ms |
+| 1,024 | 0.105 ms | 0.067 ms | 0.297 ms | 0.364 ms | 0.653 ms |
+| 2,048 | 0.183 ms | 0.077 ms | 0.567 ms | 0.639 ms | 0.883 ms |
+
+The prepacked kernel becomes faster than BF16 as groups get larger, but this
+PoC is not yet an end-to-end training speedup: dynamic activation packing is
+the bottleneck, and the prime-rl adapter currently repacks weights on every
+call. Reproduce a shape with:
+
+```bash
+uv run python benchmarks/benchmark_grouped_nvfp4.py \
+  --groups 32 --tokens-per-group 1024 --in-features 2048 --out-features 768
+```
+
+## Current scope
+
+- Forward: NVFP4 grouped GEMM; backward: BF16 grouped dgrad and wgrad.
+- Current per-expert amax scaling, not vLLM's per-token activation global
+  scaling. A future cuDNN-backed row-scale recipe can fit behind the same API.
+- No 4-over-6 recipe, dense-linear conversion, quantized checkpoint format, or
+  LoRA-specific support.
+- Packed-weight caching is exposed by the low-level API but is not yet wired to
+  training-safe invalidation after optimizer steps.
+- `torch.compile(fullgraph=False)` is supported through an intentional graph
+  break around the custom operation. Full-graph capture is not yet supported.
+- Only rows before the final logical offset have defined output. TorchTitan's
+  physical padding rows are discarded by expert-parallel combine.

--- a/packages/prime-rl-kernels/README.md
+++ b/packages/prime-rl-kernels/README.md
@@ -2,38 +2,61 @@
 
 Standalone GPU kernels used by `prime-rl`.
 
-The initial proof of concept provides grouped NVFP4 matrix multiplication for
-Blackwell GPUs without a Transformer Engine dependency. It combines a Triton
-NVFP4 packer with PyTorch's native grouped scaled-matmul backend and uses BF16
-grouped matmuls for the straight-through backward pass.
+The NVFP4 implementation owns its grouped GEMM under
+`prime_rl_kernels/nvfp4/grouped_gemm`. The SM100 CUTLASS kernel is adapted from
+MSLK, but it is compiled and loaded directly by `prime-rl-kernels`; Transformer
+Engine and MSLK are not runtime dependencies. The published NVIDIA CUTLASS
+headers are supplied by the `nvidia-cutlass` Python package.
 
 ## Requirements
 
-- NVIDIA Blackwell (SM100 or newer)
+- NVIDIA GB200/B200 (SM100)
 - CUDA 12.8 or newer
-- PyTorch 2.11 or newer built with NVFP4 grouped-matmul support
+- PyTorch 2.11 or newer with `torch.float4_e2m1fn_x2`
 
 ## API
 
 ```python
-from prime_rl_kernels import grouped_nvfp4_mm
+from prime_rl_kernels.nvfp4.grouped_gemm import grouped_gemm
 
 # x:       [total_tokens, in_features], BF16
 # weight:  [num_experts, in_features, out_features], BF16
 # offsets: cumulative token counts, one INT32 value per expert
-output = grouped_nvfp4_mm(x, weight, offsets)
+output = grouped_gemm(x, weight, offsets)
 ```
 
-`quantize_nvfp4_activations`, `quantize_nvfp4_weights`, and
-`grouped_nvfp4_mm_quantized` expose the lower-level path for callers that want
-to manage packed-weight caching.
+This is the only public kernel API. Every call derives the scales from the
+current BF16 tensors, quantizes both operands, and runs the grouped GEMM.
 
-This PoC implements NVFP4 two-level scaling: E2M1 values, E4M3 scales over
-16-value blocks, and one FP32 global scale per expert. This is deliberately not
-yet the same recipe as vLLM's `nvfp4_per_token`, which uses one activation
-global scale per token and jointly quantizes the gate/up projection. The block
-scales are emitted directly in the native 128-by-4 swizzled layout. Ragged and
-empty groups are supported, as is TorchTitan's physically padded token buffer.
+## Quantization contract
+
+- E2M1 values with one E4M3 block scale per 16 values.
+- One FP32 decode scale per activation token:
+  `token_amax / (6 * 448)`.
+- One FP32 decode scale per expert weight tensor:
+  `expert_amax / (6 * 448)`.
+- Block scales remain true group-16 scales and are stored in the native
+  128-by-4 tensor-core layout.
+- Gate and up projections are currently quantized separately.
+- Forward uses the owned SM100 grouped kernel. Backward is BF16 grouped dgrad
+  and wgrad over the original BF16 tensors.
+
+This is the same two-level per-token/per-expert NVFP4 recipe used by the online
+vLLM path. It intentionally does not implement a 4-over-6 recipe.
+
+## Compilation cache
+
+The extension is compiled lazily the first time the grouped GEMM is called.
+It contains only the dispatcher and two SM100 tile specializations. Point
+`TORCH_EXTENSIONS_DIR` at persistent storage to reuse the resulting shared
+object across jobs:
+
+```bash
+export TORCH_EXTENSIONS_DIR=/persistent/cache/prime-rl-kernels/torch-extensions
+```
+
+PyTorch's extension lock allows distributed ranks sharing that directory to
+wait on one build instead of compiling the same sources independently.
 
 ## prime-rl integration
 
@@ -44,27 +67,13 @@ Set the trainer model's quantization discriminator to `nvfp4`:
 type = "nvfp4"
 ```
 
-The integration selects this path for `GroupedExperts` while leaving dense
-linears, BF16 master parameters, checkpoints, optimizer state, and weight
-transfer unchanged. Torch expert parallelism dispatches local packed tokens to
-the same grouped kernel; the DeepEP local-expert path uses the same adapter.
+The integration selects this path for `GroupedExperts` while leaving BF16
+master parameters, checkpoints, optimizer state, dense linears, and weight
+transfer unchanged. Weights are re-quantized from the current BF16 parameters
+on every forward invocation, including activation-checkpoint recomputation.
+Torch expert parallelism and the DeepEP local-expert path use the same adapter.
 
-## GB200 snapshot
-
-The following medians were measured with 32 groups, `K=2048`, `N=768`, PyTorch
-2.11, and warm caches. They measure the native grouped GEMM independently from
-packing, then show both cached-weight and repack-both paths.
-
-| Tokens per group | BF16 GEMM | NVFP4 prepacked | Activation pack | Cached-weight total | Repack-both total |
-| ---: | ---: | ---: | ---: | ---: | ---: |
-| 256 | 0.050 ms | 0.060 ms | 0.262 ms | 0.339 ms | 0.667 ms |
-| 1,024 | 0.105 ms | 0.067 ms | 0.297 ms | 0.364 ms | 0.653 ms |
-| 2,048 | 0.183 ms | 0.077 ms | 0.567 ms | 0.639 ms | 0.883 ms |
-
-The prepacked kernel becomes faster than BF16 as groups get larger, but this
-PoC is not yet an end-to-end training speedup: dynamic activation packing is
-the bottleneck, and the prime-rl adapter currently repacks weights on every
-call. Reproduce a shape with:
+## Benchmark
 
 ```bash
 uv run python benchmarks/benchmark_grouped_nvfp4.py \
@@ -73,14 +82,11 @@ uv run python benchmarks/benchmark_grouped_nvfp4.py \
 
 ## Current scope
 
-- Forward: NVFP4 grouped GEMM; backward: BF16 grouped dgrad and wgrad.
-- Current per-expert amax scaling, not vLLM's per-token activation global
-  scaling. A future cuDNN-backed row-scale recipe can fit behind the same API.
-- No 4-over-6 recipe, dense-linear conversion, quantized checkpoint format, or
-  LoRA-specific support.
-- Packed-weight caching is exposed by the low-level API but is not yet wired to
-  training-safe invalidation after optimizer steps.
+- SM100 routed experts only.
+- Separate gate/up GEMMs; no fused gate/up weight quantization yet.
 - `torch.compile(fullgraph=False)` is supported through an intentional graph
   break around the custom operation. Full-graph capture is not yet supported.
 - Only rows before the final logical offset have defined output. TorchTitan's
   physical padding rows are discarded by expert-parallel combine.
+
+See `nvfp4/grouped_gemm/NOTICE.md` for kernel provenance and licensing.

--- a/packages/prime-rl-kernels/README.md
+++ b/packages/prime-rl-kernels/README.md
@@ -3,10 +3,12 @@
 Standalone GPU kernels used by `prime-rl`.
 
 The NVFP4 implementation owns its grouped GEMM under
-`prime_rl_kernels/nvfp4/grouped_gemm`. The SM100 CUTLASS kernel is adapted from
-MSLK, but it is compiled and loaded directly by `prime-rl-kernels`; Transformer
-Engine and MSLK are not runtime dependencies. The published NVIDIA CUTLASS
-headers are supplied by the `nvidia-cutlass` Python package.
+`prime_rl_kernels/nvfp4/grouped_gemm` and its quantizers under
+`prime_rl_kernels/nvfp4/quantize`. The SM100 CUTLASS kernel is adapted from
+MSLK. The quantizer is an owned CUDA implementation using Blackwell conversion
+instructions adapted from Transformer Engine. Neither project is a runtime
+dependency. The published NVIDIA CUTLASS headers are supplied by the
+`nvidia-cutlass` Python package.
 
 ## Requirements
 
@@ -18,15 +20,21 @@ headers are supplied by the `nvidia-cutlass` Python package.
 
 ```python
 from prime_rl_kernels.nvfp4.grouped_gemm import grouped_gemm
+from prime_rl_kernels.nvfp4.quantize import quantize_activations, quantize_weights
 
 # x:       [total_tokens, in_features], BF16
 # weight:  [num_experts, in_features, out_features], BF16
 # offsets: cumulative token counts, one INT32 value per expert
-output = grouped_gemm(x, weight, offsets)
+output = grouped_gemm(x, weight, offsets, backward="bf16_dequantized")
+
+# Standalone quantization returns packed E2M1 data, tcgen05-swizzled E4M3
+# block scales, and FP32 decode scales.
+x_nvfp4 = quantize_activations(x, offsets)
+weight_nvfp4 = quantize_weights(weight)
 ```
 
-This is the only public kernel API. Every call derives the scales from the
-current BF16 tensors, quantizes both operands, and runs the grouped GEMM.
+Every grouped GEMM call derives the scales from the current BF16 tensors,
+quantizes both operands, and runs the grouped GEMM.
 
 ## Quantization contract
 
@@ -38,18 +46,19 @@ current BF16 tensors, quantizes both operands, and runs the grouped GEMM.
 - Block scales remain true group-16 scales and are stored in the native
   128-by-4 tensor-core layout.
 - Gate and up projections are currently quantized separately.
-- Forward uses the owned SM100 grouped kernel. Backward is BF16 grouped dgrad
-  and wgrad over the original BF16 tensors.
+- Forward uses the owned SM100 grouped kernel. ``backward="bf16_dequantized"``
+  (the default) saves the exact packed forward operands and dequantizes them
+  for BF16 dgrad and wgrad. ``backward="bf16"`` instead retains and uses the
+  original BF16 operands.
 
 This is the same two-level per-token/per-expert NVFP4 recipe used by the online
 vLLM path. It intentionally does not implement a 4-over-6 recipe.
 
 ## Compilation cache
 
-The extension is compiled lazily the first time the grouped GEMM is called.
-It contains only the dispatcher and two SM100 tile specializations. Point
-`TORCH_EXTENSIONS_DIR` at persistent storage to reuse the resulting shared
-object across jobs:
+The quantization and grouped-GEMM extensions are compiled lazily on first use.
+Point `TORCH_EXTENSIONS_DIR` at persistent storage to reuse the resulting
+shared objects across jobs:
 
 ```bash
 export TORCH_EXTENSIONS_DIR=/persistent/cache/prime-rl-kernels/torch-extensions
@@ -65,6 +74,7 @@ Set the trainer model's quantization discriminator to `nvfp4`:
 ```toml
 [trainer.model.quantization]
 type = "nvfp4"
+backward = "bf16_dequantized"
 ```
 
 The integration selects this path for `GroupedExperts` while leaving BF16
@@ -72,12 +82,18 @@ master parameters, checkpoints, optimizer state, dense linears, and weight
 transfer unchanged. Weights are re-quantized from the current BF16 parameters
 on every forward invocation, including activation-checkpoint recomputation.
 Torch expert parallelism and the DeepEP local-expert path use the same adapter.
+The other supported recipe, `backward = "bf16"`, retains the original BF16
+operands for dgrad and wgrad.
 
 ## Benchmark
 
 ```bash
 uv run python benchmarks/benchmark_grouped_nvfp4.py \
   --groups 32 --tokens-per-group 1024 --in-features 2048 --out-features 768
+
+uv run python benchmarks/benchmark_nvfp4_quantize.py \
+  --kind weight --groups 32 --in-features 6144 --out-features 3072 \
+  --minimum-bandwidth 6
 ```
 
 ## Current scope
@@ -89,4 +105,5 @@ uv run python benchmarks/benchmark_grouped_nvfp4.py \
 - Only rows before the final logical offset have defined output. TorchTitan's
   physical padding rows are discarded by expert-parallel combine.
 
-See `nvfp4/grouped_gemm/NOTICE.md` for kernel provenance and licensing.
+The repository is Apache-2.0 licensed; the grouped kernel retains its MSLK
+license alongside the source.

--- a/packages/prime-rl-kernels/benchmarks/benchmark_grouped_nvfp4.py
+++ b/packages/prime-rl-kernels/benchmarks/benchmark_grouped_nvfp4.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+import torch
+import torch.nn.functional as F
+from prime_rl_kernels import (
+    grouped_nvfp4_mm,
+    grouped_nvfp4_mm_quantized,
+    quantize_nvfp4_activations,
+    quantize_nvfp4_weights,
+)
+from triton.testing import do_bench
+
+
+def _benchmark(operation: Callable[[], object], *, warmup: int, repetitions: int) -> float:
+    operation()
+    torch.cuda.synchronize()
+    return float(do_bench(operation, warmup=warmup, rep=repetitions))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark grouped NVFP4 GEMM on Blackwell")
+    parser.add_argument("--groups", type=int, default=32)
+    parser.add_argument("--tokens-per-group", type=int, default=256)
+    parser.add_argument("--in-features", type=int, default=2048)
+    parser.add_argument("--out-features", type=int, default=768)
+    parser.add_argument("--warmup", type=int, default=100)
+    parser.add_argument("--repetitions", type=int, default=300)
+    args = parser.parse_args()
+
+    torch.manual_seed(0)
+    rows = args.groups * args.tokens_per_group
+    matrix = torch.randn(rows, args.in_features, device="cuda", dtype=torch.bfloat16) * 0.1
+    # Prime's parameters are physically [G, N, K]. The grouped-matmul API sees
+    # the cheap transposed [G, K, N] view.
+    weight_storage = (
+        torch.randn(
+            args.groups,
+            args.out_features,
+            args.in_features,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        * 0.02
+    )
+    weight = weight_storage.transpose(-2, -1)
+    offsets = torch.arange(1, args.groups + 1, device="cuda", dtype=torch.int32) * args.tokens_per_group
+
+    activations_nvfp4 = quantize_nvfp4_activations(matrix, offsets)
+    weight_nvfp4 = quantize_nvfp4_weights(weight)
+    operations = {
+        "bf16": lambda: F.grouped_mm(
+            matrix,
+            weight,
+            offs=offsets,
+            out_dtype=torch.bfloat16,
+        ),
+        "activation_quantize": lambda: quantize_nvfp4_activations(matrix, offsets),
+        "weight_quantize": lambda: quantize_nvfp4_weights(weight),
+        "nvfp4_prepacked": lambda: grouped_nvfp4_mm_quantized(
+            activations_nvfp4,
+            weight_nvfp4,
+            offsets,
+        ),
+        "nvfp4_cached_weight": lambda: grouped_nvfp4_mm_quantized(
+            quantize_nvfp4_activations(matrix, offsets),
+            weight_nvfp4,
+            offsets,
+        ),
+        "nvfp4_repack_both": lambda: grouped_nvfp4_mm(matrix, weight, offsets),
+    }
+
+    flop = 2 * rows * args.in_features * args.out_features
+    print(
+        f"shape: G={args.groups}, M={rows}, K={args.in_features}, "
+        f"N={args.out_features}, tokens/group={args.tokens_per_group}"
+    )
+    for name, operation in operations.items():
+        milliseconds = _benchmark(
+            operation,
+            warmup=args.warmup,
+            repetitions=args.repetitions,
+        )
+        tflops = flop / (milliseconds * 1e9) if name in {"bf16", "nvfp4_prepacked"} else None
+        suffix = "" if tflops is None else f", {tflops:.1f} TFLOP/s"
+        print(f"{name:>21}: {milliseconds:.4f} ms{suffix}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/prime-rl-kernels/benchmarks/benchmark_grouped_nvfp4.py
+++ b/packages/prime-rl-kernels/benchmarks/benchmark_grouped_nvfp4.py
@@ -5,12 +5,7 @@ from collections.abc import Callable
 
 import torch
 import torch.nn.functional as F
-from prime_rl_kernels import (
-    grouped_nvfp4_mm,
-    grouped_nvfp4_mm_quantized,
-    quantize_nvfp4_activations,
-    quantize_nvfp4_weights,
-)
+from prime_rl_kernels import grouped_gemm
 from triton.testing import do_bench
 
 
@@ -48,8 +43,6 @@ def main() -> None:
     weight = weight_storage.transpose(-2, -1)
     offsets = torch.arange(1, args.groups + 1, device="cuda", dtype=torch.int32) * args.tokens_per_group
 
-    activations_nvfp4 = quantize_nvfp4_activations(matrix, offsets)
-    weight_nvfp4 = quantize_nvfp4_weights(weight)
     operations = {
         "bf16": lambda: F.grouped_mm(
             matrix,
@@ -57,19 +50,7 @@ def main() -> None:
             offs=offsets,
             out_dtype=torch.bfloat16,
         ),
-        "activation_quantize": lambda: quantize_nvfp4_activations(matrix, offsets),
-        "weight_quantize": lambda: quantize_nvfp4_weights(weight),
-        "nvfp4_prepacked": lambda: grouped_nvfp4_mm_quantized(
-            activations_nvfp4,
-            weight_nvfp4,
-            offsets,
-        ),
-        "nvfp4_cached_weight": lambda: grouped_nvfp4_mm_quantized(
-            quantize_nvfp4_activations(matrix, offsets),
-            weight_nvfp4,
-            offsets,
-        ),
-        "nvfp4_repack_both": lambda: grouped_nvfp4_mm(matrix, weight, offsets),
+        "nvfp4": lambda: grouped_gemm(matrix, weight, offsets),
     }
 
     flop = 2 * rows * args.in_features * args.out_features
@@ -83,9 +64,8 @@ def main() -> None:
             warmup=args.warmup,
             repetitions=args.repetitions,
         )
-        tflops = flop / (milliseconds * 1e9) if name in {"bf16", "nvfp4_prepacked"} else None
-        suffix = "" if tflops is None else f", {tflops:.1f} TFLOP/s"
-        print(f"{name:>21}: {milliseconds:.4f} ms{suffix}")
+        tflops = flop / (milliseconds * 1e9)
+        print(f"{name:>21}: {milliseconds:.4f} ms, {tflops:.1f} TFLOP/s")
 
 
 if __name__ == "__main__":

--- a/packages/prime-rl-kernels/benchmarks/benchmark_grouped_nvfp4.py
+++ b/packages/prime-rl-kernels/benchmarks/benchmark_grouped_nvfp4.py
@@ -6,13 +6,20 @@ from collections.abc import Callable
 import torch
 import torch.nn.functional as F
 from prime_rl_kernels import grouped_gemm
-from triton.testing import do_bench
 
 
 def _benchmark(operation: Callable[[], object], *, warmup: int, repetitions: int) -> float:
-    operation()
+    for _ in range(warmup):
+        operation()
     torch.cuda.synchronize()
-    return float(do_bench(operation, warmup=warmup, rep=repetitions))
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(repetitions):
+        operation()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) / repetitions
 
 
 def main() -> None:

--- a/packages/prime-rl-kernels/benchmarks/benchmark_nvfp4_quantize.py
+++ b/packages/prime-rl-kernels/benchmarks/benchmark_nvfp4_quantize.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+import torch
+from prime_rl_kernels.nvfp4.quantize import quantize_activations, quantize_weights
+
+
+def _benchmark(operation: Callable[[], object], warmup: int, repetitions: int) -> float:
+    for _ in range(warmup):
+        operation()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(repetitions):
+        operation()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) / repetitions
+
+
+def _report(name: str, milliseconds: float, transferred_bytes: float) -> float:
+    terabytes_per_second = transferred_bytes / milliseconds / 1e9
+    print(f"{name:>12}: {milliseconds:.4f} ms, {terabytes_per_second:.2f} TB/s")
+    return terabytes_per_second
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark SM100 NVFP4 quantization")
+    parser.add_argument("--kind", choices=("activation", "weight"), default="weight")
+    parser.add_argument("--groups", type=int, default=32)
+    parser.add_argument("--rows", type=int, default=43_648)
+    parser.add_argument("--in-features", type=int, default=6144)
+    parser.add_argument("--out-features", type=int, default=3072)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--repetitions", type=int, default=50)
+    parser.add_argument("--minimum-bandwidth", type=float)
+    args = parser.parse_args()
+
+    torch.manual_seed(0)
+    if args.kind == "activation":
+        source = torch.randn(
+            args.rows,
+            args.in_features,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        offsets = torch.tensor([args.rows], device="cuda", dtype=torch.int32)
+        quantize = lambda: quantize_activations(source, offsets)
+        quantized = quantize()
+        elements = source.numel()
+        metadata_bytes = args.rows * 4
+    else:
+        storage = torch.randn(
+            args.groups,
+            args.out_features,
+            args.in_features,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        weight = storage.transpose(-2, -1)
+        quantize = lambda: quantize_weights(weight)
+        quantized = quantize()
+        elements = weight.numel()
+        metadata_bytes = args.groups * 4
+
+    # Quantization reads BF16 twice (global amax and block quantization), then
+    # writes packed FP4 and one E4M3 scale per 16 values.
+    quantize_bytes = elements * (4 + 0.5 + 1 / 16) + metadata_bytes
+    # Dequantization reads packed FP4 and scales and writes BF16.
+    dequantize_bytes = elements * (0.5 + 1 / 16 + 2) + metadata_bytes
+    quantize_ms = _benchmark(quantize, args.warmup, args.repetitions)
+    dequantize_ms = _benchmark(
+        quantized.dequantize,
+        args.warmup,
+        args.repetitions,
+    )
+
+    print(f"{args.kind}: G={args.groups}, M={args.rows}, K={args.in_features}, N={args.out_features}")
+    quantize_bandwidth = _report("quantize", quantize_ms, quantize_bytes)
+    _report("dequantize", dequantize_ms, dequantize_bytes)
+    if args.minimum_bandwidth is not None and quantize_bandwidth < args.minimum_bandwidth:
+        raise RuntimeError(
+            f"quantization bandwidth {quantize_bandwidth:.2f} TB/s is below {args.minimum_bandwidth:.2f} TB/s"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/prime-rl-kernels/pyproject.toml
+++ b/packages/prime-rl-kernels/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "prime-rl-kernels"
+version = "0.1.0"
+description = "Standalone GPU kernels for prime-rl"
+readme = "README.md"
+requires-python = "~=3.12.0"
+dependencies = [
+    "torch>=2.11.0",
+    "triton>=3.6.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/prime_rl_kernels"]

--- a/packages/prime-rl-kernels/pyproject.toml
+++ b/packages/prime-rl-kernels/pyproject.toml
@@ -5,6 +5,7 @@ description = "Standalone GPU kernels for prime-rl"
 readme = "README.md"
 requires-python = "~=3.12.0"
 dependencies = [
+    "nvidia-cutlass==4.2.0.0",
     "torch>=2.11.0",
     "triton>=3.6.0",
 ]

--- a/packages/prime-rl-kernels/pyproject.toml
+++ b/packages/prime-rl-kernels/pyproject.toml
@@ -7,7 +7,6 @@ requires-python = "~=3.12.0"
 dependencies = [
     "nvidia-cutlass==4.2.0.0",
     "torch>=2.11.0",
-    "triton>=3.6.0",
 ]
 
 [build-system]

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/__init__.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/__init__.py
@@ -1,0 +1,15 @@
+from prime_rl_kernels.nvfp4 import (
+    NVFP4GroupedTensor,
+    grouped_nvfp4_mm,
+    grouped_nvfp4_mm_quantized,
+    quantize_nvfp4_activations,
+    quantize_nvfp4_weights,
+)
+
+__all__ = [
+    "NVFP4GroupedTensor",
+    "grouped_nvfp4_mm",
+    "grouped_nvfp4_mm_quantized",
+    "quantize_nvfp4_activations",
+    "quantize_nvfp4_weights",
+]

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/__init__.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/__init__.py
@@ -1,15 +1,3 @@
-from prime_rl_kernels.nvfp4 import (
-    NVFP4GroupedTensor,
-    grouped_nvfp4_mm,
-    grouped_nvfp4_mm_quantized,
-    quantize_nvfp4_activations,
-    quantize_nvfp4_weights,
-)
+from prime_rl_kernels.nvfp4 import grouped_gemm
 
-__all__ = [
-    "NVFP4GroupedTensor",
-    "grouped_nvfp4_mm",
-    "grouped_nvfp4_mm_quantized",
-    "quantize_nvfp4_activations",
-    "quantize_nvfp4_weights",
-]
+__all__ = ["grouped_gemm"]

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4.py
@@ -1,0 +1,445 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+_FP4_MAX = 6.0
+_FP8_MAX = 448.0
+_GLOBAL_SCALE_DENOMINATOR = _FP4_MAX * _FP8_MAX
+_NVFP4_BLOCK_SIZE = 16
+_SCALE_ROW_TILE = 128
+_SCALE_COL_TILE = 4
+_QUANT_BLOCK_K = 256
+_AMAX_BLOCK_K = 1024
+_METADATA_BLOCK_M = 256
+
+
+@dataclass(frozen=True)
+class NVFP4GroupedTensor:
+    """Packed NVFP4 values and their two levels of decode scales."""
+
+    data: torch.Tensor
+    block_scales: torch.Tensor
+    global_scales: torch.Tensor
+
+
+@triton.jit
+def _build_activation_metadata_kernel(
+    offsets_ptr,
+    row_groups_ptr,
+    scale_rows_ptr,
+    ROWS: tl.constexpr,
+    GROUP_COUNT: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    rows = tl.program_id(axis=0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    valid_rows = rows < ROWS
+
+    selected_group = tl.zeros((BLOCK_M,), dtype=tl.int32)
+    selected_start = tl.zeros((BLOCK_M,), dtype=tl.int32)
+    selected_padded_start = tl.zeros((BLOCK_M,), dtype=tl.int32)
+    group_start = 0
+    padded_start = 0
+    for group_index in range(GROUP_COUNT):
+        group_end = tl.load(offsets_ptr + group_index)
+        belongs_to_or_follows_group = rows >= group_start
+        selected_group = tl.where(belongs_to_or_follows_group, group_index, selected_group)
+        selected_start = tl.where(belongs_to_or_follows_group, group_start, selected_start)
+        selected_padded_start = tl.where(
+            belongs_to_or_follows_group,
+            padded_start,
+            selected_padded_start,
+        )
+        group_size = group_end - group_start
+        padded_start += tl.where(group_size > 0, (group_size + 127) // 128 * 128, 0)
+        group_start = group_end
+
+    tl.store(row_groups_ptr + rows, selected_group, mask=valid_rows)
+    tl.store(
+        scale_rows_ptr + rows,
+        rows - selected_start + selected_padded_start,
+        mask=valid_rows,
+    )
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return (value + multiple - 1) // multiple * multiple
+
+
+def _check_blackwell() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("NVFP4 grouped GEMM requires CUDA")
+    capability = torch.cuda.get_device_capability()
+    if capability < (10, 0):
+        raise RuntimeError(
+            f"NVFP4 grouped GEMM requires SM100 or newer, but the current device is SM{capability[0]}{capability[1]}"
+        )
+    if not hasattr(torch, "float4_e2m1fn_x2") or not hasattr(F, "scaled_grouped_mm"):
+        raise RuntimeError("NVFP4 grouped GEMM requires PyTorch 2.11 or newer with scaled_grouped_mm support")
+
+
+def _check_matrix(matrix: torch.Tensor, name: str) -> None:
+    if matrix.device.type != "cuda":
+        raise ValueError(f"{name} must be a CUDA tensor")
+    if matrix.dtype != torch.bfloat16:
+        raise ValueError(f"{name} must have dtype torch.bfloat16")
+    if matrix.shape[-1] % _NVFP4_BLOCK_SIZE != 0:
+        raise ValueError(f"{name}'s contraction dimension must be divisible by {_NVFP4_BLOCK_SIZE}")
+
+
+@triton.jit
+def _quantize_nvfp4_rows_kernel(
+    input_ptr,
+    output_ptr,
+    scale_ptr,
+    global_scale_ptr,
+    row_group_ptr,
+    scale_row_ptr,
+    stride_input_row,
+    stride_input_col,
+    K: tl.constexpr,
+    SCALE_COLS: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(axis=0)
+    k_block = tl.program_id(axis=1)
+    columns = k_block * BLOCK_K + tl.arange(0, BLOCK_K)
+    valid_columns = columns < K
+
+    values = tl.load(
+        input_ptr + row * stride_input_row + columns * stride_input_col,
+        mask=valid_columns,
+        other=0.0,
+    ).to(tl.float32)
+    values_by_scale_block = tl.reshape(values, (BLOCK_K // 16, 16))
+    block_amax = tl.max(tl.abs(values_by_scale_block), axis=1)
+
+    group = tl.load(row_group_ptr + row)
+    global_scale = tl.load(global_scale_ptr + group).to(tl.float32)
+    block_scale = block_amax / (6.0 * global_scale)
+    block_scale = tl.minimum(tl.maximum(block_scale, 0.001953125), 448.0)
+    block_scale_e4m3 = block_scale.to(tl.float8e4nv)
+    rounded_block_scale = block_scale_e4m3.to(tl.float32)
+    expanded_block_scale = tl.reshape(
+        tl.broadcast_to(
+            tl.reshape(rounded_block_scale, (BLOCK_K // 16, 1)),
+            (BLOCK_K // 16, 16),
+        ),
+        (BLOCK_K,),
+    )
+
+    normalized = values / (global_scale * expanded_block_scale)
+    magnitude = tl.abs(normalized)
+
+    # E2M1 positive values are {0, .5, 1, 1.5, 2, 3, 4, 6}. The
+    # alternating comparisons preserve round-to-nearest-even at midpoints.
+    codes = (magnitude > 0.25).to(tl.uint8)
+    codes += (magnitude >= 0.75).to(tl.uint8)
+    codes += (magnitude > 1.25).to(tl.uint8)
+    codes += (magnitude >= 1.75).to(tl.uint8)
+    codes += (magnitude > 2.5).to(tl.uint8)
+    codes += (magnitude >= 3.5).to(tl.uint8)
+    codes += (magnitude > 5.0).to(tl.uint8)
+    codes |= (normalized < 0).to(tl.uint8) << 3
+
+    code_pairs = tl.reshape(codes, (BLOCK_K // 2, 2))
+    low_codes, high_codes = tl.split(code_pairs)
+    packed = low_codes | (high_codes << 4)
+    packed_columns = k_block * (BLOCK_K // 2) + tl.arange(0, BLOCK_K // 2)
+    tl.store(
+        output_ptr + row * (K // 2) + packed_columns,
+        packed,
+        mask=packed_columns < K // 2,
+    )
+
+    scale_columns = k_block * (BLOCK_K // 16) + tl.arange(0, BLOCK_K // 16)
+    scale_row = tl.load(scale_row_ptr + row)
+    scale_row_in_tile = scale_row % 128
+    swizzled_scale_offsets = (
+        ((scale_row // 128) * (SCALE_COLS // 4) + scale_columns // 4) * 512
+        + (scale_row_in_tile % 32) * 16
+        + (scale_row_in_tile // 32) * 4
+        + scale_columns % 4
+    )
+    tl.store(
+        scale_ptr + swizzled_scale_offsets,
+        block_scale_e4m3,
+        mask=scale_columns < K // 16,
+    )
+
+
+@triton.jit
+def _group_amax_kernel(
+    input_ptr,
+    row_group_ptr,
+    active_rows_ptr,
+    output_ptr,
+    stride_input_row,
+    stride_input_col,
+    K: tl.constexpr,
+    HAS_ACTIVE_ROW_LIMIT: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(axis=0)
+    k_block = tl.program_id(axis=1)
+    columns = k_block * BLOCK_K + tl.arange(0, BLOCK_K)
+    values = tl.load(
+        input_ptr + row * stride_input_row + columns * stride_input_col,
+        mask=columns < K,
+        other=0.0,
+    ).to(tl.float32)
+    tile_amax = tl.max(tl.abs(values))
+    group = tl.load(row_group_ptr + row)
+    if HAS_ACTIVE_ROW_LIMIT:
+        active = row < tl.load(active_rows_ptr)
+        tl.atomic_max(output_ptr + group, tile_amax, mask=active)
+    else:
+        tl.atomic_max(output_ptr + group, tile_amax)
+
+
+def _compute_global_scales(
+    matrix: torch.Tensor,
+    row_groups: torch.Tensor,
+    group_count: int,
+    active_rows: torch.Tensor | None = None,
+) -> torch.Tensor:
+    group_amax = torch.zeros(group_count, device=matrix.device, dtype=torch.float32)
+    if matrix.shape[0] > 0:
+        active_rows_ptr = row_groups if active_rows is None else active_rows
+        grid = (matrix.shape[0], triton.cdiv(matrix.shape[1], _AMAX_BLOCK_K))
+        _group_amax_kernel[grid](
+            matrix,
+            row_groups,
+            active_rows_ptr,
+            group_amax,
+            matrix.stride(0),
+            matrix.stride(1),
+            K=matrix.shape[1],
+            HAS_ACTIVE_ROW_LIMIT=active_rows is not None,
+            BLOCK_K=_AMAX_BLOCK_K,
+            num_warps=4,
+        )
+    return torch.where(
+        group_amax > 0,
+        group_amax / _GLOBAL_SCALE_DENOMINATOR,
+        torch.ones_like(group_amax),
+    )
+
+
+def _quantize_rows(
+    matrix: torch.Tensor,
+    global_scales: torch.Tensor,
+    row_groups: torch.Tensor,
+    scale_rows: torch.Tensor,
+    padded_scale_rows: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows, contraction_size = matrix.shape
+    active_rows = row_groups.numel()
+    scale_columns = _round_up(contraction_size // _NVFP4_BLOCK_SIZE, _SCALE_COL_TILE)
+    packed = torch.empty((rows, contraction_size // 2), device=matrix.device, dtype=torch.uint8)
+    scales = torch.ones(
+        (padded_scale_rows, scale_columns),
+        device=matrix.device,
+        dtype=torch.float8_e4m3fn,
+    )
+    if active_rows > 0:
+        grid = (active_rows, triton.cdiv(contraction_size, _QUANT_BLOCK_K))
+        _quantize_nvfp4_rows_kernel[grid](
+            matrix,
+            packed,
+            scales,
+            global_scales,
+            row_groups,
+            scale_rows,
+            matrix.stride(0),
+            matrix.stride(1),
+            K=contraction_size,
+            SCALE_COLS=scale_columns,
+            BLOCK_K=_QUANT_BLOCK_K,
+            num_warps=4,
+        )
+    return packed.view(torch.float4_e2m1fn_x2), scales
+
+
+def quantize_nvfp4_activations(matrix: torch.Tensor, offsets: torch.Tensor) -> NVFP4GroupedTensor:
+    """Quantize a 2D activation matrix independently for each expert group."""
+
+    _check_blackwell()
+    if matrix.ndim != 2:
+        raise ValueError("matrix must be 2D")
+    _check_matrix(matrix, "matrix")
+    if not matrix.is_contiguous():
+        matrix = matrix.contiguous()
+    if offsets.ndim != 1 or offsets.dtype != torch.int32 or offsets.device != matrix.device:
+        raise ValueError("offsets must be a 1D int32 tensor on the same CUDA device as matrix")
+
+    group_count = offsets.numel()
+    if group_count == 0:
+        raise ValueError("offsets must contain at least one group")
+    row_groups = torch.empty(matrix.shape[0], device=matrix.device, dtype=torch.int32)
+    scale_rows = torch.empty_like(row_groups)
+    _build_activation_metadata_kernel[(triton.cdiv(matrix.shape[0], _METADATA_BLOCK_M),)](
+        offsets,
+        row_groups,
+        scale_rows,
+        ROWS=matrix.shape[0],
+        GROUP_COUNT=group_count,
+        BLOCK_M=_METADATA_BLOCK_M,
+        num_warps=4,
+    )
+    global_scales = _compute_global_scales(
+        matrix,
+        row_groups,
+        group_count,
+        active_rows=offsets[-1:],
+    )
+
+    padded_scale_rows = _round_up(
+        matrix.shape[0] + group_count * (_SCALE_ROW_TILE - 1),
+        _SCALE_ROW_TILE,
+    )
+
+    packed, block_scales = _quantize_rows(
+        matrix,
+        global_scales,
+        row_groups,
+        scale_rows,
+        padded_scale_rows,
+    )
+    return NVFP4GroupedTensor(
+        data=packed,
+        block_scales=block_scales,
+        global_scales=global_scales,
+    )
+
+
+def quantize_nvfp4_weights(weight: torch.Tensor) -> NVFP4GroupedTensor:
+    """Quantize grouped right-hand weights with logical shape ``[G, K, N]``."""
+
+    _check_blackwell()
+    if weight.ndim != 3:
+        raise ValueError("weight must be 3D")
+    if weight.device.type != "cuda" or weight.dtype != torch.bfloat16:
+        raise ValueError("weight must be a CUDA bfloat16 tensor")
+
+    groups, contraction_size, output_size = weight.shape
+    if contraction_size % _NVFP4_BLOCK_SIZE != 0:
+        raise ValueError(f"weight's contraction dimension must be divisible by {_NVFP4_BLOCK_SIZE}")
+
+    weight_rows = weight.transpose(-2, -1).contiguous()
+    flat_row_count = groups * output_size
+    flat_rows = torch.arange(flat_row_count, device=weight.device, dtype=torch.int32)
+    row_groups = flat_rows // output_size
+    global_scales = _compute_global_scales(
+        weight_rows.view(flat_row_count, contraction_size),
+        row_groups,
+        groups,
+    )
+    padded_output_size = _round_up(output_size, _SCALE_ROW_TILE)
+    scale_rows = row_groups * padded_output_size + flat_rows % output_size
+    packed, block_scales = _quantize_rows(
+        weight_rows.view(flat_row_count, contraction_size),
+        global_scales,
+        row_groups,
+        scale_rows,
+        groups * padded_output_size,
+    )
+    return NVFP4GroupedTensor(
+        data=packed.view(groups, output_size, contraction_size // 2),
+        block_scales=block_scales.view(groups, -1),
+        global_scales=global_scales,
+    )
+
+
+def grouped_nvfp4_mm_quantized(
+    activations: NVFP4GroupedTensor,
+    weight: NVFP4GroupedTensor,
+    offsets: torch.Tensor,
+) -> torch.Tensor:
+    """Run native grouped NVFP4 GEMM on already-packed inputs."""
+
+    return F.scaled_grouped_mm(
+        activations.data,
+        weight.data.transpose(-2, -1),
+        [activations.block_scales, activations.global_scales],
+        [F.ScalingType.BlockWise1x16, F.ScalingType.TensorWise],
+        [weight.block_scales, weight.global_scales],
+        [F.ScalingType.BlockWise1x16, F.ScalingType.TensorWise],
+        swizzle_a=F.SwizzleType.SWIZZLE_32_4_4,
+        swizzle_b=F.SwizzleType.SWIZZLE_32_4_4,
+        offs=offsets,
+        output_dtype=torch.bfloat16,
+    )
+
+
+def _grouped_nvfp4_mm_forward(
+    matrix: torch.Tensor,
+    weight: torch.Tensor,
+    offsets: torch.Tensor,
+) -> torch.Tensor:
+    activations_nvfp4 = quantize_nvfp4_activations(matrix, offsets)
+    weight_nvfp4 = quantize_nvfp4_weights(weight)
+    return grouped_nvfp4_mm_quantized(activations_nvfp4, weight_nvfp4, offsets)
+
+
+class _GroupedNVFP4MM(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        matrix: torch.Tensor,
+        weight: torch.Tensor,
+        offsets: torch.Tensor,
+    ) -> torch.Tensor:
+        output = _grouped_nvfp4_mm_forward(matrix, weight, offsets)
+        ctx.save_for_backward(matrix, weight, offsets)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        matrix, weight, offsets = ctx.saved_tensors
+        grad_output = grad_output.contiguous().bfloat16()
+
+        grad_matrix = grad_weight = None
+        if ctx.needs_input_grad[0]:
+            grad_matrix = F.grouped_mm(
+                grad_output,
+                weight.transpose(-2, -1),
+                offs=offsets,
+                out_dtype=torch.bfloat16,
+            )
+        if ctx.needs_input_grad[1]:
+            grad_weight = F.grouped_mm(
+                matrix.transpose(0, 1),
+                grad_output,
+                offs=offsets,
+                out_dtype=torch.bfloat16,
+            )
+        return grad_matrix, grad_weight, None
+
+
+@torch.compiler.disable
+def grouped_nvfp4_mm(
+    matrix: torch.Tensor,
+    weight: torch.Tensor,
+    offsets: torch.Tensor,
+) -> torch.Tensor:
+    """Grouped NVFP4 forward with a BF16 straight-through backward.
+
+    ``matrix`` has shape ``[M, K]``, ``weight`` has shape ``[G, K, N]``, and
+    ``offsets`` contains the cumulative row count for each of the ``G`` groups.
+    """
+
+    if matrix.ndim != 2 or weight.ndim != 3:
+        raise ValueError("matrix must be 2D and weight must be 3D")
+    if weight.shape[0] != offsets.numel():
+        raise ValueError("weight and offsets must have the same number of groups")
+    if matrix.shape[1] != weight.shape[1]:
+        raise ValueError("matrix and weight contraction dimensions must match")
+    _check_matrix(matrix, "matrix")
+    if weight.device != matrix.device or weight.dtype != matrix.dtype:
+        raise ValueError("weight must have the same CUDA device and dtype as matrix")
+    return _GroupedNVFP4MM.apply(matrix, weight, offsets)

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/__init__.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/__init__.py
@@ -1,0 +1,3 @@
+from prime_rl_kernels.nvfp4.grouped_gemm import grouped_gemm
+
+__all__ = ["grouped_gemm"]

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/__init__.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/__init__.py
@@ -1,3 +1,18 @@
 from prime_rl_kernels.nvfp4.grouped_gemm import grouped_gemm
 
-__all__ = ["grouped_gemm"]
+
+def prepare_for_compile() -> None:
+    """Load the CUDA operators and register FakeTensor shape implementations."""
+
+    from prime_rl_kernels.nvfp4.grouped_gemm._extension import (
+        _prepare_extension_for_compile as prepare_grouped_gemm,
+    )
+    from prime_rl_kernels.nvfp4.quantize._extension import (
+        _prepare_extension_for_compile as prepare_quantization,
+    )
+
+    prepare_quantization()
+    prepare_grouped_gemm()
+
+
+__all__ = ["grouped_gemm", "prepare_for_compile"]

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/_build.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/_build.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import os
+import platform
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import torch
+from torch.utils.cpp_extension import LIB_EXT, _get_build_directory, load
+
+
+def _content_addressed_name(
+    base_name: str,
+    *,
+    fingerprint_files: Iterable[Path],
+    fingerprint: Iterable[str],
+) -> str:
+    digest = hashlib.sha256()
+    for value in (
+        torch.__version__,
+        torch.version.cuda or "cpu",
+        platform.machine(),
+        f"python-{sys.version_info.major}.{sys.version_info.minor}",
+        *fingerprint,
+    ):
+        digest.update(value.encode())
+        digest.update(b"\0")
+    for path in sorted(path for path in fingerprint_files if path.is_file()):
+        digest.update(path.name.encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return f"{base_name}_{digest.hexdigest()[:16]}"
+
+
+def load_cuda_extension(
+    *,
+    base_name: str,
+    sources: list[Path],
+    fingerprint_files: Iterable[Path],
+    fingerprint: Iterable[str] = (),
+    extra_include_paths: list[Path] | None = None,
+    extra_cflags: list[str] | None = None,
+    extra_cuda_cflags: list[str] | None = None,
+) -> None:
+    """Build once per source/ABI and safely reuse the library across nodes.
+
+    ``torch.utils.cpp_extension.load`` always invokes Ninja. A shared build
+    directory is unsafe across hosts whose system-header mtimes differ: Ninja
+    may rebuild an existing ``.so`` in place while another process has it
+    mapped. Content-addressing prevents stale reuse, and the advisory lock plus
+    ready marker lets every later process load the completed library directly.
+    """
+
+    verbose = os.environ.get("PRIME_RL_KERNELS_BUILD_VERBOSE") == "1"
+    name = _content_addressed_name(
+        base_name,
+        fingerprint_files=fingerprint_files,
+        fingerprint=(
+            *(extra_cflags or ()),
+            *(extra_cuda_cflags or ()),
+            *fingerprint,
+        ),
+    )
+    build_directory = Path(_get_build_directory(name, verbose))
+    library_path = build_directory / f"{name}{LIB_EXT}"
+    ready_path = build_directory / ".prime_rl_ready"
+    lock_path = build_directory / ".prime_rl_build.lock"
+
+    with lock_path.open("a+b") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        if ready_path.is_file() and library_path.is_file():
+            try:
+                torch.ops.load_library(str(library_path))
+                return
+            except (OSError, RuntimeError):
+                ready_path.unlink(missing_ok=True)
+                library_path.unlink(missing_ok=True)
+
+        # A previous builder may have died after linking but before publishing
+        # the ready marker. Removing the library forces Ninja to relink it.
+        if not ready_path.is_file():
+            library_path.unlink(missing_ok=True)
+        # This is Torch's internal baton. No process using the content-addressed
+        # directory can legitimately hold it while we own the outer flock.
+        (build_directory / "lock").unlink(missing_ok=True)
+
+        load(
+            name=name,
+            sources=[str(path) for path in sources],
+            extra_include_paths=[
+                str(path) for path in (extra_include_paths or ())
+            ],
+            extra_cflags=extra_cflags,
+            extra_cuda_cflags=extra_cuda_cflags,
+            with_cuda=True,
+            is_python_module=False,
+            build_directory=str(build_directory),
+            verbose=verbose,
+        )
+        ready_path.write_text("ready\n")

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/MSLK_LICENSE
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/MSLK_LICENSE
@@ -1,0 +1,30 @@
+BSD License
+
+For MSLK software
+
+Copyright (c) Meta Platforms, Inc. and affiliates. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/NOTICE.md
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/NOTICE.md
@@ -1,0 +1,17 @@
+# NVFP4 grouped GEMM provenance
+
+The CUTLASS grouped-GEMM implementation in `csrc/` is adapted from
+[meta-pytorch/MSLK](https://github.com/meta-pytorch/MSLK) commit
+[`e0870cca46356ce9bbb16c26fb0b5ab1f9435445`](https://github.com/meta-pytorch/MSLK/commit/e0870cca46356ce9bbb16c26fb0b5ab1f9435445),
+which added the B200 per-token-scaled FP4 grouped GEMM.
+
+The relevant MSLK source was copied into this package and then changed to:
+
+- use the `prime_rl_kernels::nvfp4` C++ namespace and a private CUTLASS
+  namespace;
+- register a `prime_rl_kernels_nvfp4` PyTorch dispatcher operation;
+- compile only the two SM100 specializations used here;
+- accept per-token activation decode scales and per-expert weight decode
+  scales directly from the prime-rl quantizers.
+
+The adapted files remain under the BSD-style terms in `MSLK_LICENSE`.

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/__init__.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/__init__.py
@@ -1,0 +1,3 @@
+from prime_rl_kernels.nvfp4.grouped_gemm.functional import grouped_gemm
+
+__all__ = ["grouped_gemm"]

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/_extension.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/_extension.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import functools
+import importlib.util
+import os
+from pathlib import Path
+
+import torch
+from torch.utils.cpp_extension import load
+
+_EXTENSION_NAME = "prime_rl_kernels_nvfp4_sm100"
+_SOURCES = (
+    "bindings.cpp",
+    "f4f4bf16_ultra_grouped.cu",
+    "f4f4bf16_ultra_grouped_256_128_256_2_1_1.cu",
+    "f4f4bf16_ultra_grouped_256_256_256_2_1_1.cu",
+)
+
+
+def _cutlass_source_root() -> Path:
+    spec = importlib.util.find_spec("cutlass_library")
+    if spec is None or not spec.submodule_search_locations:
+        raise RuntimeError("prime-rl-kernels NVFP4 grouped GEMM requires the nvidia-cutlass package")
+    source_root = Path(next(iter(spec.submodule_search_locations))) / "source"
+    if not (source_root / "include" / "cutlass" / "cutlass.h").is_file():
+        raise RuntimeError(f"nvidia-cutlass headers were not found under {source_root}")
+    return source_root
+
+
+@functools.cache
+def _load_extension() -> None:
+    source_dir = Path(__file__).with_name("csrc")
+    cutlass_root = _cutlass_source_root()
+    load(
+        name=_EXTENSION_NAME,
+        sources=[str(source_dir / source) for source in _SOURCES],
+        extra_include_paths=[
+            str(source_dir),
+            str(cutlass_root / "include"),
+            str(cutlass_root / "tools" / "util" / "include"),
+        ],
+        extra_cflags=["-O3", "-std=c++17"],
+        extra_cuda_cflags=[
+            "-O3",
+            "-std=c++17",
+            "--expt-relaxed-constexpr",
+            "--expt-extended-lambda",
+            "--threads=4",
+            "-gencode=arch=compute_100a,code=sm_100a",
+        ],
+        with_cuda=True,
+        is_python_module=False,
+        verbose=os.environ.get("PRIME_RL_KERNELS_BUILD_VERBOSE") == "1",
+    )
+
+
+def _grouped_mm(
+    activations: torch.Tensor,
+    weight: torch.Tensor,
+    activation_block_scales: torch.Tensor,
+    weight_block_scales: torch.Tensor,
+    offsets: torch.Tensor,
+    activation_token_scales: torch.Tensor,
+    weight_expert_scales: torch.Tensor,
+) -> torch.Tensor:
+    _load_extension()
+    return torch.ops.prime_rl_kernels_nvfp4.grouped_mm.default(
+        activations,
+        weight,
+        activation_block_scales,
+        weight_block_scales,
+        offsets,
+        activation_token_scales,
+        weight_expert_scales,
+    )

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/_extension.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/_extension.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import functools
 import importlib.util
-import os
 from pathlib import Path
 
 import torch
-from torch.utils.cpp_extension import load
+
+from prime_rl_kernels.nvfp4._build import load_cuda_extension
 
 _EXTENSION_NAME = "prime_rl_kernels_nvfp4_sm100"
 _SOURCES = (
@@ -15,6 +15,29 @@ _SOURCES = (
     "f4f4bf16_ultra_grouped_256_128_256_2_1_1.cu",
     "f4f4bf16_ultra_grouped_256_256_256_2_1_1.cu",
 )
+_EXTENSION_READY = False
+
+
+def _grouped_mm_fake(
+    activations: torch.Tensor,
+    weight: torch.Tensor,
+    activation_block_scales: torch.Tensor,
+    weight_block_scales: torch.Tensor,
+    offsets: torch.Tensor,
+    activation_token_scales: torch.Tensor,
+    weight_expert_scales: torch.Tensor,
+) -> torch.Tensor:
+    del (
+        activation_block_scales,
+        weight_block_scales,
+        offsets,
+        activation_token_scales,
+        weight_expert_scales,
+    )
+    return activations.new_empty(
+        (activations.shape[0], weight.shape[-1]),
+        dtype=torch.bfloat16,
+    )
 
 
 def _cutlass_source_root() -> Path:
@@ -29,28 +52,41 @@ def _cutlass_source_root() -> Path:
 
 @functools.cache
 def _load_extension() -> None:
+    global _EXTENSION_READY
+
     source_dir = Path(__file__).with_name("csrc")
     cutlass_root = _cutlass_source_root()
-    load(
-        name=_EXTENSION_NAME,
-        sources=[str(source_dir / source) for source in _SOURCES],
+    extra_cflags = ["-O3", "-std=c++17"]
+    extra_cuda_cflags = [
+        "-O3",
+        "-std=c++17",
+        "--expt-relaxed-constexpr",
+        "--expt-extended-lambda",
+        "--threads=4",
+        "-gencode=arch=compute_100a,code=sm_100a",
+    ]
+    load_cuda_extension(
+        base_name=_EXTENSION_NAME,
+        sources=[source_dir / source for source in _SOURCES],
+        fingerprint_files=source_dir.glob("*"),
         extra_include_paths=[
-            str(source_dir),
-            str(cutlass_root / "include"),
-            str(cutlass_root / "tools" / "util" / "include"),
+            source_dir,
+            cutlass_root / "include",
+            cutlass_root / "tools" / "util" / "include",
         ],
-        extra_cflags=["-O3", "-std=c++17"],
-        extra_cuda_cflags=[
-            "-O3",
-            "-std=c++17",
-            "--expt-relaxed-constexpr",
-            "--expt-extended-lambda",
-            "--threads=4",
-            "-gencode=arch=compute_100a,code=sm_100a",
-        ],
-        with_cuda=True,
-        is_python_module=False,
-        verbose=os.environ.get("PRIME_RL_KERNELS_BUILD_VERBOSE") == "1",
+        extra_cflags=extra_cflags,
+        extra_cuda_cflags=extra_cuda_cflags,
+        fingerprint=("nvidia-cutlass-4.2.0.0",),
+    )
+    _EXTENSION_READY = True
+
+
+@functools.cache
+def _prepare_extension_for_compile() -> None:
+    _load_extension()
+    torch.library.register_fake(
+        "prime_rl_kernels_nvfp4::grouped_mm",
+        _grouped_mm_fake,
     )
 
 
@@ -63,7 +99,8 @@ def _grouped_mm(
     activation_token_scales: torch.Tensor,
     weight_expert_scales: torch.Tensor,
 ) -> torch.Tensor:
-    _load_extension()
+    if not _EXTENSION_READY:
+        _load_extension()
     return torch.ops.prime_rl_kernels_nvfp4.grouped_mm.default(
         activations,
         weight,

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/bindings.cpp
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/bindings.cpp
@@ -1,0 +1,37 @@
+#include "nvfp4_grouped.h"
+
+#include <torch/library.h>
+
+namespace prime_rl_kernels::nvfp4 {
+
+at::Tensor grouped_mm(
+    const at::Tensor& activations,
+    const at::Tensor& weight,
+    const at::Tensor& activation_block_scales,
+    const at::Tensor& weight_block_scales,
+    const at::Tensor& offsets,
+    const at::Tensor& activation_token_scales,
+    const at::Tensor& weight_expert_scales) {
+  return f4f4bf16_ultra_grouped_mm(
+      activations,
+      weight,
+      activation_block_scales,
+      weight_block_scales,
+      offsets,
+      activation_token_scales,
+      weight_expert_scales);
+}
+
+TORCH_LIBRARY_FRAGMENT(prime_rl_kernels_nvfp4, m) {
+  m.def(
+      "grouped_mm(Tensor activations, Tensor weight, "
+      "Tensor activation_block_scales, Tensor weight_block_scales, "
+      "Tensor offsets, Tensor activation_token_scales, "
+      "Tensor weight_expert_scales) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(prime_rl_kernels_nvfp4, CUDA, m) {
+  m.impl("grouped_mm", grouped_mm);
+}
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped.cu
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped.cu
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in
+ * ../MSLK_LICENSE.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+#include "f4f4bf16_ultra_grouped_manifest.cuh"
+#endif
+
+namespace prime_rl_kernels::nvfp4 {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+namespace {
+
+// Returns the compute capability of the current device as major*10 + minor.
+int get_device_sm_version() {
+  auto* props = at::cuda::getDeviceProperties(at::cuda::current_device());
+  return props->major * 10 + props->minor;
+}
+
+} // namespace
+
+Kernel_f4f4bf16_ultra_grouped
+get_ultra_kernel_via_heuristics(int M, int N, int K) {
+  const int sm = get_device_sm_version();
+  TORCH_CHECK(
+      sm == 100,
+      "prime-rl-kernels NVFP4 grouped GEMM currently requires an sm_100 GPU, "
+      "but the current device is sm_",
+      sm,
+      ".");
+  if (M <= 128) {
+    return f4f4bf16_ultra_grouped_256_128_256_2_1_1;
+  }
+  return f4f4bf16_ultra_grouped_256_256_256_2_1_1;
+}
+
+at::Tensor f4f4bf16_ultra_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    std::optional<at::Tensor> output_maybe) {
+  TORCH_CHECK(XQ.is_cuda(), "XQ must be a CUDA tensor.");
+  c10::cuda::CUDAGuard device_guard(XQ.device());
+  TORCH_CHECK(
+      WQ.device() == XQ.device() && x_scale.device() == XQ.device() &&
+          w_scale.device() == XQ.device() &&
+          offsets.device() == XQ.device() &&
+          x_global_scale.device() == XQ.device() &&
+          w_global_scale.device() == XQ.device(),
+      "all grouped GEMM inputs must be on the same CUDA device.");
+  TORCH_CHECK(offsets.dtype() == at::kInt, "offsets must be int32.");
+  TORCH_CHECK(offsets.dim() == 1, "offsets must be 1D tensor.");
+  TORCH_CHECK(offsets.is_contiguous(), "offsets must be contiguous.");
+  TORCH_CHECK(XQ.is_contiguous(), "XQ must be row major.");
+  TORCH_CHECK(WQ.transpose(-2, -1).is_contiguous(), "WQ must be column major.");
+  TORCH_CHECK(x_scale.is_contiguous(), "x_scale must be contiguous.");
+  TORCH_CHECK(w_scale.is_contiguous(), "w_scale must be contiguous.");
+  TORCH_CHECK(
+      x_global_scale.is_contiguous(),
+      "x_global_scale must be contiguous.");
+  TORCH_CHECK(
+      w_global_scale.is_contiguous(),
+      "w_global_scale must be contiguous.");
+  TORCH_CHECK(XQ.dtype() == at::kFloat4_e2m1fn_x2, "XQ must be FP4.");
+  TORCH_CHECK(WQ.dtype() == at::kFloat4_e2m1fn_x2, "WQ must be FP4.");
+  TORCH_CHECK(
+      x_scale.dtype() == at::kFloat8_e4m3fn, "x_scale must be FP8 e4m3.");
+  TORCH_CHECK(
+      w_scale.dtype() == at::kFloat8_e4m3fn, "w_scale must be FP8 e4m3.");
+  TORCH_CHECK(
+      x_global_scale.dtype() == at::kFloat, "x_global_scale must be float32.");
+  TORCH_CHECK(
+      w_global_scale.dtype() == at::kFloat, "w_global_scale must be float32.");
+  TORCH_CHECK(
+      XQ.dim() == 2 && WQ.dim() == 3,
+      "Only 2D-3D grouped GEMM (MoE forward) is supported.");
+
+  int64_t G = offsets.size(0);
+  int64_t M = XQ.size(0);
+  int64_t N = WQ.size(-1);
+  int64_t K = WQ.size(-2);
+
+  TORCH_CHECK(G > 0, "offsets must contain at least one expert.");
+  TORCH_CHECK(
+      XQ.size(-1) == K && WQ.size(0) == G,
+      "XQ shape must be (total_M, K) and WQ shape must be (G, K, N).");
+  TORCH_CHECK(
+      x_global_scale.dim() == 1 && x_global_scale.size(0) == M,
+      "x_global_scale must have total_M elements.");
+  TORCH_CHECK(
+      w_global_scale.dim() == 1 && w_global_scale.size(0) == G,
+      "w_global_scale must have G elements.");
+  TORCH_CHECK(
+      (K * 2) % 32 == 0,
+      "the unpacked contraction dimension must be divisible by 32.");
+  TORCH_CHECK(N % 8 == 0, "the output dimension must be divisible by 8.");
+
+  const int64_t scale_columns = ((K * 2 / 16 + 3) / 4) * 4;
+  const int64_t padded_output_rows = ((N + 127) / 128) * 128;
+  TORCH_CHECK(
+      x_scale.numel() >= M * scale_columns,
+      "x_scale does not contain enough block scales.");
+  TORCH_CHECK(
+      w_scale.numel() >= G * padded_output_rows * scale_columns,
+      "w_scale does not contain enough block scales.");
+
+  at::Tensor out = output_maybe.has_value()
+      ? output_maybe.value()
+      : at::empty({M, N}, XQ.options().dtype(at::kBFloat16));
+  TORCH_CHECK(
+      out.device() == XQ.device() && out.dtype() == at::kBFloat16 &&
+          out.is_contiguous() && out.dim() == 2 && out.size(0) == M &&
+          out.size(1) == N,
+      "output must be a contiguous BF16 tensor with shape (total_M, N) on "
+      "the input device.");
+
+  if (out.numel() == 0) {
+    return out;
+  }
+
+  int M_per_group = M / G;
+
+  auto kernel = get_ultra_kernel_via_heuristics(M_per_group, N, K * 2);
+
+  return kernel(
+      XQ,
+      WQ.transpose(-2, -1), // Column-major to row-major for CUTLASS.
+      x_scale,
+      w_scale,
+      offsets,
+      x_global_scale,
+      w_global_scale,
+      out);
+}
+
+#else
+
+at::Tensor f4f4bf16_ultra_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    std::optional<at::Tensor> output) {
+  throw std::runtime_error(
+      "f4f4bf16_ultra_grouped_mm requires CUDA 12.8+ and a Blackwell GPU");
+}
+
+#endif
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_256_128_256_2_1_1.cu
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_256_128_256_2_1_1.cu
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in
+ * ../MSLK_LICENSE.
+ */
+
+#include "f4f4bf16_ultra_grouped_common.cuh"
+
+namespace prime_rl_kernels::nvfp4 {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor f4f4bf16_ultra_grouped_256_128_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output) {
+  return f4f4bf16_ultra_grouped_impl<false, 256, 128, 256, 2, 1, 1>(
+      XQ,
+      WQ,
+      x_scale,
+      w_scale,
+      offsets,
+      x_global_scale,
+      w_global_scale,
+      output);
+}
+
+#endif
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_256_256_256_2_1_1.cu
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_256_256_256_2_1_1.cu
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in
+ * ../MSLK_LICENSE.
+ */
+
+#include "f4f4bf16_ultra_grouped_common.cuh"
+
+namespace prime_rl_kernels::nvfp4 {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor f4f4bf16_ultra_grouped_256_256_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output) {
+  return f4f4bf16_ultra_grouped_impl<false, 256, 256, 256, 2, 1, 1>(
+      XQ,
+      WQ,
+      x_scale,
+      w_scale,
+      offsets,
+      x_global_scale,
+      w_global_scale,
+      output);
+}
+
+#endif
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_common.cuh
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_common.cuh
@@ -1,0 +1,521 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in
+ * ../MSLK_LICENSE.
+ */
+
+#define CUTLASS_NAMESPACE prime_rl_kernels
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cutlass/util/device_memory.h>
+#include <cutlass/util/packed_stride.hpp>
+
+// clang-format off
+// The fixed ordering of the headers is required for CUTLASS 3.2+
+#include <cute/tensor.hpp>
+#include <cutlass/gemm/collective/collective_builder.hpp>     // @manual
+#include <cutlass/gemm/device/gemm_universal_adapter.h>       // @manual
+#include <cutlass/gemm/dispatch_policy.hpp>                   // @manual
+#include <cutlass/epilogue/collective/collective_builder.hpp> // @manual
+// clang-format on
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+namespace prime_rl_kernels::nvfp4 {
+
+namespace cutlass = cutlass_prime_rl_kernels;
+
+// Underlying element types (same for both Sm100 NVFP4 and Sm103 ultra NVFP4).
+using ElementData = cutlass::float_e2m1_t;
+using ElementScale = cutlass::float_ue4m3_t;
+// Sm103 ultra CollectiveBuilder expects the (data, scale) pair as a
+// cute::tuple, while the Sm100 NVFP4 CollectiveBuilder takes nv_float4_t
+// directly.
+using ElementPair = cute::tuple<ElementData, ElementScale>;
+using ElementNvf4 = cutlass::nv_float4_t<ElementData>;
+
+inline int64_t _byte_align(int64_t offset) {
+  int64_t remainder = offset % 16;
+  if (remainder != 0) {
+    offset += (16 - remainder);
+  }
+  return offset;
+}
+
+template <
+    typename ProblemShape,
+    typename StrideA,
+    typename StrideB,
+    typename StrideC,
+    typename LayoutSFA,
+    typename LayoutSFB,
+    typename Sm1xxBlkScaledConfig>
+__global__ void set_ultra_grouped_args_kernel(
+    int64_t G,
+    int64_t N,
+    int64_t K,
+    ProblemShape* problem_shape_ptr,
+    ElementData* xq,
+    const ElementData** xq_ptr,
+    ElementData* wq,
+    const ElementData** wq_ptr,
+    ElementScale* x_scale,
+    const ElementScale** x_scale_ptr,
+    ElementScale* w_scale,
+    const ElementScale** w_scale_ptr,
+    cutlass::bfloat16_t* output,
+    cutlass::bfloat16_t** output_ptr,
+    StrideA* stride_a_ptr,
+    StrideB* stride_b_ptr,
+    StrideC* stride_c_ptr,
+    int32_t* offsets,
+    LayoutSFA* layout_SFA,
+    LayoutSFB* layout_SFB,
+    float* x_global_scale,
+    const float** x_global_scale_ptr,
+    float* w_global_scale,
+    const float** w_global_scale_ptr) {
+  uint32_t group_index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (group_index >= G) {
+    return;
+  }
+
+  auto round_up = [](int64_t x, int64_t y) { return ((x + y - 1) / y) * y; };
+
+  constexpr int ele_per_quantize_group = 16; // NVFP4
+
+  int32_t M_end = offsets[group_index];
+  int32_t M_start = (group_index == 0) ? 0 : offsets[group_index - 1];
+  int32_t M_group = M_end - M_start;
+
+  if (M_group <= 0) {
+    problem_shape_ptr[group_index] = ProblemShape(0, 0, 0);
+    return;
+  }
+
+  // Problem shape is (N, M, K) due to transposed AB convention.
+  problem_shape_ptr[group_index] = ProblemShape(N, M_group, K);
+
+  // Data pointers.
+  xq_ptr[group_index] = xq + (int64_t(M_start) * K / 2);
+  wq_ptr[group_index] = wq + (int64_t(group_index) * N * K / 2);
+  output_ptr[group_index] = output + (int64_t(M_start) * N);
+
+  // Block scale offsets. Scales are padded to multiples of (128, 4).
+  int64_t K_rounded = round_up(K / ele_per_quantize_group, 4);
+  int64_t N_rounded = round_up(N, 128);
+
+  int64_t x_scale_offset = 0;
+  for (int i = 0; i < group_index; i++) {
+    int32_t prev_start = (i == 0) ? 0 : offsets[i - 1];
+    int32_t prev_M = offsets[i] - prev_start;
+    x_scale_offset += round_up(prev_M, 128) * K_rounded;
+  }
+  x_scale_ptr[group_index] = x_scale + x_scale_offset;
+  w_scale_ptr[group_index] =
+      w_scale + int64_t(group_index) * N_rounded * K_rounded;
+
+  // Strides.
+  stride_a_ptr[group_index] = cutlass::make_cute_packed_stride(
+      StrideA{}, cute::make_shape(int(M_group), int(K), 1));
+  stride_b_ptr[group_index] = cutlass::make_cute_packed_stride(
+      StrideB{}, cute::make_shape(int(N), int(K), 1));
+  stride_c_ptr[group_index] = cutlass::make_cute_packed_stride(
+      StrideC{}, cute::make_shape(int(N), int(M_group), 1));
+
+  // Scale factor layouts for block-scaled TMA.
+  layout_SFA[group_index] = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(
+      cute::make_shape(int(M_group), int(N), int(K), 1));
+  layout_SFB[group_index] = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(
+      cute::make_shape(int(M_group), int(N), int(K), 1));
+
+  // Per-token x global scale and per-expert w global scale for EVT epilogue.
+  x_global_scale_ptr[group_index] = x_global_scale + M_start;
+  w_global_scale_ptr[group_index] = w_global_scale + group_index;
+}
+
+// Sm103 ultra schedules require CUDA 13+. Alias them to Sm100 NVFP4 schedules
+// on older toolkits so that template instantiation with UseUltra=false still
+// resolves to valid types when those CUDA 12.8 builds reach the conditional.
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+using _UltraArchTag = cutlass::arch::Sm103;
+using _UltraSchedule2Sm = cutlass::gemm::
+    KernelPtrArrayTmaWarpSpecialized2SmBlockScaledMxNvf4UltraVs16Sm103;
+using _UltraSchedule1Sm = cutlass::gemm::
+    KernelPtrArrayTmaWarpSpecialized1SmBlockScaledMxNvf4UltraVs16Sm103;
+#else
+using _UltraArchTag = cutlass::arch::Sm100;
+using _UltraSchedule2Sm =
+    cutlass::gemm::KernelPtrArrayTmaWarpSpecialized2SmNvf4Sm100;
+using _UltraSchedule1Sm =
+    cutlass::gemm::KernelPtrArrayTmaWarpSpecialized1SmNvf4Sm100;
+#endif
+
+template <
+    bool UseUltra,
+    int TB_M,
+    int TB_N,
+    int TB_K,
+    int TBS_M,
+    int TBS_N,
+    int TBS_K>
+at::Tensor f4f4bf16_ultra_grouped_impl(
+    at::Tensor XQ, // FP4
+    at::Tensor WQ, // FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output) {
+  c10::cuda::CUDAGuard deviceGuard(XQ.device());
+
+  const int64_t G = offsets.size(0);
+
+  using ProblemShape =
+      cutlass::gemm::GroupProblemShape<cute::Shape<int, int, int>>;
+  using ElementC = cutlass::bfloat16_t;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+
+  constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementData>::value;
+  constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementData>::value;
+  constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+
+  using LayoutA_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutA>::type;
+  using LayoutB_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutB>::type;
+
+  using ElementAccumulator = float;
+  using ElementComputeEpilogue = float;
+  using ArchTag =
+      cute::conditional_t<UseUltra, _UltraArchTag, cutlass::arch::Sm100>;
+  using TileShape =
+      cute::Shape<cute::Int<TB_M>, cute::Int<TB_N>, cute::Int<TB_K>>;
+  using ClusterShape =
+      cute::Shape<cute::Int<TBS_M>, cute::Int<TBS_N>, cute::Int<TBS_K>>;
+
+  // Sm103 ultra path uses cute::tuple<data, scale>; Sm100 NVFP4 path takes
+  // nv_float4_t directly.
+  using ElementForBuilder =
+      cute::conditional_t<UseUltra, ElementPair, ElementNvf4>;
+
+  // Kernel schedule: ultra uses BlockScaledMxNvf4UltraVs16Sm103, Sm100 uses the
+  // standard Nvf4 ptr-array schedule (matching f4f4bf16_grouped).
+  using KernelSchedule = cute::conditional_t<
+      UseUltra,
+      cute::conditional_t<
+          (TB_M == 256) && (TBS_M % 2 == 0),
+          _UltraSchedule2Sm,
+          _UltraSchedule1Sm>,
+      cute::conditional_t<
+          (TB_M == 256) && (TBS_M % 2 == 0),
+          cutlass::gemm::KernelPtrArrayTmaWarpSpecialized2SmNvf4Sm100,
+          cutlass::gemm::KernelPtrArrayTmaWarpSpecialized1SmNvf4Sm100>>;
+  using EpilogueSchedule = cute::conditional_t<
+      (TB_M == 256) && (TBS_M % 2 == 0),
+      cutlass::epilogue::PtrArrayTmaWarpSpecialized2Sm,
+      cutlass::epilogue::PtrArrayTmaWarpSpecialized1Sm>;
+
+  // EVT epilogue: Output = Accumulator * XGlobalScaleInv * WGlobalScaleInv
+  // Due to the transposed AB convention (CUTLASS N = our M/tokens):
+  //   RowBroadcast (along CUTLASS N) → per-token x_global_scale
+  //   ScalarBroadcastPtrArray → per-group w_global_scale scalar
+  using XGlobalScale = cutlass::epilogue::fusion::Sm90RowBroadcast<
+      0,
+      TileShape,
+      ElementComputeEpilogue*,
+      ElementComputeEpilogue,
+      cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
+
+  using WGlobalScale = cutlass::epilogue::fusion::Sm90ScalarBroadcastPtrArray<
+      ElementComputeEpilogue>;
+
+  using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
+
+  using Compute0 = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies,
+      ElementComputeEpilogue,
+      ElementComputeEpilogue,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute0 =
+      cutlass::epilogue::fusion::Sm90EVT<Compute0, Accum, XGlobalScale>;
+
+  using Compute1 = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies,
+      ElementC,
+      ElementComputeEpilogue,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute1 =
+      cutlass::epilogue::fusion::Sm90EVT<Compute1, EVTCompute0, WGlobalScale>;
+
+  using EpilogueEVT = EVTCompute1;
+
+  // Ultra (Sm103) uses OpClassBlockScaledTensorOp for the epilogue; Sm100
+  // NVFP4 uses OpClassTensorOp (matches f4f4bf16_grouped_common.cuh).
+  using EpilogueOpClass = cute::conditional_t<
+      UseUltra,
+      cutlass::arch::OpClassBlockScaledTensorOp,
+      cutlass::arch::OpClassTensorOp>;
+
+  // On Sm100, Sm90ScalarBroadcastPtrArray (used by WGlobalScale above) needs a
+  // non-void C type so its pointer-array stride layout is set up correctly.
+  // On Sm103 ultra, void C performs better, so keep the original behavior
+  // there. Source C is unused (nullptr passed in arguments, no beta) in both
+  // cases — this only affects internal stride bookkeeping.
+  using EpilogueElementC = cute::conditional_t<UseUltra, void, ElementC>;
+  using EpilogueLayoutC = cute::conditional_t<
+      UseUltra,
+      void,
+      typename cutlass::layout::LayoutTranspose<LayoutC>::type*>;
+  static constexpr int EpilogueAlignmentC = UseUltra ? 0 : AlignmentC;
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          ArchTag,
+          EpilogueOpClass,
+          TileShape,
+          ClusterShape,
+          cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator,
+          ElementAccumulator,
+          EpilogueElementC,
+          EpilogueLayoutC,
+          EpilogueAlignmentC,
+          ElementC,
+          typename cutlass::layout::LayoutTranspose<LayoutC>::type*,
+          AlignmentC,
+          EpilogueSchedule,
+          EpilogueEVT>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          ArchTag,
+          cutlass::arch::OpClassBlockScaledTensorOp,
+          ElementForBuilder,
+          LayoutB_Transpose*,
+          AlignmentB,
+          ElementForBuilder,
+          LayoutA_Transpose*,
+          AlignmentA,
+          ElementAccumulator,
+          TileShape,
+          ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          KernelSchedule>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::
+      GemmUniversal<ProblemShape, CollectiveMainloop, CollectiveEpilogue>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using StrideA = typename Gemm::GemmKernel::InternalStrideA;
+  using StrideB = typename Gemm::GemmKernel::InternalStrideB;
+  using StrideC = typename Gemm::GemmKernel::InternalStrideD;
+
+  using LayoutSFA =
+      typename Gemm::GemmKernel::CollectiveMainloop::InternalLayoutSFA;
+  using LayoutSFB =
+      typename Gemm::GemmKernel::CollectiveMainloop::InternalLayoutSFB;
+  using Sm1xxBlkScaledConfig =
+      typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+
+  // Allocate a single contiguous buffer for all per-group kernel arguments.
+  const int64_t problem_size_offset = 0;
+  int64_t problem_size_buffer =
+      _byte_align(G * sizeof(ProblemShape::UnderlyingProblemShape));
+
+  const int64_t xq_offset = problem_size_offset + problem_size_buffer;
+  int64_t xq_size_buffer = _byte_align(G * sizeof(ElementData**));
+
+  const int64_t wq_offset = xq_offset + xq_size_buffer;
+  int64_t wq_size_buffer = _byte_align(G * sizeof(ElementData**));
+
+  const int64_t x_scale_offset = wq_offset + wq_size_buffer;
+  int64_t x_scale_buffer = _byte_align(G * sizeof(ElementScale**));
+
+  const int64_t w_scale_offset = x_scale_offset + x_scale_buffer;
+  int64_t w_scale_buffer = _byte_align(G * sizeof(ElementScale**));
+
+  const int64_t output_offset = w_scale_offset + w_scale_buffer;
+  int64_t output_buffer = _byte_align(G * sizeof(ElementC**));
+
+  const int64_t stride_a_offset = output_offset + output_buffer;
+  int64_t stride_a_buffer = _byte_align(G * sizeof(StrideA));
+
+  const int64_t stride_b_offset = stride_a_offset + stride_a_buffer;
+  int64_t stride_b_buffer = _byte_align(G * sizeof(StrideB));
+
+  const int64_t stride_c_offset = stride_b_offset + stride_b_buffer;
+  int64_t stride_c_buffer = _byte_align(G * sizeof(StrideC));
+
+  const int64_t layout_SFA_offset = stride_c_offset + stride_c_buffer;
+  int64_t layout_SFA_buffer = _byte_align(G * sizeof(LayoutSFA));
+
+  const int64_t layout_SFB_offset = layout_SFA_offset + layout_SFA_buffer;
+  int64_t layout_SFB_buffer = _byte_align(G * sizeof(LayoutSFB));
+
+  const int64_t x_gs_offset = layout_SFB_offset + layout_SFB_buffer;
+  int64_t x_gs_buffer = _byte_align(G * sizeof(float*));
+
+  const int64_t w_gs_offset = x_gs_offset + x_gs_buffer;
+  int64_t w_gs_buffer = _byte_align(G * sizeof(float*));
+
+  int64_t total_buffer_size = w_gs_offset + w_gs_buffer;
+
+  at::TensorOptions options = XQ.options();
+  at::Tensor kernel_args =
+      at::empty({total_buffer_size}, options.dtype(at::kByte));
+
+  char* kernel_args_ptr = reinterpret_cast<char*>(kernel_args.data_ptr());
+
+  auto* problem_shape_ptr =
+      reinterpret_cast<ProblemShape::UnderlyingProblemShape*>(
+          kernel_args_ptr + problem_size_offset);
+  const ElementData** xq_ptr =
+      reinterpret_cast<const ElementData**>(kernel_args_ptr + xq_offset);
+  const ElementData** wq_ptr =
+      reinterpret_cast<const ElementData**>(kernel_args_ptr + wq_offset);
+  const ElementScale** x_scale_ptr =
+      reinterpret_cast<const ElementScale**>(kernel_args_ptr + x_scale_offset);
+  const ElementScale** w_scale_ptr =
+      reinterpret_cast<const ElementScale**>(kernel_args_ptr + w_scale_offset);
+  ElementC** output_ptr =
+      reinterpret_cast<ElementC**>(kernel_args_ptr + output_offset);
+  StrideA* stride_a_ptr =
+      reinterpret_cast<StrideA*>(kernel_args_ptr + stride_a_offset);
+  StrideB* stride_b_ptr =
+      reinterpret_cast<StrideB*>(kernel_args_ptr + stride_b_offset);
+  StrideC* stride_c_ptr =
+      reinterpret_cast<StrideC*>(kernel_args_ptr + stride_c_offset);
+  LayoutSFA* layout_SFA_ptr =
+      reinterpret_cast<LayoutSFA*>(kernel_args_ptr + layout_SFA_offset);
+  LayoutSFB* layout_SFB_ptr =
+      reinterpret_cast<LayoutSFB*>(kernel_args_ptr + layout_SFB_offset);
+  const float** x_gs_ptr =
+      reinterpret_cast<const float**>(kernel_args_ptr + x_gs_offset);
+  const float** w_gs_ptr =
+      reinterpret_cast<const float**>(kernel_args_ptr + w_gs_offset);
+
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+
+  // WQ is [G, N, K/2] after transpose in the top-level dispatch.
+  const int64_t N = WQ.size(-2);
+  const int64_t K = WQ.size(-1) * 2; // 2 FP4 values packed per byte
+
+  constexpr int kSetupThreads = 256;
+  const int setup_blocks = (G + kSetupThreads - 1) / kSetupThreads;
+  set_ultra_grouped_args_kernel<
+      ProblemShape::UnderlyingProblemShape,
+      StrideA,
+      StrideB,
+      StrideC,
+      LayoutSFA,
+      LayoutSFB,
+      Sm1xxBlkScaledConfig><<<setup_blocks, kSetupThreads, 0, stream>>>(
+      G,
+      N,
+      K,
+      problem_shape_ptr,
+      reinterpret_cast<ElementData*>(XQ.data_ptr()),
+      xq_ptr,
+      reinterpret_cast<ElementData*>(WQ.data_ptr()),
+      wq_ptr,
+      reinterpret_cast<ElementScale*>(x_scale.data_ptr()),
+      x_scale_ptr,
+      reinterpret_cast<ElementScale*>(w_scale.data_ptr()),
+      w_scale_ptr,
+      reinterpret_cast<ElementC*>(output.data_ptr()),
+      output_ptr,
+      stride_a_ptr,
+      stride_b_ptr,
+      stride_c_ptr,
+      reinterpret_cast<int32_t*>(offsets.data_ptr()),
+      layout_SFA_ptr,
+      layout_SFB_ptr,
+      reinterpret_cast<float*>(x_global_scale.data_ptr()),
+      x_gs_ptr,
+      reinterpret_cast<float*>(w_global_scale.data_ptr()),
+      w_gs_ptr);
+
+  cutlass::KernelHardwareInfo hw_info;
+  hw_info.device_id = XQ.get_device();
+  hw_info.sm_count =
+      min(cutlass::KernelHardwareInfo::query_device_multiprocessor_count(
+              hw_info.device_id),
+          2147483647);
+
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGrouped,
+      {int(G), problem_shape_ptr, nullptr},
+      {reinterpret_cast<const ElementData**>(wq_ptr),
+       stride_b_ptr,
+       reinterpret_cast<const ElementData**>(xq_ptr),
+       stride_a_ptr,
+       reinterpret_cast<const ElementScale**>(w_scale_ptr),
+       layout_SFB_ptr,
+       reinterpret_cast<const ElementScale**>(x_scale_ptr),
+       layout_SFA_ptr},
+      {{}, nullptr, stride_c_ptr, output_ptr, stride_c_ptr},
+      hw_info};
+
+  typename Gemm::GemmKernel::TileSchedulerArguments scheduler;
+  scheduler.raster_order =
+      cutlass::gemm::kernel::detail::RasterOrderOptions::AlongM;
+  arguments.scheduler = scheduler;
+
+  // EVT epilogue arguments: Accum / XGlobalScale / WGlobalScale.
+  // Due to AB transpose, x_global_scale (per-token) goes to RowBroadcast and
+  // w_global_scale (per-expert) goes to ScalarBroadcastPtrArray.
+  // ScalarBroadcastPtrArray args: {scalars, scalar_ptrs, scalar_ptr_arrays,
+  // dScalar}
+  arguments.epilogue.thread = {
+      {
+          {}, // Accumulator
+          {x_gs_ptr}, // XGlobalScale (RowBroadcast, per-token)
+          {} // Compute0 (multiplies)
+      },
+      {{}, {}, {w_gs_ptr}}, // WGlobalScale (ScalarBroadcastPtrArray)
+      {} // Compute1 (multiplies)
+  };
+
+  Gemm gemm;
+
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+  at::Tensor workspace = at::empty(workspace_size, options.dtype(at::kByte));
+
+  cutlass::Status status = gemm.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  status = gemm.initialize(
+      arguments, reinterpret_cast<uint8_t*>(workspace.data_ptr()));
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm(at::cuda::getCurrentCUDAStream());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error(
+        std::string("cutlass cannot run: ") +
+        cutlass::cutlassGetStatusString(status));
+  }
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return output;
+}
+
+} // namespace prime_rl_kernels::nvfp4
+
+#endif
+
+#undef CUTLASS_NAMESPACE

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_manifest.cuh
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_manifest.cuh
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in
+ * ../MSLK_LICENSE.
+ */
+
+#include <ATen/ATen.h>
+
+namespace prime_rl_kernels::nvfp4 {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+// SM100 (B200) NVFP4 variants. Use TileShape K = 256.
+at::Tensor f4f4bf16_ultra_grouped_256_128_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output);
+
+at::Tensor f4f4bf16_ultra_grouped_256_256_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output);
+
+using Kernel_f4f4bf16_ultra_grouped = at::Tensor (*)(
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor);
+
+const std::unordered_map<std::string, Kernel_f4f4bf16_ultra_grouped>&
+get_f4f4bf16_ultra_grouped_kernels() {
+  static const std::unordered_map<std::string, Kernel_f4f4bf16_ultra_grouped>
+      kernels = {
+          {"f4f4bf16_ultra_grouped_256_128_256_2_1_1",
+           f4f4bf16_ultra_grouped_256_128_256_2_1_1},
+          {"f4f4bf16_ultra_grouped_256_256_256_2_1_1",
+           f4f4bf16_ultra_grouped_256_256_256_2_1_1},
+      };
+  return kernels;
+}
+
+#endif // CUDA >= 12.8
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/nvfp4_grouped.h
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/nvfp4_grouped.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <ATen/core/Tensor.h>
+
+#include <optional>
+
+namespace prime_rl_kernels::nvfp4 {
+
+at::Tensor f4f4bf16_ultra_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    std::optional<at::Tensor> output = std::nullopt);
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/functional.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/functional.py
@@ -148,7 +148,6 @@ class _GroupedNVFP4MM(torch.autograd.Function):
         return grad_matrix, grad_weight, None, None
 
 
-@torch.compiler.disable
 def grouped_gemm(
     matrix: torch.Tensor,
     weight: torch.Tensor,

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/functional.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/functional.py
@@ -7,10 +7,13 @@ import torch.nn.functional as F
 import triton
 import triton.language as tl
 
+from prime_rl_kernels.nvfp4.grouped_gemm._extension import _grouped_mm as _grouped_mm_kernel
+
 _FP4_MAX = 6.0
 _FP8_MAX = 448.0
 _GLOBAL_SCALE_DENOMINATOR = _FP4_MAX * _FP8_MAX
 _NVFP4_BLOCK_SIZE = 16
+_NVFP4_GEMM_ALIGNMENT = 32
 _SCALE_ROW_TILE = 128
 _SCALE_COL_TILE = 4
 _QUANT_BLOCK_K = 256
@@ -19,7 +22,7 @@ _METADATA_BLOCK_M = 256
 
 
 @dataclass(frozen=True)
-class NVFP4GroupedTensor:
+class _NVFP4GroupedTensor:
     """Packed NVFP4 values and their two levels of decode scales."""
 
     data: torch.Tensor
@@ -30,7 +33,6 @@ class NVFP4GroupedTensor:
 @triton.jit
 def _build_activation_metadata_kernel(
     offsets_ptr,
-    row_groups_ptr,
     scale_rows_ptr,
     ROWS: tl.constexpr,
     GROUP_COUNT: tl.constexpr,
@@ -39,7 +41,6 @@ def _build_activation_metadata_kernel(
     rows = tl.program_id(axis=0) * BLOCK_M + tl.arange(0, BLOCK_M)
     valid_rows = rows < ROWS
 
-    selected_group = tl.zeros((BLOCK_M,), dtype=tl.int32)
     selected_start = tl.zeros((BLOCK_M,), dtype=tl.int32)
     selected_padded_start = tl.zeros((BLOCK_M,), dtype=tl.int32)
     group_start = 0
@@ -47,7 +48,6 @@ def _build_activation_metadata_kernel(
     for group_index in range(GROUP_COUNT):
         group_end = tl.load(offsets_ptr + group_index)
         belongs_to_or_follows_group = rows >= group_start
-        selected_group = tl.where(belongs_to_or_follows_group, group_index, selected_group)
         selected_start = tl.where(belongs_to_or_follows_group, group_start, selected_start)
         selected_padded_start = tl.where(
             belongs_to_or_follows_group,
@@ -58,7 +58,6 @@ def _build_activation_metadata_kernel(
         padded_start += tl.where(group_size > 0, (group_size + 127) // 128 * 128, 0)
         group_start = group_end
 
-    tl.store(row_groups_ptr + rows, selected_group, mask=valid_rows)
     tl.store(
         scale_rows_ptr + rows,
         rows - selected_start + selected_padded_start,
@@ -74,12 +73,12 @@ def _check_blackwell() -> None:
     if not torch.cuda.is_available():
         raise RuntimeError("NVFP4 grouped GEMM requires CUDA")
     capability = torch.cuda.get_device_capability()
-    if capability < (10, 0):
+    if capability != (10, 0):
         raise RuntimeError(
-            f"NVFP4 grouped GEMM requires SM100 or newer, but the current device is SM{capability[0]}{capability[1]}"
+            f"NVFP4 grouped GEMM currently requires SM100, but the current device is SM{capability[0]}{capability[1]}"
         )
-    if not hasattr(torch, "float4_e2m1fn_x2") or not hasattr(F, "scaled_grouped_mm"):
-        raise RuntimeError("NVFP4 grouped GEMM requires PyTorch 2.11 or newer with scaled_grouped_mm support")
+    if not hasattr(torch, "float4_e2m1fn_x2"):
+        raise RuntimeError("NVFP4 grouped GEMM requires PyTorch with float4_e2m1fn_x2 support")
 
 
 def _check_matrix(matrix: torch.Tensor, name: str) -> None:
@@ -87,8 +86,8 @@ def _check_matrix(matrix: torch.Tensor, name: str) -> None:
         raise ValueError(f"{name} must be a CUDA tensor")
     if matrix.dtype != torch.bfloat16:
         raise ValueError(f"{name} must have dtype torch.bfloat16")
-    if matrix.shape[-1] % _NVFP4_BLOCK_SIZE != 0:
-        raise ValueError(f"{name}'s contraction dimension must be divisible by {_NVFP4_BLOCK_SIZE}")
+    if matrix.shape[-1] % _NVFP4_GEMM_ALIGNMENT != 0:
+        raise ValueError(f"{name}'s contraction dimension must be divisible by {_NVFP4_GEMM_ALIGNMENT}")
 
 
 @triton.jit
@@ -265,8 +264,8 @@ def _quantize_rows(
     return packed.view(torch.float4_e2m1fn_x2), scales
 
 
-def quantize_nvfp4_activations(matrix: torch.Tensor, offsets: torch.Tensor) -> NVFP4GroupedTensor:
-    """Quantize a 2D activation matrix independently for each expert group."""
+def _quantize_activations(matrix: torch.Tensor, offsets: torch.Tensor) -> _NVFP4GroupedTensor:
+    """Quantize a 2D activation matrix with one global scale per token."""
 
     _check_blackwell()
     if matrix.ndim != 2:
@@ -280,21 +279,21 @@ def quantize_nvfp4_activations(matrix: torch.Tensor, offsets: torch.Tensor) -> N
     group_count = offsets.numel()
     if group_count == 0:
         raise ValueError("offsets must contain at least one group")
-    row_groups = torch.empty(matrix.shape[0], device=matrix.device, dtype=torch.int32)
-    scale_rows = torch.empty_like(row_groups)
-    _build_activation_metadata_kernel[(triton.cdiv(matrix.shape[0], _METADATA_BLOCK_M),)](
-        offsets,
-        row_groups,
-        scale_rows,
-        ROWS=matrix.shape[0],
-        GROUP_COUNT=group_count,
-        BLOCK_M=_METADATA_BLOCK_M,
-        num_warps=4,
-    )
+    scale_rows = torch.empty(matrix.shape[0], device=matrix.device, dtype=torch.int32)
+    if matrix.shape[0] > 0:
+        _build_activation_metadata_kernel[(triton.cdiv(matrix.shape[0], _METADATA_BLOCK_M),)](
+            offsets,
+            scale_rows,
+            ROWS=matrix.shape[0],
+            GROUP_COUNT=group_count,
+            BLOCK_M=_METADATA_BLOCK_M,
+            num_warps=4,
+        )
+    scale_groups = torch.arange(matrix.shape[0], device=matrix.device, dtype=torch.int32)
     global_scales = _compute_global_scales(
         matrix,
-        row_groups,
-        group_count,
+        scale_groups,
+        matrix.shape[0],
         active_rows=offsets[-1:],
     )
 
@@ -306,18 +305,18 @@ def quantize_nvfp4_activations(matrix: torch.Tensor, offsets: torch.Tensor) -> N
     packed, block_scales = _quantize_rows(
         matrix,
         global_scales,
-        row_groups,
+        scale_groups,
         scale_rows,
         padded_scale_rows,
     )
-    return NVFP4GroupedTensor(
+    return _NVFP4GroupedTensor(
         data=packed,
         block_scales=block_scales,
         global_scales=global_scales,
     )
 
 
-def quantize_nvfp4_weights(weight: torch.Tensor) -> NVFP4GroupedTensor:
+def _quantize_weights(weight: torch.Tensor) -> _NVFP4GroupedTensor:
     """Quantize grouped right-hand weights with logical shape ``[G, K, N]``."""
 
     _check_blackwell()
@@ -327,8 +326,10 @@ def quantize_nvfp4_weights(weight: torch.Tensor) -> NVFP4GroupedTensor:
         raise ValueError("weight must be a CUDA bfloat16 tensor")
 
     groups, contraction_size, output_size = weight.shape
-    if contraction_size % _NVFP4_BLOCK_SIZE != 0:
-        raise ValueError(f"weight's contraction dimension must be divisible by {_NVFP4_BLOCK_SIZE}")
+    if contraction_size % _NVFP4_GEMM_ALIGNMENT != 0:
+        raise ValueError(f"weight's contraction dimension must be divisible by {_NVFP4_GEMM_ALIGNMENT}")
+    if output_size % 8 != 0:
+        raise ValueError("weight's output dimension must be divisible by 8")
 
     weight_rows = weight.transpose(-2, -1).contiguous()
     flat_row_count = groups * output_size
@@ -348,42 +349,43 @@ def quantize_nvfp4_weights(weight: torch.Tensor) -> NVFP4GroupedTensor:
         scale_rows,
         groups * padded_output_size,
     )
-    return NVFP4GroupedTensor(
+    return _NVFP4GroupedTensor(
         data=packed.view(groups, output_size, contraction_size // 2),
         block_scales=block_scales.view(groups, -1),
         global_scales=global_scales,
     )
 
 
-def grouped_nvfp4_mm_quantized(
-    activations: NVFP4GroupedTensor,
-    weight: NVFP4GroupedTensor,
+def _grouped_mm_quantized(
+    activations: _NVFP4GroupedTensor,
+    weight: _NVFP4GroupedTensor,
     offsets: torch.Tensor,
 ) -> torch.Tensor:
-    """Run native grouped NVFP4 GEMM on already-packed inputs."""
+    """Dispatch quantized operands to the owned SM100 grouped GEMM."""
 
-    return F.scaled_grouped_mm(
+    if activations.global_scales.numel() != activations.data.shape[0]:
+        raise ValueError("activation global scales must contain one value per token row")
+    if weight.global_scales.numel() != offsets.numel():
+        raise ValueError("weight global scales must contain one value per expert")
+    return _grouped_mm_kernel(
         activations.data,
         weight.data.transpose(-2, -1),
-        [activations.block_scales, activations.global_scales],
-        [F.ScalingType.BlockWise1x16, F.ScalingType.TensorWise],
-        [weight.block_scales, weight.global_scales],
-        [F.ScalingType.BlockWise1x16, F.ScalingType.TensorWise],
-        swizzle_a=F.SwizzleType.SWIZZLE_32_4_4,
-        swizzle_b=F.SwizzleType.SWIZZLE_32_4_4,
-        offs=offsets,
-        output_dtype=torch.bfloat16,
+        activations.block_scales,
+        weight.block_scales,
+        offsets,
+        activations.global_scales,
+        weight.global_scales,
     )
 
 
-def _grouped_nvfp4_mm_forward(
+def _forward(
     matrix: torch.Tensor,
     weight: torch.Tensor,
     offsets: torch.Tensor,
 ) -> torch.Tensor:
-    activations_nvfp4 = quantize_nvfp4_activations(matrix, offsets)
-    weight_nvfp4 = quantize_nvfp4_weights(weight)
-    return grouped_nvfp4_mm_quantized(activations_nvfp4, weight_nvfp4, offsets)
+    activations_nvfp4 = _quantize_activations(matrix, offsets)
+    weight_nvfp4 = _quantize_weights(weight)
+    return _grouped_mm_quantized(activations_nvfp4, weight_nvfp4, offsets)
 
 
 class _GroupedNVFP4MM(torch.autograd.Function):
@@ -394,7 +396,7 @@ class _GroupedNVFP4MM(torch.autograd.Function):
         weight: torch.Tensor,
         offsets: torch.Tensor,
     ) -> torch.Tensor:
-        output = _grouped_nvfp4_mm_forward(matrix, weight, offsets)
+        output = _forward(matrix, weight, offsets)
         ctx.save_for_backward(matrix, weight, offsets)
         return output
 
@@ -422,7 +424,7 @@ class _GroupedNVFP4MM(torch.autograd.Function):
 
 
 @torch.compiler.disable
-def grouped_nvfp4_mm(
+def grouped_gemm(
     matrix: torch.Tensor,
     weight: torch.Tensor,
     offsets: torch.Tensor,

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/functional.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/functional.py
@@ -1,72 +1,19 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from typing import Literal, TypeAlias
 
 import torch
 import torch.nn.functional as F
-import triton
-import triton.language as tl
 
 from prime_rl_kernels.nvfp4.grouped_gemm._extension import _grouped_mm as _grouped_mm_kernel
+from prime_rl_kernels.nvfp4.quantize.functional import (
+    _NVFP4Tensor,
+    quantize_activations,
+    quantize_weights,
+)
 
-_FP4_MAX = 6.0
-_FP8_MAX = 448.0
-_GLOBAL_SCALE_DENOMINATOR = _FP4_MAX * _FP8_MAX
-_NVFP4_BLOCK_SIZE = 16
 _NVFP4_GEMM_ALIGNMENT = 32
-_SCALE_ROW_TILE = 128
-_SCALE_COL_TILE = 4
-_QUANT_BLOCK_K = 256
-_AMAX_BLOCK_K = 1024
-_METADATA_BLOCK_M = 256
-
-
-@dataclass(frozen=True)
-class _NVFP4GroupedTensor:
-    """Packed NVFP4 values and their two levels of decode scales."""
-
-    data: torch.Tensor
-    block_scales: torch.Tensor
-    global_scales: torch.Tensor
-
-
-@triton.jit
-def _build_activation_metadata_kernel(
-    offsets_ptr,
-    scale_rows_ptr,
-    ROWS: tl.constexpr,
-    GROUP_COUNT: tl.constexpr,
-    BLOCK_M: tl.constexpr,
-):
-    rows = tl.program_id(axis=0) * BLOCK_M + tl.arange(0, BLOCK_M)
-    valid_rows = rows < ROWS
-
-    selected_start = tl.zeros((BLOCK_M,), dtype=tl.int32)
-    selected_padded_start = tl.zeros((BLOCK_M,), dtype=tl.int32)
-    group_start = 0
-    padded_start = 0
-    for group_index in range(GROUP_COUNT):
-        group_end = tl.load(offsets_ptr + group_index)
-        belongs_to_or_follows_group = rows >= group_start
-        selected_start = tl.where(belongs_to_or_follows_group, group_start, selected_start)
-        selected_padded_start = tl.where(
-            belongs_to_or_follows_group,
-            padded_start,
-            selected_padded_start,
-        )
-        group_size = group_end - group_start
-        padded_start += tl.where(group_size > 0, (group_size + 127) // 128 * 128, 0)
-        group_start = group_end
-
-    tl.store(
-        scale_rows_ptr + rows,
-        rows - selected_start + selected_padded_start,
-        mask=valid_rows,
-    )
-
-
-def _round_up(value: int, multiple: int) -> int:
-    return (value + multiple - 1) // multiple * multiple
+NVFP4Backward: TypeAlias = Literal["bf16", "bf16_dequantized"]
 
 
 def _check_blackwell() -> None:
@@ -90,275 +37,9 @@ def _check_matrix(matrix: torch.Tensor, name: str) -> None:
         raise ValueError(f"{name}'s contraction dimension must be divisible by {_NVFP4_GEMM_ALIGNMENT}")
 
 
-@triton.jit
-def _quantize_nvfp4_rows_kernel(
-    input_ptr,
-    output_ptr,
-    scale_ptr,
-    global_scale_ptr,
-    row_group_ptr,
-    scale_row_ptr,
-    stride_input_row,
-    stride_input_col,
-    K: tl.constexpr,
-    SCALE_COLS: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-):
-    row = tl.program_id(axis=0)
-    k_block = tl.program_id(axis=1)
-    columns = k_block * BLOCK_K + tl.arange(0, BLOCK_K)
-    valid_columns = columns < K
-
-    values = tl.load(
-        input_ptr + row * stride_input_row + columns * stride_input_col,
-        mask=valid_columns,
-        other=0.0,
-    ).to(tl.float32)
-    values_by_scale_block = tl.reshape(values, (BLOCK_K // 16, 16))
-    block_amax = tl.max(tl.abs(values_by_scale_block), axis=1)
-
-    group = tl.load(row_group_ptr + row)
-    global_scale = tl.load(global_scale_ptr + group).to(tl.float32)
-    block_scale = block_amax / (6.0 * global_scale)
-    block_scale = tl.minimum(tl.maximum(block_scale, 0.001953125), 448.0)
-    block_scale_e4m3 = block_scale.to(tl.float8e4nv)
-    rounded_block_scale = block_scale_e4m3.to(tl.float32)
-    expanded_block_scale = tl.reshape(
-        tl.broadcast_to(
-            tl.reshape(rounded_block_scale, (BLOCK_K // 16, 1)),
-            (BLOCK_K // 16, 16),
-        ),
-        (BLOCK_K,),
-    )
-
-    normalized = values / (global_scale * expanded_block_scale)
-    magnitude = tl.abs(normalized)
-
-    # E2M1 positive values are {0, .5, 1, 1.5, 2, 3, 4, 6}. The
-    # alternating comparisons preserve round-to-nearest-even at midpoints.
-    codes = (magnitude > 0.25).to(tl.uint8)
-    codes += (magnitude >= 0.75).to(tl.uint8)
-    codes += (magnitude > 1.25).to(tl.uint8)
-    codes += (magnitude >= 1.75).to(tl.uint8)
-    codes += (magnitude > 2.5).to(tl.uint8)
-    codes += (magnitude >= 3.5).to(tl.uint8)
-    codes += (magnitude > 5.0).to(tl.uint8)
-    codes |= (normalized < 0).to(tl.uint8) << 3
-
-    code_pairs = tl.reshape(codes, (BLOCK_K // 2, 2))
-    low_codes, high_codes = tl.split(code_pairs)
-    packed = low_codes | (high_codes << 4)
-    packed_columns = k_block * (BLOCK_K // 2) + tl.arange(0, BLOCK_K // 2)
-    tl.store(
-        output_ptr + row * (K // 2) + packed_columns,
-        packed,
-        mask=packed_columns < K // 2,
-    )
-
-    scale_columns = k_block * (BLOCK_K // 16) + tl.arange(0, BLOCK_K // 16)
-    scale_row = tl.load(scale_row_ptr + row)
-    scale_row_in_tile = scale_row % 128
-    swizzled_scale_offsets = (
-        ((scale_row // 128) * (SCALE_COLS // 4) + scale_columns // 4) * 512
-        + (scale_row_in_tile % 32) * 16
-        + (scale_row_in_tile // 32) * 4
-        + scale_columns % 4
-    )
-    tl.store(
-        scale_ptr + swizzled_scale_offsets,
-        block_scale_e4m3,
-        mask=scale_columns < K // 16,
-    )
-
-
-@triton.jit
-def _group_amax_kernel(
-    input_ptr,
-    row_group_ptr,
-    active_rows_ptr,
-    output_ptr,
-    stride_input_row,
-    stride_input_col,
-    K: tl.constexpr,
-    HAS_ACTIVE_ROW_LIMIT: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-):
-    row = tl.program_id(axis=0)
-    k_block = tl.program_id(axis=1)
-    columns = k_block * BLOCK_K + tl.arange(0, BLOCK_K)
-    values = tl.load(
-        input_ptr + row * stride_input_row + columns * stride_input_col,
-        mask=columns < K,
-        other=0.0,
-    ).to(tl.float32)
-    tile_amax = tl.max(tl.abs(values))
-    group = tl.load(row_group_ptr + row)
-    if HAS_ACTIVE_ROW_LIMIT:
-        active = row < tl.load(active_rows_ptr)
-        tl.atomic_max(output_ptr + group, tile_amax, mask=active)
-    else:
-        tl.atomic_max(output_ptr + group, tile_amax)
-
-
-def _compute_global_scales(
-    matrix: torch.Tensor,
-    row_groups: torch.Tensor,
-    group_count: int,
-    active_rows: torch.Tensor | None = None,
-) -> torch.Tensor:
-    group_amax = torch.zeros(group_count, device=matrix.device, dtype=torch.float32)
-    if matrix.shape[0] > 0:
-        active_rows_ptr = row_groups if active_rows is None else active_rows
-        grid = (matrix.shape[0], triton.cdiv(matrix.shape[1], _AMAX_BLOCK_K))
-        _group_amax_kernel[grid](
-            matrix,
-            row_groups,
-            active_rows_ptr,
-            group_amax,
-            matrix.stride(0),
-            matrix.stride(1),
-            K=matrix.shape[1],
-            HAS_ACTIVE_ROW_LIMIT=active_rows is not None,
-            BLOCK_K=_AMAX_BLOCK_K,
-            num_warps=4,
-        )
-    return torch.where(
-        group_amax > 0,
-        group_amax / _GLOBAL_SCALE_DENOMINATOR,
-        torch.ones_like(group_amax),
-    )
-
-
-def _quantize_rows(
-    matrix: torch.Tensor,
-    global_scales: torch.Tensor,
-    row_groups: torch.Tensor,
-    scale_rows: torch.Tensor,
-    padded_scale_rows: int,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    rows, contraction_size = matrix.shape
-    active_rows = row_groups.numel()
-    scale_columns = _round_up(contraction_size // _NVFP4_BLOCK_SIZE, _SCALE_COL_TILE)
-    packed = torch.empty((rows, contraction_size // 2), device=matrix.device, dtype=torch.uint8)
-    scales = torch.ones(
-        (padded_scale_rows, scale_columns),
-        device=matrix.device,
-        dtype=torch.float8_e4m3fn,
-    )
-    if active_rows > 0:
-        grid = (active_rows, triton.cdiv(contraction_size, _QUANT_BLOCK_K))
-        _quantize_nvfp4_rows_kernel[grid](
-            matrix,
-            packed,
-            scales,
-            global_scales,
-            row_groups,
-            scale_rows,
-            matrix.stride(0),
-            matrix.stride(1),
-            K=contraction_size,
-            SCALE_COLS=scale_columns,
-            BLOCK_K=_QUANT_BLOCK_K,
-            num_warps=4,
-        )
-    return packed.view(torch.float4_e2m1fn_x2), scales
-
-
-def _quantize_activations(matrix: torch.Tensor, offsets: torch.Tensor) -> _NVFP4GroupedTensor:
-    """Quantize a 2D activation matrix with one global scale per token."""
-
-    _check_blackwell()
-    if matrix.ndim != 2:
-        raise ValueError("matrix must be 2D")
-    _check_matrix(matrix, "matrix")
-    if not matrix.is_contiguous():
-        matrix = matrix.contiguous()
-    if offsets.ndim != 1 or offsets.dtype != torch.int32 or offsets.device != matrix.device:
-        raise ValueError("offsets must be a 1D int32 tensor on the same CUDA device as matrix")
-
-    group_count = offsets.numel()
-    if group_count == 0:
-        raise ValueError("offsets must contain at least one group")
-    scale_rows = torch.empty(matrix.shape[0], device=matrix.device, dtype=torch.int32)
-    if matrix.shape[0] > 0:
-        _build_activation_metadata_kernel[(triton.cdiv(matrix.shape[0], _METADATA_BLOCK_M),)](
-            offsets,
-            scale_rows,
-            ROWS=matrix.shape[0],
-            GROUP_COUNT=group_count,
-            BLOCK_M=_METADATA_BLOCK_M,
-            num_warps=4,
-        )
-    scale_groups = torch.arange(matrix.shape[0], device=matrix.device, dtype=torch.int32)
-    global_scales = _compute_global_scales(
-        matrix,
-        scale_groups,
-        matrix.shape[0],
-        active_rows=offsets[-1:],
-    )
-
-    padded_scale_rows = _round_up(
-        matrix.shape[0] + group_count * (_SCALE_ROW_TILE - 1),
-        _SCALE_ROW_TILE,
-    )
-
-    packed, block_scales = _quantize_rows(
-        matrix,
-        global_scales,
-        scale_groups,
-        scale_rows,
-        padded_scale_rows,
-    )
-    return _NVFP4GroupedTensor(
-        data=packed,
-        block_scales=block_scales,
-        global_scales=global_scales,
-    )
-
-
-def _quantize_weights(weight: torch.Tensor) -> _NVFP4GroupedTensor:
-    """Quantize grouped right-hand weights with logical shape ``[G, K, N]``."""
-
-    _check_blackwell()
-    if weight.ndim != 3:
-        raise ValueError("weight must be 3D")
-    if weight.device.type != "cuda" or weight.dtype != torch.bfloat16:
-        raise ValueError("weight must be a CUDA bfloat16 tensor")
-
-    groups, contraction_size, output_size = weight.shape
-    if contraction_size % _NVFP4_GEMM_ALIGNMENT != 0:
-        raise ValueError(f"weight's contraction dimension must be divisible by {_NVFP4_GEMM_ALIGNMENT}")
-    if output_size % 8 != 0:
-        raise ValueError("weight's output dimension must be divisible by 8")
-
-    weight_rows = weight.transpose(-2, -1).contiguous()
-    flat_row_count = groups * output_size
-    flat_rows = torch.arange(flat_row_count, device=weight.device, dtype=torch.int32)
-    row_groups = flat_rows // output_size
-    global_scales = _compute_global_scales(
-        weight_rows.view(flat_row_count, contraction_size),
-        row_groups,
-        groups,
-    )
-    padded_output_size = _round_up(output_size, _SCALE_ROW_TILE)
-    scale_rows = row_groups * padded_output_size + flat_rows % output_size
-    packed, block_scales = _quantize_rows(
-        weight_rows.view(flat_row_count, contraction_size),
-        global_scales,
-        row_groups,
-        scale_rows,
-        groups * padded_output_size,
-    )
-    return _NVFP4GroupedTensor(
-        data=packed.view(groups, output_size, contraction_size // 2),
-        block_scales=block_scales.view(groups, -1),
-        global_scales=global_scales,
-    )
-
-
 def _grouped_mm_quantized(
-    activations: _NVFP4GroupedTensor,
-    weight: _NVFP4GroupedTensor,
+    activations: _NVFP4Tensor,
+    weight: _NVFP4Tensor,
     offsets: torch.Tensor,
 ) -> torch.Tensor:
     """Dispatch quantized operands to the owned SM100 grouped GEMM."""
@@ -382,10 +63,14 @@ def _forward(
     matrix: torch.Tensor,
     weight: torch.Tensor,
     offsets: torch.Tensor,
-) -> torch.Tensor:
-    activations_nvfp4 = _quantize_activations(matrix, offsets)
-    weight_nvfp4 = _quantize_weights(weight)
-    return _grouped_mm_quantized(activations_nvfp4, weight_nvfp4, offsets)
+) -> tuple[torch.Tensor, _NVFP4Tensor, _NVFP4Tensor]:
+    activations_nvfp4 = quantize_activations(matrix, offsets)
+    weight_nvfp4 = quantize_weights(weight)
+    return (
+        _grouped_mm_quantized(activations_nvfp4, weight_nvfp4, offsets),
+        activations_nvfp4,
+        weight_nvfp4,
+    )
 
 
 class _GroupedNVFP4MM(torch.autograd.Function):
@@ -395,18 +80,51 @@ class _GroupedNVFP4MM(torch.autograd.Function):
         matrix: torch.Tensor,
         weight: torch.Tensor,
         offsets: torch.Tensor,
+        backward: NVFP4Backward,
     ) -> torch.Tensor:
-        output = _forward(matrix, weight, offsets)
-        ctx.save_for_backward(matrix, weight, offsets)
+        output, activations_nvfp4, weight_nvfp4 = _forward(matrix, weight, offsets)
+        ctx.backward_recipe = backward
+        if backward == "bf16":
+            ctx.save_for_backward(matrix, weight, offsets)
+        else:
+            ctx.save_for_backward(
+                activations_nvfp4.data,
+                activations_nvfp4.block_scales,
+                activations_nvfp4.global_scales,
+                weight_nvfp4.data,
+                weight_nvfp4.block_scales,
+                weight_nvfp4.global_scales,
+                offsets,
+            )
         return output
 
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):
-        matrix, weight, offsets = ctx.saved_tensors
         grad_output = grad_output.contiguous().bfloat16()
 
         grad_matrix = grad_weight = None
+        if ctx.backward_recipe == "bf16":
+            matrix, weight, offsets = ctx.saved_tensors
+        else:
+            (
+                matrix_data,
+                matrix_block_scales,
+                matrix_global_scales,
+                weight_data,
+                weight_block_scales,
+                weight_global_scales,
+                offsets,
+            ) = ctx.saved_tensors
+            matrix = weight = None
+
         if ctx.needs_input_grad[0]:
+            if weight is None:
+                weight = _NVFP4Tensor(
+                    weight_data,
+                    weight_block_scales,
+                    weight_global_scales,
+                    None,
+                ).dequantize()
             grad_matrix = F.grouped_mm(
                 grad_output,
                 weight.transpose(-2, -1),
@@ -414,13 +132,20 @@ class _GroupedNVFP4MM(torch.autograd.Function):
                 out_dtype=torch.bfloat16,
             )
         if ctx.needs_input_grad[1]:
+            if matrix is None:
+                matrix = _NVFP4Tensor(
+                    matrix_data,
+                    matrix_block_scales,
+                    matrix_global_scales,
+                    offsets,
+                ).dequantize()
             grad_weight = F.grouped_mm(
                 matrix.transpose(0, 1),
                 grad_output,
                 offs=offsets,
                 out_dtype=torch.bfloat16,
             )
-        return grad_matrix, grad_weight, None
+        return grad_matrix, grad_weight, None, None
 
 
 @torch.compiler.disable
@@ -428,13 +153,20 @@ def grouped_gemm(
     matrix: torch.Tensor,
     weight: torch.Tensor,
     offsets: torch.Tensor,
+    backward: NVFP4Backward = "bf16_dequantized",
 ) -> torch.Tensor:
-    """Grouped NVFP4 forward with a BF16 straight-through backward.
+    """Grouped NVFP4 forward with a selectable BF16 backward recipe.
 
     ``matrix`` has shape ``[M, K]``, ``weight`` has shape ``[G, K, N]``, and
     ``offsets`` contains the cumulative row count for each of the ``G`` groups.
+
+    ``bf16`` saves the original BF16 operands for backward, while
+    ``bf16_dequantized`` saves the forward's packed NVFP4 operands and
+    dequantizes them to BF16 when backward runs.
     """
 
+    if backward not in ("bf16", "bf16_dequantized"):
+        raise ValueError("backward must be 'bf16' or 'bf16_dequantized'")
     if matrix.ndim != 2 or weight.ndim != 3:
         raise ValueError("matrix must be 2D and weight must be 3D")
     if weight.shape[0] != offsets.numel():
@@ -444,4 +176,4 @@ def grouped_gemm(
     _check_matrix(matrix, "matrix")
     if weight.device != matrix.device or weight.dtype != matrix.dtype:
         raise ValueError("weight must have the same CUDA device and dtype as matrix")
-    return _GroupedNVFP4MM.apply(matrix, weight, offsets)
+    return _GroupedNVFP4MM.apply(matrix, weight, offsets, backward)

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/__init__.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/__init__.py
@@ -1,0 +1,6 @@
+from prime_rl_kernels.nvfp4.quantize.functional import (
+    quantize_activations,
+    quantize_weights,
+)
+
+__all__ = ["quantize_activations", "quantize_weights"]

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/_extension.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/_extension.py
@@ -1,33 +1,124 @@
 from __future__ import annotations
 
 import functools
-import os
 from pathlib import Path
 
 import torch
-from torch.utils.cpp_extension import load
+
+from prime_rl_kernels.nvfp4._build import load_cuda_extension
 
 _EXTENSION_NAME = "prime_rl_kernels_nvfp4_quantize_sm100"
 _SOURCES = ("bindings.cpp", "quantize.cu")
+_EXTENSION_READY = False
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _quantize_activations_fake(
+    matrix: torch.Tensor,
+    offsets: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    rows, contraction_size = matrix.shape
+    groups = offsets.shape[0]
+    scale_columns = _round_up(contraction_size // 16, 4)
+    padded_scale_rows = _round_up(rows + groups * 127, 128)
+    return (
+        matrix.new_empty((rows, contraction_size // 2), dtype=torch.uint8),
+        matrix.new_empty(
+            (padded_scale_rows, scale_columns),
+            dtype=torch.float8_e4m3fn,
+        ),
+        matrix.new_empty((rows,), dtype=torch.float32),
+    )
+
+
+def _quantize_weights_fake(
+    weight_rows: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    groups, output_size, contraction_size = weight_rows.shape
+    padded_output_size = _round_up(output_size, 128)
+    scale_columns = _round_up(contraction_size // 16, 4)
+    return (
+        weight_rows.new_empty(
+            (groups, output_size, contraction_size // 2),
+            dtype=torch.uint8,
+        ),
+        weight_rows.new_empty(
+            (groups, padded_output_size * scale_columns),
+            dtype=torch.float8_e4m3fn,
+        ),
+        weight_rows.new_empty((groups,), dtype=torch.float32),
+    )
+
+
+def _dequantize_activations_fake(
+    packed: torch.Tensor,
+    block_scales: torch.Tensor,
+    global_scales: torch.Tensor,
+    offsets: torch.Tensor,
+) -> torch.Tensor:
+    del block_scales, global_scales, offsets
+    return packed.new_empty(
+        (packed.shape[0], packed.shape[1] * 2),
+        dtype=torch.bfloat16,
+    )
+
+
+def _dequantize_weights_fake(
+    packed: torch.Tensor,
+    block_scales: torch.Tensor,
+    global_scales: torch.Tensor,
+) -> torch.Tensor:
+    del block_scales, global_scales
+    return packed.new_empty(
+        (packed.shape[0], packed.shape[1], packed.shape[2] * 2),
+        dtype=torch.bfloat16,
+    )
 
 
 @functools.cache
 def _load_extension() -> None:
+    global _EXTENSION_READY
+
     source_dir = Path(__file__).with_name("csrc")
-    load(
-        name=_EXTENSION_NAME,
-        sources=[str(source_dir / source) for source in _SOURCES],
-        extra_cflags=["-O3", "-std=c++17"],
-        extra_cuda_cflags=[
-            "-O3",
-            "-std=c++17",
-            "--expt-relaxed-constexpr",
-            "--threads=4",
-            "-gencode=arch=compute_100a,code=sm_100a",
-        ],
-        with_cuda=True,
-        is_python_module=False,
-        verbose=os.environ.get("PRIME_RL_KERNELS_BUILD_VERBOSE") == "1",
+    extra_cflags = ["-O3", "-std=c++17"]
+    extra_cuda_cflags = [
+        "-O3",
+        "-std=c++17",
+        "--expt-relaxed-constexpr",
+        "--threads=4",
+        "-gencode=arch=compute_100a,code=sm_100a",
+    ]
+    load_cuda_extension(
+        base_name=_EXTENSION_NAME,
+        sources=[source_dir / source for source in _SOURCES],
+        fingerprint_files=source_dir.glob("*"),
+        extra_cflags=extra_cflags,
+        extra_cuda_cflags=extra_cuda_cflags,
+    )
+    _EXTENSION_READY = True
+
+
+@functools.cache
+def _prepare_extension_for_compile() -> None:
+    _load_extension()
+    torch.library.register_fake(
+        "prime_rl_kernels_nvfp4::quantize_activations",
+        _quantize_activations_fake,
+    )
+    torch.library.register_fake(
+        "prime_rl_kernels_nvfp4::quantize_weights",
+        _quantize_weights_fake,
+    )
+    torch.library.register_fake(
+        "prime_rl_kernels_nvfp4::dequantize_activations",
+        _dequantize_activations_fake,
+    )
+    torch.library.register_fake(
+        "prime_rl_kernels_nvfp4::dequantize_weights",
+        _dequantize_weights_fake,
     )
 
 
@@ -35,14 +126,16 @@ def _quantize_activations(
     matrix: torch.Tensor,
     offsets: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    _load_extension()
+    if not _EXTENSION_READY:
+        _load_extension()
     return torch.ops.prime_rl_kernels_nvfp4.quantize_activations.default(matrix, offsets)
 
 
 def _quantize_weights(
     weight_rows: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    _load_extension()
+    if not _EXTENSION_READY:
+        _load_extension()
     return torch.ops.prime_rl_kernels_nvfp4.quantize_weights.default(weight_rows)
 
 
@@ -52,7 +145,8 @@ def _dequantize_activations(
     global_scales: torch.Tensor,
     offsets: torch.Tensor,
 ) -> torch.Tensor:
-    _load_extension()
+    if not _EXTENSION_READY:
+        _load_extension()
     return torch.ops.prime_rl_kernels_nvfp4.dequantize_activations.default(
         packed,
         block_scales,
@@ -66,7 +160,8 @@ def _dequantize_weights(
     block_scales: torch.Tensor,
     global_scales: torch.Tensor,
 ) -> torch.Tensor:
-    _load_extension()
+    if not _EXTENSION_READY:
+        _load_extension()
     return torch.ops.prime_rl_kernels_nvfp4.dequantize_weights.default(
         packed,
         block_scales,

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/_extension.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/_extension.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import functools
+import os
+from pathlib import Path
+
+import torch
+from torch.utils.cpp_extension import load
+
+_EXTENSION_NAME = "prime_rl_kernels_nvfp4_quantize_sm100"
+_SOURCES = ("bindings.cpp", "quantize.cu")
+
+
+@functools.cache
+def _load_extension() -> None:
+    source_dir = Path(__file__).with_name("csrc")
+    load(
+        name=_EXTENSION_NAME,
+        sources=[str(source_dir / source) for source in _SOURCES],
+        extra_cflags=["-O3", "-std=c++17"],
+        extra_cuda_cflags=[
+            "-O3",
+            "-std=c++17",
+            "--expt-relaxed-constexpr",
+            "--threads=4",
+            "-gencode=arch=compute_100a,code=sm_100a",
+        ],
+        with_cuda=True,
+        is_python_module=False,
+        verbose=os.environ.get("PRIME_RL_KERNELS_BUILD_VERBOSE") == "1",
+    )
+
+
+def _quantize_activations(
+    matrix: torch.Tensor,
+    offsets: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    _load_extension()
+    return torch.ops.prime_rl_kernels_nvfp4.quantize_activations.default(matrix, offsets)
+
+
+def _quantize_weights(
+    weight_rows: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    _load_extension()
+    return torch.ops.prime_rl_kernels_nvfp4.quantize_weights.default(weight_rows)
+
+
+def _dequantize_activations(
+    packed: torch.Tensor,
+    block_scales: torch.Tensor,
+    global_scales: torch.Tensor,
+    offsets: torch.Tensor,
+) -> torch.Tensor:
+    _load_extension()
+    return torch.ops.prime_rl_kernels_nvfp4.dequantize_activations.default(
+        packed,
+        block_scales,
+        global_scales,
+        offsets,
+    )
+
+
+def _dequantize_weights(
+    packed: torch.Tensor,
+    block_scales: torch.Tensor,
+    global_scales: torch.Tensor,
+) -> torch.Tensor:
+    _load_extension()
+    return torch.ops.prime_rl_kernels_nvfp4.dequantize_weights.default(
+        packed,
+        block_scales,
+        global_scales,
+    )

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/csrc/bindings.cpp
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/csrc/bindings.cpp
@@ -1,0 +1,49 @@
+#include <ATen/ATen.h>
+#include <torch/library.h>
+
+#include <tuple>
+
+namespace prime_rl_kernels::nvfp4 {
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+quantize_activations_cuda(
+    const at::Tensor& matrix,
+    const at::Tensor& offsets);
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+quantize_weights_cuda(const at::Tensor& weight_rows);
+
+at::Tensor dequantize_activations_cuda(
+    const at::Tensor& packed,
+    const at::Tensor& block_scales,
+    const at::Tensor& global_scales,
+    const at::Tensor& offsets);
+
+at::Tensor dequantize_weights_cuda(
+    const at::Tensor& packed,
+    const at::Tensor& block_scales,
+    const at::Tensor& global_scales);
+
+TORCH_LIBRARY_FRAGMENT(prime_rl_kernels_nvfp4, m) {
+  m.def(
+      "quantize_activations(Tensor matrix, Tensor offsets) -> "
+      "(Tensor, Tensor, Tensor)");
+  m.def(
+      "quantize_weights(Tensor weight_rows) -> "
+      "(Tensor, Tensor, Tensor)");
+  m.def(
+      "dequantize_activations(Tensor packed, Tensor block_scales, "
+      "Tensor global_scales, Tensor offsets) -> Tensor");
+  m.def(
+      "dequantize_weights(Tensor packed, Tensor block_scales, "
+      "Tensor global_scales) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(prime_rl_kernels_nvfp4, CUDA, m) {
+  m.impl("quantize_activations", quantize_activations_cuda);
+  m.impl("quantize_weights", quantize_weights_cuda);
+  m.impl("dequantize_activations", dequantize_activations_cuda);
+  m.impl("dequantize_weights", dequantize_weights_cuda);
+}
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/csrc/quantize.cu
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/csrc/quantize.cu
@@ -421,15 +421,18 @@ __global__ void quantize_activations_tiled_kernel(
       min(
           kQuantScaleTilesPerCta,
           scale_column_tiles - first_scale_tile);
-  if (threadIdx.x <
+  const int scale_vectors =
       valid_scale_tiles * kScaleRowTile * kScaleColTile /
-          static_cast<int>(sizeof(uint4))) {
+      static_cast<int>(sizeof(uint4));
+  for (int vector = threadIdx.x;
+       vector < scale_vectors;
+       vector += blockDim.x) {
     const int64_t tile_offset =
         (static_cast<int64_t>(blockIdx.x) * scale_column_tiles +
          first_scale_tile) *
         (kScaleRowTile * kScaleColTile);
-    reinterpret_cast<uint4*>(block_scales + tile_offset)[threadIdx.x] =
-        reinterpret_cast<const uint4*>(scale_tile)[threadIdx.x];
+    reinterpret_cast<uint4*>(block_scales + tile_offset)[vector] =
+        reinterpret_cast<const uint4*>(scale_tile)[vector];
   }
 }
 
@@ -485,15 +488,18 @@ __global__ void quantize_weights_tiled_kernel(
       min(
           kQuantScaleTilesPerCta,
           scale_column_tiles - first_scale_tile);
-  if (threadIdx.x <
+  const int scale_vectors =
       valid_scale_tiles * kScaleRowTile * kScaleColTile /
-          static_cast<int>(sizeof(uint4))) {
+      static_cast<int>(sizeof(uint4));
+  for (int vector = threadIdx.x;
+       vector < scale_vectors;
+       vector += blockDim.x) {
     const int64_t tile_offset =
         (static_cast<int64_t>(blockIdx.x) * scale_column_tiles +
          first_scale_tile) *
         (kScaleRowTile * kScaleColTile);
-    reinterpret_cast<uint4*>(block_scales + tile_offset)[threadIdx.x] =
-        reinterpret_cast<const uint4*>(scale_tile)[threadIdx.x];
+    reinterpret_cast<uint4*>(block_scales + tile_offset)[vector] =
+        reinterpret_cast<const uint4*>(scale_tile)[vector];
   }
 }
 

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/csrc/quantize.cu
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/csrc/quantize.cu
@@ -1,0 +1,961 @@
+/*
+ * Portions of the Blackwell BF16-to-E2M1 conversion sequence are adapted
+ * from NVIDIA Transformer Engine, Copyright NVIDIA Corporation & affiliates,
+ * under the Apache License 2.0.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+
+#include <cuda_bf16.h>
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <tuple>
+
+namespace prime_rl_kernels::nvfp4 {
+namespace {
+
+constexpr int kSfVectorSize = 16;
+constexpr int kScaleRowTile = 128;
+constexpr int kScaleColTile = 4;
+constexpr int kQuantThreads = 256;
+constexpr int kQuantScaleColsPerCta = 64;
+constexpr int kQuantScaleTilesPerCta =
+    kQuantScaleColsPerCta / kScaleColTile;
+constexpr int kQuantScaleTileElements =
+    kScaleRowTile * kQuantScaleColsPerCta;
+constexpr int kQuantItemsPerThread =
+    kQuantScaleTileElements / kQuantThreads;
+constexpr int kDequantScaleColsPerCta = 32;
+constexpr int kDequantScaleTilesPerCta =
+    kDequantScaleColsPerCta / kScaleColTile;
+constexpr int kDequantScaleTileElements =
+    kScaleRowTile * kDequantScaleColsPerCta;
+constexpr int kDequantItemsPerThread =
+    kDequantScaleTileElements / kQuantThreads;
+constexpr int kReductionThreads = 256;
+constexpr float kGlobalScaleDenominator = 6.0f * 448.0f;
+
+__host__ __device__ __forceinline__ int64_t round_up(
+    int64_t value,
+    int64_t multiple) {
+  return ((value + multiple - 1) / multiple) * multiple;
+}
+
+void check_sm100() {
+  const auto* properties =
+      at::cuda::getDeviceProperties(at::cuda::current_device());
+  TORCH_CHECK(
+      properties->major == 10 && properties->minor == 0,
+      "prime-rl-kernels NVFP4 quantization requires SM100, but the current "
+      "device is SM",
+      properties->major,
+      properties->minor,
+      ".");
+}
+
+void check_bf16_matrix(const at::Tensor& tensor, const char* name) {
+  TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor.");
+  TORCH_CHECK(tensor.scalar_type() == at::kBFloat16, name, " must be BF16.");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous.");
+}
+
+void check_quantized_tensors(
+    const at::Tensor& packed,
+    const at::Tensor& block_scales,
+    const at::Tensor& global_scales) {
+  TORCH_CHECK(packed.is_cuda(), "packed must be a CUDA tensor.");
+  TORCH_CHECK(packed.scalar_type() == at::kByte, "packed must use byte storage.");
+  TORCH_CHECK(packed.is_contiguous(), "packed must be contiguous.");
+  TORCH_CHECK(
+      block_scales.device() == packed.device() &&
+          global_scales.device() == packed.device(),
+      "quantized tensors must be on the same CUDA device.");
+  TORCH_CHECK(
+      block_scales.scalar_type() == at::kFloat8_e4m3fn,
+      "block_scales must be FP8 E4M3.");
+  TORCH_CHECK(
+      global_scales.scalar_type() == at::kFloat,
+      "global_scales must be FP32.");
+  TORCH_CHECK(
+      block_scales.is_contiguous() && global_scales.is_contiguous(),
+      "quantized tensors must be contiguous.");
+}
+
+struct alignas(16) Bf16Block {
+  uint4 vectors[2];
+};
+
+union FP4Block {
+  uint64_t packed;
+  __nv_fp4x4_e2m1 values[4];
+};
+
+__device__ __forceinline__ Bf16Block load_bf16_block(
+    const __nv_bfloat16* input) {
+  Bf16Block block;
+  const auto* vectors = reinterpret_cast<const uint4*>(input);
+  block.vectors[0] = __ldcg(vectors);
+  block.vectors[1] = __ldcg(vectors + 1);
+  return block;
+}
+
+__device__ __forceinline__ float block_amax(const Bf16Block& block) {
+  const auto* pairs = reinterpret_cast<const uint32_t*>(block.vectors);
+  uint32_t maximum = 0;
+#pragma unroll
+  for (int index = 0; index < 8; ++index) {
+    asm volatile(
+        "max.xorsign.abs.bf16x2 %0, %1, %2;"
+        : "=r"(maximum)
+        : "r"(maximum), "r"(pairs[index]));
+  }
+  const float2 values =
+      __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162*>(&maximum));
+  return fmaxf(fabsf(values.x), fabsf(values.y));
+}
+
+__device__ __forceinline__ float warp_max(float value) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value = fmaxf(value, __shfl_down_sync(0xffffffffu, value, offset));
+  }
+  return value;
+}
+
+__device__ __forceinline__ float block_max(
+    float value,
+    float* warp_maxima) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  value = warp_max(value);
+  if (lane == 0) {
+    warp_maxima[warp] = value;
+  }
+  __syncthreads();
+  if (warp == 0) {
+    value = lane < (blockDim.x >> 5) ? warp_maxima[lane] : 0.0f;
+    value = warp_max(value);
+  }
+  return __shfl_sync(0xffffffffu, value, 0);
+}
+
+// Adapted from Transformer Engine's Blackwell BF16-to-E2M1 conversion. Keeping
+// the coefficient in FP32 avoids an extra recipe-changing BF16 rounding.
+__device__ __forceinline__ uint32_t pack_e2m1_8(
+    uint64_t values_03,
+    uint64_t values_47,
+    float coefficient) {
+  uint32_t output;
+  asm volatile(
+      "{\n"
+      ".reg.b64 coefficient_2x;\n\t"
+      "mov.b64 coefficient_2x, {%3, %3};\n\t"
+      ".reg.b16 h0, h1, h2, h3, h4, h5, h6, h7;\n\t"
+      "mov.b64 {h0, h1, h2, h3}, %1;\n\t"
+      "mov.b64 {h4, h5, h6, h7}, %2;\n\t"
+      ".reg.b32 v0, v1, v2, v3, v4, v5, v6, v7;\n\t"
+      "cvt.f32.bf16 v0, h0;\n\t"
+      "cvt.f32.bf16 v1, h1;\n\t"
+      "cvt.f32.bf16 v2, h2;\n\t"
+      "cvt.f32.bf16 v3, h3;\n\t"
+      "cvt.f32.bf16 v4, h4;\n\t"
+      "cvt.f32.bf16 v5, h5;\n\t"
+      "cvt.f32.bf16 v6, h6;\n\t"
+      "cvt.f32.bf16 v7, h7;\n\t"
+      ".reg.b64 v01, v23, v45, v67;\n\t"
+      "mov.b64 v01, {v0, v1};\n\t"
+      "mov.b64 v23, {v2, v3};\n\t"
+      "mov.b64 v45, {v4, v5};\n\t"
+      "mov.b64 v67, {v6, v7};\n\t"
+      "mul.f32x2 v01, v01, coefficient_2x;\n\t"
+      "mul.f32x2 v23, v23, coefficient_2x;\n\t"
+      "mul.f32x2 v45, v45, coefficient_2x;\n\t"
+      "mul.f32x2 v67, v67, coefficient_2x;\n\t"
+      "mov.b64 {v1, v0}, v01;\n\t"
+      "mov.b64 {v3, v2}, v23;\n\t"
+      "mov.b64 {v5, v4}, v45;\n\t"
+      "mov.b64 {v7, v6}, v67;\n\t"
+      ".reg.b8 f0, f1, f2, f3;\n\t"
+      "cvt.rn.satfinite.e2m1x2.f32 f0, v0, v1;\n\t"
+      "cvt.rn.satfinite.e2m1x2.f32 f1, v2, v3;\n\t"
+      "cvt.rn.satfinite.e2m1x2.f32 f2, v4, v5;\n\t"
+      "cvt.rn.satfinite.e2m1x2.f32 f3, v6, v7;\n\t"
+      "mov.b32 %0, {f0, f1, f2, f3};\n\t"
+      "}"
+      : "=r"(output)
+      : "l"(values_03), "l"(values_47), "f"(coefficient));
+  return output;
+}
+
+__device__ __forceinline__ uint64_t pack_e2m1(
+    const Bf16Block& block,
+    float coefficient) {
+  const auto* words = reinterpret_cast<const uint64_t*>(block.vectors);
+  const uint32_t low = pack_e2m1_8(words[0], words[1], coefficient);
+  const uint32_t high = pack_e2m1_8(words[2], words[3], coefficient);
+  return static_cast<uint64_t>(low) |
+      (static_cast<uint64_t>(high) << 32);
+}
+
+__device__ __forceinline__ Bf16Block dequantize_e2m1(
+    uint64_t packed,
+    float decode_scale) {
+  FP4Block input;
+  input.packed = packed;
+  Bf16Block output;
+  auto* output_pairs = reinterpret_cast<__nv_bfloat162*>(output.vectors);
+#pragma unroll
+  for (int index = 0; index < 4; ++index) {
+    const float4 values = static_cast<float4>(input.values[index]);
+    output_pairs[index * 2] = __floats2bfloat162_rn(
+        values.x * decode_scale,
+        values.y * decode_scale);
+    output_pairs[index * 2 + 1] = __floats2bfloat162_rn(
+        values.z * decode_scale,
+        values.w * decode_scale);
+  }
+  return output;
+}
+
+__device__ __forceinline__ float reciprocal_approximate(float value) {
+  float result;
+  asm volatile("rcp.approx.ftz.f32 %0, %1;" : "=f"(result) : "f"(value));
+  return result;
+}
+
+template <int kScaleCols>
+__device__ __forceinline__ int local_scale_offset(
+    int row_in_tile,
+    int scale_column_in_cta) {
+  return (scale_column_in_cta >> 2) * (kScaleRowTile * kScaleColTile) +
+      ((row_in_tile & 31) << 4) |
+      (((row_in_tile >> 5) & 3) << 2) |
+      (scale_column_in_cta & 3);
+}
+
+__device__ __forceinline__ uint8_t quantize_block(
+    const Bf16Block& input,
+    float global_decode_scale,
+    uint64_t* packed) {
+  const float local_amax = block_amax(input);
+  float scale_value = 0.0f;
+  if (global_decode_scale > 0.0f && local_amax > 0.0f) {
+    scale_value =
+        local_amax * reciprocal_approximate(6.0f * global_decode_scale);
+  }
+  const __nv_fp8_e4m3 fp8_scale(scale_value);
+  const float decode_scale =
+      static_cast<float>(fp8_scale) * global_decode_scale;
+  const float coefficient =
+      decode_scale > 0.0f ? reciprocal_approximate(decode_scale) : 0.0f;
+  *packed = pack_e2m1(input, coefficient);
+  return fp8_scale.__x;
+}
+
+__device__ __forceinline__ bool activation_tile_metadata(
+    int tile,
+    const int32_t* offsets,
+    int group_count,
+    int* global_row_start,
+    int* valid_rows) {
+  int group_start = 0;
+  int tile_start = 0;
+  for (int group = 0; group < group_count; ++group) {
+    const int group_end = offsets[group];
+    const int group_rows = group_end - group_start;
+    const int group_tiles =
+        (group_rows + kScaleRowTile - 1) / kScaleRowTile;
+    if (tile < tile_start + group_tiles) {
+      const int tile_in_group = tile - tile_start;
+      *global_row_start =
+          group_start + tile_in_group * kScaleRowTile;
+      *valid_rows = min(
+          kScaleRowTile,
+          group_end - *global_row_start);
+      return true;
+    }
+    group_start = group_end;
+    tile_start += group_tiles;
+  }
+  return false;
+}
+
+__global__ void activation_amax_kernel(
+    const __nv_bfloat16* __restrict__ input,
+    float* __restrict__ global_scales,
+    int rows,
+    int contraction_size) {
+  __shared__ float warp_maxima[kReductionThreads / 32];
+  const int scale_columns = contraction_size / kSfVectorSize;
+  for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+    float local_amax = 0.0f;
+    for (int scale_column = threadIdx.x;
+         scale_column < scale_columns;
+         scale_column += blockDim.x) {
+      const int64_t input_offset =
+          static_cast<int64_t>(row) * contraction_size +
+          scale_column * kSfVectorSize;
+      local_amax = fmaxf(
+          local_amax,
+          block_amax(load_bf16_block(input + input_offset)));
+    }
+    const float maximum = block_max(local_amax, warp_maxima);
+    if (threadIdx.x == 0) {
+      global_scales[row] =
+          maximum > 0.0f ? maximum / kGlobalScaleDenominator : 0.0f;
+    }
+    __syncthreads();
+  }
+}
+
+__global__ void weight_amax_kernel(
+    const __nv_bfloat16* __restrict__ input,
+    float* __restrict__ expert_amax,
+    int64_t elements_per_expert,
+    int blocks_per_expert) {
+  __shared__ float warp_maxima[kReductionThreads / 32];
+  const int expert = blockIdx.x / blocks_per_expert;
+  const int expert_block = blockIdx.x % blocks_per_expert;
+  const int64_t scale_blocks = elements_per_expert / kSfVectorSize;
+  float local_amax = 0.0f;
+  for (int64_t scale_block =
+           static_cast<int64_t>(expert_block) * blockDim.x + threadIdx.x;
+       scale_block < scale_blocks;
+       scale_block += static_cast<int64_t>(blocks_per_expert) * blockDim.x) {
+    const int64_t input_offset =
+        static_cast<int64_t>(expert) * elements_per_expert +
+        scale_block * kSfVectorSize;
+    local_amax = fmaxf(
+        local_amax,
+        block_amax(load_bf16_block(input + input_offset)));
+  }
+  const float maximum = block_max(local_amax, warp_maxima);
+  if (threadIdx.x == 0) {
+    atomicMax(
+        reinterpret_cast<unsigned int*>(expert_amax + expert),
+        __float_as_uint(maximum));
+  }
+}
+
+__global__ void finalize_weight_scales_kernel(
+    const float* __restrict__ expert_amax,
+    float* __restrict__ global_scales,
+    int groups) {
+  const int expert = blockIdx.x * blockDim.x + threadIdx.x;
+  if (expert < groups) {
+    const float maximum = expert_amax[expert];
+    global_scales[expert] =
+        maximum > 0.0f ? maximum / kGlobalScaleDenominator : 0.0f;
+  }
+}
+
+__global__ void quantize_activations_tiled_kernel(
+    const __nv_bfloat16* __restrict__ input,
+    const int32_t* __restrict__ offsets,
+    uint8_t* __restrict__ packed,
+    uint8_t* __restrict__ block_scales,
+    const float* __restrict__ global_scales,
+    int contraction_size,
+    int group_count,
+    int scale_column_tiles) {
+  __shared__ alignas(16) uint8_t scale_tile[kQuantScaleTileElements];
+  __shared__ int global_row_start;
+  __shared__ int valid_rows;
+  __shared__ int active;
+
+  if (threadIdx.x == 0) {
+    active = activation_tile_metadata(
+        blockIdx.x,
+        offsets,
+        group_count,
+        &global_row_start,
+        &valid_rows);
+  }
+  __syncthreads();
+  if (!active) {
+    return;
+  }
+
+#pragma unroll
+  for (int item = 0; item < kQuantItemsPerThread; ++item) {
+    const int tile_index = threadIdx.x + item * kQuantThreads;
+    const int row_in_tile = tile_index / kQuantScaleColsPerCta;
+    const int column_in_tile = tile_index % kQuantScaleColsPerCta;
+    const int scale_column =
+        blockIdx.y * kQuantScaleColsPerCta + column_in_tile;
+    uint8_t scale = 0;
+    if (row_in_tile < valid_rows &&
+        scale_column < contraction_size / kSfVectorSize) {
+      const int row = global_row_start + row_in_tile;
+      const int64_t input_offset =
+          static_cast<int64_t>(row) * contraction_size +
+          scale_column * kSfVectorSize;
+      uint64_t packed_value;
+      scale = quantize_block(
+          load_bf16_block(input + input_offset),
+          global_scales[row],
+          &packed_value);
+      const int64_t packed_offset =
+          static_cast<int64_t>(row) * (contraction_size / 2) +
+          scale_column * 8;
+      *reinterpret_cast<uint64_t*>(packed + packed_offset) =
+          packed_value;
+    }
+    scale_tile[local_scale_offset<kQuantScaleColsPerCta>(
+        row_in_tile,
+        column_in_tile)] =
+        scale;
+  }
+  __syncthreads();
+
+  const int first_scale_tile =
+      blockIdx.y * kQuantScaleTilesPerCta;
+  const int valid_scale_tiles =
+      min(
+          kQuantScaleTilesPerCta,
+          scale_column_tiles - first_scale_tile);
+  if (threadIdx.x <
+      valid_scale_tiles * kScaleRowTile * kScaleColTile /
+          static_cast<int>(sizeof(uint4))) {
+    const int64_t tile_offset =
+        (static_cast<int64_t>(blockIdx.x) * scale_column_tiles +
+         first_scale_tile) *
+        (kScaleRowTile * kScaleColTile);
+    reinterpret_cast<uint4*>(block_scales + tile_offset)[threadIdx.x] =
+        reinterpret_cast<const uint4*>(scale_tile)[threadIdx.x];
+  }
+}
+
+__global__ void quantize_weights_tiled_kernel(
+    const __nv_bfloat16* __restrict__ input,
+    const float* __restrict__ global_scales,
+    uint8_t* __restrict__ packed,
+    uint8_t* __restrict__ block_scales,
+    int output_size,
+    int contraction_size,
+    int output_row_tiles,
+    int scale_column_tiles) {
+  __shared__ alignas(16) uint8_t scale_tile[kQuantScaleTileElements];
+  const int expert = blockIdx.x / output_row_tiles;
+  const int output_tile = blockIdx.x % output_row_tiles;
+  const int output_row_start = output_tile * kScaleRowTile;
+
+#pragma unroll
+  for (int item = 0; item < kQuantItemsPerThread; ++item) {
+    const int tile_index = threadIdx.x + item * kQuantThreads;
+    const int row_in_tile = tile_index / kQuantScaleColsPerCta;
+    const int column_in_tile = tile_index % kQuantScaleColsPerCta;
+    const int output_row = output_row_start + row_in_tile;
+    const int scale_column =
+        blockIdx.y * kQuantScaleColsPerCta + column_in_tile;
+    uint8_t scale = 0;
+    if (output_row < output_size &&
+        scale_column < contraction_size / kSfVectorSize) {
+      const int64_t row =
+          static_cast<int64_t>(expert) * output_size + output_row;
+      const int64_t input_offset =
+          row * contraction_size + scale_column * kSfVectorSize;
+      uint64_t packed_value;
+      scale = quantize_block(
+          load_bf16_block(input + input_offset),
+          global_scales[expert],
+          &packed_value);
+      const int64_t packed_offset =
+          row * (contraction_size / 2) + scale_column * 8;
+      *reinterpret_cast<uint64_t*>(packed + packed_offset) =
+          packed_value;
+    }
+    scale_tile[local_scale_offset<kQuantScaleColsPerCta>(
+        row_in_tile,
+        column_in_tile)] =
+        scale;
+  }
+  __syncthreads();
+
+  const int first_scale_tile =
+      blockIdx.y * kQuantScaleTilesPerCta;
+  const int valid_scale_tiles =
+      min(
+          kQuantScaleTilesPerCta,
+          scale_column_tiles - first_scale_tile);
+  if (threadIdx.x <
+      valid_scale_tiles * kScaleRowTile * kScaleColTile /
+          static_cast<int>(sizeof(uint4))) {
+    const int64_t tile_offset =
+        (static_cast<int64_t>(blockIdx.x) * scale_column_tiles +
+         first_scale_tile) *
+        (kScaleRowTile * kScaleColTile);
+    reinterpret_cast<uint4*>(block_scales + tile_offset)[threadIdx.x] =
+        reinterpret_cast<const uint4*>(scale_tile)[threadIdx.x];
+  }
+}
+
+__global__ void dequantize_activations_tiled_kernel(
+    const uint8_t* __restrict__ packed,
+    const uint8_t* __restrict__ block_scales,
+    const float* __restrict__ global_scales,
+    const int32_t* __restrict__ offsets,
+    __nv_bfloat16* __restrict__ output,
+    int contraction_size,
+    int group_count,
+    int scale_column_tiles) {
+  __shared__ alignas(16) uint8_t scale_tile[kDequantScaleTileElements];
+  __shared__ int global_row_start;
+  __shared__ int valid_rows;
+  __shared__ int active;
+
+  if (threadIdx.x == 0) {
+    active = activation_tile_metadata(
+        blockIdx.x,
+        offsets,
+        group_count,
+        &global_row_start,
+        &valid_rows);
+  }
+  const int first_scale_tile =
+      blockIdx.y * kDequantScaleTilesPerCta;
+  const int valid_scale_tiles =
+      min(
+          kDequantScaleTilesPerCta,
+          scale_column_tiles - first_scale_tile);
+  if (threadIdx.x <
+      valid_scale_tiles * kScaleRowTile * kScaleColTile /
+          static_cast<int>(sizeof(uint4))) {
+    const int64_t tile_offset =
+        (static_cast<int64_t>(blockIdx.x) * scale_column_tiles +
+         first_scale_tile) *
+        (kScaleRowTile * kScaleColTile);
+    reinterpret_cast<uint4*>(scale_tile)[threadIdx.x] =
+        reinterpret_cast<const uint4*>(
+            block_scales + tile_offset)[threadIdx.x];
+  }
+  __syncthreads();
+  if (!active) {
+    return;
+  }
+
+#pragma unroll
+  for (int item = 0; item < kDequantItemsPerThread; ++item) {
+    const int tile_index = threadIdx.x + item * kQuantThreads;
+    const int row_in_tile = tile_index / kDequantScaleColsPerCta;
+    const int column_in_tile = tile_index % kDequantScaleColsPerCta;
+    const int scale_column =
+        blockIdx.y * kDequantScaleColsPerCta + column_in_tile;
+    if (row_in_tile < valid_rows &&
+        scale_column < contraction_size / kSfVectorSize) {
+      const int row = global_row_start + row_in_tile;
+      const int64_t packed_offset =
+          static_cast<int64_t>(row) * (contraction_size / 2) +
+          scale_column * 8;
+      const uint64_t packed_value =
+          *reinterpret_cast<const uint64_t*>(packed + packed_offset);
+      const uint8_t scale_bits =
+          scale_tile[local_scale_offset<kDequantScaleColsPerCta>(
+              row_in_tile,
+              column_in_tile)];
+      __nv_fp8_e4m3 scale;
+      scale.__x = scale_bits;
+      const float decode_scale =
+          static_cast<float>(scale) * global_scales[row];
+      const Bf16Block values =
+          dequantize_e2m1(packed_value, decode_scale);
+      const int64_t output_offset =
+          static_cast<int64_t>(row) * contraction_size +
+          scale_column * kSfVectorSize;
+      auto* output_vectors =
+          reinterpret_cast<uint4*>(output + output_offset);
+      output_vectors[0] = values.vectors[0];
+      output_vectors[1] = values.vectors[1];
+    }
+  }
+}
+
+__global__ void dequantize_weights_tiled_kernel(
+    const uint8_t* __restrict__ packed,
+    const uint8_t* __restrict__ block_scales,
+    const float* __restrict__ global_scales,
+    __nv_bfloat16* __restrict__ output,
+    int output_size,
+    int contraction_size,
+    int output_row_tiles,
+    int scale_column_tiles) {
+  __shared__ alignas(16) uint8_t scale_tile[kDequantScaleTileElements];
+  const int expert = blockIdx.x / output_row_tiles;
+  const int output_tile = blockIdx.x % output_row_tiles;
+  const int output_row_start = output_tile * kScaleRowTile;
+
+  const int first_scale_tile =
+      blockIdx.y * kDequantScaleTilesPerCta;
+  const int valid_scale_tiles =
+      min(
+          kDequantScaleTilesPerCta,
+          scale_column_tiles - first_scale_tile);
+  if (threadIdx.x <
+      valid_scale_tiles * kScaleRowTile * kScaleColTile /
+          static_cast<int>(sizeof(uint4))) {
+    const int64_t tile_offset =
+        (static_cast<int64_t>(blockIdx.x) * scale_column_tiles +
+         first_scale_tile) *
+        (kScaleRowTile * kScaleColTile);
+    reinterpret_cast<uint4*>(scale_tile)[threadIdx.x] =
+        reinterpret_cast<const uint4*>(
+            block_scales + tile_offset)[threadIdx.x];
+  }
+  __syncthreads();
+
+#pragma unroll
+  for (int item = 0; item < kDequantItemsPerThread; ++item) {
+    const int tile_index = threadIdx.x + item * kQuantThreads;
+    const int row_in_tile = tile_index / kDequantScaleColsPerCta;
+    const int column_in_tile = tile_index % kDequantScaleColsPerCta;
+    const int output_row = output_row_start + row_in_tile;
+    const int scale_column =
+        blockIdx.y * kDequantScaleColsPerCta + column_in_tile;
+    if (output_row < output_size &&
+        scale_column < contraction_size / kSfVectorSize) {
+      const int64_t row =
+          static_cast<int64_t>(expert) * output_size + output_row;
+      const int64_t packed_offset =
+          row * (contraction_size / 2) + scale_column * 8;
+      const uint64_t packed_value =
+          *reinterpret_cast<const uint64_t*>(packed + packed_offset);
+      const uint8_t scale_bits =
+          scale_tile[local_scale_offset<kDequantScaleColsPerCta>(
+              row_in_tile,
+              column_in_tile)];
+      __nv_fp8_e4m3 scale;
+      scale.__x = scale_bits;
+      const float decode_scale =
+          static_cast<float>(scale) * global_scales[expert];
+      const Bf16Block values =
+          dequantize_e2m1(packed_value, decode_scale);
+      const int64_t output_offset =
+          row * contraction_size + scale_column * kSfVectorSize;
+      auto* output_vectors =
+          reinterpret_cast<uint4*>(output + output_offset);
+      output_vectors[0] = values.vectors[0];
+      output_vectors[1] = values.vectors[1];
+    }
+  }
+}
+
+int weight_amax_blocks_per_expert(
+    int device,
+    int groups,
+    int64_t scale_blocks_per_expert) {
+  const auto* properties = at::cuda::getDeviceProperties(device);
+  const int target = std::max(
+      1,
+      (properties->multiProcessorCount * 4 + groups - 1) / groups);
+  const int available = std::max<int64_t>(
+      1,
+      (scale_blocks_per_expert + kReductionThreads - 1) /
+          kReductionThreads);
+  return std::min(256, std::min(target, available));
+}
+
+int activation_amax_threads(int contraction_size) {
+  const int scale_columns = contraction_size / kSfVectorSize;
+  return std::min(
+      kReductionThreads,
+      std::max(32, static_cast<int>(round_up(scale_columns, 32))));
+}
+
+int activation_amax_blocks(
+    int device,
+    int rows,
+    int threads,
+    int contraction_size) {
+  if (contraction_size >= 2688) {
+    return rows;
+  }
+  const auto* properties = at::cuda::getDeviceProperties(device);
+  const int blocks_per_sm = std::max(1, 1024 / threads);
+  return std::min(rows, properties->multiProcessorCount * blocks_per_sm);
+}
+
+} // namespace
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+quantize_activations_cuda(
+    const at::Tensor& matrix,
+    const at::Tensor& offsets) {
+  check_bf16_matrix(matrix, "matrix");
+  TORCH_CHECK(matrix.dim() == 2, "matrix must be 2D.");
+  TORCH_CHECK(
+      matrix.size(1) > 0 && matrix.size(1) % 32 == 0,
+      "matrix's contraction dimension must be a positive multiple of 32.");
+  TORCH_CHECK(offsets.is_cuda(), "offsets must be a CUDA tensor.");
+  TORCH_CHECK(offsets.scalar_type() == at::kInt, "offsets must be int32.");
+  TORCH_CHECK(
+      offsets.dim() == 1 && offsets.numel() > 0,
+      "offsets must be a non-empty 1D tensor.");
+  TORCH_CHECK(offsets.is_contiguous(), "offsets must be contiguous.");
+  TORCH_CHECK(
+      offsets.device() == matrix.device(),
+      "matrix and offsets must be on the same device.");
+
+  c10::cuda::CUDAGuard device_guard(matrix.device());
+  check_sm100();
+
+  const int64_t rows = matrix.size(0);
+  const int64_t contraction_size = matrix.size(1);
+  const int64_t group_count = offsets.numel();
+  const int64_t scale_columns =
+      round_up(contraction_size / kSfVectorSize, kScaleColTile);
+  const int64_t scale_column_tiles =
+      scale_columns / kScaleColTile;
+  const int64_t scale_column_ctas =
+      round_up(scale_column_tiles, kQuantScaleTilesPerCta) /
+      kQuantScaleTilesPerCta;
+  const int64_t padded_scale_rows =
+      round_up(rows + group_count * (kScaleRowTile - 1), kScaleRowTile);
+  const int64_t scale_row_tiles =
+      padded_scale_rows / kScaleRowTile;
+
+  auto packed = at::empty(
+      {rows, contraction_size / 2},
+      matrix.options().dtype(at::kByte));
+  auto block_scales = at::empty(
+      {padded_scale_rows, scale_columns},
+      matrix.options().dtype(at::kFloat8_e4m3fn));
+  auto global_scales =
+      at::empty({rows}, matrix.options().dtype(at::kFloat));
+
+  if (rows > 0) {
+    const int device = matrix.get_device();
+    const cudaStream_t stream =
+        at::cuda::getCurrentCUDAStream(device);
+    const int amax_threads =
+        activation_amax_threads(contraction_size);
+    const int amax_blocks =
+        activation_amax_blocks(
+            device,
+            rows,
+            amax_threads,
+            contraction_size);
+    activation_amax_kernel<<<amax_blocks, amax_threads, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(matrix.data_ptr()),
+        global_scales.mutable_data_ptr<float>(),
+        rows,
+        contraction_size);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    const dim3 grid(scale_row_tiles, scale_column_ctas);
+    quantize_activations_tiled_kernel
+        <<<grid, kQuantThreads, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(matrix.data_ptr()),
+            offsets.const_data_ptr<int32_t>(),
+            packed.mutable_data_ptr<uint8_t>(),
+            reinterpret_cast<uint8_t*>(block_scales.mutable_data_ptr()),
+            global_scales.const_data_ptr<float>(),
+            contraction_size,
+            group_count,
+            scale_column_tiles);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+  return {packed, block_scales, global_scales};
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+quantize_weights_cuda(const at::Tensor& weight_rows) {
+  check_bf16_matrix(weight_rows, "weight_rows");
+  TORCH_CHECK(weight_rows.dim() == 3, "weight_rows must be 3D.");
+  TORCH_CHECK(weight_rows.size(0) > 0, "weight_rows must contain an expert.");
+  TORCH_CHECK(
+      weight_rows.size(2) > 0 && weight_rows.size(2) % 32 == 0,
+      "weight_rows' contraction dimension must be a positive multiple of 32.");
+
+  c10::cuda::CUDAGuard device_guard(weight_rows.device());
+  check_sm100();
+
+  const int64_t groups = weight_rows.size(0);
+  const int64_t output_size = weight_rows.size(1);
+  const int64_t contraction_size = weight_rows.size(2);
+  const int64_t padded_output_size =
+      round_up(output_size, kScaleRowTile);
+  const int64_t output_row_tiles =
+      padded_output_size / kScaleRowTile;
+  const int64_t scale_columns =
+      round_up(contraction_size / kSfVectorSize, kScaleColTile);
+  const int64_t scale_column_tiles =
+      scale_columns / kScaleColTile;
+  const int64_t scale_column_ctas =
+      round_up(scale_column_tiles, kQuantScaleTilesPerCta) /
+      kQuantScaleTilesPerCta;
+
+  auto packed = at::empty(
+      {groups, output_size, contraction_size / 2},
+      weight_rows.options().dtype(at::kByte));
+  auto block_scales = at::empty(
+      {groups, padded_output_size * scale_columns},
+      weight_rows.options().dtype(at::kFloat8_e4m3fn));
+  auto global_scales =
+      at::empty({groups}, weight_rows.options().dtype(at::kFloat));
+
+  if (output_size > 0) {
+    const int device = weight_rows.get_device();
+    const int64_t scale_blocks_per_expert =
+        output_size * contraction_size / kSfVectorSize;
+    const int blocks_per_expert = weight_amax_blocks_per_expert(
+        device,
+        groups,
+        scale_blocks_per_expert);
+    auto expert_amax =
+        at::zeros({groups}, weight_rows.options().dtype(at::kFloat));
+    const cudaStream_t stream =
+        at::cuda::getCurrentCUDAStream(device);
+    weight_amax_kernel
+        <<<groups * blocks_per_expert, kReductionThreads, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(
+                weight_rows.data_ptr()),
+            expert_amax.mutable_data_ptr<float>(),
+            output_size * contraction_size,
+            blocks_per_expert);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    finalize_weight_scales_kernel<<<1, 256, 0, stream>>>(
+        expert_amax.const_data_ptr<float>(),
+        global_scales.mutable_data_ptr<float>(),
+        groups);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    const dim3 grid(
+        groups * output_row_tiles,
+        scale_column_ctas);
+    quantize_weights_tiled_kernel
+        <<<grid, kQuantThreads, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(
+                weight_rows.data_ptr()),
+            global_scales.const_data_ptr<float>(),
+            packed.mutable_data_ptr<uint8_t>(),
+            reinterpret_cast<uint8_t*>(block_scales.mutable_data_ptr()),
+            output_size,
+            contraction_size,
+            output_row_tiles,
+            scale_column_tiles);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+  return {packed, block_scales, global_scales};
+}
+
+at::Tensor dequantize_activations_cuda(
+    const at::Tensor& packed,
+    const at::Tensor& block_scales,
+    const at::Tensor& global_scales,
+    const at::Tensor& offsets) {
+  check_quantized_tensors(packed, block_scales, global_scales);
+  TORCH_CHECK(packed.dim() == 2, "packed activations must be 2D.");
+  TORCH_CHECK(
+      global_scales.dim() == 1 &&
+          global_scales.size(0) == packed.size(0),
+      "activation global_scales must contain one value per row.");
+  TORCH_CHECK(
+      offsets.is_cuda() && offsets.scalar_type() == at::kInt &&
+          offsets.dim() == 1 && offsets.numel() > 0 &&
+          offsets.is_contiguous() && offsets.device() == packed.device(),
+      "offsets must be a non-empty contiguous CUDA int32 tensor on the "
+      "same device.");
+
+  c10::cuda::CUDAGuard device_guard(packed.device());
+  check_sm100();
+
+  const int64_t rows = packed.size(0);
+  const int64_t contraction_size = packed.size(1) * 2;
+  const int64_t scale_columns =
+      round_up(contraction_size / kSfVectorSize, kScaleColTile);
+  const int64_t scale_column_tiles =
+      scale_columns / kScaleColTile;
+  const int64_t scale_column_ctas =
+      round_up(scale_column_tiles, kDequantScaleTilesPerCta) /
+      kDequantScaleTilesPerCta;
+  TORCH_CHECK(
+      block_scales.numel() % (scale_columns * kScaleRowTile) == 0,
+      "activation block_scales have an invalid swizzled shape.");
+  const int64_t scale_row_tiles =
+      block_scales.numel() / (scale_columns * kScaleRowTile);
+  auto output = at::empty(
+      {rows, contraction_size},
+      packed.options().dtype(at::kBFloat16));
+  if (rows > 0) {
+    const cudaStream_t stream =
+        at::cuda::getCurrentCUDAStream(packed.get_device());
+    const dim3 grid(scale_row_tiles, scale_column_ctas);
+    dequantize_activations_tiled_kernel
+        <<<grid, kQuantThreads, 0, stream>>>(
+            packed.const_data_ptr<uint8_t>(),
+            reinterpret_cast<const uint8_t*>(block_scales.data_ptr()),
+            global_scales.const_data_ptr<float>(),
+            offsets.const_data_ptr<int32_t>(),
+            reinterpret_cast<__nv_bfloat16*>(
+                output.mutable_data_ptr()),
+            contraction_size,
+            offsets.numel(),
+            scale_column_tiles);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+  return output;
+}
+
+at::Tensor dequantize_weights_cuda(
+    const at::Tensor& packed,
+    const at::Tensor& block_scales,
+    const at::Tensor& global_scales) {
+  check_quantized_tensors(packed, block_scales, global_scales);
+  TORCH_CHECK(packed.dim() == 3, "packed weights must be 3D.");
+  TORCH_CHECK(
+      global_scales.dim() == 1 &&
+          global_scales.size(0) == packed.size(0),
+      "weight global_scales must contain one value per expert.");
+
+  c10::cuda::CUDAGuard device_guard(packed.device());
+  check_sm100();
+
+  const int64_t groups = packed.size(0);
+  const int64_t output_size = packed.size(1);
+  const int64_t contraction_size = packed.size(2) * 2;
+  const int64_t padded_output_size =
+      round_up(output_size, kScaleRowTile);
+  const int64_t output_row_tiles =
+      padded_output_size / kScaleRowTile;
+  const int64_t scale_columns =
+      round_up(contraction_size / kSfVectorSize, kScaleColTile);
+  const int64_t scale_column_tiles =
+      scale_columns / kScaleColTile;
+  const int64_t scale_column_ctas =
+      round_up(scale_column_tiles, kDequantScaleTilesPerCta) /
+      kDequantScaleTilesPerCta;
+  TORCH_CHECK(
+      block_scales.numel() ==
+          groups * padded_output_size * scale_columns,
+      "weight block_scales have an invalid swizzled shape.");
+  auto output = at::empty(
+      {groups, output_size, contraction_size},
+      packed.options().dtype(at::kBFloat16));
+  if (output_size > 0) {
+    const cudaStream_t stream =
+        at::cuda::getCurrentCUDAStream(packed.get_device());
+    const dim3 grid(
+        groups * output_row_tiles,
+        scale_column_ctas);
+    dequantize_weights_tiled_kernel
+        <<<grid, kQuantThreads, 0, stream>>>(
+            packed.const_data_ptr<uint8_t>(),
+            reinterpret_cast<const uint8_t*>(block_scales.data_ptr()),
+            global_scales.const_data_ptr<float>(),
+            reinterpret_cast<__nv_bfloat16*>(
+                output.mutable_data_ptr()),
+            output_size,
+            contraction_size,
+            output_row_tiles,
+            scale_column_tiles);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+  return output;
+}
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/functional.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/functional.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from prime_rl_kernels.nvfp4.quantize._extension import (
+    _dequantize_activations,
+    _dequantize_weights,
+)
+from prime_rl_kernels.nvfp4.quantize._extension import (
+    _quantize_activations as _quantize_activations_kernel,
+)
+from prime_rl_kernels.nvfp4.quantize._extension import (
+    _quantize_weights as _quantize_weights_kernel,
+)
+
+_NVFP4_GEMM_ALIGNMENT = 32
+
+
+@dataclass(frozen=True)
+class _NVFP4Tensor:
+    data: torch.Tensor
+    block_scales: torch.Tensor
+    global_scales: torch.Tensor
+    offsets: torch.Tensor | None
+
+    def dequantize(self) -> torch.Tensor:
+        packed = self.data.view(torch.uint8)
+        if self.offsets is not None:
+            return _dequantize_activations(
+                packed,
+                self.block_scales,
+                self.global_scales,
+                self.offsets,
+            )
+        return _dequantize_weights(
+            packed,
+            self.block_scales,
+            self.global_scales,
+        ).transpose(-2, -1)
+
+
+def _check_blackwell() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("NVFP4 quantization requires CUDA")
+    capability = torch.cuda.get_device_capability()
+    if capability != (10, 0):
+        raise RuntimeError(
+            f"NVFP4 quantization currently requires SM100, but the current device is SM{capability[0]}{capability[1]}"
+        )
+    if not hasattr(torch, "float4_e2m1fn_x2"):
+        raise RuntimeError("NVFP4 quantization requires PyTorch with float4_e2m1fn_x2 support")
+
+
+def _check_bf16_cuda(tensor: torch.Tensor, name: str) -> None:
+    if tensor.device.type != "cuda" or tensor.dtype != torch.bfloat16:
+        raise ValueError(f"{name} must be a CUDA bfloat16 tensor")
+
+
+@torch.compiler.disable
+def quantize_activations(matrix: torch.Tensor, offsets: torch.Tensor) -> _NVFP4Tensor:
+    """Quantize ``[M, K]`` activations with one FP32 decode scale per token."""
+
+    _check_blackwell()
+    if matrix.ndim != 2:
+        raise ValueError("matrix must be 2D")
+    _check_bf16_cuda(matrix, "matrix")
+    if matrix.shape[1] % _NVFP4_GEMM_ALIGNMENT != 0:
+        raise ValueError(f"matrix's contraction dimension must be divisible by {_NVFP4_GEMM_ALIGNMENT}")
+    if not matrix.is_contiguous():
+        matrix = matrix.contiguous()
+    if offsets.ndim != 1 or offsets.numel() == 0 or offsets.dtype != torch.int32 or offsets.device != matrix.device:
+        raise ValueError("offsets must be a non-empty 1D int32 tensor on the same CUDA device as matrix")
+    if not offsets.is_contiguous():
+        offsets = offsets.contiguous()
+
+    packed, block_scales, global_scales = _quantize_activations_kernel(
+        matrix,
+        offsets,
+    )
+    return _NVFP4Tensor(
+        data=packed.view(torch.float4_e2m1fn_x2),
+        block_scales=block_scales,
+        global_scales=global_scales,
+        offsets=offsets,
+    )
+
+
+@torch.compiler.disable
+def quantize_weights(weight: torch.Tensor) -> _NVFP4Tensor:
+    """Quantize logical ``[G, K, N]`` weights with one FP32 decode scale per expert."""
+
+    _check_blackwell()
+    if weight.ndim != 3:
+        raise ValueError("weight must be 3D")
+    _check_bf16_cuda(weight, "weight")
+
+    _, contraction_size, output_size = weight.shape
+    if contraction_size % _NVFP4_GEMM_ALIGNMENT != 0:
+        raise ValueError(f"weight's contraction dimension must be divisible by {_NVFP4_GEMM_ALIGNMENT}")
+    if output_size % 8 != 0:
+        raise ValueError("weight's output dimension must be divisible by 8")
+
+    weight_rows = weight.transpose(-2, -1)
+    if not weight_rows.is_contiguous():
+        weight_rows = weight_rows.contiguous()
+    packed, block_scales, global_scales = _quantize_weights_kernel(
+        weight_rows,
+    )
+    return _NVFP4Tensor(
+        data=packed.view(torch.float4_e2m1fn_x2),
+        block_scales=block_scales,
+        global_scales=global_scales,
+        offsets=None,
+    )

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/functional.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/functional.py
@@ -58,7 +58,6 @@ def _check_bf16_cuda(tensor: torch.Tensor, name: str) -> None:
         raise ValueError(f"{name} must be a CUDA bfloat16 tensor")
 
 
-@torch.compiler.disable
 def quantize_activations(matrix: torch.Tensor, offsets: torch.Tensor) -> _NVFP4Tensor:
     """Quantize ``[M, K]`` activations with one FP32 decode scale per token."""
 
@@ -87,7 +86,6 @@ def quantize_activations(matrix: torch.Tensor, offsets: torch.Tensor) -> _NVFP4T
     )
 
 
-@torch.compiler.disable
 def quantize_weights(weight: torch.Tensor) -> _NVFP4Tensor:
     """Quantize logical ``[G, K, N]`` weights with one FP32 decode scale per expert."""
 

--- a/packages/prime-rl-kernels/tests/test_nvfp4.py
+++ b/packages/prime-rl-kernels/tests/test_nvfp4.py
@@ -1,0 +1,114 @@
+import pytest
+import torch
+from prime_rl_kernels import (
+    grouped_nvfp4_mm,
+    grouped_nvfp4_mm_quantized,
+    quantize_nvfp4_activations,
+    quantize_nvfp4_weights,
+)
+
+
+def _blackwell_nvfp4_available() -> bool:
+    return (
+        torch.cuda.is_available()
+        and torch.cuda.get_device_capability() >= (10, 0)
+        and hasattr(torch, "float4_e2m1fn_x2")
+        and hasattr(torch.nn.functional, "scaled_grouped_mm")
+    )
+
+
+@pytest.mark.skipif(not _blackwell_nvfp4_available(), reason="NVFP4 grouped GEMM requires Blackwell")
+def test_grouped_nvfp4_forward_and_backward() -> None:
+    torch.manual_seed(42)
+    sizes = [7, 33, 0, 88]
+    groups = len(sizes)
+    rows = sum(sizes)
+    contraction_size = 256
+    output_size = 128
+    offsets = torch.cumsum(
+        torch.tensor(sizes, device="cuda", dtype=torch.int32),
+        dim=0,
+        dtype=torch.int32,
+    )
+    matrix = (torch.randn(rows, contraction_size, device="cuda", dtype=torch.bfloat16) * 0.1).requires_grad_()
+    weight = (
+        torch.randn(
+            groups,
+            contraction_size,
+            output_size,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        * 0.02
+    ).requires_grad_()
+
+    output = grouped_nvfp4_mm(matrix, weight, offsets)
+    reference = torch._grouped_mm(
+        matrix.detach(),
+        weight.detach(),
+        offs=offsets,
+        out_dtype=torch.bfloat16,
+    )
+    torch.testing.assert_close(output, reference, atol=0.08, rtol=0.08)
+
+    quantized_output = grouped_nvfp4_mm_quantized(
+        quantize_nvfp4_activations(matrix.detach(), offsets),
+        quantize_nvfp4_weights(weight.detach()),
+        offsets,
+    )
+    torch.testing.assert_close(quantized_output, output.detach(), atol=0, rtol=0)
+
+    grad_output = torch.randn_like(output)
+    output.backward(grad_output)
+    reference_grad_matrix = torch._grouped_mm(
+        grad_output,
+        weight.detach().transpose(-2, -1),
+        offs=offsets,
+        out_dtype=torch.bfloat16,
+    )
+    reference_grad_weight = torch._grouped_mm(
+        matrix.detach().transpose(0, 1),
+        grad_output,
+        offs=offsets,
+        out_dtype=torch.bfloat16,
+    )
+    torch.testing.assert_close(matrix.grad, reference_grad_matrix, atol=0, rtol=0)
+    torch.testing.assert_close(weight.grad, reference_grad_weight, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not _blackwell_nvfp4_available(), reason="NVFP4 grouped GEMM requires Blackwell")
+def test_grouped_nvfp4_ignores_physical_tail_rows() -> None:
+    """TorchTitan pads its permute buffer beyond the final logical offset."""
+
+    torch.manual_seed(7)
+    sizes = [7, 33, 0, 88]
+    logical_rows = sum(sizes)
+    physical_rows = logical_rows + 32
+    contraction_size = 256
+    output_size = 128
+    offsets = torch.cumsum(
+        torch.tensor(sizes, device="cuda", dtype=torch.int32),
+        dim=0,
+        dtype=torch.int32,
+    )
+    matrix = torch.randn(physical_rows, contraction_size, device="cuda", dtype=torch.bfloat16) * 0.1
+    matrix[logical_rows:] = 1_000
+    weight = (
+        torch.randn(
+            len(sizes),
+            contraction_size,
+            output_size,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        * 0.02
+    )
+
+    padded_output = grouped_nvfp4_mm(matrix, weight, offsets)
+    logical_output = grouped_nvfp4_mm(matrix[:logical_rows].contiguous(), weight, offsets)
+    torch.testing.assert_close(
+        padded_output[:logical_rows],
+        logical_output,
+        atol=0,
+        rtol=0,
+    )

--- a/packages/prime-rl-kernels/tests/test_nvfp4.py
+++ b/packages/prime-rl-kernels/tests/test_nvfp4.py
@@ -108,3 +108,39 @@ def test_grouped_nvfp4_ignores_physical_tail_rows() -> None:
         atol=0,
         rtol=0,
     )
+
+
+@pytest.mark.skipif(not _blackwell_nvfp4_available(), reason="NVFP4 grouped GEMM requires Blackwell")
+def test_nvfp4_quantization_writes_complete_swizzled_scale_tiles() -> None:
+    """Every scale is written when a CTA covers more vectors than threads."""
+
+    contraction_size = 2048
+    rows = 128
+    groups = 2
+    output_size = 128
+    offsets = torch.tensor([rows], device="cuda", dtype=torch.int32)
+    matrix = torch.ones(rows, contraction_size, device="cuda", dtype=torch.bfloat16)
+    weight = torch.ones(
+        groups,
+        contraction_size,
+        output_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+
+    activation_scales = quantize_activations(matrix, offsets).block_scales.float()
+    weight_scales = quantize_weights(weight).block_scales.float()
+    valid_activation_scales = activation_scales.flatten()[: rows * (contraction_size // 16)]
+
+    torch.testing.assert_close(
+        valid_activation_scales,
+        torch.full_like(valid_activation_scales, 448),
+        atol=0,
+        rtol=0,
+    )
+    torch.testing.assert_close(
+        weight_scales,
+        torch.full_like(weight_scales, 448),
+        atol=0,
+        rtol=0,
+    )

--- a/packages/prime-rl-kernels/tests/test_nvfp4.py
+++ b/packages/prime-rl-kernels/tests/test_nvfp4.py
@@ -1,19 +1,13 @@
 import pytest
 import torch
-from prime_rl_kernels import (
-    grouped_nvfp4_mm,
-    grouped_nvfp4_mm_quantized,
-    quantize_nvfp4_activations,
-    quantize_nvfp4_weights,
-)
+from prime_rl_kernels import grouped_gemm
 
 
 def _blackwell_nvfp4_available() -> bool:
     return (
         torch.cuda.is_available()
-        and torch.cuda.get_device_capability() >= (10, 0)
+        and torch.cuda.get_device_capability() == (10, 0)
         and hasattr(torch, "float4_e2m1fn_x2")
-        and hasattr(torch.nn.functional, "scaled_grouped_mm")
     )
 
 
@@ -42,7 +36,7 @@ def test_grouped_nvfp4_forward_and_backward() -> None:
         * 0.02
     ).requires_grad_()
 
-    output = grouped_nvfp4_mm(matrix, weight, offsets)
+    output = grouped_gemm(matrix, weight, offsets)
     reference = torch._grouped_mm(
         matrix.detach(),
         weight.detach(),
@@ -50,13 +44,6 @@ def test_grouped_nvfp4_forward_and_backward() -> None:
         out_dtype=torch.bfloat16,
     )
     torch.testing.assert_close(output, reference, atol=0.08, rtol=0.08)
-
-    quantized_output = grouped_nvfp4_mm_quantized(
-        quantize_nvfp4_activations(matrix.detach(), offsets),
-        quantize_nvfp4_weights(weight.detach()),
-        offsets,
-    )
-    torch.testing.assert_close(quantized_output, output.detach(), atol=0, rtol=0)
 
     grad_output = torch.randn_like(output)
     output.backward(grad_output)
@@ -104,8 +91,8 @@ def test_grouped_nvfp4_ignores_physical_tail_rows() -> None:
         * 0.02
     )
 
-    padded_output = grouped_nvfp4_mm(matrix, weight, offsets)
-    logical_output = grouped_nvfp4_mm(matrix[:logical_rows].contiguous(), weight, offsets)
+    padded_output = grouped_gemm(matrix, weight, offsets)
+    logical_output = grouped_gemm(matrix[:logical_rows].contiguous(), weight, offsets)
     torch.testing.assert_close(
         padded_output[:logical_rows],
         logical_output,

--- a/packages/prime-rl-kernels/tests/test_nvfp4.py
+++ b/packages/prime-rl-kernels/tests/test_nvfp4.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from prime_rl_kernels import grouped_gemm
+from prime_rl_kernels.nvfp4.quantize import quantize_activations, quantize_weights
 
 
 def _blackwell_nvfp4_available() -> bool:
@@ -12,7 +13,8 @@ def _blackwell_nvfp4_available() -> bool:
 
 
 @pytest.mark.skipif(not _blackwell_nvfp4_available(), reason="NVFP4 grouped GEMM requires Blackwell")
-def test_grouped_nvfp4_forward_and_backward() -> None:
+@pytest.mark.parametrize("backward", ["bf16", "bf16_dequantized"])
+def test_grouped_nvfp4_forward_and_backward(backward: str) -> None:
     torch.manual_seed(42)
     sizes = [7, 33, 0, 88]
     groups = len(sizes)
@@ -36,25 +38,32 @@ def test_grouped_nvfp4_forward_and_backward() -> None:
         * 0.02
     ).requires_grad_()
 
-    output = grouped_gemm(matrix, weight, offsets)
+    quantized_matrix = quantize_activations(matrix.detach(), offsets)
+    quantized_weight = quantize_weights(weight.detach())
+    dequantized_matrix = quantized_matrix.dequantize()
+    dequantized_weight = quantized_weight.dequantize()
+
+    output = grouped_gemm(matrix, weight, offsets, backward=backward)
     reference = torch._grouped_mm(
-        matrix.detach(),
-        weight.detach(),
+        dequantized_matrix,
+        dequantized_weight,
         offs=offsets,
         out_dtype=torch.bfloat16,
     )
-    torch.testing.assert_close(output, reference, atol=0.08, rtol=0.08)
+    torch.testing.assert_close(output, reference, atol=0.01, rtol=0.01)
 
     grad_output = torch.randn_like(output)
     output.backward(grad_output)
+    backward_matrix = matrix.detach() if backward == "bf16" else dequantized_matrix
+    backward_weight = weight.detach() if backward == "bf16" else dequantized_weight
     reference_grad_matrix = torch._grouped_mm(
         grad_output,
-        weight.detach().transpose(-2, -1),
+        backward_weight.transpose(-2, -1),
         offs=offsets,
         out_dtype=torch.bfloat16,
     )
     reference_grad_weight = torch._grouped_mm(
-        matrix.detach().transpose(0, 1),
+        backward_matrix.transpose(0, 1),
         grad_output,
         offs=offsets,
         out_dtype=torch.bfloat16,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = "~=3.12.0"
 dependencies = [
     "prime-rl-configs",
+    "prime-rl-kernels",
     "prime-pydantic-config",
     "beartype>=0.21.0",
     "datasets>=4.0.0",
@@ -181,6 +182,7 @@ torchao = false
 
 [tool.uv.sources]
 prime-rl-configs = { path = "packages/prime-rl-configs", editable = true }
+prime-rl-kernels = { path = "packages/prime-rl-kernels", editable = true }
 # prime-rl depends on the one `verifiers` package (v0 + v1 + the legacy bridge + the built-in v1
 # harnesses/tasksets, now bundled in verifiers.v1). v0 envs resolve from
 # deps/{verifiers,research-environments}/environments; v1 tasksets (`-v1`) and the `compact`

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -32,6 +32,7 @@ from prime_rl.configs.trainer import (
     FP8Config,
     ModelConfig,
     MXFP8Config,
+    NVFP4Config,
     TokenizerConfig,
 )
 from prime_rl.trainer.distributed import DeepEPExpertParallel, MXFP8AllToAllExpertParallel
@@ -55,6 +56,7 @@ from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
 from prime_rl.trainer.models.layers.moe import LatentMoE, MoE, TokenChoiceTopKRouter
 from prime_rl.trainer.models.layers.mxfp8_grouped_gemm import apply_mxfp8_moe_grouped_gemm
 from prime_rl.trainer.models.layers.mxfp8_linear import replace_linear_with_mxfp8_linear
+from prime_rl.trainer.models.layers.nvfp4_grouped_gemm import apply_nvfp4_moe_grouped_gemm
 from prime_rl.trainer.parallel_dims import ParallelDims
 from prime_rl.trainer.weights import (
     load_state_dict,
@@ -594,6 +596,7 @@ def get_model(
     # DeepGEMM FP8 grouped GEMM. MXFP8 grouped GEMM is applied by wrapping the expert
     # weights with torchao (see apply_quantization), so it leaves this flag False and
     # the experts keep calling torch._grouped_mm — which the wrapper tensor intercepts.
+    # NVFP4 is likewise selected on GroupedExperts after model construction.
     model_config.fp8 = isinstance(config.quantization, FP8Config) and config.quantization.enable_grouped_gemm
 
     if config.index_cache is not None:
@@ -1141,8 +1144,9 @@ def apply_quantization(model: nn.Module, config: ModelConfig) -> None:
     Runs after the LM head is injected but before LoRA / EP / FSDP so the swapped
     modules and wrapped parameters are picked up by the later parallelisms. The
     FP8 grouped GEMM (DeepGEMM) is gated separately via ``model_config.fp8`` since
-    it lives inside the modeling code; here we only handle the dense-linear swap
-    and the torchao MXFP8 expert-weight wrapping.
+    it lives inside the modeling code; here we handle dense-linear swaps,
+    torchao MXFP8 expert-weight wrapping, and selection of the native NVFP4
+    grouped-expert path.
     """
     quant = config.quantization
     if quant is None:
@@ -1159,6 +1163,13 @@ def apply_quantization(model: nn.Module, config: ModelConfig) -> None:
         replace_linear_with_mxfp8_linear(model, recipe=quant.recipe, ignore_modules=quant.ignore_patterns)
         if quant.enable_grouped_gemm:
             apply_mxfp8_moe_grouped_gemm(model, recipe=quant.recipe)
+    elif isinstance(quant, NVFP4Config):
+        capability = torch.cuda.get_device_capability()
+        if capability < (10, 0):
+            raise ValueError(
+                f"NVFP4 quantization requires SM100 (Blackwell) or newer, but device is SM{capability[0]}{capability[1]}."
+            )
+        apply_nvfp4_moe_grouped_gemm(model)
 
 
 def apply_ep(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims):

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1169,7 +1169,7 @@ def apply_quantization(model: nn.Module, config: ModelConfig) -> None:
             raise ValueError(
                 f"NVFP4 quantization requires SM100 (Blackwell) or newer, but device is SM{capability[0]}{capability[1]}."
             )
-        apply_nvfp4_moe_grouped_gemm(model)
+        apply_nvfp4_moe_grouped_gemm(model, backward=quant.backward)
 
 
 def apply_ep(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims):

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -155,6 +155,17 @@ def _run_experts_fp8_grouped_mm(
     return _run_experts_grouped_mm_impl(w1, w2, w3, x, num_tokens_per_expert, fp8=True)
 
 
+@expert_parallel
+def _run_experts_nvfp4_grouped_mm(
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    w3: torch.Tensor,
+    x: torch.Tensor,
+    num_tokens_per_expert: torch.Tensor,
+) -> torch.Tensor:
+    return _run_experts_grouped_mm_impl(w1, w2, w3, x, num_tokens_per_expert, nvfp4=True)
+
+
 def _run_experts_grouped_mm_impl(
     w1: torch.Tensor,
     w2: torch.Tensor,
@@ -162,12 +173,22 @@ def _run_experts_grouped_mm_impl(
     x: torch.Tensor,
     num_tokens_per_expert: torch.Tensor,
     fp8: bool = False,
+    nvfp4: bool = False,
 ) -> torch.Tensor:
     offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
     # grouped mm between a 2D tensor and a 3D tensor
     assert x.dim() == 2
 
-    if fp8:
+    if fp8 and nvfp4:
+        raise ValueError("FP8 and NVFP4 grouped GEMM cannot both be enabled")
+
+    if nvfp4:
+        from prime_rl_kernels import grouped_nvfp4_mm
+
+        h = F.silu(grouped_nvfp4_mm(x.bfloat16(), w1.bfloat16().transpose(-2, -1), offsets))
+        h = h * grouped_nvfp4_mm(x.bfloat16(), w3.bfloat16().transpose(-2, -1), offsets)
+        out = grouped_nvfp4_mm(h, w2.bfloat16().transpose(-2, -1), offsets).type_as(x)
+    elif fp8:
         from prime_rl.trainer.models.layers.fp8_grouped_gemm import grouped_fp8_gemm
 
         h = F.silu(grouped_fp8_gemm(x.bfloat16(), w1.bfloat16().transpose(-2, -1), offsets))
@@ -197,6 +218,7 @@ class GroupedExperts(nn.Module):
         self.w3 = nn.Parameter(torch.empty(num_experts, hidden_dim, dim))
         self.use_grouped_mm = use_grouped_mm
         self.fp8 = fp8
+        self.nvfp4 = False
         self.ep_comm_backend: EPCommBackend = "torch"
 
     def set_ep_comm_backend(self, backend: EPCommBackend) -> None:
@@ -207,7 +229,15 @@ class GroupedExperts(nn.Module):
         w2 = self.w2.to_local()
         w3 = self.w3.to_local()
         if self.use_grouped_mm:
-            return _run_experts_grouped_mm_impl(w1, w2, w3, x, num_tokens_per_expert, fp8=self.fp8)
+            return _run_experts_grouped_mm_impl(
+                w1,
+                w2,
+                w3,
+                x,
+                num_tokens_per_expert,
+                fp8=self.fp8,
+                nvfp4=self.nvfp4,
+            )
         return _run_experts_for_loop_impl(w1, w2, w3, x, num_tokens_per_expert)
 
     def forward(
@@ -219,6 +249,8 @@ class GroupedExperts(nn.Module):
             return self._forward_deepep(x, num_tokens_per_expert)
 
         if self.use_grouped_mm:
+            if self.nvfp4:
+                return _run_experts_nvfp4_grouped_mm(self.w1, self.w2, self.w3, x, num_tokens_per_expert)
             if self.fp8:
                 return _run_experts_fp8_grouped_mm(self.w1, self.w2, self.w3, x, num_tokens_per_expert)
             return _run_experts_grouped_mm(self.w1, self.w2, self.w3, x, num_tokens_per_expert)

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -12,7 +12,7 @@ import torch.nn.functional as F
 from torch import nn
 from torchtitan.distributed.expert_parallel import expert_parallel
 
-from prime_rl.configs.trainer import EPCommBackend
+from prime_rl.configs.trainer import EPCommBackend, NVFP4Backward
 
 
 @dataclass
@@ -163,7 +163,34 @@ def _run_experts_nvfp4_grouped_mm(
     x: torch.Tensor,
     num_tokens_per_expert: torch.Tensor,
 ) -> torch.Tensor:
-    return _run_experts_grouped_mm_impl(w1, w2, w3, x, num_tokens_per_expert, nvfp4=True)
+    return _run_experts_grouped_mm_impl(
+        w1,
+        w2,
+        w3,
+        x,
+        num_tokens_per_expert,
+        nvfp4=True,
+        nvfp4_backward="bf16_dequantized",
+    )
+
+
+@expert_parallel
+def _run_experts_nvfp4_bf16_grouped_mm(
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    w3: torch.Tensor,
+    x: torch.Tensor,
+    num_tokens_per_expert: torch.Tensor,
+) -> torch.Tensor:
+    return _run_experts_grouped_mm_impl(
+        w1,
+        w2,
+        w3,
+        x,
+        num_tokens_per_expert,
+        nvfp4=True,
+        nvfp4_backward="bf16",
+    )
 
 
 def _run_experts_grouped_mm_impl(
@@ -174,6 +201,7 @@ def _run_experts_grouped_mm_impl(
     num_tokens_per_expert: torch.Tensor,
     fp8: bool = False,
     nvfp4: bool = False,
+    nvfp4_backward: NVFP4Backward = "bf16_dequantized",
 ) -> torch.Tensor:
     offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
     # grouped mm between a 2D tensor and a 3D tensor
@@ -185,9 +213,26 @@ def _run_experts_grouped_mm_impl(
     if nvfp4:
         from prime_rl_kernels.nvfp4.grouped_gemm import grouped_gemm
 
-        h = F.silu(grouped_gemm(x.bfloat16(), w1.bfloat16().transpose(-2, -1), offsets))
-        h = h * grouped_gemm(x.bfloat16(), w3.bfloat16().transpose(-2, -1), offsets)
-        out = grouped_gemm(h, w2.bfloat16().transpose(-2, -1), offsets).type_as(x)
+        h = F.silu(
+            grouped_gemm(
+                x.bfloat16(),
+                w1.bfloat16().transpose(-2, -1),
+                offsets,
+                backward=nvfp4_backward,
+            )
+        )
+        h = h * grouped_gemm(
+            x.bfloat16(),
+            w3.bfloat16().transpose(-2, -1),
+            offsets,
+            backward=nvfp4_backward,
+        )
+        out = grouped_gemm(
+            h,
+            w2.bfloat16().transpose(-2, -1),
+            offsets,
+            backward=nvfp4_backward,
+        ).type_as(x)
     elif fp8:
         from prime_rl.trainer.models.layers.fp8_grouped_gemm import grouped_fp8_gemm
 
@@ -219,6 +264,7 @@ class GroupedExperts(nn.Module):
         self.use_grouped_mm = use_grouped_mm
         self.fp8 = fp8
         self.nvfp4 = False
+        self.nvfp4_backward: NVFP4Backward = "bf16_dequantized"
         self.ep_comm_backend: EPCommBackend = "torch"
 
     def set_ep_comm_backend(self, backend: EPCommBackend) -> None:
@@ -237,6 +283,7 @@ class GroupedExperts(nn.Module):
                 num_tokens_per_expert,
                 fp8=self.fp8,
                 nvfp4=self.nvfp4,
+                nvfp4_backward=self.nvfp4_backward,
             )
         return _run_experts_for_loop_impl(w1, w2, w3, x, num_tokens_per_expert)
 
@@ -250,6 +297,14 @@ class GroupedExperts(nn.Module):
 
         if self.use_grouped_mm:
             if self.nvfp4:
+                if self.nvfp4_backward == "bf16":
+                    return _run_experts_nvfp4_bf16_grouped_mm(
+                        self.w1,
+                        self.w2,
+                        self.w3,
+                        x,
+                        num_tokens_per_expert,
+                    )
                 return _run_experts_nvfp4_grouped_mm(self.w1, self.w2, self.w3, x, num_tokens_per_expert)
             if self.fp8:
                 return _run_experts_fp8_grouped_mm(self.w1, self.w2, self.w3, x, num_tokens_per_expert)

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -183,11 +183,11 @@ def _run_experts_grouped_mm_impl(
         raise ValueError("FP8 and NVFP4 grouped GEMM cannot both be enabled")
 
     if nvfp4:
-        from prime_rl_kernels import grouped_nvfp4_mm
+        from prime_rl_kernels.nvfp4.grouped_gemm import grouped_gemm
 
-        h = F.silu(grouped_nvfp4_mm(x.bfloat16(), w1.bfloat16().transpose(-2, -1), offsets))
-        h = h * grouped_nvfp4_mm(x.bfloat16(), w3.bfloat16().transpose(-2, -1), offsets)
-        out = grouped_nvfp4_mm(h, w2.bfloat16().transpose(-2, -1), offsets).type_as(x)
+        h = F.silu(grouped_gemm(x.bfloat16(), w1.bfloat16().transpose(-2, -1), offsets))
+        h = h * grouped_gemm(x.bfloat16(), w3.bfloat16().transpose(-2, -1), offsets)
+        out = grouped_gemm(h, w2.bfloat16().transpose(-2, -1), offsets).type_as(x)
     elif fp8:
         from prime_rl.trainer.models.layers.fp8_grouped_gemm import grouped_fp8_gemm
 

--- a/src/prime_rl/trainer/models/layers/nvfp4_grouped_gemm.py
+++ b/src/prime_rl/trainer/models/layers/nvfp4_grouped_gemm.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from torch import nn
+from torchtitan.distributed.expert_parallel import set_token_group_alignment_size_m
+
+from prime_rl.trainer.models.layers.moe import GroupedExperts
+from prime_rl.utils.logger import get_logger
+
+_NVFP4_TOKEN_GROUP_ALIGN = 32
+
+
+def apply_nvfp4_moe_grouped_gemm(model: nn.Module) -> None:
+    """Select the NVFP4 grouped path for supported routed-expert modules."""
+
+    set_token_group_alignment_size_m(_NVFP4_TOKEN_GROUP_ALIGN)
+    replaced = 0
+    for module in model.modules():
+        if isinstance(module, GroupedExperts):
+            module.nvfp4 = True
+            replaced += 1
+
+    if replaced == 0:
+        raise ValueError("NVFP4 grouped GEMM was requested, but the model has no supported GroupedExperts modules")
+    get_logger().info(
+        f"Enabled NVFP4 grouped GEMM for {replaced} routed-expert modules "
+        f"(token_group_align={_NVFP4_TOKEN_GROUP_ALIGN})"
+    )

--- a/src/prime_rl/trainer/models/layers/nvfp4_grouped_gemm.py
+++ b/src/prime_rl/trainer/models/layers/nvfp4_grouped_gemm.py
@@ -19,6 +19,9 @@ def apply_nvfp4_moe_grouped_gemm(
     if backward not in ("bf16", "bf16_dequantized"):
         raise ValueError("backward must be 'bf16' or 'bf16_dequantized'")
 
+    from prime_rl_kernels.nvfp4 import prepare_for_compile
+
+    prepare_for_compile()
     set_token_group_alignment_size_m(_NVFP4_TOKEN_GROUP_ALIGN)
     replaced = 0
     for module in model.modules():

--- a/src/prime_rl/trainer/models/layers/nvfp4_grouped_gemm.py
+++ b/src/prime_rl/trainer/models/layers/nvfp4_grouped_gemm.py
@@ -3,25 +3,33 @@ from __future__ import annotations
 from torch import nn
 from torchtitan.distributed.expert_parallel import set_token_group_alignment_size_m
 
+from prime_rl.configs.trainer import NVFP4Backward
 from prime_rl.trainer.models.layers.moe import GroupedExperts
 from prime_rl.utils.logger import get_logger
 
 _NVFP4_TOKEN_GROUP_ALIGN = 32
 
 
-def apply_nvfp4_moe_grouped_gemm(model: nn.Module) -> None:
+def apply_nvfp4_moe_grouped_gemm(
+    model: nn.Module,
+    backward: NVFP4Backward = "bf16_dequantized",
+) -> None:
     """Select the NVFP4 grouped path for supported routed-expert modules."""
+
+    if backward not in ("bf16", "bf16_dequantized"):
+        raise ValueError("backward must be 'bf16' or 'bf16_dequantized'")
 
     set_token_group_alignment_size_m(_NVFP4_TOKEN_GROUP_ALIGN)
     replaced = 0
     for module in model.modules():
         if isinstance(module, GroupedExperts):
             module.nvfp4 = True
+            module.nvfp4_backward = backward
             replaced += 1
 
     if replaced == 0:
         raise ValueError("NVFP4 grouped GEMM was requested, but the model has no supported GroupedExperts modules")
     get_logger().info(
         f"Enabled NVFP4 grouped GEMM for {replaced} routed-expert modules "
-        f"(token_group_align={_NVFP4_TOKEN_GROUP_ALIGN})"
+        f"(token_group_align={_NVFP4_TOKEN_GROUP_ALIGN}, backward={backward})"
     )

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -11,7 +11,7 @@ from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.configs.rl import RLConfig
 from prime_rl.configs.sft import SFTConfig
 from prime_rl.configs.trainer import ModelConfig as TrainerModelConfig
-from prime_rl.configs.trainer import TrainerConfig
+from prime_rl.configs.trainer import NVFP4Config, TrainerConfig
 from prime_rl.utils.config import BaseConfig, cli, to_toml_dict
 
 # All config config classes
@@ -154,6 +154,19 @@ def test_cli_overrides_toml(tmp_path):
 def test_removed_fused_lm_head_chunk_size_field_is_rejected():
     with pytest.raises(ValidationError, match="fused_lm_head_chunk_size"):
         TrainerModelConfig.model_validate({"fused_lm_head_chunk_size": "auto"})
+
+
+def test_nvfp4_quantization_config():
+    config = TrainerModelConfig.model_validate({"quantization": {"type": "nvfp4"}})
+    assert isinstance(config.quantization, NVFP4Config)
+
+    with pytest.raises(ValidationError, match="moe_use_grouped_mm"):
+        TrainerModelConfig.model_validate(
+            {
+                "moe_use_grouped_mm": False,
+                "quantization": {"type": "nvfp4"},
+            }
+        )
 
 
 def test_to_toml_dict_roundtrips_explicit_none(tmp_path):

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -159,6 +159,11 @@ def test_removed_fused_lm_head_chunk_size_field_is_rejected():
 def test_nvfp4_quantization_config():
     config = TrainerModelConfig.model_validate({"quantization": {"type": "nvfp4"}})
     assert isinstance(config.quantization, NVFP4Config)
+    assert config.quantization.backward == "bf16_dequantized"
+
+    config = TrainerModelConfig.model_validate({"quantization": {"type": "nvfp4", "backward": "bf16"}})
+    assert isinstance(config.quantization, NVFP4Config)
+    assert config.quantization.backward == "bf16"
 
     with pytest.raises(ValidationError, match="moe_use_grouped_mm"):
         TrainerModelConfig.model_validate(

--- a/tests/unit/train/models/test_nvfp4_grouped_gemm.py
+++ b/tests/unit/train/models/test_nvfp4_grouped_gemm.py
@@ -1,0 +1,53 @@
+import copy
+
+import pytest
+import torch
+
+from prime_rl.trainer.models.layers.moe import GroupedExperts
+from prime_rl.trainer.models.layers.nvfp4_grouped_gemm import apply_nvfp4_moe_grouped_gemm
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
+        reason="NVFP4 grouped GEMM requires Blackwell",
+    ),
+]
+
+
+def test_nvfp4_grouped_experts_forward_and_backward():
+    torch.manual_seed(42)
+    reference = (
+        GroupedExperts(
+            dim=256,
+            hidden_dim=128,
+            num_experts=4,
+            use_grouped_mm=True,
+        )
+        .cuda()
+        .bfloat16()
+    )
+    reference.init_weights(0.02)
+    nvfp4 = copy.deepcopy(reference)
+    apply_nvfp4_moe_grouped_gemm(nvfp4)
+
+    counts = torch.tensor([7, 33, 0, 88], device="cuda", dtype=torch.int32)
+    matrix = torch.randn(int(counts.sum().item()), 256, device="cuda", dtype=torch.bfloat16) * 0.1
+    matrix_reference = matrix.detach().clone().requires_grad_()
+    matrix_nvfp4 = matrix.detach().clone().requires_grad_()
+
+    output_reference = reference(matrix_reference, counts)
+    output_nvfp4 = nvfp4(matrix_nvfp4, counts)
+    torch.testing.assert_close(output_nvfp4, output_reference, atol=0.08, rtol=0.2)
+
+    grad_output = torch.randn_like(output_reference)
+    output_reference.backward(grad_output)
+    output_nvfp4.backward(grad_output)
+    for tensor in (
+        output_nvfp4,
+        matrix_nvfp4.grad,
+        nvfp4.w1.grad,
+        nvfp4.w2.grad,
+        nvfp4.w3.grad,
+    ):
+        assert torch.isfinite(tensor).all()

--- a/tests/unit/train/models/test_nvfp4_grouped_gemm.py
+++ b/tests/unit/train/models/test_nvfp4_grouped_gemm.py
@@ -2,6 +2,7 @@ import copy
 
 import pytest
 import torch
+from torch.utils.checkpoint import checkpoint
 
 from prime_rl.trainer.models.layers.moe import GroupedExperts
 from prime_rl.trainer.models.layers.nvfp4_grouped_gemm import apply_nvfp4_moe_grouped_gemm
@@ -9,8 +10,8 @@ from prime_rl.trainer.models.layers.nvfp4_grouped_gemm import apply_nvfp4_moe_gr
 pytestmark = [
     pytest.mark.gpu,
     pytest.mark.skipif(
-        not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-        reason="NVFP4 grouped GEMM requires Blackwell",
+        not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 0),
+        reason="NVFP4 grouped GEMM currently requires SM100",
     ),
 ]
 
@@ -37,7 +38,7 @@ def test_nvfp4_grouped_experts_forward_and_backward():
     matrix_nvfp4 = matrix.detach().clone().requires_grad_()
 
     output_reference = reference(matrix_reference, counts)
-    output_nvfp4 = nvfp4(matrix_nvfp4, counts)
+    output_nvfp4 = checkpoint(nvfp4, matrix_nvfp4, counts, use_reentrant=False)
     torch.testing.assert_close(output_nvfp4, output_reference, atol=0.08, rtol=0.2)
 
     grad_output = torch.randn_like(output_reference)

--- a/tests/unit/train/models/test_nvfp4_grouped_gemm.py
+++ b/tests/unit/train/models/test_nvfp4_grouped_gemm.py
@@ -16,7 +16,8 @@ pytestmark = [
 ]
 
 
-def test_nvfp4_grouped_experts_forward_and_backward():
+@pytest.mark.parametrize("backward", ["bf16", "bf16_dequantized"])
+def test_nvfp4_grouped_experts_forward_and_backward(backward):
     torch.manual_seed(42)
     reference = (
         GroupedExperts(
@@ -30,7 +31,7 @@ def test_nvfp4_grouped_experts_forward_and_backward():
     )
     reference.init_weights(0.02)
     nvfp4 = copy.deepcopy(reference)
-    apply_nvfp4_moe_grouped_gemm(nvfp4)
+    apply_nvfp4_moe_grouped_gemm(nvfp4, backward=backward)
 
     counts = torch.tensor([7, 33, 0, 88], device="cuda", dtype=torch.int32)
     matrix = torch.randn(int(counts.sum().item()), 256, device="cuda", dtype=torch.bfloat16) * 0.1

--- a/uv.lock
+++ b/uv.lock
@@ -5142,6 +5142,7 @@ dependencies = [
     { name = "prime" },
     { name = "prime-pydantic-config" },
     { name = "prime-rl-configs" },
+    { name = "prime-rl-kernels" },
     { name = "pyarrow" },
     { name = "pybase64" },
     { name = "pyzmq" },
@@ -5258,6 +5259,7 @@ requires-dist = [
     { name = "prime-rl", extras = ["flash-attn-cute"], marker = "extra == 'all'" },
     { name = "prime-rl", extras = ["quack"], marker = "extra == 'all'" },
     { name = "prime-rl-configs", editable = "packages/prime-rl-configs" },
+    { name = "prime-rl-kernels", editable = "packages/prime-rl-kernels" },
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pybase64", specifier = ">=1.4.2" },
     { name = "pyzmq", specifier = ">=27.1.0" },
@@ -5321,6 +5323,21 @@ requires-dist = [
     { name = "tomli", specifier = ">=2.2.1" },
     { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "verifiers", specifier = ">=0.2.1" },
+]
+
+[[package]]
+name = "prime-rl-kernels"
+version = "0.1.0"
+source = { editable = "packages/prime-rl-kernels" }
+dependencies = [
+    { name = "torch" },
+    { name = "triton" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "torch", specifier = ">=2.11.0" },
+    { name = "triton", specifier = ">=3.6.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -5348,14 +5348,12 @@ source = { editable = "packages/prime-rl-kernels" }
 dependencies = [
     { name = "nvidia-cutlass" },
     { name = "torch" },
-    { name = "triton" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "nvidia-cutlass", specifier = "==4.2.0.0" },
     { name = "torch", specifier = ">=2.11.0" },
-    { name = "triton", specifier = ">=3.6.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4343,6 +4343,22 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cutlass"
+version = "4.2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-python" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "pydot" },
+    { name = "scipy" },
+    { name = "treelib" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/6b/e86fc2fd536dd4b8bd2209aa31d7002610c501b0802337787eac9c9b328c/nvidia_cutlass-4.2.0.0-py3-none-any.whl", hash = "sha256:f9599ada45c7bcb6bf53f7d3f0a7d154183e53451c01bfa59eecd37dd4a693f6", size = 6440597, upload-time = "2025-09-19T20:57:32.371Z" },
+]
+
+[[package]]
 name = "nvidia-cutlass-dsl"
 version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5330,12 +5346,14 @@ name = "prime-rl-kernels"
 version = "0.1.0"
 source = { editable = "packages/prime-rl-kernels" }
 dependencies = [
+    { name = "nvidia-cutlass" },
     { name = "torch" },
     { name = "triton" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "nvidia-cutlass", specifier = "==4.2.0.0" },
     { name = "torch", specifier = ">=2.11.0" },
     { name = "triton", specifier = ">=3.6.0" },
 ]
@@ -5699,6 +5717,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
+name = "pydot"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/35/b17cb89ff865484c6a20ef46bf9d95a5f07328292578de0b295f4a6beec2/pydot-4.0.1.tar.gz", hash = "sha256:c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5", size = 162594, upload-time = "2025-06-17T20:09:56.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl", hash = "sha256:869c0efadd2708c0be1f916eb669f3d664ca684bc57ffb7ecc08e70d5e93fee6", size = 37087, upload-time = "2025-06-17T20:09:55.25Z" },
 ]
 
 [[package]]
@@ -7568,6 +7598,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/c8/97da3af4796495e46421e9344738addb3602fa6426ea695be3fcbadbee37/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:199d09985190852e0912da2b8d26c932159be314bc04952cf917ed0e4c633e6b", size = 106072, upload-time = "2025-09-01T07:13:39.798Z" },
     { url = "https://files.pythonhosted.org/packages/13/be/c964e8130be08cc9bd6627d845f0e4460945b158429d39510953bbcb8fcc/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dfcf789064c58dc13c0a4edb550acacfc6f0f280577f1e7a00de3e89fc7f8ddc", size = 104388, upload-time = "2025-09-01T07:13:40.866Z" },
     { url = "https://files.pythonhosted.org/packages/ee/89/9b773dee0f8961d1bb8d7baf0a204ab587618df19897c1ef260916f318ec/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b852d3aee8a36186dbcc32c798b11b4869f9b5041743b63b65c2ef793db7a54", size = 98377, upload-time = "2025-09-01T07:13:41.838Z" },
+]
+
+[[package]]
+name = "treelib"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/31/145bdbee73d7ee4ac4e879c37faa196a32208b288ca4f308c1ad8db3f010/treelib-1.8.0.tar.gz", hash = "sha256:e1be2c6b66ffbfae85079fc4c76fb4909946d01d915ee29ff6795de53aed5d55", size = 28607, upload-time = "2025-06-29T15:06:49.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/24/32361f5d0e2eff7ff1881ac6833b6b090cfe34515b1ee9082636cbe69442/treelib-1.8.0-py3-none-any.whl", hash = "sha256:5235d1ebf988c5026f26ce6e5e0cd470007f16d4978185f5c9b3eee8a25aef81", size = 30728, upload-time = "2025-06-29T15:06:48.248Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This draft adds an owned NVFP4 routed-expert path for SM100 without a Transformer Engine or MSLK runtime dependency.

- keeps the grouped GEMM under `prime_rl_kernels/nvfp4/grouped_gemm`
- adapts MSLK's B200 CUTLASS grouped kernel behind a private CUTLASS namespace
- adds owned CUDA quantization/dequantization kernels under `prime_rl_kernels/nvfp4/quantize`
- exposes `grouped_gemm(matrix, weight, offsets, backward=...)` plus standalone activation/weight quantizers
- quantizes the current BF16 activations and weights on every forward invocation
- integrates the operator with `GroupedExperts` behind `[trainer.model.quantization] type = "nvfp4"`
- supports both Torch expert parallelism and the DeepEP local-expert path
- leaves BF16 master parameters, optimizer state, checkpoints, dense layers, and weight transfer unchanged

The copied grouped-GEMM sources retain MSLK's BSD license. The Blackwell BF16-to-E2M1 conversion sequence is adapted from Transformer Engine under Apache-2.0. CUTLASS 4.2 headers are a build dependency only.

## Quantization contract

- activation outer scale: one FP32 scale per token, `token_amax / (6 * 448)`
- weight outer scale: one FP32 scale per expert, `expert_amax / (6 * 448)`
- block scale: E4M3 over each contiguous group of 16 values
- values: packed E2M1
- block-scale storage: native tcgen05 128x4 swizzled layout
- gate and up weights: quantized separately
- no 4-over-6 recipe

The activation recipe was sampled against FlashInfer's per-token online NVFP4 quantizer. It follows the same scaling and layout contract; approximately 0.06–0.07% of sampled packed/scale bytes differed from rounding details, so bitwise identity is not claimed.

## Backward recipes

`trainer.model.quantization.backward` accepts exactly two values:

- `bf16_dequantized` (default): save the forward's packed FP4 values, block scales, and outer scales; lazily dequantize only the operands needed by backward; run BF16 grouped dgrad/wgrad
- `bf16`: retain the original BF16 operands and run BF16 grouped dgrad/wgrad over them

Both recipes use the same NVFP4 forward. The config value is threaded through model setup, Torch EP, DeepEP, and the custom autograd operator.

## GB200 validation

- CUDA 12.8, PyTorch 2.11, CUTLASS 4.2, SM100
- 6 focused tests passed:
  - config default and explicit recipe selection
  - both backward recipes against exact recipe-specific BF16 grouped-matmul references
  - ragged and empty experts
  - physical token-buffer tails
  - both recipes through `GroupedExperts` with non-reentrant activation checkpointing
- Ruff format and lint checks passed for all changed Python files
- weight `[G=32, K=6144, N=3072]`: 6.65 TB/s quantization, 6.17 TB/s dequantization
- large per-token activation cases reach roughly 6.0–6.5 TB/s from K=2880 through K=6144; short token batches remain latency-bound
- persistent `TORCH_EXTENSIONS_DIR` caches both lazy extensions; after the one-time rebuild, the complete `GroupedExperts` recipe test completed in about 13 seconds

## Current scope

- SM100 routed experts only
- BF16 stored weights and optimizer state
- dense linears remain BF16
- gate/up projections are not jointly quantized yet
- `torch.compile(fullgraph=False)` crosses an intentional graph break
- only rows before the final logical expert offset have defined output; TorchTitan discards the physical tail during combine
