### PR TITLE
fix: set cp=4 for GLM-4.5-Air advanced examples

### DIFF
--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -46,7 +46,7 @@ enable_router_replay = true
 [trainer.model]
 impl = "custom"
 attn = "flash_attention_3"
-cp = 8
+cp = 4
 cp_style = "ulysses"
 fused_lm_head_token_chunk_size = 1024
 optim_cpu_offload = true

--- a/examples/advanced/glm-4.5-air/swe.toml
+++ b/examples/advanced/glm-4.5-air/swe.toml
@@ -7,7 +7,7 @@
 # term is pass_rate-scaled and normalized by the group's own max before the GRPO baseline
 # subtraction.
 #
-# 2 train + 4 infer nodes. Trainer uses cp=8 (ulysses) plus
+# 2 train + 4 infer nodes. Trainer uses cp=4 (ulysses) plus
 # the memory improvements from the GLM-5.1 prod run (research-prod rlm5/prod.toml): LM-head token
 # chunking, activation checkpointing (freq=1) + activation offloading (max_inflight=1), optimizer
 # CPU offload, and skip-gather / skip-optimizer checkpointing.
@@ -57,7 +57,7 @@ enable_router_replay = true
 [trainer.model]
 impl = "custom"
 attn = "flash_attention_3"
-cp = 8
+cp = 4
 cp_style = "ulysses"
 fused_lm_head_token_chunk_size = 1024
 optim_cpu_offload = true

--- a/examples/advanced/glm-4.5-air/terminal.toml
+++ b/examples/advanced/glm-4.5-air/terminal.toml
@@ -47,7 +47,7 @@ enable_router_replay = true
 [trainer.model]
 impl = "custom"
 attn = "flash_attention_3"
-cp = 8
+cp = 4
 cp_style = "ulysses"
 fused_lm_head_token_chunk_size = 1024
 optim_cpu_offload = true


### PR DESCRIPTION
## Summary
- Set `trainer.model.cp` from 8 to 4 in the GLM-4.5-Air advanced example configs (`swe.toml`, `search.toml`, `terminal.toml`)
- Updated the `swe.toml` header comment to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only training config tuning; no application or library code changes.
> 
> **Overview**
> Lowers **Ulysses context parallel** on the GLM-4.5-Air advanced example trainer from **`cp = 8` to `cp = 4`** in `search.toml`, `swe.toml`, and `terminal.toml`.
> 
> The **`swe.toml`** header comment is updated so it documents **`cp=4`** instead of **`cp=8`**. No other trainer, orchestrator, or inference settings change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6802944b1753b033024a8b4f3c85a1c070265721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->