### PR TITLE
fix(orchestrator): fail fast when an env server dies

### DIFF
--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -161,6 +161,7 @@ The binary batches consumed by the trainer still live at `{output_dir}/rollouts/
 A few warnings are normal. Escalate when errors are persistent, growing, or hit a large fraction of rollouts.
 
 - **Env workers**: exceptions in env code, timeouts, sandbox errors, OOM kills (most common source — runs user code).
+- **Env server death**: an env server that dies is reported, not waited on. At startup the orchestrator raises `Env server <name> died on startup with exit code N` with the tail of `logs/envs/{train,eval}/<name>.log` quoted inline; mid-run it raises `Env server <name> exited with code N`. A worker inside a live server dying instead shows up as errored rollouts (`env server worker died (exit code N)`) plus `EnvServerPool worker N died` in the env log — the pool replaces it up to 3 times, then every rollout for that env fails with `no live workers`.
 - **Orchestrator**: empty/errored rollout spikes, weight-broadcast failures, checkpoint errors.
 - **Trainer**: NCCL/CUDA errors, OOM, NaN loss or gradients.
 - **Inference**: NCCL/CUDA errors, OOM, request timeouts.

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -23,16 +23,16 @@ import asyncio
 import atexit
 import multiprocessing as mp
 import os
-import queue
 import sys
 from collections.abc import Iterator, Sequence
 from itertools import islice
+from multiprocessing.connection import Connection
 from multiprocessing.process import BaseProcess
 from pathlib import Path
 from typing import Generic, TypeVar
 
 import verifiers.v1 as vf
-from verifiers.v1.serve import EnvClient, env_config_data
+from verifiers.v1.serve import EnvClient, env_config_data, wait_for_address
 
 from prime_rl.configs.orchestrator import EnvConfig, EvalEnvConfig, TrainEnvConfig
 from prime_rl.orchestrator.algo import Algorithm, build_algorithm
@@ -45,8 +45,10 @@ from prime_rl.utils.logger import get_logger
 # task.idx + task.model_dump).
 ROLLOUT_TYPE = Rollout[vf.WireTaskData]
 
-# Max wait for a spawned env server to bind and report its address. A legacy
-# child loads its dataset before reporting, so this is generous.
+# Max wait for a spawned env server to load its env and report its address. A legacy
+# child loads its dataset before reporting, so this is generous. A server that *dies*
+# is caught immediately (``wait_for_address`` polls its exit code), so this bounds only
+# a genuinely slow start.
 ENV_SERVER_SPAWN_TIMEOUT = 600.0
 
 
@@ -61,7 +63,8 @@ def _run_env_server(
     """Spawned-process entry point: redirect this process's output to ``log_file`` (the
     server's logging + any subprocess-runtime output), then serve via ``serve_env``. The
     worker-pool sizing arrives in ``kwargs`` (``max_workers`` / ``multiplex`` / ``elastic``
-    from the env's ``pool``). ``serve_env`` applies ``log_setup`` here and in every spawned
+    from the env's ``pool``), as does the ``death_pipe`` that ties this server's lifetime to
+    the orchestrator's. ``serve_env`` applies ``log_setup`` here and in every spawned
     worker; a worker inherits this process's redirected stdout/stderr, so its per-rollout
     logs reach ``log_file`` too. Top-level so it stays picklable for the ``spawn`` start
     method. ``legacy`` picks the v0 bridge."""
@@ -98,6 +101,9 @@ class Env:
         Consumed once — by ``TrainSource`` (train) or ``EvalEnv.start`` (eval)."""
         self._env_client: EnvClient | None = None
         self._env_server_process: BaseProcess | None = None
+        self._death_pipe: Connection | None = None
+        """Our end of the server's death pipe — closing it (even on our SIGKILL) tells the
+        server to terminate, so an env server never outlives the orchestrator."""
 
     @property
     def name(self) -> str:
@@ -140,9 +146,11 @@ class Env:
     async def _spawn(self, log_dir: Path, log_level: str, json_logging: bool) -> str:
         """Spawn a v1 EnvServer child process (it runs the agents; the tasks come from
         us). The server binds an OS-assigned port (``:0``) and reports the concrete
-        address back over a queue — no free-port guess, no TOCTOU race. Its output
-        goes to ``<log_dir>/<name>.log`` (``log_dir`` is already the train/eval-split
-        ``.../logs/envs/{train,eval}`` the orchestrator passes in)."""
+        address back over a queue once its env is loaded — no free-port guess, no TOCTOU
+        race, and no waiting on a server that already died (``wait_for_address`` watches
+        its exit code and quotes its log). Its output goes to ``<log_dir>/<name>.log``
+        (``log_dir`` is already the train/eval-split ``.../logs/envs/{train,eval}`` the
+        orchestrator passes in)."""
         ctx = mp.get_context("spawn")
         address_queue: mp.Queue = ctx.Queue()
         log_file = log_dir / f"{self.name}.log"
@@ -159,6 +167,9 @@ class Env:
             # Picklable dict — the narrowed config class doesn't survive the spawn.
             else dict(legacy=False, config_data=env_config_data(self.config.env))
         )
+        # Death pipe: the server self-terminates if we die abruptly. We hold the parent
+        # end for the process's lifetime — its close (even on our SIGKILL) is the signal.
+        parent_conn, child_conn = ctx.Pipe()
         process = ctx.Process(
             target=_run_env_server,
             kwargs=dict(
@@ -168,16 +179,23 @@ class Env:
                 **vf.pool_serve_kwargs(self.config.pool),
                 address="tcp://127.0.0.1:0",
                 address_queue=address_queue,
+                death_pipe=child_conn,
                 **server_kwargs,
             ),
             daemon=False,
         )
         process.start()
+        child_conn.close()  # the child holds its end; ours signals death when it closes
         self._env_server_process = process
+        self._death_pipe = parent_conn
         try:
-            address = await asyncio.to_thread(address_queue.get, timeout=ENV_SERVER_SPAWN_TIMEOUT)
-        except queue.Empty:
-            raise RuntimeError(f"Env server {self.name} did not report its address within {ENV_SERVER_SPAWN_TIMEOUT}s")
+            address = await wait_for_address(
+                process,
+                address_queue,
+                name=f"Env server {self.name}",
+                timeout=ENV_SERVER_SPAWN_TIMEOUT,
+                log_file=log_file,
+            )
         finally:
             address_queue.close()
             address_queue.join_thread()
@@ -238,11 +256,11 @@ class Env:
         )
         return [ROLLOUT_TYPE.model_construct(**dict(wire)) for wire in wires]
 
-    def shutdown(self) -> None:
-        if self._env_server_process is None:
-            return
-        self._env_server_process.terminate()
-        self._env_server_process = None
+    @property
+    def exitcode(self) -> int | None:
+        """The spawned server's exit code, or ``None`` while it runs (also ``None`` for an
+        external server, which isn't ours to supervise)."""
+        return self._env_server_process.exitcode if self._env_server_process is not None else None
 
 
 class TrainEnv(Env):
@@ -304,10 +322,26 @@ class Envs(Generic[EnvT]):
 
     async def start(self, log_dir: Path, log_level: str | None = None, json_logging: bool = False) -> None:
         """Spawn env servers (where needed) and connect, one at a time. Each server
-        binds an OS-assigned port and reports it back, so there's no port race."""
+        binds an OS-assigned port and reports it back, so there's no port race.
+
+        Registered for shutdown *before* the first spawn: if a later env fails to start,
+        the servers already up are still ours to terminate. They are non-daemonic, so
+        leaking one would wedge interpreter exit on an implicit join."""
+        atexit.register(self.shutdown)
         for env in self:
             await env.start(log_dir=log_dir, log_level=log_level, json_logging=json_logging)
-        atexit.register(self.shutdown)
+
+    def check_alive(self) -> None:
+        """Raise if a spawned env server has exited. Its in-flight requests die with it and
+        the dispatcher awaits rollout replies untimed, so an unnoticed death is a silent
+        stall — fail the run loudly instead."""
+        for env in self:
+            exitcode = env.exitcode
+            if exitcode is not None:
+                raise RuntimeError(
+                    f"Env server {env.name} exited with code {exitcode} — see its log in "
+                    f"logs/envs/. Rollouts for this env cannot complete."
+                )
 
     def shutdown(self) -> None:
         """Terminate all spawned env server processes."""
@@ -326,6 +360,9 @@ class Envs(Generic[EnvT]):
                 p.join(timeout=5)
         for env in self:
             env._env_server_process = None
+            if env._death_pipe is not None:
+                env._death_pipe.close()
+                env._death_pipe = None
 
 
 class TrainEnvs(Envs[TrainEnv]):

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -260,7 +260,10 @@ class Env:
     def exitcode(self) -> int | None:
         """The spawned server's exit code, or ``None`` while it runs (also ``None`` for an
         external server, which isn't ours to supervise)."""
-        return self._env_server_process.exitcode if self._env_server_process is not None else None
+        process = self._env_server_process
+        if process is None or process.is_alive():
+            return None
+        return process.exitcode
 
 
 class TrainEnv(Env):

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -514,6 +514,12 @@ class Orchestrator:
                 self.stopped.set()
                 break
 
+            # An env server that dies mid-run takes its in-flight rollouts with it and
+            # would otherwise go unnoticed — the pipeline would just quietly stop filling.
+            self.train_envs.check_alive()
+            if self.eval_envs is not None:
+                self.eval_envs.check_alive()
+
             try:
                 episode: list[Rollout] = await asyncio.wait_for(self.dispatcher.out_q.get(), timeout=0.5)
             except asyncio.TimeoutError:

--- a/uv.lock
+++ b/uv.lock
@@ -67,6 +67,7 @@ members = [
     "i3-science-v1",
     "ifbench-v1",
     "ifeval-v1",
+    "kuhn-poker-v1",
     "lean-v1",
     "livecodebench-v1",
     "longbenchpro-v1",
@@ -3230,6 +3231,17 @@ wheels = [
 ]
 
 [[package]]
+name = "kuhn-poker-v1"
+version = "0.1.0"
+source = { editable = "deps/verifiers/environments/kuhn_poker_v1" }
+dependencies = [
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
+
+[[package]]
 name = "langdetect"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -5325,7 +5337,7 @@ requires-dist = [
 
 [[package]]
 name = "prime-sandboxes"
-version = "0.2.32"
+version = "0.2.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -5335,9 +5347,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/fd/f57ad87b273ae1696ca620deaac2c56e28a54905d2d2791a5b9a387f443c/prime_sandboxes-0.2.32.tar.gz", hash = "sha256:ea3d6230cdfb5af2e4542814996257bad60fc9913f15f776a65ca1ef05f4f504", size = 77656, upload-time = "2026-07-17T17:41:02.296Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/a9/880685cefd503aa92d2b49da46b60ba807015f8839c344a83d8c5bc02f30/prime_sandboxes-0.2.33.tar.gz", hash = "sha256:4253a3c345ccf6c07b41a81790f8515763333f094d20bc405a257432461e81d8", size = 81228, upload-time = "2026-07-22T23:23:55.715Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a3/c345509abf8f7707c0c3e9d6badba2e057781d1c05a88a46733ab67521e5/prime_sandboxes-0.2.32-py3-none-any.whl", hash = "sha256:4fe730622e51c489f8f86e7ad959fd8320db6d7a9fe22442ae3c680687da4c22", size = 40897, upload-time = "2026-07-17T17:41:00.935Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1b/10b1044b8aaef561c32a34140f4a13c7310f73f92f9546337e2e8e6a5239/prime_sandboxes-0.2.33-py3-none-any.whl", hash = "sha256:92c9647557e76191ba926ac8ed01708de9ec4450142131b673cd5cf8d9d7ea56", size = 42773, upload-time = "2026-07-22T23:23:54.381Z" },
 ]
 
 [[package]]
@@ -7859,7 +7871,7 @@ requires-dist = [
     { name = "openai-agents", specifier = ">=0.8.2" },
     { name = "openenv", marker = "extra == 'openenv'", specifier = ">=0.4.1" },
     { name = "prime-pydantic-config", extras = ["toml"], specifier = ">=0.4.2" },
-    { name = "prime-sandboxes", specifier = ">=0.2.31" },
+    { name = "prime-sandboxes", specifier = ">=0.2.33" },
     { name = "prime-tunnel", specifier = ">=0.1.8" },
     { name = "pydantic", specifier = ">=2.12.3" },
     { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },
@@ -7902,6 +7914,7 @@ examples = [
     { name = "deepwiki-v1", editable = "deps/verifiers/environments/deepwiki_v1" },
     { name = "glossary-v1", editable = "deps/verifiers/environments/glossary_v1" },
     { name = "gsm8k-v1", editable = "deps/verifiers/environments/gsm8k_v1" },
+    { name = "kuhn-poker-v1", editable = "deps/verifiers/environments/kuhn_poker_v1" },
     { name = "openenv-wordle-v1", editable = "deps/verifiers/environments/openenv_wordle_v1" },
     { name = "proposer-solver-v1", editable = "deps/verifiers/environments/proposer_solver_v1" },
     { name = "reverse-text-v1", editable = "deps/verifiers/environments/reverse_text_v1" },


### PR DESCRIPTION
## Problem

If a spawned environment server died during startup, the orchestrator kept waiting on its address queue for up to 600 seconds. The real exception remained in the env log. A server that died later could also leave untimed rollout requests pending indefinitely.

## Changes

- Read spawned-server addresses through `verifiers.v1.serve.wait_for_address`, which polls the child exit code and includes the env log tail in startup failures.
- Check owned env-server processes on every orchestrator loop pass so mid-run deaths fail the run promptly.
- Tie each spawned server to the orchestrator with a death pipe so abrupt orchestrator exits do not orphan brokers, workers, sandboxes, or tunnels.
- Register shutdown before spawning the first environment, ensuring partial startup is cleaned up.
- Keep the monitoring skill aligned with the new failure messages.

The `deps/verifiers` pin points to the conflict-resolved head of [verifiers#2131](https://github.com/PrimeIntellect-ai/verifiers/pull/2131), which provides the readiness handshake, worker reaping, and shared address-wait helper. Repoint it to `main` after that PR merges.

## Verification

- `uv sync --all-packages --locked`
- `uv run ruff check` and `uv run ruff format --check` on the touched Python files
- `uv run pre-commit run --all-files`
- 263 orchestrator, config, and utility tests passed
- Spawned-process smoke checks covered a startup import failure, a healthy pooled server, and mid-run server death

The remaining trainer-model tests require the CI-only `flash_attn` extra and are left to the PR checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestrator env process supervision and main-loop behavior; mis-detection could abort healthy runs, but scope is limited to spawned env servers and improves failure visibility over silent stalls.
> 
> **Overview**
> **Env server lifecycle** is tightened so dead servers are detected quickly instead of hanging startup or stalling the pipeline mid-run.
> 
> Spawned env servers now report their address through `wait_for_address` (verifiers), which polls the child exit code and surfaces startup failures with a tail of the env log. Each spawn gets a **death pipe** so the server exits when the orchestrator dies abruptly, and shutdown registers **before** the first spawn so partial startup still cleans up non-daemon children.
> 
> The orchestrator main loop calls `check_alive()` on train/eval env collections each iteration and raises if an owned server has exited. The monitor-run skill documents the new startup vs mid-run vs worker-pool failure messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46ad01a062867a98e47e10de2c560727e5d0d8c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->