### PR TITLE
chore(ci): enable nightly FFT cron

### DIFF
--- a/.github/workflows/nightly-fft.yaml
+++ b/.github/workflows/nightly-fft.yaml
@@ -13,9 +13,9 @@ on:
                 required: false
                 default: ""
 
-    # Scheduled run at 3AM PST (11AM UTC) — disabled for now, enable once dry-run passes
-    # schedule:
-    #     - cron: "0 11 * * *"
+    # Scheduled run at 3AM PST (11AM UTC)
+    schedule:
+        - cron: "0 11 * * *"
 
 permissions:
     contents: read


### PR DESCRIPTION
Flip the nightly FFT schedule on. Dry-run dispatches on main have been green.

- uncomment `schedule: - cron "0 11 * * *"` in `nightly-fft.yaml`
- runs daily at 3 AM PST across the 5 configs in `configs/ci/nightly-fft/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that turns on an existing workflow schedule; no application, auth, or data-path code is modified.
> 
> **Overview**
> **Enables the daily scheduled run** for the Nightly FFT workflow by uncommenting the `schedule` trigger with cron `0 11 * * *` (3 AM PST / 11 AM UTC) in `nightly-fft.yaml`.
> 
> Manual `workflow_dispatch` behavior is unchanged. Scheduled runs will use the existing discover-and-dispatch flow over all configs in `configs/ci/nightly-fft/`, resolving the latest published `prime-rl` dev image when no tag is pinned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43cbf125140699135ac5811a340548d849471930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->