### PR TITLE
fix(ci): build ghcr image on release via explicit dispatch

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -1,8 +1,6 @@
 name: Build Image (ghcr)
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       ref:
@@ -27,12 +25,12 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: primeintellect-ai/prime-rl
-  BUILD_REF: ${{ github.event.release.tag_name || inputs.ref || github.ref_name }}
-  BUILD_TAG: ${{ github.event.release.tag_name || inputs.tag || '' }}
+  BUILD_REF: ${{ inputs.ref || github.ref_name }}
+  BUILD_TAG: ${{ inputs.tag || '' }}
   BUILD_PLATFORMS: ${{ inputs.platforms || 'both' }}
 
 concurrency:
-  group: build-image-${{ github.event.release.tag_name || inputs.tag || inputs.ref || github.ref_name }}
+  group: build-image-${{ inputs.tag || inputs.ref || github.ref_name }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -119,6 +119,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Needed to dispatch build_image.yaml below (POST .../dispatches).
+      actions: write
     steps:
       - name: Publish draft release
         env:
@@ -127,11 +129,22 @@ jobs:
         run: |
           gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
 
+      # Publishing runs as GITHUB_TOKEN, whose events don't retrigger
+      # workflows, so dispatch the image build explicitly.
+      - name: Trigger image build for the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.auto-tag-on-main.outputs.tag }}
+        run: |
+          gh workflow run build_image.yaml --repo "$GITHUB_REPOSITORY" -f ref="$TAG"
+
   tag-and-release:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Needed to dispatch build_image.yaml below (POST .../dispatches).
+      actions: write
     steps:
       - name: Checkout tagged release (dispatch)
         if: github.event_name == 'workflow_dispatch'
@@ -195,6 +208,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Publish draft release
+        id: publish
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.release.outputs.tag }}
@@ -207,6 +221,17 @@ jobs:
           fi
           if [ "$STATE" = "false" ]; then
             echo "Release $TAG is already published; nothing to do."
+            echo "published=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
+      # Skipped when the release was already published (no rebuild needed).
+      - name: Trigger image build for the release
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          gh workflow run build_image.yaml --repo "$GITHUB_REPOSITORY" -f ref="$TAG"


### PR DESCRIPTION
## Problem

`build_image.yaml` has an `on: release: [published]` trigger, but **no release has ever triggered it** — every run is a manual `workflow_dispatch` on `main`. As a result, release commits (`v0.5.0`, `v0.6.0`, `v0.7.0`) have **no GHCR image** at all.

Root cause: `tag-and-release.yaml` publishes the draft release with `gh release edit --draft=false` using the default `GITHUB_TOKEN`, and **events raised by `GITHUB_TOKEN` do not retrigger workflows** (documented, recursion guard). So `on: release` in `build_image.yaml` can never fire the way releases are actually published. This is already noted in a comment at the top of `tag-and-release.yaml`.

## Fix

Dispatch `build_image.yaml` explicitly after publishing, using `gh workflow run` — `workflow_dispatch` (and `repository_dispatch`) are the documented **exceptions** to the no-retrigger rule, so this works with the existing `GITHUB_TOKEN`, no PAT or App required.

- Add a `Trigger image build for the release` step to **both** publish paths:
  - `release-from-auto-tag` (auto version-bump → release on `main`)
  - `tag-and-release` (manual `workflow_dispatch` / `v*` tag push), gated on a new `published` output so it fires only when this run actually flipped the draft to published (skips the idempotent "already published" case).
- Add `actions: write` to both jobs — required for `gh workflow run` to call `POST .../dispatches`.
- Remove the now-dead `on: release` trigger from `build_image.yaml` and its unreachable `github.event.release.*` fallbacks, so the workflow reads as dispatch-only.

## Scope / notes

- This fixes **future** releases. Existing releases (e.g. `v0.7.0`) still need a one-time backfill dispatch (already run).
- Release images are tagged `commit-<short-sha>` (9-char via `git rev-parse --short`) as before — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes; no app runtime, auth, or data paths—fixes missing release images with idempotent dispatch gating.
> 
> **Overview**
> Release publishes via `GITHUB_TOKEN` never fired `build_image.yaml`’s `on: release` trigger, so stable releases had no GHCR images. **This PR wires image builds in explicitly** after a release is actually published.
> 
> `tag-and-release.yaml` now runs `gh workflow run build_image.yaml -f ref="$TAG"` on both publish paths (`release-from-auto-tag` and `tag-and-release`), with **`actions: write`** so dispatch is allowed. The manual/tag path only dispatches when this run flips draft → published (`published` step output); already-published releases skip a redundant rebuild.
> 
> `build_image.yaml` drops the dead **`release`** trigger and **`github.event.release.*`** env/concurrency fallbacks so the workflow is **dispatch-only**, matching how releases will invoke it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68bb17fd150da8e5e699ea5c4d51199fc06a18fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->