### PR TITLE
fix: eval at checkpoint step on resume instead of next interval boundary

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -301,6 +301,11 @@ class EvalConfig(BaseConfig):
     """If True, skip the startup eval that otherwise runs before any
     train rollouts."""
 
+    retrigger_on_resume: bool = False
+    """If True, re-trigger evals at the checkpoint step on resume (e.g. after a
+    crash that left in-flight evals unfinished). By default, assumes a clean
+    exit where all evals already completed."""
+
     @model_validator(mode="after")
     def resolve_env_defaults(self):
         """Resolve per-env overrides: inherit group-level sampling, num_examples,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -470,7 +470,11 @@ class Orchestrator:
         ]
 
         # Base-model eval (policy v0) — fires before any train rollouts, logged at the first
-        # step, unless ``eval.skip_first_step=True`` (or this is a resume)
+        # step, unless ``eval.skip_first_step=True``. On resume, defaults to assuming a clean
+        # exit (evals already completed); set ``eval.retrigger_on_resume=True`` to also re-fire
+        # interval-aligned evals at the checkpoint step (e.g. after a crash).
+        if config.eval is not None and config.eval.retrigger_on_resume and self.resume_step is not None:
+            self.maybe_trigger_eval(self.resume_step)
         self.maybe_trigger_eval(self.progress.step)
 
         # Anchor step-time clock so the first step measures startup → first batch


### PR DESCRIPTION
## Problem

When resuming from a checkpoint, evals that were due at the checkpoint step were silently skipped. The orchestrator sets `progress.step = resume_step + 1` on resume, and `EvalSource` had `first_trigger = not is_resumed` (i.e. `False`), so the startup `trigger(progress.step)` checked `(resume_step + 1) % interval` instead of `resume_step % interval` — missing interval-aligned evals and deferring them to the next boundary.

## Solution

Add a `eval.retrigger_on_resume: bool = False` config flag. On resume:

- **Default (`False`)**: assumes a clean exit where all evals already completed — no re-trigger (current behavior, safe default).
- **`True`**: the startup trigger fires at both `resume_step` (recovering checkpoint-aligned evals) and `progress.step` (checking evals due at the resume step). This covers both envs whose interval divides the checkpoint step and envs whose interval divides the resume step.

This distinguishes Mika's two cases:
1. **Clean exit**: ckpt + eval at step x, run finishes cleanly (evals drained). Default behavior — no re-trigger.
2. **Crash**: ckpt + eval at step x, run crashes before eval finishes. User sets `retrigger_on_resume=True` to re-fire.

No changes to `EvalSource` — the existing `first_trigger = not is_resumed` already skips the base eval on resume and just does the interval check, so passing `resume_step` to `trigger()` is sufficient.

### Usage

```toml
[eval]
retrigger_on_resume = true  # re-fire evals at checkpoint step on resume
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in orchestrator startup flag only; default preserves existing resume behavior with no eval re-trigger.
> 
> **Overview**
> Adds **`eval.retrigger_on_resume`** (default **`false`**) so resume behavior can distinguish a clean shutdown from a crash that left evals unfinished.
> 
> When **`true`** and the run resumes from a checkpoint, startup calls **`maybe_trigger_eval(resume_step)`** before the usual trigger at **`progress.step`** (`resume_step + 1`). Interval checks therefore use the checkpoint step (`resume_step % interval`) instead of skipping or deferring evals that were due at the saved step.
> 
> Default **`false`** keeps today’s assumption that evals already completed on exit; no **`EvalSource`** changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e81321716ea49407b8eec505eb441f8dab493cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->