### PR TITLE
chore: bump verifiers + research-environments to latest main

### DIFF
--- a/configs/basic/alphabet-sort/rl.toml
+++ b/configs/basic/alphabet-sort/rl.toml
@@ -35,7 +35,8 @@ max_completion_tokens = 768
 [[orchestrator.train.env]]
 name = "alphabet-sort"
 env.taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [ckpt] # Checkpoint at the end of training
 

--- a/configs/basic/hendrycks-sanity/rl.toml
+++ b/configs/basic/hendrycks-sanity/rl.toml
@@ -22,7 +22,8 @@ seq_len = 8192
 [[orchestrator.train.env]]
 name = "hendrycks-math"
 env.taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer.model]
 seq_len = 16384

--- a/configs/basic/reverse-text/rl.toml
+++ b/configs/basic/reverse-text/rl.toml
@@ -25,7 +25,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/basic/wiki-search/rl.toml
+++ b/configs/basic/wiki-search/rl.toml
@@ -43,7 +43,8 @@ max_completion_tokens = 512
 [[orchestrator.train.env]]
 name = "wiki-search"
 env.taskset = { id = "wiki-search-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [ckpt] # Checkpoint at the end of training
 

--- a/configs/basic/wordle/rl.toml
+++ b/configs/basic/wordle/rl.toml
@@ -24,7 +24,8 @@ group_size = 8
 [[orchestrator.train.env]]
 name = "wordle"
 env.taskset = { id = "wordle-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.player.harness = { id = "null" }
+env.player.runtime = { type = "subprocess" }
 
 [orchestrator.train.sampling]
 max_completion_tokens = 1024

--- a/configs/ci/integration/alphabet_sort.toml
+++ b/configs/ci/integration/alphabet_sort.toml
@@ -25,7 +25,8 @@ max_completion_tokens = 384
 [[orchestrator.train.env]]
 name = "alphabet-sort"
 env.taskset = { id = "alphabet-sort-v1", min_turns = 2, max_turns = 2, min_names_per_turn = 1, max_names_per_turn = 3, task = { similarity_power = 4, power_per_turn = false } }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [inference]
 

--- a/configs/ci/integration/reverse-text-lora/resume.toml
+++ b/configs/ci/integration/reverse-text-lora/resume.toml
@@ -29,7 +29,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [inference]
 enable_lora = true

--- a/configs/ci/integration/reverse-text-lora/start.toml
+++ b/configs/ci/integration/reverse-text-lora/start.toml
@@ -28,7 +28,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [inference]
 enable_lora = true

--- a/configs/ci/integration/reverse-text-moe/start.toml
+++ b/configs/ci/integration/reverse-text-moe/start.toml
@@ -28,7 +28,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [inference]
 gpu_memory_utilization = 0.7

--- a/configs/ci/integration/reverse-text-multi-run/orchestrator.toml
+++ b/configs/ci/integration/reverse-text-multi-run/orchestrator.toml
@@ -17,7 +17,8 @@ max_completion_tokens = 128
 [[train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [ckpt]
 interval = 10

--- a/configs/ci/integration/reverse-text-rl-opd/start.toml
+++ b/configs/ci/integration/reverse-text-rl-opd/start.toml
@@ -40,7 +40,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.eval]
 interval = 1
@@ -52,7 +53,8 @@ max_completion_tokens = 128
 [[orchestrator.eval.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/ci/integration/reverse-text-rl-sft/start.toml
+++ b/configs/ci/integration/reverse-text-rl-sft/start.toml
@@ -46,7 +46,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.eval]
 interval = 1
@@ -58,7 +59,8 @@ max_completion_tokens = 128
 [[orchestrator.eval.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/ci/integration/reverse-text/resume.toml
+++ b/configs/ci/integration/reverse-text/resume.toml
@@ -26,7 +26,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [inference]
 

--- a/configs/ci/integration/reverse-text/start.toml
+++ b/configs/ci/integration/reverse-text/start.toml
@@ -25,7 +25,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [inference]
 

--- a/configs/ci/nightly-fft/alphabet-sort.toml
+++ b/configs/ci/nightly-fft/alphabet-sort.toml
@@ -21,7 +21,8 @@ group_size = 16
 [[orchestrator.train.env]]
 name = "alphabet-sort"
 env.taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.train.sampling]
 max_completion_tokens = 768

--- a/configs/ci/nightly-fft/hendrycks-sanity.toml
+++ b/configs/ci/nightly-fft/hendrycks-sanity.toml
@@ -21,7 +21,8 @@ seq_len = 8192
 [[orchestrator.train.env]]
 name = "hendrycks-math"
 env.taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.eval]
 interval = 50
@@ -29,7 +30,8 @@ interval = 50
 [[orchestrator.eval.env]]
 name = "aime2024"
 env.taskset = { id = "aime24-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 group_size = 32
 
 [trainer]

--- a/configs/ci/nightly-fft/reverse-text.toml
+++ b/configs/ci/nightly-fft/reverse-text.toml
@@ -21,7 +21,8 @@ group_size = 16
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.train.sampling]
 max_completion_tokens = 128

--- a/configs/ci/nightly-fft/wiki-search.toml
+++ b/configs/ci/nightly-fft/wiki-search.toml
@@ -26,7 +26,8 @@ enforce = true
 [[orchestrator.train.env]]
 name = "wiki-search"
 env.taskset = { id = "wiki-search-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.train.sampling]
 max_completion_tokens = 512

--- a/configs/ci/nightly-fft/wordle.toml
+++ b/configs/ci/nightly-fft/wordle.toml
@@ -21,7 +21,8 @@ group_size = 16
 [[orchestrator.train.env]]
 name = "wordle"
 env.taskset = { id = "wordle-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.player.harness = { id = "null" }
+env.player.runtime = { type = "subprocess" }
 
 [orchestrator.train.sampling]
 max_completion_tokens = 1024

--- a/configs/ci/nightly/multimodal_color_codeword.toml
+++ b/configs/ci/nightly/multimodal_color_codeword.toml
@@ -23,7 +23,8 @@ max_completion_tokens = 64
 [[orchestrator.train.env]]
 name = "color-codeword"
 env.taskset = { id = "color-codeword-v1", images_per_turn = 1 }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer]
 

--- a/configs/debug/algo/echo.toml
+++ b/configs/debug/algo/echo.toml
@@ -27,7 +27,8 @@ alpha = 0.1
 [[orchestrator.train.env]]
 name = "alphabet-sort"
 env.taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.train.sampling]
 max_completion_tokens = 512

--- a/configs/debug/algo/grpo.toml
+++ b/configs/debug/algo/grpo.toml
@@ -24,7 +24,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.eval]
 interval = 1
@@ -36,7 +37,8 @@ max_completion_tokens = 128
 [[orchestrator.eval.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/max_rl.toml
+++ b/configs/debug/algo/max_rl.toml
@@ -24,7 +24,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.eval]
 interval = 1
@@ -36,7 +37,8 @@ max_completion_tokens = 128
 [[orchestrator.eval.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/mixed_grpo_opd.toml
+++ b/configs/debug/algo/mixed_grpo_opd.toml
@@ -34,12 +34,14 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text-grpo"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [[orchestrator.train.env]]
 name = "reverse-text-opd"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.train.env.algo]
 type = "opd"
@@ -58,7 +60,8 @@ max_completion_tokens = 128
 [[orchestrator.eval.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/opd.toml
+++ b/configs/debug/algo/opd.toml
@@ -36,7 +36,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.eval]
 interval = 1
@@ -48,7 +49,8 @@ max_completion_tokens = 128
 [[orchestrator.eval.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/opd_lora.toml
+++ b/configs/debug/algo/opd_lora.toml
@@ -36,7 +36,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.eval]
 interval = 1
@@ -48,7 +49,8 @@ max_completion_tokens = 128
 [[orchestrator.eval.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer.optim]
 lr = 1e-4

--- a/configs/debug/algo/self_distill.toml
+++ b/configs/debug/algo/self_distill.toml
@@ -32,7 +32,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.eval]
 interval = 1
@@ -44,7 +45,8 @@ max_completion_tokens = 128
 [[orchestrator.eval.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/sft_distill.toml
+++ b/configs/debug/algo/sft_distill.toml
@@ -41,7 +41,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.eval]
 interval = 1
@@ -53,7 +54,8 @@ max_completion_tokens = 128
 [[orchestrator.eval.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/sft_distill_lora.toml
+++ b/configs/debug/algo/sft_distill_lora.toml
@@ -41,7 +41,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.eval]
 interval = 1
@@ -53,7 +54,8 @@ max_completion_tokens = 128
 [[orchestrator.eval.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer.optim]
 lr = 1e-4

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -118,14 +118,16 @@ type = "grpo"
 
 [[orchestrator.train.env]]
 name = "math"
-taskset = { id = "math-v1" }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "math-v1" }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 # inherits the top-level grpo
 
 [[orchestrator.train.env]]
 name = "terminal"
-taskset = { id = "terminal-v1" }
-harness = { id = "bash", runtime = { type = "subprocess" } }
+env.taskset = { id = "terminal-v1" }
+env.agent.harness = { id = "bash" }
+env.agent.runtime = { type = "subprocess" }
 algo = { type = "echo" }   # this env runs its own algorithm
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,19 +150,22 @@ Training environments are an array of tables — set one per env, optionally wit
 [[orchestrator.train.env]]
 name = "gsm8k"
 env.taskset = { id = "gsm8k-v1", split = "train" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 ratio = 3  # 75% of batches
 
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 ratio = 1  # default — 25% of batches
 
 [[orchestrator.eval.env]]
 name = "gsm8k-eval"
 env.taskset = { id = "gsm8k-v1", split = "test" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 ```
 
 `ratio` defaults to `1` (equal weight per env); values are relative weights normalized to probabilities across envs.

--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -95,7 +95,8 @@ num_turns_weight = 0.0
 # the plugged BC-style prompt is replaced by the reference judge's stock prompt).
 [[orchestrator.train.env]]
 name = "openseeker"
-env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] } }
+env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = [65536, 131072] }
+env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] }
 
 [orchestrator.train.env.env.taskset]
 id = "openseeker-v1"
@@ -117,7 +118,8 @@ choices = ["A", "B"]
 
 [[orchestrator.train.env]]
 name = "redsearcher"
-env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] } }
+env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = [65536, 131072] }
+env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] }
 
 [orchestrator.train.env.env.taskset]
 id = "redsearcher-v1" # optional `difficulty` filter (easy/medium/hard)
@@ -145,7 +147,8 @@ interval = 20
 [[orchestrator.eval.env]]
 name = "browsecomp"
 num_examples = 500 # full set is 1266; cap eval at 500
-env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] } }
+env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = 98304 }
+env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] }
 env.agent.timeout = { rollout = 3600 }
 
 [orchestrator.eval.env.env.taskset]

--- a/examples/advanced/glm-4.5-air/swe.toml
+++ b/examples/advanced/glm-4.5-air/swe.toml
@@ -100,7 +100,8 @@ thinking_retention = "all"
 [[orchestrator.train.env]]
 name = "scaleswe"
 env.taskset = { id = "scaleswe-v1" }
-env.agent.harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe"] } }
+env.agent.harness = { id = "rlm", summarize_at_tokens = [65536, 131072] }
+env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe"] }
 
 [orchestrator.prime_monitor]
 
@@ -112,7 +113,8 @@ interval = 20
 [[orchestrator.eval.env]]
 name = "swebench-verified"
 env.taskset = { id = "swebench-verified-v1" }
-env.agent.harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe"] } }
+env.agent.harness = { id = "rlm", summarize_at_tokens = 98304 }
+env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe"] }
 env.agent.timeout = { rollout = 3600 }
 
 # --- Inference ---

--- a/examples/advanced/glm-4.5-air/terminal.toml
+++ b/examples/advanced/glm-4.5-air/terminal.toml
@@ -93,7 +93,8 @@ num_turns_weight = 0.1
 
 [[orchestrator.train.env]]
 name = "tmax"
-env.agent.harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] } }
+env.agent.harness = { id = "rlm", summarize_at_tokens = [65536, 131072] }
+env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] }
 
 [orchestrator.train.env.env.taskset]
 id = "tmax-v1"
@@ -120,7 +121,8 @@ interval = 20
 
 [[orchestrator.eval.env]]
 name = "swebench-verified"
-env.agent.harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] } }
+env.agent.harness = { id = "rlm", summarize_at_tokens = 98304 }
+env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] }
 env.agent.timeout = { rollout = 3600 }
 
 [orchestrator.eval.env.env.taskset]
@@ -143,7 +145,8 @@ id = "swebench-verified-v1"
 [[orchestrator.eval.env]]
 name = "terminal-bench-2"
 group_size = 4 # avg@4
-env.agent.harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] } }
+env.agent.harness = { id = "rlm", summarize_at_tokens = 98304 }
+env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] }
 env.agent.timeout = { rollout = 3600 }
 
 [orchestrator.eval.env.env.taskset]

--- a/examples/advanced/glm-5.2/swe-llmd.toml
+++ b/examples/advanced/glm-5.2/swe-llmd.toml
@@ -99,7 +99,8 @@ extra_body = {chat_template_kwargs = {clear_thinking = false}}
 [[orchestrator.train.env]]
 name = "r2e"
 env.taskset = { id = "r2e-gym-v1" }
-env.agent.harness = { id = "rlm", runtime = { type = "prime", labels = ["glm5-llmd"] } }
+env.agent.harness = { id = "rlm" }
+env.agent.runtime = { type = "prime", labels = ["glm5-llmd"] }
 
 [inference]
 enable_expert_parallel = true

--- a/examples/advanced/glm-5.2/swe.toml
+++ b/examples/advanced/glm-5.2/swe.toml
@@ -74,7 +74,8 @@ interval = 20
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
 env.taskset = { id = "swebench-verified-v1" }
-env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["glm5-pd-disag", "swe-bench-verified"] } }
+env.agent.harness = { id = "bash" }
+env.agent.runtime = { type = "prime", labels = ["glm5-pd-disag", "swe-bench-verified"] }
 
 [[orchestrator.post_batch_filters]]
 type = "gibberish"

--- a/examples/advanced/intellect-3.1/rl.toml
+++ b/examples/advanced/intellect-3.1/rl.toml
@@ -51,31 +51,36 @@ oversampling_factor = 2
 name = "swe"
 ratio = 0.3
 env.taskset = { id = "r2e-gym-v1" }
-env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["intellect-3.1", "swe"] } }
+env.agent.harness = { id = "bash" }
+env.agent.runtime = { type = "prime", labels = ["intellect-3.1", "swe"] }
 
 [[orchestrator.train.env]]
 name = "deepdive"
 ratio = 0.2
 env.taskset = { id = "deepdive-v1" }
-env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], runtime = { type = "prime", labels = ["intellect-3.1", "deepdive"] } }
+env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"] }
+env.agent.runtime = { type = "prime", labels = ["intellect-3.1", "deepdive"] }
 
 [[orchestrator.train.env]]
 name = "math"
 ratio = 0.3
 env.taskset = { id = "i3_math_v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [[orchestrator.train.env]]
 name = "logic"
 ratio = 0.2
 env.taskset = { id = "i3_logic_v1", filter = { max = 0.874 } }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [[orchestrator.train.env]]
 name = "code"
 ratio = 0.2
 env.taskset = { id = "i3_code_v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [[orchestrator.pre_batch_filters]]
 type = "zero_advantage"
@@ -87,12 +92,14 @@ interval = 25
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
 env.taskset = { id = "swebench-verified-v1" }
-env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["intellect-3.1", "swe-bench-verified"] } }
+env.agent.harness = { id = "bash" }
+env.agent.runtime = { type = "prime", labels = ["intellect-3.1", "swe-bench-verified"] }
 
 [[orchestrator.eval.env]]
 name = "aime2025"
 env.taskset = { id = "aime25-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [inference.parallel]
 tp = 8

--- a/examples/advanced/minimax-m2.5/swe.toml
+++ b/examples/advanced/minimax-m2.5/swe.toml
@@ -52,7 +52,8 @@ max_off_policy_steps = 16
 [[orchestrator.train.env]]
 name = "swe"
 env.taskset = { id = "r2e-gym-v1" }
-env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["minimax-swe", "swe"] } }
+env.agent.harness = { id = "bash" }
+env.agent.runtime = { type = "prime", labels = ["minimax-swe", "swe"] }
 
 [orchestrator.eval]
 interval = 25
@@ -60,7 +61,8 @@ interval = 25
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
 env.taskset = { id = "swebench-verified-v1" }
-env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["minimax-swe", "swe-bench-verified"] } }
+env.agent.harness = { id = "bash" }
+env.agent.runtime = { type = "prime", labels = ["minimax-swe", "swe-bench-verified"] }
 
 [inference.parallel]
 tp = 8

--- a/examples/advanced/nemotron-3-super/swe.toml
+++ b/examples/advanced/nemotron-3-super/swe.toml
@@ -84,7 +84,8 @@ truncate_history_thinking = false
 [[orchestrator.train.env]]
 name = "scaleswe"
 env.taskset = { id = "scaleswe-v1" }
-env.agent.harness = { id = "rlm", summarize_at_tokens = [65536, 131072], runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["nemotron-3-super-swe"] } }
+env.agent.harness = { id = "rlm", summarize_at_tokens = [65536, 131072] }
+env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["nemotron-3-super-swe"] }
 
 [orchestrator.prime_monitor]
 
@@ -94,7 +95,8 @@ interval = 20
 [[orchestrator.eval.env]]
 name = "swebench-verified"
 env.taskset = { id = "swebench-verified-v1" }
-env.agent.harness = { id = "rlm", summarize_at_tokens = 98304, runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["nemotron-3-super-swe"] } }
+env.agent.harness = { id = "rlm", summarize_at_tokens = 98304 }
+env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["nemotron-3-super-swe"] }
 env.agent.timeout = { rollout = 3600 }
 
 [inference]

--- a/examples/advanced/qwen3-30b-a3b/math.toml
+++ b/examples/advanced/qwen3-30b-a3b/math.toml
@@ -51,7 +51,8 @@ max_completion_tokens = 32768
 [[orchestrator.train.env]]
 name = "math"
 env.taskset = { id = "i3_math_v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.eval]
 interval = 25
@@ -59,7 +60,8 @@ interval = 25
 [[orchestrator.eval.env]]
 name = "aime2025"
 env.taskset = { id = "aime25-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [inference.parallel]
 tp = 8

--- a/examples/advanced/qwen3-30b-a3b/swe.toml
+++ b/examples/advanced/qwen3-30b-a3b/swe.toml
@@ -49,7 +49,8 @@ max_off_policy_steps = 16
 [[orchestrator.train.env]]
 name = "swe"
 env.taskset = { id = "r2e-gym-v1" }
-env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["qwen30b-swe", "swe"] } }
+env.agent.harness = { id = "bash" }
+env.agent.runtime = { type = "prime", labels = ["qwen30b-swe", "swe"] }
 
 [orchestrator.eval]
 interval = 25
@@ -57,7 +58,8 @@ interval = 25
 [[orchestrator.eval.env]]
 name = "swe-bench-verified"
 env.taskset = { id = "swebench-verified-v1" }
-env.agent.harness = { id = "bash", runtime = { type = "prime", labels = ["qwen30b-swe", "swe-bench-verified"] } }
+env.agent.harness = { id = "bash" }
+env.agent.runtime = { type = "prime", labels = ["qwen30b-swe", "swe-bench-verified"] }
 
 [inference.parallel]
 tp = 8

--- a/examples/advanced/qwen3-30b-a3b/tool.toml
+++ b/examples/advanced/qwen3-30b-a3b/tool.toml
@@ -37,7 +37,8 @@ max_off_policy_steps = 32
 
 [[orchestrator.train.env]]
 env.taskset = { id = "general-agent-v1", task = { tools = { colocated = true } }, min_tier = 1 }
-env.agent.harness = { id = "null", runtime = { type = "modal" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "modal" }
 
 [inference]
 gpu_memory_utilization = 0.85

--- a/examples/basic/alphabet-sort/rl.toml
+++ b/examples/basic/alphabet-sort/rl.toml
@@ -34,6 +34,7 @@ max_completion_tokens = 768
 [[orchestrator.train.env]]
 name = "alphabet-sort"
 env.taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [inference] # Default inference config

--- a/examples/basic/hendrycks-sanity/rl.toml
+++ b/examples/basic/hendrycks-sanity/rl.toml
@@ -19,7 +19,8 @@ seq_len = 8192
 [[orchestrator.train.env]]
 name = "hendrycks-math"
 env.taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [orchestrator.eval]
 interval = 50
@@ -27,7 +28,8 @@ interval = 50
 [[orchestrator.eval.env]]
 name = "aime2024"
 env.taskset = { id = "aime24-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 group_size = 32
 
 [trainer.model]

--- a/examples/basic/reverse-text/rl.toml
+++ b/examples/basic/reverse-text/rl.toml
@@ -18,7 +18,8 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [trainer.optim]
 lr = 3e-6

--- a/examples/basic/wiki-search/README.md
+++ b/examples/basic/wiki-search/README.md
@@ -135,8 +135,9 @@ The V1 taskset fixes the question bank and searchable corpus. You can replace it
 ```toml
 [[orchestrator.train.env]]
 name = "wiki-search"
-taskset = { id = "wiki-search-v1", task = { judges = [{ id = "reference", model = "openai/gpt-5.4-nano" }] } }
-harness = { id = "null", runtime = { type = "subprocess" } }
+env.taskset = { id = "wiki-search-v1", task = { judges = [{ id = "reference", model = "openai/gpt-5.4-nano" }] } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 ```
 
 ## Notes

--- a/examples/basic/wiki-search/rl.toml
+++ b/examples/basic/wiki-search/rl.toml
@@ -47,7 +47,8 @@ enforce = true
 [[orchestrator.train.env]]
 name = "wiki-search"
 env.taskset = { id = "wiki-search-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 
 [ckpt] # Checkpoint at the end of training
 

--- a/examples/basic/wordle/rl.toml
+++ b/examples/basic/wordle/rl.toml
@@ -21,7 +21,8 @@ group_size = 16
 [[orchestrator.train.env]]
 name = "wordle"
 env.taskset = { id = "wordle-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.player.harness = { id = "null" }
+env.player.runtime = { type = "subprocess" }
 
 [orchestrator.train.sampling]
 max_completion_tokens = 1024

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -44,7 +44,8 @@ Incompatible combinations (e.g. CP requires flash attention) must raise in a `mo
 [[orchestrator.train.env]]
 name = "reverse-text"
 env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null", runtime = { type = "subprocess" } }
+env.agent.harness = { id = "null" }
+env.agent.runtime = { type = "subprocess" }
 ```
 
 CLI: `--orchestrator.train.env.0.env.taskset.id reverse-text-v1`.

--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -142,8 +142,17 @@ class CustomMetrics(StatGroup):
 
     def stats(self) -> dict[str, Stat]:
         names = sorted({name for r in self.rollouts for name in getattr(r, self.attr)})
+        # Rewards are ``vf.Reward`` (raw score + weight); report the raw score — the
+        # weighted headline is already the trace-level ``reward``.
         return {
-            name: Stat([getattr(r, self.attr)[name] for r in self.rollouts if name in getattr(r, self.attr)])
+            name: Stat(
+                [
+                    float(getattr(value, "score", value))
+                    for r in self.rollouts
+                    if name in getattr(r, self.attr)
+                    for value in [getattr(r, self.attr)[name]]
+                ]
+            )
             for name in names
         }
 

--- a/tests/unit/orchestrator/test_advantage.py
+++ b/tests/unit/orchestrator/test_advantage.py
@@ -101,7 +101,7 @@ def _build_rollout(
         task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt=None)),
         nodes=nodes,
         calls=calls,
-        rewards={"reward": reward},
+        rewards={"reward": vf.Reward(score=reward)},
         metrics=metrics or {},
     )
     rollout.env_name = env_name

--- a/tests/unit/orchestrator/test_algorithms.py
+++ b/tests/unit/orchestrator/test_algorithms.py
@@ -258,7 +258,7 @@ def _two_turn_rollout(observation_role: str = "tool") -> Rollout:
     rollout = Rollout(
         task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt=None)),
         nodes=nodes,
-        rewards={"r": 1.0},
+        rewards={"r": vf.Reward(score=1.0)},
         env_name="test-env",
     )
     rollout.samples = trace_to_samples(rollout, env_name="test-env")
@@ -309,7 +309,7 @@ def test_echo_weights_only_content_tokens_when_is_content_present():
     rollout = Rollout(
         task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt=None)),
         nodes=nodes,
-        rewards={"r": 1.0},
+        rewards={"r": vf.Reward(score=1.0)},
         env_name="test-env",
     )
     rollout.samples = trace_to_samples(rollout, env_name="test-env")

--- a/tests/unit/orchestrator/test_filters.py
+++ b/tests/unit/orchestrator/test_filters.py
@@ -58,7 +58,7 @@ def _make_rollout(
     else:
         nodes = [_assistant_node(completion_ids, completion_logprobs)]
     rollout = Rollout[vf.TaskData](
-        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="")), nodes=nodes, rewards={"reward": reward}
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="")), nodes=nodes, rewards={"reward": vf.Reward(score=reward)}
     )
     rollout.env_name = "test"
     rollout.group_id = uuid.uuid4()
@@ -140,7 +140,7 @@ def test_gibberish_aligns_logprobs_under_generation_prompt_scaffold():
     rollout = Rollout[vf.TaskData](
         task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="")),
         nodes=[_scaffold_assistant_node([50, 80, 120_000], [-1.0, -0.5, gibberish_filter.logprob_threshold - 1.0])],
-        rewards={"reward": 1.0},
+        rewards={"reward": vf.Reward(score=1.0)},
     )
 
     result = gibberish_filter.check(rollout)

--- a/tests/unit/orchestrator/test_filters.py
+++ b/tests/unit/orchestrator/test_filters.py
@@ -58,7 +58,9 @@ def _make_rollout(
     else:
         nodes = [_assistant_node(completion_ids, completion_logprobs)]
     rollout = Rollout[vf.TaskData](
-        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="")), nodes=nodes, rewards={"reward": vf.Reward(score=reward)}
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="")),
+        nodes=nodes,
+        rewards={"reward": vf.Reward(score=reward)},
     )
     rollout.env_name = "test"
     rollout.group_id = uuid.uuid4()

--- a/tests/unit/orchestrator/test_metrics.py
+++ b/tests/unit/orchestrator/test_metrics.py
@@ -2,6 +2,7 @@ import math
 from types import SimpleNamespace
 
 import pytest
+import verifiers.v1 as vf
 
 from prime_rl.orchestrator.metrics import EvalRollouts, Stat, TrainRollouts
 from prime_rl.orchestrator.utils import compute_pass_metrics
@@ -141,8 +142,8 @@ def test_stop_condition_breakdown():
 
 def test_nested_metrics_and_rewards():
     rollouts = [
-        mk(metrics={"acc": 1.0}, rewards={"correct": 1.0, "format": 0.0}),
-        mk(metrics={"acc": 3.0, "fmt": 5.0}, rewards={"correct": 0.0, "format": 1.0}),
+        mk(metrics={"acc": 1.0}, rewards={"correct": vf.Reward(score=1.0), "format": vf.Reward(score=0.0)}),
+        mk(metrics={"acc": 3.0, "fmt": 5.0}, rewards={"correct": vf.Reward(score=0.0), "format": vf.Reward(score=1.0)}),
     ]
     m = TrainRollouts(rollouts).metrics
     assert m.metrics["acc"].mean() == 2.0 and m.rewards["correct"].mean() == 0.5  # nested group access

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -38,7 +38,7 @@ def _build_rollout(*, example_id: int, reward: float, task: str) -> Rollout:
     rollout = Rollout[vf.TaskData](
         task=vf.TraceTask(type="Task", data=vf.TaskData(idx=example_id, prompt=f"prompt-{example_id}")),
         nodes=nodes,
-        rewards={"reward": reward},
+        rewards={"reward": vf.Reward(score=reward)},
     )
     rollout.env_name = task
     # Per-token advantage stream (full-length-N): 0.0 on the 3 prompt tokens,

--- a/uv.lock
+++ b/uv.lock
@@ -67,6 +67,7 @@ members = [
     "i3-science-v1",
     "ifbench-v1",
     "ifeval-v1",
+    "kuhn-poker-v1",
     "lean-v1",
     "livecodebench-v1",
     "longbenchpro-v1",
@@ -593,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "bfcl-v3-v1"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "deps/research-environments/environments/tool_use/bfcl_v3_v1" }
 dependencies = [
     { name = "bfcl-eval" },
@@ -605,7 +606,7 @@ dependencies = [
 requires-dist = [
     { name = "bfcl-eval", git = "https://github.com/mikasenghaas/gorilla.git?subdirectory=berkeley-function-call-leaderboard&rev=898763a" },
     { name = "soundfile", specifier = ">=0.13.0" },
-    { name = "verifiers", specifier = ">=0.2.0" },
+    { name = "verifiers", specifier = ">=0.2.2.dev21" },
 ]
 
 [[package]]
@@ -3230,6 +3231,17 @@ wheels = [
 ]
 
 [[package]]
+name = "kuhn-poker-v1"
+version = "0.1.0"
+source = { editable = "deps/verifiers/environments/kuhn_poker_v1" }
+dependencies = [
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
+
+[[package]]
 name = "langdetect"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -3973,7 +3985,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "multi-swe-bench" },
-    { name = "verifiers", specifier = ">=0.2.2.dev5" },
+    { name = "verifiers", specifier = ">=0.2.2.dev27" },
 ]
 
 [[package]]
@@ -4644,7 +4656,7 @@ dependencies = [
 requires-dist = [
     { name = "datasets" },
     { name = "huggingface-hub" },
-    { name = "verifiers", specifier = ">=0.2.2.dev5" },
+    { name = "verifiers", specifier = ">=0.2.2.dev27" },
 ]
 
 [[package]]
@@ -5325,7 +5337,7 @@ requires-dist = [
 
 [[package]]
 name = "prime-sandboxes"
-version = "0.2.32"
+version = "0.2.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -5335,9 +5347,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/fd/f57ad87b273ae1696ca620deaac2c56e28a54905d2d2791a5b9a387f443c/prime_sandboxes-0.2.32.tar.gz", hash = "sha256:ea3d6230cdfb5af2e4542814996257bad60fc9913f15f776a65ca1ef05f4f504", size = 77656, upload-time = "2026-07-17T17:41:02.296Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/a9/880685cefd503aa92d2b49da46b60ba807015f8839c344a83d8c5bc02f30/prime_sandboxes-0.2.33.tar.gz", hash = "sha256:4253a3c345ccf6c07b41a81790f8515763333f094d20bc405a257432461e81d8", size = 81228, upload-time = "2026-07-22T23:23:55.715Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a3/c345509abf8f7707c0c3e9d6badba2e057781d1c05a88a46733ab67521e5/prime_sandboxes-0.2.32-py3-none-any.whl", hash = "sha256:4fe730622e51c489f8f86e7ad959fd8320db6d7a9fe22442ae3c680687da4c22", size = 40897, upload-time = "2026-07-17T17:41:00.935Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1b/10b1044b8aaef561c32a34140f4a13c7310f73f92f9546337e2e8e6a5239/prime_sandboxes-0.2.33-py3-none-any.whl", hash = "sha256:92c9647557e76191ba926ac8ed01708de9ec4450142131b673cd5cf8d9d7ea56", size = 42773, upload-time = "2026-07-22T23:23:54.381Z" },
 ]
 
 [[package]]
@@ -6019,7 +6031,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.2.2.dev5" },
+    { name = "verifiers", specifier = ">=0.2.2.dev27" },
 ]
 
 [[package]]
@@ -6334,7 +6346,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.2.2.dev5" },
+    { name = "verifiers", specifier = ">=0.2.2.dev27" },
 ]
 
 [[package]]
@@ -6453,7 +6465,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "verifiers", extras = ["harbor"], specifier = ">=0.2.1" }]
+requires-dist = [{ name = "verifiers", extras = ["harbor"], specifier = ">=0.2.2.dev27" }]
 
 [[package]]
 name = "sentence-transformers"
@@ -6871,7 +6883,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "verifiers", extras = ["harbor"], specifier = ">=0.2.1" }]
+requires-dist = [{ name = "verifiers", extras = ["harbor"], specifier = ">=0.2.2.dev27" }]
 
 [[package]]
 name = "swebench-pro-v1"
@@ -6882,7 +6894,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "verifiers", specifier = ">=0.2.1" }]
+requires-dist = [{ name = "verifiers", specifier = ">=0.2.2.dev27" }]
 
 [[package]]
 name = "swebench-verified-v1"
@@ -6893,7 +6905,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "verifiers", specifier = ">=0.2.1" }]
+requires-dist = [{ name = "verifiers", specifier = ">=0.2.2.dev27" }]
 
 [[package]]
 name = "swelego-v1"
@@ -6907,7 +6919,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.2.2.dev5" },
+    { name = "verifiers", specifier = ">=0.2.2.dev27" },
 ]
 
 [[package]]
@@ -6922,7 +6934,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets" },
-    { name = "verifiers", specifier = ">=0.2.2.dev5" },
+    { name = "verifiers", specifier = ">=0.2.2.dev27" },
 ]
 
 [[package]]
@@ -6946,7 +6958,7 @@ requires-dist = [
     { name = "datasets" },
     { name = "swebench" },
     { name = "swesmith", git = "https://github.com/SWE-bench/SWE-smith.git?rev=9b74ac0" },
-    { name = "verifiers", specifier = ">=0.2.2.dev5" },
+    { name = "verifiers", specifier = ">=0.2.2.dev27" },
 ]
 
 [[package]]
@@ -7859,7 +7871,7 @@ requires-dist = [
     { name = "openai-agents", specifier = ">=0.8.2" },
     { name = "openenv", marker = "extra == 'openenv'", specifier = ">=0.4.1" },
     { name = "prime-pydantic-config", extras = ["toml"], specifier = ">=0.4.2" },
-    { name = "prime-sandboxes", specifier = ">=0.2.31" },
+    { name = "prime-sandboxes", specifier = ">=0.2.33" },
     { name = "prime-tunnel", specifier = ">=0.1.8" },
     { name = "pydantic", specifier = ">=2.12.3" },
     { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },
@@ -7902,6 +7914,7 @@ examples = [
     { name = "deepwiki-v1", editable = "deps/verifiers/environments/deepwiki_v1" },
     { name = "glossary-v1", editable = "deps/verifiers/environments/glossary_v1" },
     { name = "gsm8k-v1", editable = "deps/verifiers/environments/gsm8k_v1" },
+    { name = "kuhn-poker-v1", editable = "deps/verifiers/environments/kuhn_poker_v1" },
     { name = "openenv-wordle-v1", editable = "deps/verifiers/environments/openenv_wordle_v1" },
     { name = "proposer-solver-v1", editable = "deps/verifiers/environments/proposer_solver_v1" },
     { name = "reverse-text-v1", editable = "deps/verifiers/environments/reverse_text_v1" },


### PR DESCRIPTION
## Summary

Bumps both env submodules to latest `main` to pull in the agentic-judge work and the raw-reward trace change, and migrates the repo to the config shapes those introduce.

- **`deps/verifiers` → `de5ffa2c7`**: configurable agentic-judge env (PrimeIntellect-ai/verifiers#2109), runtime moved onto the agent seat (PrimeIntellect-ai/verifiers#2106), and raw `{score, weight}` trace rewards (PrimeIntellect-ai/verifiers#2119).
- **`deps/research-environments` → `18039eef8`**: out-of-the-box `judges/swe` artifacts (PrimeIntellect-ai/research-environments#720); all SWE taskset pins at `verifiers>=0.2.2.dev27`.
- **Configs**: the harness no longer carries `runtime`; it moves to the agent seat (`env.<seat>.runtime = { ... }`). Applied across `configs/` and `examples/`. `wordle-v1`'s seat is `player`, not `agent`.
- **Orchestrator metrics**: `trace.rewards` values are now `vf.Reward` (raw score + weight). Per-name reward `Stat`s read the raw `.score`; the weighted headline is unchanged (it's the trace-level `reward`). Unit-test trace builders construct `vf.Reward(...)`.
- **Lockfile** regenerated.

## Verification

- `uv run pytest tests/unit --ignore tests/unit/train`: **396 passed** (the `tests/unit/train/*` modules need `flash_attn`, a GPU extra not installed here, so they're excluded — unrelated to this bump).
- All 104 `test_configs` cases parse under the new addressing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide config migration could break runs if any TOML was missed; reward metric changes affect W&B breakdowns but not headline `reward`. Dependency bumps touch many env packages and sandboxes.
> 
> **Overview**
> Bumps **verifiers** and **research-environments** and updates the repo for their new config and trace shapes.
> 
> **Orchestrator env config:** `runtime` is no longer nested under `harness`. Configs now set `env.<seat>.harness` and `env.<seat>.runtime` as sibling keys (e.g. `env.agent.runtime = { type = "subprocess" }`). Wordle uses the `player` seat instead of `agent`. This is applied across `configs/`, `examples/`, and docs (`configuration.md`, `algorithms.md`, `skills/configs/SKILL.md`).
> 
> **Trace rewards:** Per-component trace rewards are now `vf.Reward(score, weight)`. `CustomMetrics` logs the raw `.score` for per-name reward breakdowns; unit tests construct `vf.Reward(...)` in rollout fixtures.
> 
> **Lockfile:** `uv.lock` picks up newer `verifiers` pins for SWE envs, `prime-sandboxes` 0.2.33, `bfcl-v3-v1` 0.3.0, and adds `kuhn-poker-v1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60dc241f84f8f88bdfa6c418642674d0bcdfb5d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->