### PR TITLE
fix(nightly-fft): restore auto-resolve latest v*.dev* when no image_tag input

### DIFF
--- a/.github/workflows/nightly-fft.yaml
+++ b/.github/workflows/nightly-fft.yaml
@@ -120,11 +120,17 @@ jobs:
                   # manifest step didn't finish), so pull the top N candidates
                   # and verify each with a manifest HEAD via the anonymous
                   # registry token flow; take the newest one that resolves.
+                  # Disable pipefail locally: `grep` may exit 1 on no matches
+                  # (empty tag list) and `head` may SIGPIPE `sort` after
+                  # reading its 10 lines. Both would abort the step before the
+                  # explicit no-candidates guard below runs.
+                  set +o pipefail
                   candidates=$(gh api --paginate \
                       "/orgs/primeintellect-ai/packages/container/prime-rl/versions" \
                       --jq '.[].metadata.container.tags[]' \
                       | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+$' \
                       | sort -Vru | head -n 10)
+                  set -o pipefail
                   if [ -z "$candidates" ]; then
                       echo "No v*.dev* tag listed on GHCR." >&2
                       exit 1

--- a/.github/workflows/nightly-fft.yaml
+++ b/.github/workflows/nightly-fft.yaml
@@ -113,12 +113,44 @@ jobs:
                       exit 0
                   fi
 
-                  # No dispatch input: let the config's top-level
-                  # `image_tag = "..."` win. Emitting an empty tag causes the
-                  # dispatch step to omit `--image-tag`, so prime-cli falls
-                  # back to the value in the toml.
-                  echo "No image_tag input; deferring to the config's own image_tag."
-                  echo "tag=" >> "$GITHUB_OUTPUT"
+                  # No dispatch input: auto-resolve the newest v*.dev* tag on
+                  # GHCR (the point of a nightly is to catch regressions on
+                  # tip-of-main). The GHCR versions API can list a tag before
+                  # its manifest is actually pullable (build in-flight, or
+                  # manifest step didn't finish), so pull the top N candidates
+                  # and verify each with a manifest HEAD via the anonymous
+                  # registry token flow; take the newest one that resolves.
+                  candidates=$(gh api --paginate \
+                      "/orgs/primeintellect-ai/packages/container/prime-rl/versions" \
+                      --jq '.[].metadata.container.tags[]' \
+                      | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+$' \
+                      | sort -Vru | head -n 10)
+                  if [ -z "$candidates" ]; then
+                      echo "No v*.dev* tag listed on GHCR." >&2
+                      exit 1
+                  fi
+                  registry_token=$(curl -fsSL \
+                      "https://ghcr.io/token?scope=repository:primeintellect-ai/prime-rl:pull" \
+                      | jq -r .token)
+                  tag=""
+                  for cand in $candidates; do
+                      code=$(curl -sS -o /dev/null -w '%{http_code}' \
+                          -H "Authorization: Bearer $registry_token" \
+                          -H 'Accept: application/vnd.oci.image.index.v1+json' \
+                          -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
+                          "https://ghcr.io/v2/primeintellect-ai/prime-rl/manifests/$cand")
+                      if [ "$code" = "200" ]; then
+                          tag="$cand"
+                          break
+                      fi
+                      echo "Skip $cand — manifest HEAD returned $code"
+                  done
+                  if [ -z "$tag" ]; then
+                      echo "None of the top v*.dev* tags have a published manifest." >&2
+                      exit 1
+                  fi
+                  echo "Latest published prime-rl image tag on GHCR: $tag"
+                  echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
             - name: Install uv
               uses: astral-sh/setup-uv@v7
@@ -147,21 +179,13 @@ jobs:
                   printf 'name = "%s"\n\n' "$run_name" > "$dispatch_cfg"
                   cat "${{ matrix.config_file }}" >> "$dispatch_cfg"
                   echo "Dispatched run name: $run_name"
-                  # Only pass --image-tag when we resolved one (either from the
-                  # dispatch input, or a future auto-resolver). Otherwise omit
-                  # it so `prime train` falls back to the top-level `image_tag`
-                  # baked into the checked-in toml.
-                  image_tag_flag=""
-                  if [ -n "${{ steps.image.outputs.tag }}" ]; then
-                      image_tag_flag="--image-tag ${{ steps.image.outputs.tag }}"
-                  fi
                   # Forward WANDB_API_KEY / HF_TOKEN into the hosted payload:
                   # the full-FT dispatch path (`prime train`) only picks up
                   # secrets that were explicitly collected via `-e` / `--env-file`,
                   # not ambient env, so the workflow env: block alone is not
                   # enough to reach the hosted trainer/orchestrator pods.
                   prime train "$dispatch_cfg" \
-                      $image_tag_flag \
+                      --image-tag "${{ steps.image.outputs.tag }}" \
                       -e WANDB_API_KEY \
                       -e HF_TOKEN \
                       --yes --output json


### PR DESCRIPTION
Restores the pre-#3133 nightly default: when `workflow_dispatch` has no `image_tag` input, auto-resolve the newest `v*.dev*` tag on GHCR and pin the dispatch to it. That's the whole point of a nightly, to catch regressions on tip-of-main.

- #3133 removed the auto-resolve branch, falling through to the platform's `main` alias (~50 commits stale per PR #3619). That crashed the run on validation.
- Explicit `-F image_tag=<tag>` override (from #3132) is preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change to image tag resolution; no application runtime or auth logic touched.
> 
> **Overview**
> When **`workflow_dispatch`** leaves **`image_tag`** empty, the nightly FFT workflow again **pins** hosted runs to the **newest published `v*.dev*`** **`prime-rl`** image on GHCR instead of deferring to the config/platform default (which had drifted stale).
> 
> The resolve step lists up to **10** semver-sorted dev tags via the GHCR versions API, then **HEAD-checks manifests** (anonymous registry token) and picks the first pullable tag. **`prime train`** always receives **`--image-tag`** from the resolve step output; the optional flag path is removed. **Explicit `image_tag` input** still validates charset and manifest before use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5beba59bf84bfa4d54d713aa405000bb2074d3b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->