### PR TITLE
fix(trainer): skip identity HF↔PrimeRL conversion (fixes RO model-cache crash on dense Qwen3)

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -937,22 +937,10 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
         snapshot_keys = dict.fromkeys(load_state_dict_keys(source_path))
         model_keys = dict.fromkeys(model.state_dict().keys())
 
-        # If the model considers the snapshot's state dict to be in *both* HF
-        # and PrimeRL formats simultaneously, the conversion between them is
-        # identity (e.g. dense Qwen3 — both `convert_to_hf` and `convert_to_prime`
-        # are pass-throughs). Skip the convert-and-write branch entirely and
-        # load directly from `source_path`, which is what `snapshot_path`
-        # already points at. Otherwise `save_state_dict` would try to mkdir
-        # `<snapshot>/prime` under a potentially read-only model-cache mount
-        # (pi-rft's converter sidecar no-ops for identity conversions, so
-        # `<snapshot>/prime` is never populated in the cache).
-        identity_conversion = model.is_hf_state_dict(snapshot_keys) and model.is_prime_state_dict(snapshot_keys)
+        snapshot_is_hf = model.is_hf_state_dict(snapshot_keys)
+        snapshot_is_prime = model.is_prime_state_dict(snapshot_keys)
 
-        if identity_conversion:
-            logger.debug(
-                "Snapshot state dict matches both HF and PrimeRL formats — identity conversion, loading directly from source."
-            )
-        elif model.is_hf_state_dict(snapshot_keys) and model.is_prime_state_dict(model_keys):
+        if snapshot_is_hf and not snapshot_is_prime and model.is_prime_state_dict(model_keys):
             logger.warning(
                 "Found HF weight format in snapshot state dict and PrimeRL weight format in model state dict. Trying to auto-convert..."
             )
@@ -966,7 +954,7 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
                 save_state_dict(snapshot_state_dict, snapshot_path)
                 del snapshot_state_dict
 
-        elif model.is_prime_state_dict(snapshot_keys) and model.is_hf_state_dict(model_keys):
+        elif snapshot_is_prime and not snapshot_is_hf and model.is_hf_state_dict(model_keys):
             logger.warning(
                 "Found PrimeRL weight format in snapshot state dict and HF weight format in model state dict. Trying to auto-convert..."
             )

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -946,9 +946,7 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
         # `<snapshot>/prime` under a potentially read-only model-cache mount
         # (pi-rft's converter sidecar no-ops for identity conversions, so
         # `<snapshot>/prime` is never populated in the cache).
-        identity_conversion = model.is_hf_state_dict(snapshot_keys) and model.is_prime_state_dict(
-            snapshot_keys
-        )
+        identity_conversion = model.is_hf_state_dict(snapshot_keys) and model.is_prime_state_dict(snapshot_keys)
 
         if identity_conversion:
             logger.debug(

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -937,7 +937,24 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
         snapshot_keys = dict.fromkeys(load_state_dict_keys(source_path))
         model_keys = dict.fromkeys(model.state_dict().keys())
 
-        if model.is_hf_state_dict(snapshot_keys) and model.is_prime_state_dict(model_keys):
+        # If the model considers the snapshot's state dict to be in *both* HF
+        # and PrimeRL formats simultaneously, the conversion between them is
+        # identity (e.g. dense Qwen3 — both `convert_to_hf` and `convert_to_prime`
+        # are pass-throughs). Skip the convert-and-write branch entirely and
+        # load directly from `source_path`, which is what `snapshot_path`
+        # already points at. Otherwise `save_state_dict` would try to mkdir
+        # `<snapshot>/prime` under a potentially read-only model-cache mount
+        # (pi-rft's converter sidecar no-ops for identity conversions, so
+        # `<snapshot>/prime` is never populated in the cache).
+        identity_conversion = model.is_hf_state_dict(snapshot_keys) and model.is_prime_state_dict(
+            snapshot_keys
+        )
+
+        if identity_conversion:
+            logger.debug(
+                "Snapshot state dict matches both HF and PrimeRL formats — identity conversion, loading directly from source."
+            )
+        elif model.is_hf_state_dict(snapshot_keys) and model.is_prime_state_dict(model_keys):
             logger.warning(
                 "Found HF weight format in snapshot state dict and PrimeRL weight format in model state dict. Trying to auto-convert..."
             )


### PR DESCRIPTION
Dense Qwen3 (`Qwen3ForCausalLM`, see `models/qwen3/modeling_qwen3.py:105-117`) has `is_hf_state_dict` and `is_prime_state_dict` returning `True` unconditionally, and `convert_to_hf` / `convert_to_prime` are pass-throughs. The current `load_dcp_from_hf` still enters the conversion branch, calls the (identity) conversion, and tries to write the result into `<snapshot>/prime`. When the snapshot lives on a read-only mount — e.g. pi-rft's model-cache PVC on the research cluster (`readOnly: true` on the trainer's `/model-cache` volume), where the converter sidecar deliberately no-ops for identity conversions and never populates `<snapshot>/prime` — this crashes:

```
OSError: [Errno 30] Read-only file system: '/model-cache/models--PrimeIntellect--Qwen3-1.7B-Wordle-SFT/snapshots/b4052d5a.../prime'
```

Detect the case (`is_hf_state_dict(snapshot_keys) and is_prime_state_dict(snapshot_keys)` — model considers the same state dict to be in both formats simultaneously) and load directly from `source_path`, skipping both the conversion call and the disk write. No behaviour change for models with actual conversions (MoE).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional change in weight-load path; real conversions still run when only one format flag matches the snapshot.
> 
> **Overview**
> **`load_dcp_from_hf`** no longer treats a snapshot as needing HF→Prime or Prime→HF conversion when the checkpoint keys satisfy **both** `is_hf_state_dict` and `is_prime_state_dict`. Conversion branches now require a **real** mismatch (`snapshot_is_hf and not snapshot_is_prime` vs Prime model, or the reverse for HF model).
> 
> That stops dense **Qwen3** loads from entering identity conversion and trying to write under `<snapshot>/prime` or `hf` on a **read-only** model cache (e.g. pi-rft `/model-cache`), which previously surfaced as `OSError: Read-only file system`. **MoE** paths with actual format differences are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fea5aadcfcda9a11d1122aa2d795b039e96d6b20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->