### PR TITLE
feat: add all torchtitan EP backends (deepep_v2, hybridep, minimal_async_ep)

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -59,8 +59,10 @@ GLM-5.2 adds IndexShare: the DSA sparse-attention indexer runs only on a subset 
 `model.ep_comm_backend` picks the all-to-all kernel used for EP dispatch/combine:
 
 - **`torch`** (default): TorchTitan's all-to-all collective. Works everywhere, no extra install.
-- **`deepep`**: Utilizes DeepEP's custom all-to-all collectives. This provides better performance if EP dimension spans multiple nodes. We provide pre-built binaries for H100/H200 with cuda runtime 12.9 installed, you can install them by running `uv sync --all-extras`.
-DeepEP requires some careful tuning to achieve optimal performance, tuning parameters are `deepep_num_sms` and `deepep_token_chunk_size`.
+- **`deepep`**: DeepEP v1 custom all-to-all collectives. Better performance when the EP dimension spans multiple nodes. Pre-built binaries for H100/H200 with CUDA 12.9 are installed via `uv sync --all-extras`. Tuning parameters: `deepep_num_sms` and `deepep_token_chunk_size`.
+- **`deepep_v2`**: DeepEP v2 `ElasticBuffer` kernels — unified high-throughput/low-latency dispatch/combine with autograd support. Same tuning parameters as `deepep`. Requires DeepEP v2 (>= 2.0.0). Imported from torchtitan.
+- **`hybridep`**: HybridEP kernels optimized for GB200 NVLink72 systems. Supports blocking (default) and non-blocking dispatch via `hybridep_non_blocking_capacity_factor`. Optional per-expert padding via `hybridep_pad_multiple` (e.g. 32 for MXFP8). Vendored with handle_id pattern for torch compatibility.
+- **`minimal_async_ep`**: Symmetric-memory all-to-all using custom Triton kernels. Intended for the constrained launch shape where EP = DP and CP is disabled (`cp=1`). No external EP library dependency beyond Triton. Imported from torchtitan.
 
 With DeepEP, gradient clipping is currently not supported. (`optim.max_norm` is set to `None` automatically.)
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -98,10 +98,10 @@ EP shards MoE expert weights across the EP mesh, dramatically reducing the FSDP 
 [trainer.model]
 impl = "custom"
 ep = 8                     # explicit EP degree; must divide num_experts
