### PR TITLE
fix(nightly-fft): pin hendrycks attn to flash_attention_2

### DIFF
--- a/configs/ci/nightly-fft/hendrycks-sanity.toml
+++ b/configs/ci/nightly-fft/hendrycks-sanity.toml
@@ -36,6 +36,7 @@ group_size = 32
 
 [trainer.model]
 seq_len = 16384
+attn = "flash_attention_2"
 
 [inference.parallel]
 dp = 4


### PR DESCRIPTION
Hendrycks nightly-fft crash-loops because R1-Distill-Qwen-1.5B is Qwen2 arch (not in prime-rl's custom-impl support list), so `impl='auto'` resolves to `hf`, which then clashes with the platform's default `attn='flash_attention_3'`.

- Pin `attn = "flash_attention_2"` under `[trainer.model]` — fa2 works with hf impl on H200.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI config change with no production training or auth impact.
> 
> **Overview**
> Stops the **hendrycks** nightly-FFT job from crash-looping by pinning trainer attention to **`flash_attention_2`** in `hendrycks-sanity.toml`.
> 
> For **R1-Distill-Qwen-1.5B** (Qwen2), `impl='auto'` falls back to the HF path, which conflicts with the platform default **`flash_attention_3`**; FA2 is the supported pairing on H200 for this setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a39118e176a8702c44503dd8d7d23f9005e94bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->