### PR TITLE
fix(ci): allow branch/commit refs in ghcr image build

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -83,27 +83,30 @@ jobs:
           INPUT_TAG: ${{ env.BUILD_TAG }}
           PLATFORMS: ${{ env.BUILD_PLATFORMS }}
         run: |
-          case "$INPUT_REF" in
-            main|v[0-9]*|*.dev[0-9]*) ;;
-            *)
-              echo "ref '${INPUT_REF}' not allowed for ghcr publish (must be main, v*, or *.dev*)" >&2
-              exit 1
-              ;;
-          esac
-
           if [ -n "$INPUT_TAG" ] && [ "$INPUT_TAG" != "$INPUT_REF" ] && [ "$INPUT_REF" != "main" ]; then
             echo "custom 'tag' that differs from 'ref' is only allowed when ref=main; got ref='${INPUT_REF}' tag='${INPUT_TAG}'" >&2
             exit 1
           fi
 
-          raw_tag="$INPUT_TAG"
-          if [ -z "$raw_tag" ]; then
-            raw_tag="$INPUT_REF"
+          sanitize() {
+            echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-50
+          }
+
+          # A ref that is exactly a git tag builds under that tag verbatim;
+          # any other ref (branch / arbitrary commit) is prefixed with
+          # `git describe` so the tag carries the nearest release, commit
+          # distance and short sha (e.g. v0.7.0-42-g1a2b3c4d5-fix-my-branch)
+          # and can't collide with a clean release tag.
+          if [ -n "$INPUT_TAG" ]; then
+            tag=$(sanitize "$INPUT_TAG")
+          elif tag=$(git describe --tags --exact-match 2>/dev/null); then
+            :
+          else
+            tag="$(git describe --tags --always)-$(sanitize "$INPUT_REF")"
           fi
 
-          tag=$(echo "$raw_tag" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g' | sed 's/--*/-/g' | cut -c1-50 | sed 's/^-//;s/-$//')
           if [ -z "$tag" ]; then
-            echo "Could not derive a valid image tag from '${raw_tag}'." >&2
+            echo "Could not derive a valid image tag from ref='${INPUT_REF}' tag='${INPUT_TAG}'." >&2
             exit 1
           fi
 

--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -36,8 +36,39 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  authorize:
+    name: Authorize dispatcher
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Require maintain or admin
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.triggering_actor }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Manual dispatches are restricted to repo members with maintain
+          # or admin. Automated dispatches from in-repo workflows (devx_tag
+          # dev-image builds, the release build) run as github-actions[bot]
+          # via GITHUB_TOKEN — allow those through.
+          if [ "$ACTOR" = "github-actions[bot]" ]; then
+            echo "Dispatcher is repo automation ($ACTOR); allowed."
+            exit 0
+          fi
+          role=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.role_name' 2>/dev/null || true)
+          echo "Dispatcher $ACTOR has repo role: ${role:-<none>}"
+          case "$role" in
+            admin|maintain)
+              echo "Authorized." ;;
+            *)
+              echo "::error::$ACTOR (role: ${role:-none}) is not allowed to trigger image builds; requires maintain or admin." >&2
+              exit 1 ;;
+          esac
+
   prepare:
     name: Prepare build
+    needs: authorize
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -43,15 +43,18 @@ jobs:
       contents: read
     steps:
       - name: Require maintain or admin
+        # Gate MANUAL dispatches only; other events (e.g. release) are
+        # already privileged and pass through. Guard the step, not the job —
+        # a skipped job would skip `prepare` via `needs: authorize`.
+        if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
           ACTOR: ${{ github.triggering_actor }}
           REPO: ${{ github.repository }}
         run: |
-          # Manual dispatches are restricted to repo members with maintain
-          # or admin. Automated dispatches from in-repo workflows (devx_tag
-          # dev-image builds, the release build) run as github-actions[bot]
-          # via GITHUB_TOKEN — allow those through.
+          # Restricted to repo members with maintain or admin. Automated
+          # in-repo dispatches (devx_tag dev-image builds, the release build)
+          # run as github-actions[bot] via GITHUB_TOKEN — allow those through.
           if [ "$ACTOR" = "github-actions[bot]" ]; then
             echo "Dispatcher is repo automation ($ACTOR); allowed."
             exit 0


### PR DESCRIPTION
## Problem

`build_image.yaml`'s `ref` input advertises itself as `"Branch, tag, or commit to build"`, but the `Resolve image vars` step rejected any ref that wasn't `main`, `v*`, or `*.dev*`:

```
ref 'fix/skip-identity-conversion-on-read-only-cache' not allowed for ghcr publish (must be main, v*, or *.dev*)
```

So dispatching an image build off a feature branch failed, contradicting the input's own documentation.

## Fix

- **Drop the ref allowlist.** The ref is already checked out by the prior `Checkout` step (so its existence is validated), and the tag string is sanitized right after — the `case` was pure policy.
- **`git describe`-based tag naming** for non-tag refs. A ref that is exactly a tag builds under that tag verbatim (`v0.7.0`); any other ref is prefixed with `git describe` so the tag carries the nearest release + commit distance + short sha and can't collide with a clean release tag. Example for a feature branch:
  ```
  v0.7.1.dev55-3-gfea5aadcf-fix-skip-identity-conversion-on-read-only-cache
  ```
- The per-commit **`commit-<sha>`** tag is unchanged — it's the tag the platform pins for dispatches.

The `custom tag only when ref=main` guard is untouched, so a plain branch build (no `-f tag=...`) works.

## Notes

- The bare `commit-<sha>` (and bare version) manifest is only created when `platforms=both`; an `amd64-only` dispatch pushes only the `-amd64`-suffixed tags. Dispatch with `-f platforms=both` to get a pin-able `commit-<sha>`.
- Verified the resolve logic under `bash -e` for tag / branch / main / custom-tag / rejected-custom-tag cases; YAML parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broader who can publish arbitrary refs to GHCR (with RBAC on manual dispatch) and changed tagging semantics for non-release refs; release flows and commit pinning behavior are intentionally preserved.
> 
> **Overview**
> **Aligns GHCR image builds with the documented `ref` input** by removing the `main` / `v*` / `*.dev*` allowlist in **Resolve image vars**, so feature branches and arbitrary commits can publish after checkout. Non-tag refs get **distinct image tags** via `git describe` plus a sanitized ref suffix so they do not overwrite clean release tags; exact tag checkouts still use the tag name, and the **custom tag only when `ref=main`** rule is unchanged.
> 
> **Adds an `authorize` job** ahead of `prepare` that runs only on `workflow_dispatch`, requiring **maintain or admin** (with an exception for `github-actions[bot]` automation). Release-triggered builds are unaffected because the check is gated on the step, not the whole job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33402e20b76abfb3b9b9f68d14d31a67df5c98c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->