-ep_comm_backend = "torch"  # or "deepep"
+ep_comm_backend = "torch"  # or "deepep", "deepep_v2", "hybridep", "minimal_async_ep"
 ```
 
-`ep_comm_backend = "deepep"` uses DeepEP's custom dispatch/combine kernels for speed, with two extra knobs (`deepep_num_sms`, `deepep_token_chunk_size`) — tune on your hardware.
+`ep_comm_backend = "deepep"` uses DeepEP v1's custom dispatch/combine kernels for speed, with two extra knobs (`deepep_num_sms`, `deepep_token_chunk_size`) — tune on your hardware. `deepep_v2` uses DeepEP v2's unified `ElasticBuffer` API (>= 2.0.0). `hybridep` targets GB200 NVLink72 systems. `minimal_async_ep` uses symmetric-memory all-to-all (requires cp=1).
 
 ### Context Parallelism
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -19,7 +19,7 @@ from prime_rl.utils.config import BaseConfig
 # -- Shared trainer configs (used by both SFT and RL trainers) --
 
 AttnImplementation: TypeAlias = Literal["flash_attention_2", "flash_attention_3", "flash_attention_4", "auto"]
-EPCommBackend: TypeAlias = Literal["torch", "deepep"]
+EPCommBackend: TypeAlias = Literal["torch", "deepep", "deepep_v2", "hybridep", "minimal_async_ep"]
 
 
 class GCConfig(BaseConfig):
@@ -181,13 +181,19 @@ class ModelConfig(BaseModelConfig):
     """Expert parallelism degree for MoE layers. 1 disables EP. ``auto`` resolves to ``min(fsdp_island_size, 8)`` for MoE models (where ``fsdp_island_size = world_size // dp_replicate``), and to 1 for non-MoE models. Set an explicit integer to override."""
 
     ep_comm_backend: EPCommBackend = "torch"
-    """Communication backend for expert parallelism. ``torch`` uses TorchTitan all-to-all collectives; ``deepep`` uses DeepEP custom kernels."""
+    """Communication backend for expert parallelism. ``torch`` uses TorchTitan all-to-all collectives; ``deepep`` uses DeepEP v1 custom kernels; ``deepep_v2`` uses DeepEP v2 ElasticBuffer kernels; ``hybridep`` uses HybridEP kernels for GB200 NVLink72 systems; ``minimal_async_ep`` uses symmetric-memory all-to-all (no TP/CP/PP/SP)."""
 
     deepep_num_sms: int = Field(20, ge=1)
-    """SMs allocated for DeepEP intranode dispatch/combine kernels. Also determines internode RDMA channel count (``num_channels = num_sms / 2``). Lower values leave more SMs for compute; higher values speed up dispatch/combine. The optimal value depends on EP degree and hardware. Only used when ``ep_comm_backend='deepep'``."""
+    """SMs allocated for DeepEP intranode dispatch/combine kernels. Also determines internode RDMA channel count (``num_channels = num_sms / 2``). Lower values leave more SMs for compute; higher values speed up dispatch/combine. The optimal value depends on EP degree and hardware. Only used when ``ep_comm_backend='deepep'`` or ``'deepep_v2'``."""
 
     deepep_token_chunk_size: int | None = Field(None, ge=1)
-    """Token chunk size for DeepEP MoE pipelining. When set, DeepEP dispatch for chunk i+1 is launched while experts compute chunk i. Only used when ``ep_comm_backend='deepep'``."""
+    """Token chunk size for DeepEP MoE pipelining. When set, DeepEP dispatch for chunk i+1 is launched while experts compute chunk i. Only used when ``ep_comm_backend='deepep'`` or ``'deepep_v2'``."""
+
+    hybridep_non_blocking_capacity_factor: float | None = Field(None, gt=0, le=1)
+    """Capacity factor for non-blocking HybridEP dispatch. None = blocking mode (default). A float in (0, 1] enables CPU-free non-blocking dispatch. Only used when ``ep_comm_backend='hybridep'``."""
+
+    hybridep_pad_multiple: int | None = Field(None, ge=1)
+    """Pad per-expert token groups to this multiple for HybridEP (e.g. 32 for MXFP8). Only used when ``ep_comm_backend='hybridep'``."""
 
     cp: int = 1
     """Context parallelism degree. 1 disables CP."""
@@ -291,6 +297,9 @@ class ModelConfig(BaseModelConfig):
 
         if isinstance(self.ep, int) and self.ep <= 1:
             raise ValueError(f"model.ep_comm_backend='{self.ep_comm_backend}' requires model.ep > 1.")
+
+        if self.ep_comm_backend == "minimal_async_ep" and self.cp != 1:
+            raise ValueError("model.ep_comm_backend='minimal_async_ep' requires model.cp=1.")
 
         return self
 
@@ -626,7 +635,7 @@ class TrainerConfig(BaseConfig):
 
     @model_validator(mode="after")
     def deepep_disables_grad_clipping(self):
-        if self.model.ep_comm_backend == "deepep" and self.optim.max_norm is not None:
+        if self.model.ep_comm_backend in ("deepep", "deepep_v2") and self.optim.max_norm is not None:
             warnings.warn(
                 "Gradient clipping is not compatible with DeepEP. "
                 "Automatically setting optim.max_norm to None (disabled).",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ prime-pydantic-config = { path = "deps/pydantic-config", editable = true }
 torch = { index = "pytorch-cu128" }
 torchvision = { index = "pytorch-cu128" }
 torchaudio = { index = "pytorch-cu128" }
-torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "23e4dfc" }
+torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "cc286a6" }
 torchao = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.6.0/torchao-0.17.0+git02105d46c-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 flash-attn-4 = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "96bd151" }

--- a/src/prime_rl/trainer/distributed/__init__.py
+++ b/src/prime_rl/trainer/distributed/__init__.py
@@ -1,3 +1,17 @@
-from prime_rl.trainer.distributed.expert_parallel import DeepEPExpertParallel, MXFP8AllToAllExpertParallel, get_ep_group
+from prime_rl.trainer.distributed.expert_parallel import (
+    DeepEPExpertParallel,
+    DeepEPv2ExpertParallel,
+    HybridEPExpertParallel,
+    MinimalAsyncEPExpertParallel,
+    MXFP8AllToAllExpertParallel,
+    get_ep_group,
+)
 
-__all__ = ["DeepEPExpertParallel", "MXFP8AllToAllExpertParallel", "get_ep_group"]
+__all__ = [
+    "DeepEPExpertParallel",
+    "DeepEPv2ExpertParallel",
+    "HybridEPExpertParallel",
+    "MinimalAsyncEPExpertParallel",
+    "MXFP8AllToAllExpertParallel",
+    "get_ep_group",
+]

--- a/src/prime_rl/trainer/distributed/expert_parallel.py
+++ b/src/prime_rl/trainer/distributed/expert_parallel.py
@@ -7,7 +7,8 @@ from torch.distributed.tensor import DeviceMesh, Shard, distribute_module, distr
 from torch.distributed.tensor.parallel import ParallelStyle
 from torchao.prototype.moe_training.ep import a2a_combine_hp_fwd_mxfp8_bwd, a2a_dispatch_mxfp8_fwd_hp_bwd
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
-from torchtitan.distributed.expert_parallel import ExpertParallel
+
+from prime_rl.trainer.distributed.tt_expert_parallel import ExpertParallel
 
 
 class _MXFP8Dispatch(torch.autograd.Function):
@@ -85,3 +86,15 @@ class DeepEPExpertParallel(ParallelStyle):
 
 def get_ep_group(experts: nn.Module) -> ProcessGroup:
     return experts._ep_group
+
+
+class DeepEPv2ExpertParallel(DeepEPExpertParallel):
+    """Weight sharding for DeepEP v2 (same Shard(0) as v1)."""
+
+
+class HybridEPExpertParallel(DeepEPExpertParallel):
+    """Weight sharding for HybridEP (same Shard(0) as v1)."""
+
+
+class MinimalAsyncEPExpertParallel(DeepEPExpertParallel):
+    """Weight sharding for MinimalAsyncEP (same Shard(0) as v1)."""

--- a/src/prime_rl/trainer/distributed/hybridep.py
+++ b/src/prime_rl/trainer/distributed/hybridep.py
@@ -1,0 +1,340 @@
+"""HybridEP: Expert Parallel Communication for GB200 NVLink72 Systems.
+
+Ported from torchtitan.distributed.deepep.hybridep. Provides efficient token
+dispatch/combine for MoE training via TMA-optimized all-to-all on GB200.
+Uses a handle_id + cache pattern (like deepep.py) instead of CustomClassBase
+for compatibility with the installed torch version.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+_buffer: Any = None
+
+# Handle cache: maps int handle_id -> opaque deep_ep dispatch handle
+_handle_cache: dict[int, Any] = {}
+_handle_counter = 0
+
+
+def _get_next_handle_id() -> torch.Tensor:
+    global _handle_counter
+    _handle_counter += 1
+    return torch.tensor([_handle_counter], dtype=torch.int64, device="cpu")
+
+
+@dataclass
+class DispatchState:
+    """State from dispatch needed for combine.
+
+    Attributes:
+        handle_id: CPU tensor used to retrieve the cached dispatch handle.
+        permuted_scores: Routing scores applied to expert outputs in combine.
+        num_tokens: Original input token count.
+    """
+
+    handle_id: torch.Tensor
+    permuted_scores: torch.Tensor | None = None
+    num_tokens: int = 0
+
+
+def _num_permuted_tokens_for_non_blocking(
+    num_tokens: int,
+    ep_size: int,
+    num_local_experts: int,
+    top_k: int,
+    moe_expert_capacity_factor: float,
+    pad_multiple: int | None = None,
+) -> int:
+    n = int(num_tokens * ep_size * min(num_local_experts, top_k) * moe_expert_capacity_factor)
+    if pad_multiple is not None:
+        n = ((n + pad_multiple - 1) // pad_multiple) * pad_multiple
+    return n
+
+
+# ============================================================================
+# Custom op registration
+# ============================================================================
+
+_lib = torch.library.Library("hybridep", "DEF")
+
+_lib.define(
+    "dispatch(Tensor x, Tensor topk_idx, Tensor topk_weights, "
+    "int num_experts, int ep_size, str group_name, "
+    "bool non_blocking, float? moe_expert_capacity_factor, int? pad_multiple) "
+    "-> (Tensor, Tensor, Tensor, Tensor)"
+)
+_lib.define("combine(Tensor x, Tensor handle_id, int num_tokens, int? pad_multiple) -> Tensor")
+_lib.define(
+    "dispatch_bwd(Tensor grad_combined, Tensor handle_id, int num_permuted_tokens, int? pad_multiple) -> Tensor"
+)
+_lib.define(
+    "combine_bwd(Tensor grad_hidden, Tensor grad_scores, Tensor handle_id, int num_tokens, int num_experts) -> (Tensor, Tensor)"
+)
+
+
+_DEEPEP_MULTINODE_NUM_SMS = 20
+
+
+@torch.library.impl(_lib, "dispatch", "CUDA")
+def _dispatch_op_impl(
+    x: torch.Tensor,
+    topk_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+    num_experts: int,
+    ep_size: int,
+    group_name: str,
+    non_blocking: bool,
+    moe_expert_capacity_factor: float | None,
+    pad_multiple: int | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """HybridEP dispatch with permute."""
+    global _buffer
+    num_local_experts = num_experts // ep_size
+
+    group = dist.distributed_c10d._resolve_process_group(group_name)
+    get_buffer(
+        group=group,
+        hidden_dim=x.shape[1],
+        num_tokens=x.shape[0],
+        num_local_experts=num_local_experts,
+    )
+
+    from deep_ep.hybrid_ep_buffer import indices_to_map
+
+    routing_map, probs = indices_to_map(topk_idx, topk_weights.float(), x.shape[0], num_experts)
+
+    num_permuted_tokens = None
+    if non_blocking:
+        assert moe_expert_capacity_factor is not None
+        num_permuted_tokens = _num_permuted_tokens_for_non_blocking(
+            x.shape[0],
+            ep_size,
+            num_local_experts,
+            topk_idx.shape[1],
+            moe_expert_capacity_factor,
+            pad_multiple=pad_multiple,
+        )
+
+    hidden, scores, _, tokens_per_expert, handle = _buffer.dispatch_with_permute(
+        hidden=x,
+        routing_map=routing_map,
+        probs=probs,
+        scaling_factor=None,
+        num_of_experts_per_rank=num_local_experts,
+        pad_multiple=pad_multiple,
+        num_permuted_tokens=num_permuted_tokens,
+        non_blocking=non_blocking,
+    )
+
+    if scores is None:
+        scores = torch.empty(0, device=x.device, dtype=torch.float32)
+    if tokens_per_expert.device != x.device:
+        tokens_per_expert = tokens_per_expert.to(x.device)
+
+    handle_id = _get_next_handle_id()
+    _handle_cache[handle_id.item()] = handle
+
+    return hidden, scores, tokens_per_expert, handle_id
+
+
+def _dispatch_setup_context(ctx, inputs, output):
+    x, topk_idx, _, num_experts, *_ = inputs
+    _, _, _, handle_id = output
+    ctx.input_dtype = x.dtype
+    ctx.num_experts = num_experts
+    ctx.saved_handle_id = handle_id
+    ctx.save_for_backward(topk_idx)
+
+
+def _dispatch_backward(
+    ctx,
+    grad_hidden,
+    grad_scores,
+    grad_tpe,
+    grad_handle_id,
+):
+    global _buffer
+    if grad_hidden is None:
+        return None, None, None, None, None, None, None, None, None
+
+    handle = _handle_cache.pop(ctx.saved_handle_id.item(), None)
+    assert handle is not None
+
+    (topk_idx,) = ctx.saved_tensors
+
+    grad_x, grad_probs_dense = _buffer.combine_with_unpermute(
+        hidden=grad_hidden,
+        probs=grad_scores if grad_scores.numel() > 0 else None,
+        handle=handle,
+    )
+    grad_x = grad_x.to(ctx.input_dtype)
+
+    if grad_probs_dense is None:
+        grad_probs_dense = torch.empty(0, device=grad_hidden.device, dtype=torch.float32)
+
+    grad_weights = grad_probs_dense.gather(dim=1, index=topk_idx) if grad_probs_dense.numel() > 0 else None
+    return grad_x, None, grad_weights, None, None, None, None, None, None
+
+
+@torch.library.impl(_lib, "combine", "CUDA")
+def _combine_op_impl(
+    x: torch.Tensor,
+    handle_id: torch.Tensor,
+    num_tokens: int,
+    pad_multiple: int | None,
+) -> torch.Tensor:
+    global _buffer
+    if _buffer is None:
+        raise RuntimeError("HybridEP buffer not initialized.")
+
+    handle = _handle_cache.get(handle_id.item())
+    assert handle is not None, f"Handle not found for handle_id={handle_id.item()}"
+
+    combined, _ = _buffer.combine_with_unpermute(hidden=x, handle=handle)
+    return combined
+
+
+def _combine_setup_context(ctx, inputs, output):
+    x, handle_id, _num_tokens, pad_multiple = inputs
+    ctx.saved_handle_id = handle_id
+    ctx.num_permuted_tokens = x.shape[0]
+    ctx.pad_multiple = pad_multiple
+
+
+def _combine_backward(ctx, grad_combined):
+    global _buffer
+    if _buffer is None:
+        raise RuntimeError("HybridEP buffer not initialized.")
+
+    handle = _handle_cache.pop(ctx.saved_handle_id.item(), None)
+    assert handle is not None
+
+    grad_x, _, _, _, _ = _buffer.dispatch_with_permute(
+        hidden=grad_combined,
+        scaling_factor=None,
+        handle=handle,
+        num_permuted_tokens=ctx.num_permuted_tokens,
+        pad_multiple=ctx.pad_multiple,
+    )
+    return grad_x, None, None, None
+
+
+torch.library.register_autograd("hybridep::dispatch", _dispatch_backward, setup_context=_dispatch_setup_context)
+torch.library.register_autograd("hybridep::combine", _combine_backward, setup_context=_combine_setup_context)
+
+
+_NUM_SMS_DISPATCH = 16
+_NUM_SMS_COMBINE = 16
+
+
+def get_buffer(
+    group: dist.ProcessGroup,
+    hidden_dim: int,
+    num_tokens: int,
+    num_local_experts: int,
+    fp8_dispatch: bool = False,
+) -> None:
+    """Ensure the global HybridEP buffer is initialized."""
+    global _buffer
+
+    if fp8_dispatch:
+        raise AssertionError("HybridEP FP8 dispatch not yet supported")
+
+    from deep_ep import HybridEPBuffer
+
+    max_tokens_per_rank = num_tokens
+
+    needs_reinit = (
+        _buffer is None
+        or _buffer.group != group
+        or _buffer.configurer.buffer_config.hidden_dim < hidden_dim
+        or _buffer.configurer.buffer_config.max_num_of_tokens_per_rank < max_tokens_per_rank
+        or _buffer.configurer.buffer_config.num_of_experts_per_rank < num_local_experts
+    )
+
+    if needs_reinit:
+        _buffer = HybridEPBuffer(
+            group=group,
+            hidden_dim=hidden_dim,
+            max_num_of_tokens_per_rank=max_tokens_per_rank,
+            num_local_experts=num_local_experts,
+            use_fp8=fp8_dispatch,
+            num_sms_dispatch_api=_NUM_SMS_DISPATCH,
+            num_sms_combine_api=_NUM_SMS_COMBINE,
+            load_cached_kernels=True,
+            use_shared_buffer=True,
+            enable_custom_allgather=True,
+        )
+
+
+def dispatch_tokens(
+    hidden_states: torch.Tensor,
+    selected_experts_indices: torch.Tensor,
+    top_scores: torch.Tensor,
+    num_local_experts: int,
+    num_experts: int,
+    group: dist.ProcessGroup,
+    non_blocking_expert_capacity_factor: float | None = None,
+    pad_multiple: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, DispatchState]:
+    """Dispatch tokens to experts via HybridEP all-to-all.
+
+    Routing scores are applied to the expert outputs in combine_tokens,
+    after expert computation.
+    """
+    non_blocking = non_blocking_expert_capacity_factor is not None
+
+    selected_experts_indices = selected_experts_indices.contiguous()
+    top_scores = top_scores.contiguous()
+
+    ep_size = group.size()
+    group_name = group.group_name
+
+    (
+        hidden,
+        permuted_scores,
+        tokens_per_expert,
+        handle_id,
+    ) = torch.ops.hybridep.dispatch(
+        hidden_states,
+        selected_experts_indices,
+        top_scores,
+        num_experts,
+        ep_size,
+        group_name,
+        non_blocking,
+        non_blocking_expert_capacity_factor,
+        pad_multiple,
+    )
+
+    if permuted_scores is not None and permuted_scores.dtype != hidden.dtype:
+        permuted_scores = permuted_scores.to(hidden.dtype)
+
+    state = DispatchState(
+        handle_id=handle_id,
+        permuted_scores=permuted_scores,
+        num_tokens=hidden_states.shape[0],
+    )
+    return hidden, tokens_per_expert, state
+
+
+def combine_tokens(
+    hidden_states: torch.Tensor,
+    state: DispatchState,
+    pad_multiple: int | None = None,
+) -> torch.Tensor:
+    """Combine expert outputs back to original token order."""
+    if state.permuted_scores is not None:
+        hidden_states = hidden_states * state.permuted_scores.reshape(-1, 1)
+
+    return torch.ops.hybridep.combine(hidden_states, state.handle_id, state.num_tokens, pad_multiple)
+
+
+__all__ = [
+    "dispatch_tokens",
+    "combine_tokens",
+    "DispatchState",
+]

--- a/src/prime_rl/trainer/distributed/moe/indices.py
+++ b/src/prime_rl/trainer/distributed/moe/indices.py
@@ -1,0 +1,321 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import triton
+import triton.language as tl
+
+__all__ = ["generate_permute_indices"]
+
+
+# parallelized kernel
+@triton.jit
+def _fill_indices_kernel(
+    tokens_per_expert_group_ptr,
+    start_index_values_ptr,
+    write_offsets_ptr,
+    output_ptr,
+    experts_per_rank: tl.constexpr,
+    num_ranks: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,  # Number of threads per block
+):
+    pid = tl.program_id(axis=0)
+    num_programs = tl.num_programs(axis=0)
+
+    # map programs (blocks) to the experts and loop (grid stride) if needed
+    for expert_id in range(pid, experts_per_rank, num_programs):
+        # read this experts write offset
+        write_offset = tl.load(write_offsets_ptr + expert_id)
+
+        for r in range(num_ranks):
+            # index into tokens_per_expert_group array
+            i = r * experts_per_rank + expert_id
+
+            # load start index and number of tokens for this expert-rank pair
+            start_index = tl.load(start_index_values_ptr + i)
+            length = tl.load(tokens_per_expert_group_ptr + i)
+
+            # each thread in block processes tokens in parallel
+            offsets = tl.arange(0, BLOCK_SIZE)
+
+            # tokens are processed in chunks of BLOCK_SIZE
+            for chunk_start in range(0, length, BLOCK_SIZE):
+                chunk_offsets = chunk_start + offsets
+
+                # mask valid indices
+                mask = chunk_offsets < length
+
+                values = start_index + chunk_offsets
+
+                # destination
+                dest_indices = write_offset + chunk_offsets
+
+                # store
+                tl.store(output_ptr + dest_indices, values, mask=mask)
+
+            # update write offset for next rank
+            write_offset += length
+
+
+# ==============
+# wrapper
+# ==============
+
+
+def fill_indices_wrapper(
+    tokens_per_expert_group: torch.Tensor,
+    start_index_values: torch.Tensor,
+    write_offsets: torch.Tensor,
+    experts_per_rank: int,
+    num_ranks: int,
+    max_len: int,
+    block_size: int = 128,
+    max_blocks: int = 1024,  # cap on total number of blocks to launch
+):
+    # preallocate output
+    permuted_indices = torch.full((max_len,), -1, dtype=torch.int32, device=tokens_per_expert_group.device)
+
+    # write offsets is per local expert...
+    num_blocks = min(experts_per_rank, max_blocks)
+    # grid = one block per expert unless capped and then we loop...
+    grid = (num_blocks,)
+
+    # launch kernel
+    _fill_indices_kernel[grid](
+        tokens_per_expert_group,
+        start_index_values,
+        write_offsets,
+        permuted_indices,
+        experts_per_rank,
+        num_ranks,
+        BLOCK_SIZE=block_size,
+    )
+    return permuted_indices
+
+
+# reference
+def fill_indices_cpu(
+    tokens_per_expert_group: torch.Tensor,
+    start_index_values: torch.Tensor,
+    write_offsets: torch.Tensor,
+    experts_per_rank: int,
+    num_ranks: int,
+    max_len: int,
+):
+    # We need to preallocate the output - we ignore device and force it on cpu
+    # device = tokens_per_expert_group.device
+    permuted_indices = torch.full(
+        (max_len,),
+        -1,
+        dtype=torch.int32,
+    )  # device=device)
+    # Fill the permuted indices
+    # For each local expert
+    for e in range(experts_per_rank):
+        write_start = write_offsets[e].item()
+        # For each remote rank
+        for r in range(num_ranks):
+            i = r * experts_per_rank + e
+            start_index = start_index_values[i].item()
+            length = tokens_per_expert_group[i].item()
+            # Fill in the indices
+            if length > 0:
+                end_idx = min(write_start + length, max_len)
+                permuted_indices[write_start:end_idx] = torch.arange(
+                    start_index,
+                    start_index + (end_idx - write_start),
+                    dtype=torch.int32,
+                    # device=device,
+                )
+            write_start += length
+    return permuted_indices
+
+
+def generate_permute_indices(
+    tokens_per_expert_group: torch.Tensor,
+    experts_per_rank: int,
+    num_ranks: int,
+    max_len: int,
+    alignment: int,
+    use_cpu: bool = False,
+):
+    """
+    Prepare permutation indices and the number of tokens for each expert.
+
+    Args:
+        tokens_per_expert_group: number of tokens for each expert from all ranks.
+        experts_per_rank: number of experts per rank.
+        num_ranks: number of ranks.
+        max_len: maximum length of the output index vector.
+        alignment: alignment for each returned element in `m_sizes` and padding min for zero token experts.
+        use_cpu: whether to use CPU implementation.
+
+
+    Returns:
+        permuted_indices: Tensor of indices that map original token order to the expert-grouped order.
+        m_sizes: aligned number of tokens for each expert (padded to alignment boundary).
+        m_offsets: Cumulative sum of m_sizes. The exclusive ending position for each expert's tokens.
+
+    Explanatory details:
+        `tokens_per_expert_group` is of shape (num_ranks * experts_per_rank,), for example:
+        From: |       rank 0      |       rank 1      |
+        To:   | E0 | E1 | E2 | E3 | E0 | E1 | E2 | E3 |
+              |  4 |  2 |  1 |  3 |  1 |  2 |  3 |  4 |
+    """
+
+    # prefix sum to get start index of each expert (parallel scan kernel in future?)
+    start_index_values = torch.cumsum(tokens_per_expert_group, 0) - tokens_per_expert_group
+
+    # total tokens for each expert (sum over ranks)
+    total_tokens_per_expert = tokens_per_expert_group.view(num_ranks, -1).sum(0)
+
+    # pad out empty experts to alignment requirement
+    total_tokens_per_expert = torch.clamp_min(total_tokens_per_expert, alignment)
+
+    # align the chunk sizes (cdiv)
+    m_sizes = ((total_tokens_per_expert + alignment - 1) // alignment * alignment).to(torch.int32)
+
+    # additional prefix sum to get write offset of each expert in permuted_indices
+    # write offsets is per local expert, not global
+    m_offsets = torch.cumsum(m_sizes, 0)
+    write_offsets = m_offsets - m_sizes
+
+    # Select the implementation to use
+    if use_cpu:
+        permuted_indices = fill_indices_cpu(
+            tokens_per_expert_group,
+            start_index_values,
+            write_offsets,
+            experts_per_rank,
+            num_ranks,
+            max_len,
+        )
+    else:
+        permuted_indices = fill_indices_wrapper(
+            tokens_per_expert_group,
+            start_index_values,
+            write_offsets,
+            experts_per_rank,
+            num_ranks,
+            max_len,
+        )
+
+    return permuted_indices, m_sizes, m_offsets.to(torch.int32)
+
+
+# Below is for testing only
+
+
+def simple_test():
+    device = torch.device("cuda", 0)
+    experts_per_rank = 4
+    num_ranks = 4
+    tokens_per_expert_group = torch.full((num_ranks * experts_per_rank,), 4, dtype=torch.int32, device=device)
+    max_len = 128
+    alignment = 32
+    # Use the GPU kernel
+    permuted_indices_gpu, m_sizes, _ = generate_permute_indices(
+        tokens_per_expert_group, experts_per_rank, num_ranks, max_len, alignment
+    )
+    # Use the CPU method
+    permuted_indices_cpu, m_sizes, _ = generate_permute_indices(
+        tokens_per_expert_group,
+        experts_per_rank,
+        num_ranks,
+        max_len,
+        alignment,
+        use_cpu=True,
+    )
+    # Check that the results are the same
+
+    assert torch.equal(permuted_indices_gpu.cpu(), permuted_indices_cpu)
+    assert torch.equal(
+        torch.remainder(m_sizes, alignment),
+        torch.zeros(experts_per_rank, device=device),
+    )
+    # Print the results
+    print(f"{permuted_indices_gpu=}, \n{permuted_indices_cpu=}")
+    print(f"{m_sizes=}")
+    print("Success")
+    return True  # assert would have failed meaning getting here is success.
+
+
+def test_with_zero_tokens():
+    device = torch.device("cuda", 0)
+    experts_per_rank = 4
+    num_ranks = 2
+
+    # Create a test case where some experts have zero tokens
+    tokens_per_expert_group = torch.tensor(
+        [4, 0, 2, 3, 1, 0, 0, 5],  # Some experts have zero tokens
+        dtype=torch.int32,
+        device=device,
+    )
+
+    max_len = 128
+    alignment = 8
+
+    # Use the GPU kernel
+    permuted_indices_gpu, m_sizes, m_offsets = generate_permute_indices(
+        tokens_per_expert_group,
+        experts_per_rank,
+        num_ranks,
+        max_len,
+        alignment,
+    )
+
+    # Use the CPU method
+    permuted_indices_cpu, m_sizes_cpu, m_offsets_cpu = generate_permute_indices(
+        tokens_per_expert_group,
+        experts_per_rank,
+        num_ranks,
+        max_len,
+        alignment,
+        use_cpu=True,
+    )
+
+    # Check that the results are the same
+    assert torch.equal(permuted_indices_gpu.cpu(), permuted_indices_cpu)
+    assert torch.equal(m_sizes, m_sizes_cpu)
+
+    # Verify that experts with zero tokens have at least min_slots_per_expert
+    total_tokens_per_expert = tokens_per_expert_group.view(num_ranks, -1).sum(0)
+    zero_token_experts = total_tokens_per_expert == 0
+    if zero_token_experts.any():
+        assert (m_sizes[zero_token_experts] >= alignment).all()
+
+    # Check alignment
+    assert torch.equal(
+        torch.remainder(m_sizes, alignment),
+        torch.zeros(experts_per_rank, device=device),
+    )
+
+    # Print the results
+    print(f"tokens_per_expert_group = {tokens_per_expert_group}")
+    print(f"total_tokens_per_expert = {total_tokens_per_expert}")
+    print(f"m_sizes = {m_sizes}")
+    print(f"m_offsets = {m_offsets}")
+    print(f"permuted_indices = {permuted_indices_gpu[: sum(m_sizes).item()]}")
+
+    # Check that experts with zero tokens have -1 in their slots
+    for e in range(experts_per_rank):
+        start = (m_offsets[e] - m_sizes[e]).item()
+        end = m_offsets[e].item()
+        expert_indices = permuted_indices_gpu[start:end]
+        if total_tokens_per_expert[e] == 0:
+            assert (expert_indices == -1).all(), f"Expert {e} with zero tokens should have all -1 indices"
+            assert expert_indices.size(0) >= alignment, (
+                f"Expert {e} with zero tokens should have at least {alignment} slots"
+            )
+            print(f"Expert {e} has zero tokens and {expert_indices.size(0)} slots with all -1")
+
+    print("All tests passed successfully!")
+    return True
+
+
+if __name__ == "__main__":
+    simple_test()
+    test_with_zero_tokens()

--- a/src/prime_rl/trainer/distributed/tt_expert_parallel.py
+++ b/src/prime_rl/trainer/distributed/tt_expert_parallel.py
@@ -1,0 +1,349 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from functools import partial
+from typing import Callable, Literal
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.tensor import (
+    DeviceMesh,
+    DTensor,
+    Replicate,
+    Shard,
+    distribute_module,
+    distribute_tensor,
+)
+from torch.distributed.tensor.parallel import ParallelStyle
+from torch.distributed.tensor.placement_types import Placement
+
+
+# from torch.distributed._functional_collectives import all_to_all_single_autograd
+# TODO: there is memory leak issue with AC + all_to_all_single_autograd
+# This is a temporary fix by @rakkit https://github.com/pytorch/torchtitan/issues/1467
+class _A2A(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, out_splits, in_splits, group):
+        if isinstance(out_splits, torch.Tensor):
+            out_splits = out_splits.tolist()
+        if isinstance(in_splits, torch.Tensor):
+            in_splits = in_splits.tolist()
+        T_out = int(sum(out_splits))
+
+        y = x.new_empty((T_out,) + tuple(x.shape[1:]))  # allocate by output splits
+        dist.all_to_all_single(y, x.contiguous(), out_splits, in_splits, group=group)
+
+        ctx.in_splits = in_splits
+        ctx.out_splits = out_splits
+        ctx.group = group
+        return y
+
+    @staticmethod
+    def backward(ctx, grad_y):
+        # grad wrt input has length sum(in_splits)
+        T_in = int(sum(ctx.in_splits))
+        grad_x = grad_y.new_empty((T_in,) + tuple(grad_y.shape[1:]))
+        dist.all_to_all_single(grad_x, grad_y.contiguous(), ctx.in_splits, ctx.out_splits, group=ctx.group)
+        return grad_x, None, None, None
+
+
+def all_to_all_single_autograd(x, out_splits, in_splits, group):
+    return _A2A.apply(x, out_splits, in_splits, group)
+
+
+TOKEN_GROUP_ALIGN_SIZE_M = 8
+ValidTokenGroupAlignmentSize = Literal[8, 16, 32]
+
+
+def set_token_group_alignment_size_m(
+    alignment_size: ValidTokenGroupAlignmentSize,
+) -> None:
+    """
+    Set the token group alignment size for token groups in MoE. This is implemented by
+    padding each token group size to the next multiple of TOKEN_GROUP_ALIGN_SIZE_M.
+
+    Valid values are: 8, 16, or 32.
+    Different values are needed for different cases:
+
+    * For bf16, 8 is enough (16 byte alignment / 2 bytes per elem = 8 elements).
+    * For fp8, 16 byte alignment / 1 byte per elem = 16 elements.
+    * For mxfp8, we need 32 (or block_size) because scaling block size is (1 x 32),
+      so when doing per-token-group quantization on each logically distinct subtensor,
+      we need to ensure the contracting dim is divisible by block_size.
+      In the backward pass, grad_weight = (grad_output_t @ input).t() has gemm dims
+      of (N, M) @ (M, K) so M is the contracting dim, and group offsets are along M,
+      so we need 32 element alignment.
+    """
+    global TOKEN_GROUP_ALIGN_SIZE_M
+    TOKEN_GROUP_ALIGN_SIZE_M = alignment_size
+
+
+# implementation of Tensor Parallel for the GroupedExperts in MoE
+class TensorParallel(ParallelStyle):
+    def _partition_fn(self, name, module, device_mesh):
+        # w1 shape = (experts, out_dim, in_dim)
+        module.register_parameter(
+            "w1", nn.Parameter(distribute_tensor(module.w1, device_mesh, [Shard(1)]))
+        )  # Column-wise sharding
+
+        # w2 shape = (experts, in_dim, out_dim)
+        module.register_parameter(
+            "w2",
+            nn.Parameter(distribute_tensor(module.w2, device_mesh, [Shard(2)])),
+        )  # Row-wise sharding
+
+        # w3 shape = (experts, out_dim, in_dim)
+        module.register_parameter(
+            "w3",
+            nn.Parameter(distribute_tensor(module.w3, device_mesh, [Shard(1)])),
+        )  # Column-wise sharding
+
+    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+        return distribute_module(
+            module,
+            device_mesh,
+            self._partition_fn,
+        )
+
+
+# NOTE: This is to achieve replicate computation on the gate module in the MoE router.
+# It does nothing other than (1) setting the module parameters as DTensors on the given mesh
+# and (2) inserting hooks to module boundary to change torch.Tensor to DTensor and back.
+# The reason we need this wrapping is to ensure all parameters are on the same 1D/2D mesh,
+# which is assumed by (1) gradient norm clipping, and (2) optimizer fused implementation.
+class NoParallel(ParallelStyle):
+    def __init__(
+        self,
+        *,
+        input_layout: Placement | None = None,
+        output_layout: Placement | None = None,
+        use_local_output: bool = True,
+    ):
+        super().__init__()
+        self.input_layout = input_layout or Replicate()
+        self.output_layout = output_layout or Replicate()
+        self.desired_input_layout = Replicate()
+        self.use_local_output = use_local_output
+
+    @staticmethod
+    def _prepare_input_fn(input_layout, desired_input_layout, mod, inputs, device_mesh):
+        # annotate module input placements/sharding with input_layouts
+        input_tensor = inputs[0]
+        if not isinstance(input_tensor, DTensor):
+            input_tensor = DTensor.from_local(input_tensor, device_mesh, (input_layout,), run_check=False)
+
+        if input_layout != desired_input_layout:
+            input_tensor = input_tensor.redistribute(placements=(desired_input_layout,), async_op=True)
+        return (input_tensor, *inputs[1:])
+
+    @staticmethod
+    def _prepare_output_fn(output_layout, use_local_output, mod, outputs, device_mesh):
+        if outputs.placements != (output_layout,):
+            outputs = outputs.redistribute(placements=(output_layout,), async_op=True)
+        # back to local tensor
+        return outputs.to_local() if use_local_output else outputs
+
+    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+        return distribute_module(
+            module,
+            device_mesh,
+            None,
+            partial(self._prepare_input_fn, self.input_layout, self.desired_input_layout),
+            partial(self._prepare_output_fn, self.output_layout, self.use_local_output),
+        )
+
+
+class ExpertParallel(ParallelStyle):
+    def __init__(self):
+        super().__init__()
+        self.input_splits = None
+        self.output_splits = None
+
+    # performing all-to-all dispatch on the input
+    def _token_dispatch(self, mod, inputs, device_mesh):
+        # annotate module input placements/sharding with input_layouts
+        routed_input, num_tokens_per_expert = inputs
+
+        # generate the input splits and output splits for all-to-all
+        with torch.no_grad():
+            num_tokens_per_expert_group = num_tokens_per_expert.new_empty(num_tokens_per_expert.shape[0])
+            dist.all_to_all_single(
+                num_tokens_per_expert_group,
+                num_tokens_per_expert,
+                group=device_mesh.get_group(),
+            )
+            # NOTE: this would incur a device-to-host sync
+            self.input_splits = num_tokens_per_expert.view(device_mesh.shape[0], -1).sum(dim=1).tolist()
+            self.output_splits = num_tokens_per_expert_group.view(device_mesh.shape[0], -1).sum(dim=1).tolist()
+
+        # perform all-to-all
+        routed_input = all_to_all_single_autograd(
+            routed_input,
+            self.output_splits,
+            self.input_splits,
+            device_mesh.get_group(),
+        )
+
+        # NOTE: After this all-to-all, the routed input is put on proper EP rank.
+        # However, the num_tokens_per_expert_group is not of the final target format
+        # [#tokens for local expert 0, #tokens for local expert 1, ...]
+        # Rather, it is of the format
+        # [#tokens for local expert 0 from EP rank 0, #tokens for local expert 1 from EP rank 0, ...,
+        #  #tokens for local expert 0 from EP rank 1, #tokens for local expert 1 from EP rank 1, ...]
+        # We need to perform another shuffle to get the correct format -- this is done via the function
+        # generate_permute_indices in moe.py, which also does padding to make sure the number of tokens
+        # each expert gets locally is a multiple of ALIGN_SIZE_M.
+
+        return routed_input, num_tokens_per_expert_group
+
+    @staticmethod
+    def _partition_fn(name, mod, device_mesh):
+        # shard on the expert dimension
+        for name, param in mod.named_parameters(recurse=False):
+            dist_param = nn.Parameter(distribute_tensor(param, device_mesh, [Shard(0)]))
+            mod.register_parameter(name, dist_param)
+
+    # performing all-to-all combine on the output
+    def _token_combine(self, mod, routed_output, device_mesh):
+        routed_output = all_to_all_single_autograd(
+            routed_output,
+            self.input_splits,
+            self.output_splits,
+            device_mesh.get_group(),
+        )
+        return routed_output
+
+    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+        return distribute_module(
+            module,
+            device_mesh,
+            partition_fn=ExpertParallel._partition_fn,
+            input_fn=self._token_dispatch,
+            output_fn=self._token_combine,
+        )
+
+
+# This class is for dp2ep with TP (without TP we can just use ExpertParallel)
+class ExpertTensorParallel(ExpertParallel):
+    def __init__(
+        self,
+        tp_mesh: DeviceMesh,
+        ep_mesh: DeviceMesh,
+    ):
+        super().__init__()
+        # TODO: has to pass in the meshes in addition to the [ep, tp] device_mesh,
+        #       as DeviceMesh doesn't support slicing from a submesh.
+        self.tp_mesh = tp_mesh
+        self.ep_mesh = ep_mesh
+
+    def _token_dispatch(self, mod, inputs, device_mesh):
+        # token dispatch happens on the EP mesh, whereas device_mesh is [ep, tp] mesh
+        return super()._token_dispatch(mod, inputs, self.ep_mesh)
+
+    def _partition_fn_2d(self, name, mod, ep_tp_mesh):
+        # w1 shape = (experts, out_dim, in_dim)
+        mod.register_parameter(
+            "w1",
+            nn.Parameter(distribute_tensor(mod.w1, ep_tp_mesh, [Shard(0), Shard(1)])),
+        )  # Column-wise sharding
+
+        # w2 shape = (experts, in_dim, out_dim)
+        mod.register_parameter(
+            "w2",
+            nn.Parameter(distribute_tensor(mod.w2, ep_tp_mesh, [Shard(0), Shard(2)])),
+        )  # Row-wise sharding
+
+        # w3 shape = (experts, out_dim, in_dim)
+        mod.register_parameter(
+            "w3",
+            nn.Parameter(distribute_tensor(mod.w3, ep_tp_mesh, [Shard(0), Shard(1)])),
+        )  # Column-wise sharding
+
+    def _token_combine(self, mod, routed_output, device_mesh):
+        # token combine happens on the EP mesh, whereas device_mesh is [ep, tp] mesh
+        return super()._token_combine(mod, routed_output, self.ep_mesh)
+
+    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+        return distribute_module(
+            module,
+            device_mesh,
+            partition_fn=self._partition_fn_2d,
+            input_fn=self._token_dispatch,
+            output_fn=self._token_combine,
+        )
+
+
+def expert_parallel(func: Callable) -> Callable:
+    """
+    This is a wrapper applied to the GroupedExperts computation, serving
+    the following three purposes:
+    1. Convert parameters from DTensors to plain Tensors, to work with
+    dynamic-shape inputs which cannot be easily expressed as DTensors.
+    2. In Expert Parallel, apply the generate_permute_indices kernel to
+    permute the inputs to be ordered by local experts (see the _token_dispatch
+    function in ExpertParallel) and permute the outputs back.
+    3. In order to use torch._grouped_mm, we need to make sure the number of
+    tokens each expert gets is a multiple of ALIGN_SIZE_M. The generate_permute_indices
+    kernel also helps achieve this via padding, without incurring synchronization
+    between device and host. Note that this will create side effects when wrapping
+    the for-loop implementation of GroupedExperts, as it does not need padding.
+
+    Among the above:
+    1 and 2 are needed only when expert_parallel_degree > 1.
+    3 is needed even for single-device computation.
+    2 can be moved to ExpertParallel _token_dispatch if not coupled with 3.
+    """
+
+    def wrapper(
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        w3: torch.Tensor,
+        x: torch.Tensor,
+        num_tokens_per_expert: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        global TOKEN_GROUP_ALIGN_SIZE_M
+        if isinstance(w1, DTensor):
+            w1 = w1.to_local()
+            w2 = w2.to_local()
+            w3 = w3.to_local()
+
+        if num_tokens_per_expert is not None:
+            from prime_rl.trainer.distributed.moe.indices import (
+                generate_permute_indices,
+            )
+
+            experts_per_ep_rank = w1.shape[0]
+            num_ep_ranks = num_tokens_per_expert.shape[0] // experts_per_ep_rank
+
+            with torch.no_grad():
+                (
+                    permuted_indices,
+                    num_tokens_per_expert,
+                    _,  # offsets,
+                ) = generate_permute_indices(
+                    num_tokens_per_expert,
+                    experts_per_ep_rank,
+                    num_ep_ranks,
+                    x.shape[0] + experts_per_ep_rank * TOKEN_GROUP_ALIGN_SIZE_M,
+                    TOKEN_GROUP_ALIGN_SIZE_M,
+                )
+
+            x = torch.vstack((x, x.new_zeros((x.shape[-1]))))
+            input_shape = x.shape
+            x = x[permuted_indices, :]
+
+        out = func(w1, w2, w3, x, num_tokens_per_expert)
+
+        if num_tokens_per_expert is not None:
+            out_unpermuted = out.new_empty(input_shape)
+            out_unpermuted[permuted_indices, :] = out
+            out = out_unpermuted[:-1]
+
+        return out
+
+    return wrapper

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -21,7 +21,6 @@ from torch.distributed.checkpoint.state_dict_loader import load as dcp_load
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import CPUOffloadPolicy, FSDPModule, MixedPrecisionPolicy, OffloadPolicy, fully_shard
 from torch.distributed.tensor.parallel import parallelize_module
-from torchtitan.distributed.expert_parallel import ExpertParallel
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, GenerationConfig, PretrainedConfig
 from transformers.tokenization_utils import PreTrainedTokenizer
 from transformers.utils.import_utils import is_flash_attn_3_available
@@ -35,6 +34,7 @@ from prime_rl.configs.trainer import (
     TokenizerConfig,
 )
 from prime_rl.trainer.distributed import DeepEPExpertParallel, MXFP8AllToAllExpertParallel
+from prime_rl.trainer.distributed.tt_expert_parallel import ExpertParallel
 from prime_rl.trainer.lora import apply_lora_to_model, freeze_all_except_lora_and_specified, strip_lora_from_state_dict
 from prime_rl.trainer.models import (
     AutoModelForCausalLMPrimeRL,
@@ -483,7 +483,7 @@ def is_tt_moe_model(model: nn.Module) -> bool:
 
 def configure_moe_ep_backend(model: nn.Module, config: ModelConfig) -> None:
     backend = config.ep_comm_backend
-    if backend == "deepep":
+    if backend in ("deepep", "deepep_v2"):
         from prime_rl.trainer.distributed.deepep import configure_num_sms
 
         configure_num_sms(config.deepep_num_sms)
@@ -493,6 +493,11 @@ def configure_moe_ep_backend(model: nn.Module, config: ModelConfig) -> None:
             continue
         transformer_block.mlp.set_ep_comm_backend(backend)
         transformer_block.mlp.set_deepep_token_chunk_size(config.deepep_token_chunk_size)
+        if backend == "hybridep":
+            transformer_block.mlp.set_hybridep_config(
+                config.hybridep_non_blocking_capacity_factor,
+                config.hybridep_pad_multiple,
+            )
 
 
 def get_load_balance_stats(
@@ -1172,6 +1177,18 @@ def apply_ep(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims)
                     parallelize_plan = MXFP8AllToAllExpertParallel()
                 else:
                     parallelize_plan = ExpertParallel()
+            elif config.ep_comm_backend == "deepep_v2":
+                from prime_rl.trainer.distributed import DeepEPv2ExpertParallel
+
+                parallelize_plan = DeepEPv2ExpertParallel()
+            elif config.ep_comm_backend == "hybridep":
+                from prime_rl.trainer.distributed import HybridEPExpertParallel
+
+                parallelize_plan = HybridEPExpertParallel()
+            elif config.ep_comm_backend == "minimal_async_ep":
+                from prime_rl.trainer.distributed import MinimalAsyncEPExpertParallel
+
+                parallelize_plan = MinimalAsyncEPExpertParallel()
             else:
                 parallelize_plan = DeepEPExpertParallel()
             parallelize_module(

--- a/src/prime_rl/trainer/models/layers/lora/multi_moe.py
+++ b/src/prime_rl/trainer/models/layers/lora/multi_moe.py
@@ -352,9 +352,14 @@ class MultiLoRAGroupedExperts(MultiLoRAModule):
             w3_lora_a = w3_lora_a.to_local()
             w3_lora_b = w3_lora_b.to_local()
 
-            if getattr(self.base_layer, "ep_comm_backend", "torch") != "deepep":
-                from torchtitan.distributed.expert_parallel import TOKEN_GROUP_ALIGN_SIZE_M
-                from torchtitan.experiments.kernels.moe.indices import generate_permute_indices
+            if getattr(self.base_layer, "ep_comm_backend", "torch") not in {
+                "deepep",
+                "deepep_v2",
+                "hybridep",
+                "minimal_async_ep",
+            }:
+                from prime_rl.trainer.distributed.moe.indices import generate_permute_indices
+                from prime_rl.trainer.distributed.tt_expert_parallel import TOKEN_GROUP_ALIGN_SIZE_M
 
                 experts_per_ep_rank = base_w1.shape[0]
                 num_ep_ranks = num_tokens_per_expert.shape[0] // experts_per_ep_rank
@@ -661,9 +666,14 @@ class MultiLoRANonGatedGroupedExperts(MultiLoRAModule):
             w2_lora_a = w2_lora_a.to_local()
             w2_lora_b = w2_lora_b.to_local()
 
-            if getattr(self.base_layer, "ep_comm_backend", "torch") != "deepep":
-                from torchtitan.distributed.expert_parallel import TOKEN_GROUP_ALIGN_SIZE_M
-                from torchtitan.experiments.kernels.moe.indices import generate_permute_indices
+            if getattr(self.base_layer, "ep_comm_backend", "torch") not in {
+                "deepep",
+                "deepep_v2",
+                "hybridep",
+                "minimal_async_ep",
+            }:
+                from prime_rl.trainer.distributed.moe.indices import generate_permute_indices
+                from prime_rl.trainer.distributed.tt_expert_parallel import TOKEN_GROUP_ALIGN_SIZE_M
 
                 experts_per_ep_rank = base_w1.shape[0]
                 num_ep_ranks = num_tokens_per_expert.shape[0] // experts_per_ep_rank
@@ -955,9 +965,14 @@ class MultiLoRAGptOssGroupedExperts(MultiLoRAModule):
             d_a = d_a.to_local()
             d_b = d_b.to_local()
 
-            if getattr(self.base_layer, "ep_comm_backend", "torch") != "deepep":
-                from torchtitan.distributed.expert_parallel import TOKEN_GROUP_ALIGN_SIZE_M
-                from torchtitan.experiments.kernels.moe.indices import generate_permute_indices
+            if getattr(self.base_layer, "ep_comm_backend", "torch") not in {
+                "deepep",
+                "deepep_v2",
+                "hybridep",
+                "minimal_async_ep",
+            }:
+                from prime_rl.trainer.distributed.moe.indices import generate_permute_indices
+                from prime_rl.trainer.distributed.tt_expert_parallel import TOKEN_GROUP_ALIGN_SIZE_M
 
                 experts_per_ep_rank = base_gu.shape[0]
                 num_ep_ranks = num_tokens_per_expert.shape[0] // experts_per_ep_rank

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -215,7 +215,7 @@ class GroupedExperts(nn.Module):
         x: torch.Tensor,
         num_tokens_per_expert: torch.Tensor,
     ) -> torch.Tensor:
-        if self.ep_comm_backend == "deepep":
+        if self.ep_comm_backend in ("deepep", "deepep_v2", "hybridep", "minimal_async_ep"):
             return self._forward_deepep(x, num_tokens_per_expert)
 
         if self.use_grouped_mm:
@@ -368,7 +368,7 @@ class GptOssGroupedExperts(nn.Module):
         )
 
     def forward(self, x: torch.Tensor, num_tokens_per_expert: torch.Tensor) -> torch.Tensor:
-        if self.ep_comm_backend == "deepep":
+        if self.ep_comm_backend in ("deepep", "deepep_v2", "hybridep", "minimal_async_ep"):
             return self._forward_deepep(x, num_tokens_per_expert)
 
         if self.use_grouped_mm:
@@ -595,6 +595,8 @@ class MoE(nn.Module):
         )
         self.score_before_experts = moe_args.score_before_experts
         self.deepep_token_chunk_size: int | None = None
+        self.hybridep_non_blocking_capacity_factor: float | None = None
+        self.hybridep_pad_multiple: int | None = None
 
         # define fields for auxiliary-loss-free load balancing (https://arxiv.org/abs/2408.15664)
         # NOTE: tokens_per_expert is accumulated in the model forward pass.
@@ -707,6 +709,166 @@ class MoE(nn.Module):
         routed_output = routed_outputs[0] if len(routed_outputs) == 1 else torch.cat(routed_outputs, dim=0)
         return routed_output if shared_output is None else shared_output + routed_output
 
+    def _run_deepep_v2_routed_experts(
+        self,
+        x: torch.Tensor,
+        selected_experts_indices: torch.Tensor,
+        top_scores: torch.Tensor,
+    ) -> torch.Tensor:
+        from torchtitan.distributed.deepep.deepep import (
+            combine_tokens,
+            dispatch_tokens,
+            sync_combine,
+        )
+
+        from prime_rl.trainer.distributed.expert_parallel import get_ep_group
+
+        if x.shape[0] == 0:
+            shared_output = self.shared_expert(x) if self.shared_expert is not None else None
+            return x.new_zeros(x.shape) if shared_output is None else shared_output
+
+        group = get_ep_group(self.experts)
+        num_local_experts = self.experts.num_experts // group.size()
+        chunk_size = min(self.deepep_token_chunk_size or x.shape[0], x.shape[0])
+
+        routed_outputs: list[torch.Tensor] = []
+        for chunk_start in range(0, x.shape[0], chunk_size):
+            chunk_end = min(chunk_start + chunk_size, x.shape[0])
+            hidden_states, num_tokens_per_expert, state = dispatch_tokens(
+                x[chunk_start:chunk_end],
+                selected_experts_indices[chunk_start:chunk_end],
+                top_scores[chunk_start:chunk_end],
+                num_local_experts=num_local_experts,
+                num_experts=self.experts.num_experts,
+                group=group,
+                num_max_tokens_per_rank=None,
+            )
+            routed_output = self._run_local_routed_experts(hidden_states, num_tokens_per_expert)
+            routed_outputs.append(combine_tokens(routed_output, state))
+
+        shared_output = self.shared_expert(x) if self.shared_expert is not None else None
+        sync_combine()
+        routed_output = routed_outputs[0] if len(routed_outputs) == 1 else torch.cat(routed_outputs, dim=0)
+        return routed_output if shared_output is None else shared_output + routed_output
+
+    def _run_hybridep_routed_experts(
+        self,
+        x: torch.Tensor,
+        selected_experts_indices: torch.Tensor,
+        top_scores: torch.Tensor,
+    ) -> torch.Tensor:
+        from prime_rl.trainer.distributed.expert_parallel import get_ep_group
+        from prime_rl.trainer.distributed.hybridep import combine_tokens, dispatch_tokens
+
+        if x.shape[0] == 0:
+            shared_output = self.shared_expert(x) if self.shared_expert is not None else None
+            return x.new_zeros(x.shape) if shared_output is None else shared_output
+
+        group = get_ep_group(self.experts)
+        num_local_experts = self.experts.num_experts // group.size()
+
+        hidden_states, num_tokens_per_expert, state = dispatch_tokens(
+            x,
+            selected_experts_indices,
+            top_scores,
+            num_local_experts=num_local_experts,
+            num_experts=self.experts.num_experts,
+            group=group,
+            non_blocking_expert_capacity_factor=self.hybridep_non_blocking_capacity_factor,
+            pad_multiple=self.hybridep_pad_multiple,
+        )
+        routed_output = self._run_local_routed_experts(hidden_states, num_tokens_per_expert)
+        combined = combine_tokens(routed_output, state, pad_multiple=self.hybridep_pad_multiple)
+
+        shared_output = self.shared_expert(x) if self.shared_expert is not None else None
+        return combined if shared_output is None else shared_output + combined
+
+    def _run_minimal_async_ep_routed_experts(
+        self,
+        x: torch.Tensor,
+        selected_experts_indices: torch.Tensor,
+        top_scores: torch.Tensor,
+    ) -> torch.Tensor:
+        from torchtitan.distributed.minimal_async_ep import combine_op, dispatch_op, init_buffer
+
+        from prime_rl.trainer.distributed.expert_parallel import get_ep_group
+
+        if x.shape[0] == 0:
+            shared_output = self.shared_expert(x) if self.shared_expert is not None else None
+            return x.new_zeros(x.shape) if shared_output is None else shared_output
+
+        group = get_ep_group(self.experts)
+        ep_size = group.size()
+        num_local_experts = self.experts.num_experts // ep_size
+        top_k = self.router.top_k
+
+        if not getattr(self, "_minimal_async_ep_initialized", False):
+            tokens_per_rank = x.shape[0]
+            init_buffer(
+                group=group,
+                hidden_dim=x.shape[1],
+                tokens_per_rank=tokens_per_rank,
+                num_local_experts=num_local_experts,
+                top_k=top_k,
+                dtype=x.dtype,
+                device=x.device,
+            )
+            self._minimal_async_ep_initialized = True
+
+        num_local_tokens_per_expert = torch.histc(
+            selected_experts_indices.reshape(-1).float(),
+            bins=self.experts.num_experts,
+            min=0,
+            max=self.experts.num_experts,
+        ).to(torch.int64)
+
+        receive_capacity = ep_size * x.shape[0] * min(top_k, num_local_experts)
+
+        (
+            hidden_states,
+            dispatch_dst_ranks,
+            dispatch_dst_rows,
+            combine_dst_ranks,
+            combine_dst_rows,
+            combine_num_valid_rows,
+            E_row_to_T_row,
+            T_row_to_E_row,
+            num_tokens_per_local_expert,
+        ) = dispatch_op(
+            x,
+            selected_experts_indices,
+            num_local_tokens_per_expert,
+            receive_capacity,
+            ep_size,
+        )
+
+        routed_output = self._run_local_routed_experts(hidden_states, num_tokens_per_local_expert)
+
+        combined, _ = combine_op(
+            routed_output,
+            dispatch_dst_ranks,
+            dispatch_dst_rows,
+            combine_dst_ranks,
+            combine_dst_rows,
+            combine_num_valid_rows,
+            T_row_to_E_row,
+            E_row_to_T_row,
+            top_scores.view(-1),
+            x.shape[0],
+            top_k,
+        )
+
+        shared_output = self.shared_expert(x) if self.shared_expert is not None else None
+        return combined if shared_output is None else shared_output + combined
+
+    def set_hybridep_config(
+        self,
+        non_blocking_capacity_factor: float | None,
+        pad_multiple: int | None,
+    ) -> None:
+        self.hybridep_non_blocking_capacity_factor = non_blocking_capacity_factor
+        self.hybridep_pad_multiple = pad_multiple
+
     def forward(
         self,
         x: torch.Tensor,
@@ -747,8 +909,15 @@ class MoE(nn.Module):
             self.tokens_per_expert.add_(num_tokens_per_expert)
             self.routing_confidence_sum.add_(routing_confidence_sum)
 
-        if self.ep_comm_backend == "deepep":
-            routed_output = self._run_deepep_routed_experts(x, selected_experts_indices, top_scores)
+        if self.ep_comm_backend in ("deepep", "deepep_v2", "hybridep", "minimal_async_ep"):
+            if self.ep_comm_backend == "deepep":
+                routed_output = self._run_deepep_routed_experts(x, selected_experts_indices, top_scores)
+            elif self.ep_comm_backend == "deepep_v2":
+                routed_output = self._run_deepep_v2_routed_experts(x, selected_experts_indices, top_scores)
+            elif self.ep_comm_backend == "hybridep":
+                routed_output = self._run_hybridep_routed_experts(x, selected_experts_indices, top_scores)
+            elif self.ep_comm_backend == "minimal_async_ep":
+                routed_output = self._run_minimal_async_ep_routed_experts(x, selected_experts_indices, top_scores)
             return routed_output.reshape(bs, slen, dim)
 
         # top_scores and token_indices_experts_sorted shape (bs*slen*top_k,)
@@ -918,7 +1087,7 @@ class NonGatedGroupedExperts(nn.Module):
         x: torch.Tensor,
         num_tokens_per_expert: torch.Tensor,
     ) -> torch.Tensor:
-        if self.ep_comm_backend == "deepep":
+        if self.ep_comm_backend in ("deepep", "deepep_v2", "hybridep", "minimal_async_ep"):
             return self._forward_deepep(x, num_tokens_per_expert)
         if self.use_grouped_mm:
             if self.fp8:
@@ -1077,6 +1246,8 @@ class LatentMoE(nn.Module):
         self.reorderer = TokenReorderer(num_experts=num_experts, top_k=top_k)
         self.shared_expert = BCNonGatedFeedForward(dim=dim, hidden_dim=shared_expert_intermediate_size)
         self.deepep_token_chunk_size: int | None = None
+        self.hybridep_non_blocking_capacity_factor: float | None = None
+        self.hybridep_pad_multiple: int | None = None
 
         if latent_dim is not None:
             self.fc1_latent_proj = nn.Linear(dim, latent_dim, bias=False)
@@ -1192,6 +1363,171 @@ class LatentMoE(nn.Module):
         routed_output = self.fc2_latent_proj(routed_output)
         return shared_output + routed_output
 
+    def _run_deepep_v2_routed_experts(
+        self,
+        x: torch.Tensor,
+        selected_experts_indices: torch.Tensor,
+        top_scores: torch.Tensor,
+    ) -> torch.Tensor:
+        from torchtitan.distributed.deepep.deepep import (
+            combine_tokens,
+            dispatch_tokens,
+            sync_combine,
+        )
+
+        from prime_rl.trainer.distributed.expert_parallel import get_ep_group
+
+        if x.shape[0] == 0:
+            return self.shared_expert(x)
+
+        group = get_ep_group(self.experts)
+        num_local_experts = self.experts.num_experts // group.size()
+        latent_x = self.fc1_latent_proj(x)
+        chunk_size = min(self.deepep_token_chunk_size or latent_x.shape[0], latent_x.shape[0])
+
+        routed_outputs: list[torch.Tensor] = []
+        for chunk_start in range(0, latent_x.shape[0], chunk_size):
+            chunk_end = min(chunk_start + chunk_size, latent_x.shape[0])
+            hidden_states, num_tokens_per_expert, state = dispatch_tokens(
+                latent_x[chunk_start:chunk_end],
+                selected_experts_indices[chunk_start:chunk_end],
+                top_scores[chunk_start:chunk_end],
+                num_local_experts=num_local_experts,
+                num_experts=self.experts.num_experts,
+                group=group,
+                num_max_tokens_per_rank=None,
+            )
+            routed_output = self._run_local_routed_experts(hidden_states, num_tokens_per_expert)
+            routed_outputs.append(combine_tokens(routed_output, state))
+
+        shared_output = self.shared_expert(x)
+        sync_combine()
+        routed_output = routed_outputs[0] if len(routed_outputs) == 1 else torch.cat(routed_outputs, dim=0)
+        routed_output = routed_output * self.routed_scaling_factor
+        routed_output = self.fc2_latent_proj(routed_output)
+        return shared_output + routed_output
+
+    def _run_hybridep_routed_experts(
+        self,
+        x: torch.Tensor,
+        selected_experts_indices: torch.Tensor,
+        top_scores: torch.Tensor,
+    ) -> torch.Tensor:
+        from prime_rl.trainer.distributed.expert_parallel import get_ep_group
+        from prime_rl.trainer.distributed.hybridep import combine_tokens, dispatch_tokens
+
+        if x.shape[0] == 0:
+            return self.shared_expert(x)
+
+        group = get_ep_group(self.experts)
+        num_local_experts = self.experts.num_experts // group.size()
+        latent_x = self.fc1_latent_proj(x)
+
+        hidden_states, num_tokens_per_expert, state = dispatch_tokens(
+            latent_x,
+            selected_experts_indices,
+            top_scores,
+            num_local_experts=num_local_experts,
+            num_experts=self.experts.num_experts,
+            group=group,
+            non_blocking_expert_capacity_factor=self.hybridep_non_blocking_capacity_factor,
+            pad_multiple=self.hybridep_pad_multiple,
+        )
+        routed_output = self._run_local_routed_experts(hidden_states, num_tokens_per_expert)
+        combined = combine_tokens(routed_output, state, pad_multiple=self.hybridep_pad_multiple)
+
+        shared_output = self.shared_expert(x)
+        combined = combined * self.routed_scaling_factor
+        combined = self.fc2_latent_proj(combined)
+        return shared_output + combined
+
+    def _run_minimal_async_ep_routed_experts(
+        self,
+        x: torch.Tensor,
+        selected_experts_indices: torch.Tensor,
+        top_scores: torch.Tensor,
+    ) -> torch.Tensor:
+        from torchtitan.distributed.minimal_async_ep import combine_op, dispatch_op, init_buffer
+
+        from prime_rl.trainer.distributed.expert_parallel import get_ep_group
+
+        if x.shape[0] == 0:
+            return self.shared_expert(x)
+
+        group = get_ep_group(self.experts)
+        ep_size = group.size()
+        num_local_experts = self.experts.num_experts // ep_size
+        top_k = self.router.top_k
+        latent_x = self.fc1_latent_proj(x)
+
+        if not getattr(self, "_minimal_async_ep_initialized", False):
+            init_buffer(
+                group=group,
+                hidden_dim=latent_x.shape[1],
+                tokens_per_rank=latent_x.shape[0],
+                num_local_experts=num_local_experts,
+                top_k=top_k,
+                dtype=latent_x.dtype,
+                device=latent_x.device,
+            )
+            self._minimal_async_ep_initialized = True
+
+        num_local_tokens_per_expert = torch.histc(
+            selected_experts_indices.reshape(-1).float(),
+            bins=self.experts.num_experts,
+            min=0,
+            max=self.experts.num_experts,
+        ).to(torch.int64)
+
+        receive_capacity = ep_size * latent_x.shape[0] * min(top_k, num_local_experts)
+
+        (
+            hidden_states,
+            dispatch_dst_ranks,
+            dispatch_dst_rows,
+            combine_dst_ranks,
+            combine_dst_rows,
+            combine_num_valid_rows,
+            E_row_to_T_row,
+            T_row_to_E_row,
+            num_tokens_per_local_expert,
+        ) = dispatch_op(
+            latent_x,
+            selected_experts_indices,
+            num_local_tokens_per_expert,
+            receive_capacity,
+            ep_size,
+        )
+
+        routed_output = self._run_local_routed_experts(hidden_states, num_tokens_per_local_expert)
+
+        combined, _ = combine_op(
+            routed_output,
+            dispatch_dst_ranks,
+            dispatch_dst_rows,
+            combine_dst_ranks,
+            combine_dst_rows,
+            combine_num_valid_rows,
+            T_row_to_E_row,
+            E_row_to_T_row,
+            top_scores.view(-1),
+            latent_x.shape[0],
+            top_k,
+        )
+
+        shared_output = self.shared_expert(x)
+        combined = combined * self.routed_scaling_factor
+        combined = self.fc2_latent_proj(combined)
+        return shared_output + combined
+
+    def set_hybridep_config(
+        self,
+        non_blocking_capacity_factor: float | None,
+        pad_multiple: int | None,
+    ) -> None:
+        self.hybridep_non_blocking_capacity_factor = non_blocking_capacity_factor
+        self.hybridep_pad_multiple = pad_multiple
+
     def forward(self, x: torch.Tensor, routed_experts: torch.Tensor | None = None) -> torch.Tensor:
         bs, slen, dim = x.shape
         x_flat = x.view(-1, dim)
@@ -1209,8 +1545,15 @@ class LatentMoE(nn.Module):
             self.tokens_per_expert.add_(num_tokens_per_expert)
             self.routing_confidence_sum.add_(routing_confidence_sum)
 
-        if self.ep_comm_backend == "deepep":
-            routed_output = self._run_deepep_routed_experts(x_flat, selected_experts_indices, top_scores)
+        if self.ep_comm_backend in ("deepep", "deepep_v2", "hybridep", "minimal_async_ep"):
+            if self.ep_comm_backend == "deepep":
+                routed_output = self._run_deepep_routed_experts(x_flat, selected_experts_indices, top_scores)
+            elif self.ep_comm_backend == "deepep_v2":
+                routed_output = self._run_deepep_v2_routed_experts(x_flat, selected_experts_indices, top_scores)
+            elif self.ep_comm_backend == "hybridep":
+                routed_output = self._run_hybridep_routed_experts(x_flat, selected_experts_indices, top_scores)
+            elif self.ep_comm_backend == "minimal_async_ep":
+                routed_output = self._run_minimal_async_ep_routed_experts(x_flat, selected_experts_indices, top_scores)
             return routed_output.reshape(bs, slen, dim)
 
         (

--- a/src/prime_rl/trainer/models/layers/mxfp8_grouped_gemm.py
+++ b/src/prime_rl/trainer/models/layers/mxfp8_grouped_gemm.py
@@ -8,10 +8,10 @@ from torchao.prototype.moe_training.config import MXFP8TrainingOpConfig, MXFP8Tr
 from torchao.prototype.moe_training.kernels.mxfp8 import triton_mx_block_rearrange_2d_M_groups
 from torchao.prototype.moe_training.tensor import MXFP8TrainingWeightWrapperTensor
 from torchao.quantization.quant_api import quantize_
-from torchtitan.distributed.expert_parallel import set_token_group_alignment_size_m
-from torchtitan.experiments.kernels.moe import indices as tt_indices
 
 from prime_rl.configs.trainer import MXFP8Recipe
+from prime_rl.trainer.distributed.moe import indices as tt_indices
+from prime_rl.trainer.distributed.tt_expert_parallel import set_token_group_alignment_size_m
 from prime_rl.trainer.models.layers.moe import GroupedExperts, NonGatedGroupedExperts
 from prime_rl.utils.logger import get_logger
 

--- a/uv.lock
+++ b/uv.lock
@@ -5273,7 +5273,7 @@ requires-dist = [
     { name = "torchao", marker = "platform_machine == 'x86_64'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.6.0/torchao-0.17.0+git02105d46c-cp312-cp312-linux_x86_64.whl" },
     { name = "torchaudio", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torchdata", specifier = ">=0.11.0" },
-    { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=23e4dfc" },
+    { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=cc286a6" },
     { name = "torchvision", index = "https://download.pytorch.org/whl/cu128" },
     { name = "transformers", specifier = "==5.6.2" },
     { name = "uvloop", specifier = ">=0.21.0" },
@@ -7442,17 +7442,33 @@ wheels = [
 ]
 
 [[package]]
+name = "spmd-types"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/d4/adbc2fc5b9e5c5078c63dce783439236dfb9bc0fbb884c548be440acfaec/spmd_types-0.2.1.tar.gz", hash = "sha256:4a7364e22553384a5c94decb3a390945f9a880eaf42689cf48af836e9c928c36", size = 105220, upload-time = "2026-06-05T19:06:53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/da/332e1ff31f68b6425baabf035652b4ae784e3e3aa483d93e27baf83cf2b5/spmd_types-0.2.1-py3-none-any.whl", hash = "sha256:0b7ba23a73b9c2a86a24d517880867a9d9d03da32c1aef74445a49c22b135891", size = 118384, upload-time = "2026-06-05T19:06:52Z" },
+]
+dependencies = [
+    { name = "torch" },
+]
+
+[[package]]
 name = "torchtitan"
-version = "0.1.0"
-source = { git = "https://github.com/pytorch/torchtitan?rev=23e4dfc#23e4dfca5ca52587dbaf18f67bee8d73e875df5b" }
+version = "0.2.2"
+source = { git = "https://github.com/pytorch/torchtitan?rev=cc286a6#cc286a63599e42480a07928cc362e514ae448a85" }
 dependencies = [
     { name = "datasets" },
+    { name = "einops" },
     { name = "fsspec" },
+    { name = "pillow" },
+    { name = "safetensors" },
+    { name = "spmd-types" },
     { name = "tensorboard" },
     { name = "tokenizers" },
-    { name = "tomli" },
     { name = "torchdata" },
     { name = "tyro" },
+    { name = "wandb" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Ports all three expert-parallel (EP) communication backends from [torchtitan](https://github.com/pytorch/torchtitan) into prime-rl, alongside the existing `torch` (all-to-all) and `deepep` (DeepEP v1) backends.

### Approach: Bump torchtitan pin + vendor only what's removed

Bumps the torchtitan pin from `23e4dfc` to `cc286a6` (latest) to gain direct access to the `deepep` v2 and `minimal_async_ep` modules. Vendors the two modules that were **removed** from latest torchtitan (`expert_parallel.py` and `moe/indices.py`) and adapts `hybridep.py` for torch API compatibility.

### New EP Backends

| Backend | `ep_comm_backend` | Source | Dependencies |
|---|---|---|---|
| DeepEP v2 | `"deepep_v2"` | **Imported from torchtitan** | `deep_ep` ≥ 2.0.0 |
| HybridEP | `"hybridep"` | **Vendored** (handle_id + cache pattern, `CustomClassBase` not in our torch) | `deep_ep` with HybridEP |
| MinimalAsyncEP | `"minimal_async_ep"` | **Imported from torchtitan** | Triton (ships with PyTorch) |

### Vendored modules (removed from latest torchtitan)

- `tt_expert_parallel.py` (~349 lines): `ExpertParallel` class, `expert_parallel` decorator, `TOKEN_GROUP_ALIGN_SIZE_M`, `set_token_group_alignment_size_m`
- `moe/indices.py` (~321 lines): `generate_permute_indices`
- `hybridep.py` (~340 lines): adapted from torchtitan, uses handle_id + cache instead of `CustomClassBase`

### Files Modified

- **`pyproject.toml` + `uv.lock`**: Bump torchtitan pin to `cc286a6`, add `spmd-types` dependency
- **`packages/prime-rl-configs/.../trainer.py`**: Extended `EPCommBackend` Literal, added `hybridep_non_blocking_capacity_factor` and `hybridep_pad_multiple` config fields, validation rules
- **`src/prime_rl/trainer/distributed/expert_parallel.py`**: Added `DeepEPv2ExpertParallel`, `HybridEPExpertParallel`, `MinimalAsyncEPExpertParallel` weight-sharding styles
- **`src/prime_rl/trainer/model.py`**: Updated `configure_moe_ep_backend()` and `apply_ep()` to wire all new backends
- **`src/prime_rl/trainer/models/layers/moe.py`**: Added dispatch/combine methods for all new backends to `MoE` and `LatentMoE`; updated forward dispatch
- **`src/prime_rl/trainer/models/layers/lora/multi_moe.py`**: Skip token permutation for all non-torch backends
- **All files**: Updated imports from `torchtitan.distributed.expert_parallel` → `prime_rl.trainer.distributed.tt_expert_parallel`
- **`docs/advanced.md`, `docs/scaling.md`**: Documented all new EP backends
