### PR TITLE
feat: add NVFP4 grouped expert recipe

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -40,10 +40,11 @@ The custom path enables EP, CP, selective activation checkpointing, low-precisio
 
 ### Low-precision training
 
-Set `[trainer.model.quantization]` to train dense linears and MoE expert GEMMs in low precision. Two backends are available via the `type` discriminator:
+Set `[trainer.model.quantization]` to train dense linears and/or MoE expert GEMMs in low precision. Three backends are available via the `type` discriminator:
 
 - `type = "fp8"` — DeepGEMM FP8 blockwise (requires SM90+ / Hopper). Options: `enable_grouped_gemm` (FP8 MoE expert GEMM). Both default on.
 - `type = "mxfp8"` — torchao MXFP8 microscaling (requires SM100+ / Blackwell). Options: `enable_grouped_gemm`, `enable_a2a` (MXFP8 expert-parallel all-to-all), and `recipe` (`mxfp8_rceil` default or `mxfp8_rceil_wgrad_with_hp`).
+- `type = "nvfp4"` — native NVFP4 grouped GEMM for routed experts on SM100. BF16 weights are quantized on every forward with one FP32 decode scale per expert; fused gate-up weights therefore share a scale. Activations use one FP32 decode scale per token. `backward` selects `dequant_bf16` (default, reconstruct the packed forward operands) or `bf16` (retain the original BF16 operands). Dense linears, master parameters, checkpoints, and weight transfer remain unchanged.
 
 ```toml
 [trainer.model.quantization]

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -144,7 +144,12 @@ class MXFP8Config(BaseConfig):
     ignore_patterns: list[str] = _DEFAULT_FP8_IGNORE_PATTERNS
 
 
-QuantizationConfig: TypeAlias = Annotated[FP8Config | MXFP8Config, Field(discriminator="type")]
+class NVFP4Config(BaseConfig):
+    type: Literal["nvfp4"] = "nvfp4"
+    backward: Literal["dequant_bf16", "bf16"] = "dequant_bf16"
+
+
+QuantizationConfig: TypeAlias = Annotated[FP8Config | MXFP8Config | NVFP4Config, Field(discriminator="type")]
 
 
 class ModelConfig(BaseModelConfig):

--- a/packages/prime-rl-kernels/README.md
+++ b/packages/prime-rl-kernels/README.md
@@ -1,0 +1,97 @@
+# prime-rl-kernels
+
+Standalone GPU kernels used by `prime-rl`.
+
+The NVFP4 implementation owns its grouped GEMM under
+`prime_rl_kernels/nvfp4/grouped_gemm` and its quantizers under
+`prime_rl_kernels/nvfp4/quantize`. The SM100 CUTLASS kernel is adapted from
+MSLK. The quantizer is an owned CUDA implementation using Blackwell conversion
+instructions adapted from Transformer Engine. Neither project is a runtime
+dependency. The published NVIDIA CUTLASS headers are supplied by the
+`nvidia-cutlass` Python package.
+
+## Requirements
+
+- NVIDIA GB200/B200 (SM100)
+- CUDA 12.8 or newer
+- PyTorch 2.11 or newer with `torch.float4_e2m1fn_x2`
+
+## API
+
+```python
+from prime_rl_kernels.nvfp4.grouped_gemm import grouped_gemm
+from prime_rl_kernels.nvfp4.quantize import quantize_activations, quantize_weights
+
+# x:       [total_tokens, in_features], BF16
+# weight:  [num_experts, in_features, out_features], BF16
+# offsets: cumulative token counts, one INT32 value per expert
+output = grouped_gemm(x, weight, offs=offsets)
+
+# Standalone quantization returns packed E2M1 data, tcgen05-swizzled E4M3
+# block scales, and FP32 decode scales.
+x_nvfp4 = quantize_activations(x, offsets)
+weight_nvfp4 = quantize_weights(weight)
+```
+
+Every grouped GEMM call derives the scales from the current BF16 tensors,
+quantizes both operands, and runs the grouped GEMM.
+
+## Quantization contract
+
+- E2M1 values with one E4M3 block scale per 16 values.
+- One FP32 decode scale per activation token:
+  `token_amax / (6 * 448)`.
+- One FP32 decode scale per expert weight tensor:
+  `expert_amax / (6 * 448)`.
+- Block scales remain true group-16 scales and are stored in the native
+  128-by-4 tensor-core layout.
+- Fused gate-up weights use one shared per-expert scale.
+- Forward uses the owned SM100 grouped kernel. Backward either saves the exact
+  packed forward operands and dequantizes them for BF16 dgrad and wgrad, or
+  retains the original BF16 operands.
+
+This is the same two-level per-token/per-expert NVFP4 recipe used by the online
+vLLM path. It intentionally does not implement a 4-over-6 recipe.
+
+## Compilation cache
+
+The quantization and grouped-GEMM extensions are compiled lazily on first use.
+Point `TORCH_EXTENSIONS_DIR` at persistent storage to reuse the resulting
+shared objects across jobs:
+
+```bash
+export TORCH_EXTENSIONS_DIR=/persistent/cache/prime-rl-kernels/torch-extensions
+```
+
+PyTorch's extension lock allows distributed ranks sharing that directory to
+wait on one build instead of compiling the same sources independently.
+
+## prime-rl integration
+
+Set the trainer model's quantization discriminator to `nvfp4`:
+
+```toml
+[trainer.model.quantization]
+type = "nvfp4"
+backward = "dequant_bf16"
+```
+
+The integration selects this path for `GroupedExperts` while leaving BF16
+master parameters, checkpoints, optimizer state, dense linears, and weight
+transfer unchanged. Weights are re-quantized from the current BF16 parameters
+on every forward invocation, including activation-checkpoint recomputation.
+Torch expert parallelism and the DeepEP local-expert path use the same adapter.
+Set `backward = "bf16"` to retain the original BF16 operands for backward
+instead of reconstructing them from the quantized forward operands.
+
+## Current scope
+
+- SM100 routed experts only.
+- Runtime-fused gate-up projection with a shared per-expert scale.
+- `torch.compile(fullgraph=False)` is supported through an intentional graph
+  break around the custom operation. Full-graph capture is not yet supported.
+- Only rows before the final logical offset have defined output. TorchTitan's
+  physical padding rows are discarded by expert-parallel combine.
+
+The repository is Apache-2.0 licensed; the grouped kernel retains its MSLK
+license alongside the source.

--- a/packages/prime-rl-kernels/pyproject.toml
+++ b/packages/prime-rl-kernels/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "prime-rl-kernels"
+version = "0.1.0"
+description = "Standalone GPU kernels for prime-rl"
+readme = "README.md"
+requires-python = "~=3.12.0"
+dependencies = [
+    "nvidia-cutlass==4.2.0.0",
+    "torch>=2.11.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/prime_rl_kernels"]

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/__init__.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/__init__.py
@@ -1,0 +1,3 @@
+from prime_rl_kernels.nvfp4 import grouped_gemm
+
+__all__ = ["grouped_gemm"]

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/__init__.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/__init__.py
@@ -1,0 +1,18 @@
+from prime_rl_kernels.nvfp4.grouped_gemm import grouped_gemm
+
+
+def prepare_for_compile() -> None:
+    """Load the CUDA operators and register FakeTensor shape implementations."""
+
+    from prime_rl_kernels.nvfp4.grouped_gemm._extension import (
+        _prepare_extension_for_compile as prepare_grouped_gemm,
+    )
+    from prime_rl_kernels.nvfp4.quantize._extension import (
+        _prepare_extension_for_compile as prepare_quantization,
+    )
+
+    prepare_quantization()
+    prepare_grouped_gemm()
+
+
+__all__ = ["grouped_gemm", "prepare_for_compile"]

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/_build.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/_build.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import os
+import platform
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import torch
+from torch.utils.cpp_extension import LIB_EXT, _get_build_directory, load
+
+
+def _content_addressed_name(
+    base_name: str,
+    *,
+    fingerprint_files: Iterable[Path],
+    fingerprint: Iterable[str],
+) -> str:
+    digest = hashlib.sha256()
+    for value in (
+        torch.__version__,
+        torch.version.cuda or "cpu",
+        platform.machine(),
+        f"python-{sys.version_info.major}.{sys.version_info.minor}",
+        *fingerprint,
+    ):
+        digest.update(value.encode())
+        digest.update(b"\0")
+    for path in sorted(path for path in fingerprint_files if path.is_file()):
+        digest.update(path.name.encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return f"{base_name}_{digest.hexdigest()[:16]}"
+
+
+def load_cuda_extension(
+    *,
+    base_name: str,
+    sources: list[Path],
+    fingerprint_files: Iterable[Path],
+    fingerprint: Iterable[str] = (),
+    extra_include_paths: list[Path] | None = None,
+    extra_cflags: list[str] | None = None,
+    extra_cuda_cflags: list[str] | None = None,
+) -> None:
+    """Build once per source/ABI and safely reuse the library across nodes.
+
+    ``torch.utils.cpp_extension.load`` always invokes Ninja. A shared build
+    directory is unsafe across hosts whose system-header mtimes differ: Ninja
+    may rebuild an existing ``.so`` in place while another process has it
+    mapped. Content-addressing prevents stale reuse, and the advisory lock plus
+    ready marker lets every later process load the completed library directly.
+    """
+
+    verbose = os.environ.get("PRIME_RL_KERNELS_BUILD_VERBOSE") == "1"
+    name = _content_addressed_name(
+        base_name,
+        fingerprint_files=fingerprint_files,
+        fingerprint=(
+            *(extra_cflags or ()),
+            *(extra_cuda_cflags or ()),
+            *fingerprint,
+        ),
+    )
+    build_directory = Path(_get_build_directory(name, verbose))
+    library_path = build_directory / f"{name}{LIB_EXT}"
+    ready_path = build_directory / ".prime_rl_ready"
+    lock_path = build_directory / ".prime_rl_build.lock"
+
+    with lock_path.open("a+b") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        if ready_path.is_file() and library_path.is_file():
+            try:
+                torch.ops.load_library(str(library_path))
+                return
+            except (OSError, RuntimeError):
+                ready_path.unlink(missing_ok=True)
+                library_path.unlink(missing_ok=True)
+
+        # A previous builder may have died after linking but before publishing
+        # the ready marker. Removing the library forces Ninja to relink it.
+        if not ready_path.is_file():
+            library_path.unlink(missing_ok=True)
+        # This is Torch's internal baton. No process using the content-addressed
+        # directory can legitimately hold it while we own the outer flock.
+        (build_directory / "lock").unlink(missing_ok=True)
+
+        load(
+            name=name,
+            sources=[str(path) for path in sources],
+            extra_include_paths=[str(path) for path in (extra_include_paths or ())],
+            extra_cflags=extra_cflags,
+            extra_cuda_cflags=extra_cuda_cflags,
+            with_cuda=True,
+            is_python_module=False,
+            build_directory=str(build_directory),
+            verbose=verbose,
+        )
+        ready_path.write_text("ready\n")

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/MSLK_LICENSE
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/MSLK_LICENSE
@@ -1,0 +1,30 @@
+BSD License
+
+For MSLK software
+
+Copyright (c) Meta Platforms, Inc. and affiliates. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/__init__.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/__init__.py
@@ -1,0 +1,3 @@
+from prime_rl_kernels.nvfp4.grouped_gemm.functional import grouped_gemm
+
+__all__ = ["grouped_gemm"]

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/_extension.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/_extension.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import functools
+import importlib.util
+from pathlib import Path
+
+import torch
+
+from prime_rl_kernels.nvfp4._build import load_cuda_extension
+
+_EXTENSION_NAME = "prime_rl_kernels_nvfp4_sm100"
+_SOURCES = (
+    "bindings.cpp",
+    "f4f4bf16_ultra_grouped.cu",
+    "f4f4bf16_ultra_grouped_256_128_256_2_1_1.cu",
+    "f4f4bf16_ultra_grouped_256_256_256_2_1_1.cu",
+)
+_EXTENSION_READY = False
+
+
+def _grouped_mm_fake(
+    activations: torch.Tensor,
+    weight: torch.Tensor,
+    activation_block_scales: torch.Tensor,
+    weight_block_scales: torch.Tensor,
+    offsets: torch.Tensor,
+    activation_token_scales: torch.Tensor,
+    weight_expert_scales: torch.Tensor,
+) -> torch.Tensor:
+    del (
+        activation_block_scales,
+        weight_block_scales,
+        offsets,
+        activation_token_scales,
+        weight_expert_scales,
+    )
+    return activations.new_empty(
+        (activations.shape[0], weight.shape[-1]),
+        dtype=torch.bfloat16,
+    )
+
+
+def _cutlass_source_root() -> Path:
+    spec = importlib.util.find_spec("cutlass_library")
+    if spec is None or not spec.submodule_search_locations:
+        raise RuntimeError("prime-rl-kernels NVFP4 grouped GEMM requires the nvidia-cutlass package")
+    source_root = Path(next(iter(spec.submodule_search_locations))) / "source"
+    if not (source_root / "include" / "cutlass" / "cutlass.h").is_file():
+        raise RuntimeError(f"nvidia-cutlass headers were not found under {source_root}")
+    return source_root
+
+
+@functools.cache
+def _load_extension() -> None:
+    global _EXTENSION_READY
+
+    source_dir = Path(__file__).with_name("csrc")
+    cutlass_root = _cutlass_source_root()
+    extra_cflags = ["-O3", "-std=c++17"]
+    extra_cuda_cflags = [
+        "-O3",
+        "-std=c++17",
+        "--expt-relaxed-constexpr",
+        "--expt-extended-lambda",
+        "--threads=4",
+        "-gencode=arch=compute_100a,code=sm_100a",
+    ]
+    load_cuda_extension(
+        base_name=_EXTENSION_NAME,
+        sources=[source_dir / source for source in _SOURCES],
+        fingerprint_files=source_dir.glob("*"),
+        extra_include_paths=[
+            source_dir,
+            cutlass_root / "include",
+            cutlass_root / "tools" / "util" / "include",
+        ],
+        extra_cflags=extra_cflags,
+        extra_cuda_cflags=extra_cuda_cflags,
+        fingerprint=("nvidia-cutlass-4.2.0.0",),
+    )
+    _EXTENSION_READY = True
+
+
+@functools.cache
+def _prepare_extension_for_compile() -> None:
+    _load_extension()
+    torch.library.register_fake(
+        "prime_rl_kernels_nvfp4::grouped_mm",
+        _grouped_mm_fake,
+    )
+
+
+def _grouped_mm(
+    activations: torch.Tensor,
+    weight: torch.Tensor,
+    activation_block_scales: torch.Tensor,
+    weight_block_scales: torch.Tensor,
+    offsets: torch.Tensor,
+    activation_token_scales: torch.Tensor,
+    weight_expert_scales: torch.Tensor,
+) -> torch.Tensor:
+    if not _EXTENSION_READY:
+        _load_extension()
+    return torch.ops.prime_rl_kernels_nvfp4.grouped_mm.default(
+        activations,
+        weight,
+        activation_block_scales,
+        weight_block_scales,
+        offsets,
+        activation_token_scales,
+        weight_expert_scales,
+    )

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/bindings.cpp
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/bindings.cpp
@@ -1,0 +1,37 @@
+#include "nvfp4_grouped.h"
+
+#include <torch/library.h>
+
+namespace prime_rl_kernels::nvfp4 {
+
+at::Tensor grouped_mm(
+    const at::Tensor& activations,
+    const at::Tensor& weight,
+    const at::Tensor& activation_block_scales,
+    const at::Tensor& weight_block_scales,
+    const at::Tensor& offsets,
+    const at::Tensor& activation_token_scales,
+    const at::Tensor& weight_expert_scales) {
+  return f4f4bf16_ultra_grouped_mm(
+      activations,
+      weight,
+      activation_block_scales,
+      weight_block_scales,
+      offsets,
+      activation_token_scales,
+      weight_expert_scales);
+}
+
+TORCH_LIBRARY_FRAGMENT(prime_rl_kernels_nvfp4, m) {
+  m.def(
+      "grouped_mm(Tensor activations, Tensor weight, "
+      "Tensor activation_block_scales, Tensor weight_block_scales, "
+      "Tensor offsets, Tensor activation_token_scales, "
+      "Tensor weight_expert_scales) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(prime_rl_kernels_nvfp4, CUDA, m) {
+  m.impl("grouped_mm", grouped_mm);
+}
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped.cu
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped.cu
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in
+ * ../MSLK_LICENSE.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+#include "f4f4bf16_ultra_grouped_manifest.cuh"
+#endif
+
+namespace prime_rl_kernels::nvfp4 {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+namespace {
+
+// Returns the compute capability of the current device as major*10 + minor.
+int get_device_sm_version() {
+  auto* props = at::cuda::getDeviceProperties(at::cuda::current_device());
+  return props->major * 10 + props->minor;
+}
+
+} // namespace
+
+Kernel_f4f4bf16_ultra_grouped
+get_ultra_kernel_via_heuristics(int M, int N, int K) {
+  const int sm = get_device_sm_version();
+  TORCH_CHECK(
+      sm == 100,
+      "prime-rl-kernels NVFP4 grouped GEMM currently requires an sm_100 GPU, "
+      "but the current device is sm_",
+      sm,
+      ".");
+  if (M <= 128) {
+    return f4f4bf16_ultra_grouped_256_128_256_2_1_1;
+  }
+  return f4f4bf16_ultra_grouped_256_256_256_2_1_1;
+}
+
+at::Tensor f4f4bf16_ultra_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    std::optional<at::Tensor> output_maybe) {
+  TORCH_CHECK(XQ.is_cuda(), "XQ must be a CUDA tensor.");
+  c10::cuda::CUDAGuard device_guard(XQ.device());
+  TORCH_CHECK(
+      WQ.device() == XQ.device() && x_scale.device() == XQ.device() &&
+          w_scale.device() == XQ.device() &&
+          offsets.device() == XQ.device() &&
+          x_global_scale.device() == XQ.device() &&
+          w_global_scale.device() == XQ.device(),
+      "all grouped GEMM inputs must be on the same CUDA device.");
+  TORCH_CHECK(offsets.dtype() == at::kInt, "offsets must be int32.");
+  TORCH_CHECK(offsets.dim() == 1, "offsets must be 1D tensor.");
+  TORCH_CHECK(offsets.is_contiguous(), "offsets must be contiguous.");
+  TORCH_CHECK(XQ.is_contiguous(), "XQ must be row major.");
+  TORCH_CHECK(WQ.transpose(-2, -1).is_contiguous(), "WQ must be column major.");
+  TORCH_CHECK(x_scale.is_contiguous(), "x_scale must be contiguous.");
+  TORCH_CHECK(w_scale.is_contiguous(), "w_scale must be contiguous.");
+  TORCH_CHECK(
+      x_global_scale.is_contiguous(),
+      "x_global_scale must be contiguous.");
+  TORCH_CHECK(
+      w_global_scale.is_contiguous(),
+      "w_global_scale must be contiguous.");
+  TORCH_CHECK(XQ.dtype() == at::kFloat4_e2m1fn_x2, "XQ must be FP4.");
+  TORCH_CHECK(WQ.dtype() == at::kFloat4_e2m1fn_x2, "WQ must be FP4.");
+  TORCH_CHECK(
+      x_scale.dtype() == at::kFloat8_e4m3fn, "x_scale must be FP8 e4m3.");
+  TORCH_CHECK(
+      w_scale.dtype() == at::kFloat8_e4m3fn, "w_scale must be FP8 e4m3.");
+  TORCH_CHECK(
+      x_global_scale.dtype() == at::kFloat, "x_global_scale must be float32.");
+  TORCH_CHECK(
+      w_global_scale.dtype() == at::kFloat, "w_global_scale must be float32.");
+  TORCH_CHECK(
+      XQ.dim() == 2 && WQ.dim() == 3,
+      "Only 2D-3D grouped GEMM (MoE forward) is supported.");
+
+  int64_t G = offsets.size(0);
+  int64_t M = XQ.size(0);
+  int64_t N = WQ.size(-1);
+  int64_t K = WQ.size(-2);
+
+  TORCH_CHECK(G > 0, "offsets must contain at least one expert.");
+  TORCH_CHECK(
+      XQ.size(-1) == K && WQ.size(0) == G,
+      "XQ shape must be (total_M, K) and WQ shape must be (G, K, N).");
+  TORCH_CHECK(
+      x_global_scale.dim() == 1 && x_global_scale.size(0) == M,
+      "x_global_scale must have total_M elements.");
+  TORCH_CHECK(
+      w_global_scale.dim() == 1 && w_global_scale.size(0) == G,
+      "w_global_scale must have G elements.");
+  TORCH_CHECK(
+      (K * 2) % 32 == 0,
+      "the unpacked contraction dimension must be divisible by 32.");
+  TORCH_CHECK(N % 8 == 0, "the output dimension must be divisible by 8.");
+
+  const int64_t scale_columns = ((K * 2 / 16 + 3) / 4) * 4;
+  const int64_t padded_output_rows = ((N + 127) / 128) * 128;
+  TORCH_CHECK(
+      x_scale.numel() >= M * scale_columns,
+      "x_scale does not contain enough block scales.");
+  TORCH_CHECK(
+      w_scale.numel() >= G * padded_output_rows * scale_columns,
+      "w_scale does not contain enough block scales.");
+
+  at::Tensor out = output_maybe.has_value()
+      ? output_maybe.value()
+      : at::empty({M, N}, XQ.options().dtype(at::kBFloat16));
+  TORCH_CHECK(
+      out.device() == XQ.device() && out.dtype() == at::kBFloat16 &&
+          out.is_contiguous() && out.dim() == 2 && out.size(0) == M &&
+          out.size(1) == N,
+      "output must be a contiguous BF16 tensor with shape (total_M, N) on "
+      "the input device.");
+
+  if (out.numel() == 0) {
+    return out;
+  }
+
+  int M_per_group = M / G;
+
+  auto kernel = get_ultra_kernel_via_heuristics(M_per_group, N, K * 2);
+
+  return kernel(
+      XQ,
+      WQ.transpose(-2, -1), // Column-major to row-major for CUTLASS.
+      x_scale,
+      w_scale,
+      offsets,
+      x_global_scale,
+      w_global_scale,
+      out);
+}
+
+#else
+
+at::Tensor f4f4bf16_ultra_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    std::optional<at::Tensor> output) {
+  throw std::runtime_error(
+      "f4f4bf16_ultra_grouped_mm requires CUDA 12.8+ and a Blackwell GPU");
+}
+
+#endif
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_256_128_256_2_1_1.cu
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_256_128_256_2_1_1.cu
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in
+ * ../MSLK_LICENSE.
+ */
+
+#include "f4f4bf16_ultra_grouped_common.cuh"
+
+namespace prime_rl_kernels::nvfp4 {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor f4f4bf16_ultra_grouped_256_128_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output) {
+  return f4f4bf16_ultra_grouped_impl<false, 256, 128, 256, 2, 1, 1>(
+      XQ,
+      WQ,
+      x_scale,
+      w_scale,
+      offsets,
+      x_global_scale,
+      w_global_scale,
+      output);
+}
+
+#endif
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_256_256_256_2_1_1.cu
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_256_256_256_2_1_1.cu
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in
+ * ../MSLK_LICENSE.
+ */
+
+#include "f4f4bf16_ultra_grouped_common.cuh"
+
+namespace prime_rl_kernels::nvfp4 {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+at::Tensor f4f4bf16_ultra_grouped_256_256_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output) {
+  return f4f4bf16_ultra_grouped_impl<false, 256, 256, 256, 2, 1, 1>(
+      XQ,
+      WQ,
+      x_scale,
+      w_scale,
+      offsets,
+      x_global_scale,
+      w_global_scale,
+      output);
+}
+
+#endif
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_common.cuh
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_common.cuh
@@ -1,0 +1,525 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in
+ * ../MSLK_LICENSE.
+ */
+
+#define CUTLASS_NAMESPACE prime_rl_kernels
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cutlass/util/device_memory.h>
+#include <cutlass/util/packed_stride.hpp>
+
+// clang-format off
+// The fixed ordering of the headers is required for CUTLASS 3.2+
+#include <cute/tensor.hpp>
+#include <cutlass/gemm/collective/collective_builder.hpp>     // @manual
+#include <cutlass/gemm/device/gemm_universal_adapter.h>       // @manual
+#include <cutlass/gemm/dispatch_policy.hpp>                   // @manual
+#include <cutlass/epilogue/collective/collective_builder.hpp> // @manual
+// clang-format on
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+namespace prime_rl_kernels::nvfp4 {
+
+namespace cutlass = cutlass_prime_rl_kernels;
+
+// Underlying element types (same for both Sm100 NVFP4 and Sm103 ultra NVFP4).
+using ElementData = cutlass::float_e2m1_t;
+using ElementScale = cutlass::float_ue4m3_t;
+// Sm103 ultra CollectiveBuilder expects the (data, scale) pair as a
+// cute::tuple, while the Sm100 NVFP4 CollectiveBuilder takes nv_float4_t
+// directly.
+using ElementPair = cute::tuple<ElementData, ElementScale>;
+using ElementNvf4 = cutlass::nv_float4_t<ElementData>;
+
+inline int64_t _byte_align(int64_t offset) {
+  int64_t remainder = offset % 16;
+  if (remainder != 0) {
+    offset += (16 - remainder);
+  }
+  return offset;
+}
+
+template <
+    typename ProblemShape,
+    typename StrideA,
+    typename StrideB,
+    typename StrideC,
+    typename LayoutSFA,
+    typename LayoutSFB,
+    typename Sm1xxBlkScaledConfig>
+__global__ void set_ultra_grouped_args_kernel(
+    int64_t G,
+    int64_t N,
+    int64_t K,
+    ProblemShape* problem_shape_ptr,
+    ElementData* xq,
+    const ElementData** xq_ptr,
+    ElementData* wq,
+    const ElementData** wq_ptr,
+    ElementScale* x_scale,
+    const ElementScale** x_scale_ptr,
+    ElementScale* w_scale,
+    const ElementScale** w_scale_ptr,
+    cutlass::bfloat16_t* output,
+    cutlass::bfloat16_t** output_ptr,
+    StrideA* stride_a_ptr,
+    StrideB* stride_b_ptr,
+    StrideC* stride_c_ptr,
+    int32_t* offsets,
+    LayoutSFA* layout_SFA,
+    LayoutSFB* layout_SFB,
+    float* x_global_scale,
+    const float** x_global_scale_ptr,
+    float* w_global_scale,
+    const float** w_global_scale_ptr) {
+  uint32_t group_index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (group_index >= G) {
+    return;
+  }
+
+  auto round_up = [](int64_t x, int64_t y) { return ((x + y - 1) / y) * y; };
+
+  constexpr int ele_per_quantize_group = 16; // NVFP4
+
+  int32_t M_end = offsets[group_index];
+  int32_t M_start = (group_index == 0) ? 0 : offsets[group_index - 1];
+  int32_t M_group = M_end - M_start;
+
+  if (M_group <= 0) {
+    problem_shape_ptr[group_index] = ProblemShape(0, 0, 0);
+    return;
+  }
+
+  // Problem shape is (N, M, K) due to transposed AB convention.
+  problem_shape_ptr[group_index] = ProblemShape(N, M_group, K);
+
+  // Data pointers.
+  xq_ptr[group_index] = xq + (int64_t(M_start) * K / 2);
+  wq_ptr[group_index] = wq + (int64_t(group_index) * N * K / 2);
+  output_ptr[group_index] = output + (int64_t(M_start) * N);
+
+  // Block scale offsets. Scales are padded to multiples of (128, 4).
+  int64_t K_rounded = round_up(K / ele_per_quantize_group, 4);
+  int64_t N_rounded = round_up(N, 128);
+
+  int64_t x_scale_offset = 0;
+  for (int i = 0; i < group_index; i++) {
+    int32_t prev_start = (i == 0) ? 0 : offsets[i - 1];
+    int32_t prev_M = offsets[i] - prev_start;
+    x_scale_offset += round_up(prev_M, 128) * K_rounded;
+  }
+  x_scale_ptr[group_index] = x_scale + x_scale_offset;
+  w_scale_ptr[group_index] =
+      w_scale + int64_t(group_index) * N_rounded * K_rounded;
+
+  // Strides.
+  stride_a_ptr[group_index] = cutlass::make_cute_packed_stride(
+      StrideA{}, cute::make_shape(int(M_group), int(K), 1));
+  stride_b_ptr[group_index] = cutlass::make_cute_packed_stride(
+      StrideB{}, cute::make_shape(int(N), int(K), 1));
+  stride_c_ptr[group_index] = cutlass::make_cute_packed_stride(
+      StrideC{}, cute::make_shape(int(N), int(M_group), 1));
+
+  // Scale factor layouts for block-scaled TMA.
+  layout_SFA[group_index] = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(
+      cute::make_shape(int(M_group), int(N), int(K), 1));
+  layout_SFB[group_index] = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(
+      cute::make_shape(int(M_group), int(N), int(K), 1));
+
+  // Per-token x global scale and per-expert w global scale for EVT epilogue.
+  x_global_scale_ptr[group_index] = x_global_scale + M_start;
+  w_global_scale_ptr[group_index] = w_global_scale + group_index;
+}
+
+// Sm103 ultra schedules require CUDA 13+. Alias them to Sm100 NVFP4 schedules
+// on older toolkits so that template instantiation with UseUltra=false still
+// resolves to valid types when those CUDA 12.8 builds reach the conditional.
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 13000)
+using _UltraArchTag = cutlass::arch::Sm103;
+using _UltraSchedule2Sm = cutlass::gemm::
+    KernelPtrArrayTmaWarpSpecialized2SmBlockScaledMxNvf4UltraVs16Sm103;
+using _UltraSchedule1Sm = cutlass::gemm::
+    KernelPtrArrayTmaWarpSpecialized1SmBlockScaledMxNvf4UltraVs16Sm103;
+#else
+using _UltraArchTag = cutlass::arch::Sm100;
+using _UltraSchedule2Sm =
+    cutlass::gemm::KernelPtrArrayTmaWarpSpecialized2SmNvf4Sm100;
+using _UltraSchedule1Sm =
+    cutlass::gemm::KernelPtrArrayTmaWarpSpecialized1SmNvf4Sm100;
+#endif
+
+template <
+    bool UseUltra,
+    int TB_M,
+    int TB_N,
+    int TB_K,
+    int TBS_M,
+    int TBS_N,
+    int TBS_K>
+at::Tensor f4f4bf16_ultra_grouped_impl(
+    at::Tensor XQ, // FP4
+    at::Tensor WQ, // FP4
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output) {
+  c10::cuda::CUDAGuard deviceGuard(XQ.device());
+
+  const int64_t G = offsets.size(0);
+
+  using ProblemShape =
+      cutlass::gemm::GroupProblemShape<cute::Shape<int, int, int>>;
+  using ElementC = cutlass::bfloat16_t;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+
+  constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementData>::value;
+  constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementData>::value;
+  constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+
+  using LayoutA_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutA>::type;
+  using LayoutB_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutB>::type;
+
+  using ElementAccumulator = float;
+  using ElementComputeEpilogue = float;
+  using ArchTag =
+      cute::conditional_t<UseUltra, _UltraArchTag, cutlass::arch::Sm100>;
+  using TileShape =
+      cute::Shape<cute::Int<TB_M>, cute::Int<TB_N>, cute::Int<TB_K>>;
+  using ClusterShape =
+      cute::Shape<cute::Int<TBS_M>, cute::Int<TBS_N>, cute::Int<TBS_K>>;
+
+  // Sm103 ultra path uses cute::tuple<data, scale>; Sm100 NVFP4 path takes
+  // nv_float4_t directly.
+  using ElementForBuilder =
+      cute::conditional_t<UseUltra, ElementPair, ElementNvf4>;
+
+  // Kernel schedule: ultra uses BlockScaledMxNvf4UltraVs16Sm103, Sm100 uses the
+  // standard Nvf4 ptr-array schedule (matching f4f4bf16_grouped).
+  using KernelSchedule = cute::conditional_t<
+      UseUltra,
+      cute::conditional_t<
+          (TB_M == 256) && (TBS_M % 2 == 0),
+          _UltraSchedule2Sm,
+          _UltraSchedule1Sm>,
+      cute::conditional_t<
+          (TB_M == 256) && (TBS_M % 2 == 0),
+          cutlass::gemm::KernelPtrArrayTmaWarpSpecialized2SmNvf4Sm100,
+          cutlass::gemm::KernelPtrArrayTmaWarpSpecialized1SmNvf4Sm100>>;
+  using EpilogueSchedule = cute::conditional_t<
+      (TB_M == 256) && (TBS_M % 2 == 0),
+      cutlass::epilogue::PtrArrayTmaWarpSpecialized2Sm,
+      cutlass::epilogue::PtrArrayTmaWarpSpecialized1Sm>;
+
+  // EVT epilogue: Output = Accumulator * XGlobalScaleInv * WGlobalScaleInv
+  // Due to the transposed AB convention (CUTLASS N = our M/tokens):
+  //   RowBroadcast (along CUTLASS N) → per-token x_global_scale
+  //   ScalarBroadcastPtrArray → per-group w_global_scale scalar
+  using XGlobalScale = cutlass::epilogue::fusion::Sm90RowBroadcast<
+      0,
+      TileShape,
+      ElementComputeEpilogue*,
+      ElementComputeEpilogue,
+      cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
+
+  using WGlobalScale = cutlass::epilogue::fusion::Sm90ScalarBroadcastPtrArray<
+      ElementComputeEpilogue>;
+
+  using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
+
+  using Compute0 = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies,
+      ElementComputeEpilogue,
+      ElementComputeEpilogue,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute0 =
+      cutlass::epilogue::fusion::Sm90EVT<Compute0, Accum, XGlobalScale>;
+
+  using Compute1 = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies,
+      ElementC,
+      ElementComputeEpilogue,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute1 =
+      cutlass::epilogue::fusion::Sm90EVT<Compute1, EVTCompute0, WGlobalScale>;
+
+  using EpilogueEVT = EVTCompute1;
+
+  // Ultra (Sm103) uses OpClassBlockScaledTensorOp for the epilogue; Sm100
+  // NVFP4 uses OpClassTensorOp (matches f4f4bf16_grouped_common.cuh).
+  using EpilogueOpClass = cute::conditional_t<
+      UseUltra,
+      cutlass::arch::OpClassBlockScaledTensorOp,
+      cutlass::arch::OpClassTensorOp>;
+
+  // On Sm100, Sm90ScalarBroadcastPtrArray (used by WGlobalScale above) needs a
+  // non-void C type so its pointer-array stride layout is set up correctly.
+  // On Sm103 ultra, void C performs better, so keep the original behavior
+  // there. Source C is unused (nullptr passed in arguments, no beta) in both
+  // cases — this only affects internal stride bookkeeping.
+  using EpilogueElementC = cute::conditional_t<UseUltra, void, ElementC>;
+  using EpilogueLayoutC = cute::conditional_t<
+      UseUltra,
+      void,
+      typename cutlass::layout::LayoutTranspose<LayoutC>::type*>;
+  static constexpr int EpilogueAlignmentC = UseUltra ? 0 : AlignmentC;
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          ArchTag,
+          EpilogueOpClass,
+          TileShape,
+          ClusterShape,
+          cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator,
+          ElementAccumulator,
+          EpilogueElementC,
+          EpilogueLayoutC,
+          EpilogueAlignmentC,
+          ElementC,
+          typename cutlass::layout::LayoutTranspose<LayoutC>::type*,
+          AlignmentC,
+          EpilogueSchedule,
+          EpilogueEVT>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          ArchTag,
+          cutlass::arch::OpClassBlockScaledTensorOp,
+          ElementForBuilder,
+          LayoutB_Transpose*,
+          AlignmentB,
+          ElementForBuilder,
+          LayoutA_Transpose*,
+          AlignmentA,
+          ElementAccumulator,
+          TileShape,
+          ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          KernelSchedule>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::
+      GemmUniversal<ProblemShape, CollectiveMainloop, CollectiveEpilogue>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using StrideA = typename Gemm::GemmKernel::InternalStrideA;
+  using StrideB = typename Gemm::GemmKernel::InternalStrideB;
+  using StrideC = typename Gemm::GemmKernel::InternalStrideD;
+
+  using LayoutSFA =
+      typename Gemm::GemmKernel::CollectiveMainloop::InternalLayoutSFA;
+  using LayoutSFB =
+      typename Gemm::GemmKernel::CollectiveMainloop::InternalLayoutSFB;
+  using Sm1xxBlkScaledConfig =
+      typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+
+  // Allocate a single contiguous buffer for all per-group kernel arguments.
+  const int64_t problem_size_offset = 0;
+  int64_t problem_size_buffer =
+      _byte_align(G * sizeof(ProblemShape::UnderlyingProblemShape));
+
+  const int64_t xq_offset = problem_size_offset + problem_size_buffer;
+  int64_t xq_size_buffer = _byte_align(G * sizeof(ElementData**));
+
+  const int64_t wq_offset = xq_offset + xq_size_buffer;
+  int64_t wq_size_buffer = _byte_align(G * sizeof(ElementData**));
+
+  const int64_t x_scale_offset = wq_offset + wq_size_buffer;
+  int64_t x_scale_buffer = _byte_align(G * sizeof(ElementScale**));
+
+  const int64_t w_scale_offset = x_scale_offset + x_scale_buffer;
+  int64_t w_scale_buffer = _byte_align(G * sizeof(ElementScale**));
+
+  const int64_t output_offset = w_scale_offset + w_scale_buffer;
+  int64_t output_buffer = _byte_align(G * sizeof(ElementC**));
+
+  const int64_t stride_a_offset = output_offset + output_buffer;
+  int64_t stride_a_buffer = _byte_align(G * sizeof(StrideA));
+
+  const int64_t stride_b_offset = stride_a_offset + stride_a_buffer;
+  int64_t stride_b_buffer = _byte_align(G * sizeof(StrideB));
+
+  const int64_t stride_c_offset = stride_b_offset + stride_b_buffer;
+  int64_t stride_c_buffer = _byte_align(G * sizeof(StrideC));
+
+  const int64_t layout_SFA_offset = stride_c_offset + stride_c_buffer;
+  int64_t layout_SFA_buffer = _byte_align(G * sizeof(LayoutSFA));
+
+  const int64_t layout_SFB_offset = layout_SFA_offset + layout_SFA_buffer;
+  int64_t layout_SFB_buffer = _byte_align(G * sizeof(LayoutSFB));
+
+  const int64_t x_gs_offset = layout_SFB_offset + layout_SFB_buffer;
+  int64_t x_gs_buffer = _byte_align(G * sizeof(float*));
+
+  const int64_t w_gs_offset = x_gs_offset + x_gs_buffer;
+  int64_t w_gs_buffer = _byte_align(G * sizeof(float*));
+
+  int64_t total_buffer_size = w_gs_offset + w_gs_buffer;
+
+  at::TensorOptions options = XQ.options();
+  at::Tensor kernel_args =
+      at::empty({total_buffer_size}, options.dtype(at::kByte));
+
+  char* kernel_args_ptr = reinterpret_cast<char*>(kernel_args.data_ptr());
+
+  auto* problem_shape_ptr =
+      reinterpret_cast<ProblemShape::UnderlyingProblemShape*>(
+          kernel_args_ptr + problem_size_offset);
+  const ElementData** xq_ptr =
+      reinterpret_cast<const ElementData**>(kernel_args_ptr + xq_offset);
+  const ElementData** wq_ptr =
+      reinterpret_cast<const ElementData**>(kernel_args_ptr + wq_offset);
+  const ElementScale** x_scale_ptr =
+      reinterpret_cast<const ElementScale**>(kernel_args_ptr + x_scale_offset);
+  const ElementScale** w_scale_ptr =
+      reinterpret_cast<const ElementScale**>(kernel_args_ptr + w_scale_offset);
+  ElementC** output_ptr =
+      reinterpret_cast<ElementC**>(kernel_args_ptr + output_offset);
+  StrideA* stride_a_ptr =
+      reinterpret_cast<StrideA*>(kernel_args_ptr + stride_a_offset);
+  StrideB* stride_b_ptr =
+      reinterpret_cast<StrideB*>(kernel_args_ptr + stride_b_offset);
+  StrideC* stride_c_ptr =
+      reinterpret_cast<StrideC*>(kernel_args_ptr + stride_c_offset);
+  LayoutSFA* layout_SFA_ptr =
+      reinterpret_cast<LayoutSFA*>(kernel_args_ptr + layout_SFA_offset);
+  LayoutSFB* layout_SFB_ptr =
+      reinterpret_cast<LayoutSFB*>(kernel_args_ptr + layout_SFB_offset);
+  const float** x_gs_ptr =
+      reinterpret_cast<const float**>(kernel_args_ptr + x_gs_offset);
+  const float** w_gs_ptr =
+      reinterpret_cast<const float**>(kernel_args_ptr + w_gs_offset);
+
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+
+  // WQ is [G, N, K/2] after transpose in the top-level dispatch.
+  const int64_t N = WQ.size(-2);
+  const int64_t K = WQ.size(-1) * 2; // 2 FP4 values packed per byte
+
+  constexpr int kSetupThreads = 256;
+  const int setup_blocks = (G + kSetupThreads - 1) / kSetupThreads;
+  set_ultra_grouped_args_kernel<
+      ProblemShape::UnderlyingProblemShape,
+      StrideA,
+      StrideB,
+      StrideC,
+      LayoutSFA,
+      LayoutSFB,
+      Sm1xxBlkScaledConfig><<<setup_blocks, kSetupThreads, 0, stream>>>(
+      G,
+      N,
+      K,
+      problem_shape_ptr,
+      reinterpret_cast<ElementData*>(XQ.data_ptr()),
+      xq_ptr,
+      reinterpret_cast<ElementData*>(WQ.data_ptr()),
+      wq_ptr,
+      reinterpret_cast<ElementScale*>(x_scale.data_ptr()),
+      x_scale_ptr,
+      reinterpret_cast<ElementScale*>(w_scale.data_ptr()),
+      w_scale_ptr,
+      reinterpret_cast<ElementC*>(output.data_ptr()),
+      output_ptr,
+      stride_a_ptr,
+      stride_b_ptr,
+      stride_c_ptr,
+      reinterpret_cast<int32_t*>(offsets.data_ptr()),
+      layout_SFA_ptr,
+      layout_SFB_ptr,
+      reinterpret_cast<float*>(x_global_scale.data_ptr()),
+      x_gs_ptr,
+      reinterpret_cast<float*>(w_global_scale.data_ptr()),
+      w_gs_ptr);
+
+  cutlass::KernelHardwareInfo hw_info;
+  hw_info.device_id = XQ.get_device();
+  hw_info.sm_count =
+      min(cutlass::KernelHardwareInfo::query_device_multiprocessor_count(
+              hw_info.device_id),
+          2147483647);
+
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGrouped,
+      {int(G), problem_shape_ptr, nullptr},
+      {reinterpret_cast<const ElementData**>(wq_ptr),
+       stride_b_ptr,
+       reinterpret_cast<const ElementData**>(xq_ptr),
+       stride_a_ptr,
+       reinterpret_cast<const ElementScale**>(w_scale_ptr),
+       layout_SFB_ptr,
+       reinterpret_cast<const ElementScale**>(x_scale_ptr),
+       layout_SFA_ptr},
+      {{}, nullptr, stride_c_ptr, output_ptr, stride_c_ptr},
+      hw_info};
+
+  typename Gemm::GemmKernel::TileSchedulerArguments scheduler;
+  scheduler.raster_order =
+      cutlass::gemm::kernel::detail::RasterOrderOptions::AlongM;
+  arguments.scheduler = scheduler;
+
+  // EVT epilogue arguments: Accum / XGlobalScale / WGlobalScale.
+  // Due to AB transpose, x_global_scale (per-token) goes to RowBroadcast and
+  // w_global_scale (per-expert) goes to ScalarBroadcastPtrArray.
+  // ScalarBroadcastPtrArray args: {scalars, scalar_ptrs, scalar_ptr_arrays,
+  // dScalar}
+  arguments.epilogue.thread = {
+      {
+          {}, // Accumulator
+          {x_gs_ptr}, // XGlobalScale (RowBroadcast, per-token)
+          {} // Compute0 (multiplies)
+      },
+      {{}, {}, {w_gs_ptr}}, // WGlobalScale (ScalarBroadcastPtrArray)
+      {} // Compute1 (multiplies)
+  };
+
+  Gemm gemm;
+
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+  at::Tensor workspace = at::empty(workspace_size, options.dtype(at::kByte));
+
+  cutlass::Status status = gemm.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error(
+        std::string("cutlass cannot implement: ") +
+        cutlass::cutlassGetStatusString(status));
+  }
+
+  status = gemm.initialize(
+      arguments, reinterpret_cast<uint8_t*>(workspace.data_ptr()));
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error(
+        std::string("cutlass cannot initialize: ") +
+        cutlass::cutlassGetStatusString(status));
+  }
+
+  status = gemm(at::cuda::getCurrentCUDAStream());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error(
+        std::string("cutlass cannot run: ") +
+        cutlass::cutlassGetStatusString(status));
+  }
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return output;
+}
+
+} // namespace prime_rl_kernels::nvfp4
+
+#endif
+
+#undef CUTLASS_NAMESPACE

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_manifest.cuh
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/f4f4bf16_ultra_grouped_manifest.cuh
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in
+ * ../MSLK_LICENSE.
+ */
+
+#include <ATen/ATen.h>
+
+namespace prime_rl_kernels::nvfp4 {
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
+
+// SM100 (B200) NVFP4 variants. Use TileShape K = 256.
+at::Tensor f4f4bf16_ultra_grouped_256_128_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output);
+
+at::Tensor f4f4bf16_ultra_grouped_256_256_256_2_1_1(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    at::Tensor output);
+
+using Kernel_f4f4bf16_ultra_grouped = at::Tensor (*)(
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor);
+
+const std::unordered_map<std::string, Kernel_f4f4bf16_ultra_grouped>&
+get_f4f4bf16_ultra_grouped_kernels() {
+  static const std::unordered_map<std::string, Kernel_f4f4bf16_ultra_grouped>
+      kernels = {
+          {"f4f4bf16_ultra_grouped_256_128_256_2_1_1",
+           f4f4bf16_ultra_grouped_256_128_256_2_1_1},
+          {"f4f4bf16_ultra_grouped_256_256_256_2_1_1",
+           f4f4bf16_ultra_grouped_256_256_256_2_1_1},
+      };
+  return kernels;
+}
+
+#endif // CUDA >= 12.8
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/nvfp4_grouped.h
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/csrc/nvfp4_grouped.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <ATen/core/Tensor.h>
+
+#include <optional>
+
+namespace prime_rl_kernels::nvfp4 {
+
+at::Tensor f4f4bf16_ultra_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    at::Tensor x_global_scale,
+    at::Tensor w_global_scale,
+    std::optional<at::Tensor> output = std::nullopt);
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/functional.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/grouped_gemm/functional.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+import torch.nn.functional as F
+
+from prime_rl_kernels.nvfp4.grouped_gemm._extension import _grouped_mm as _grouped_mm_kernel
+from prime_rl_kernels.nvfp4.quantize.functional import (
+    _NVFP4Tensor,
+    quantize_activations,
+    quantize_weights,
+)
+
+NVFP4Backward = Literal["dequant_bf16", "bf16"]
+
+
+class _GroupedNVFP4MM(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        matrix: torch.Tensor,
+        weight: torch.Tensor,
+        offsets: torch.Tensor,
+        backward: NVFP4Backward,
+    ) -> torch.Tensor:
+        activations_nvfp4 = quantize_activations(matrix, offsets)
+        weight_nvfp4 = quantize_weights(weight)
+        output = _grouped_mm_kernel(
+            activations_nvfp4.data,
+            weight_nvfp4.data.transpose(-2, -1),
+            activations_nvfp4.block_scales,
+            weight_nvfp4.block_scales,
+            offsets,
+            activations_nvfp4.global_scales,
+            weight_nvfp4.global_scales,
+        )
+        ctx.backward_mode = backward
+        if backward == "bf16":
+            ctx.save_for_backward(matrix, weight, offsets)
+        else:
+            ctx.save_for_backward(
+                activations_nvfp4.data,
+                activations_nvfp4.block_scales,
+                activations_nvfp4.global_scales,
+                weight_nvfp4.data,
+                weight_nvfp4.block_scales,
+                weight_nvfp4.global_scales,
+                offsets,
+            )
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        grad_output = grad_output.contiguous().bfloat16()
+        if ctx.backward_mode == "bf16":
+            matrix, weight, offsets = ctx.saved_tensors
+        else:
+            (
+                matrix_data,
+                matrix_block_scales,
+                matrix_global_scales,
+                weight_data,
+                weight_block_scales,
+                weight_global_scales,
+                offsets,
+            ) = ctx.saved_tensors
+
+        grad_matrix = grad_weight = None
+        if ctx.needs_input_grad[0]:
+            if ctx.backward_mode == "dequant_bf16":
+                weight = _NVFP4Tensor(
+                    weight_data,
+                    weight_block_scales,
+                    weight_global_scales,
+                    None,
+                ).dequantize()
+            grad_matrix = F.grouped_mm(
+                grad_output,
+                weight.transpose(-2, -1),
+                offs=offsets,
+                out_dtype=torch.bfloat16,
+            )
+        if ctx.needs_input_grad[1]:
+            if ctx.backward_mode == "dequant_bf16":
+                matrix = _NVFP4Tensor(
+                    matrix_data,
+                    matrix_block_scales,
+                    matrix_global_scales,
+                    offsets,
+                ).dequantize()
+            grad_weight = F.grouped_mm(
+                matrix.transpose(0, 1),
+                grad_output,
+                offs=offsets,
+                out_dtype=torch.bfloat16,
+            )
+        return grad_matrix, grad_weight, None, None
+
+
+def grouped_gemm(
+    matrix: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    offs: torch.Tensor,
+    backward: NVFP4Backward = "dequant_bf16",
+) -> torch.Tensor:
+    """Grouped NVFP4 forward with the selected BF16 backward operands.
+
+    ``matrix`` has shape ``[M, K]``, ``weight`` has shape ``[G, K, N]``, and
+    ``offs`` contains the cumulative row count for each of the ``G`` groups.
+    ``dequant_bf16`` reconstructs both operands from the packed forward tensors;
+    ``bf16`` retains the original BF16 operands.
+    """
+
+    if backward not in ("dequant_bf16", "bf16"):
+        raise ValueError(f"unsupported NVFP4 backward mode: {backward}")
+    if matrix.ndim != 2 or weight.ndim != 3:
+        raise ValueError("matrix must be 2D and weight must be 3D")
+    if weight.shape[0] != offs.numel():
+        raise ValueError("weight and offsets must have the same number of groups")
+    if matrix.shape[1] != weight.shape[1]:
+        raise ValueError("matrix and weight contraction dimensions must match")
+    if weight.device != matrix.device or weight.dtype != matrix.dtype:
+        raise ValueError("weight must have the same CUDA device and dtype as matrix")
+    return _GroupedNVFP4MM.apply(matrix, weight, offs, backward)

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/__init__.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/__init__.py
@@ -1,0 +1,6 @@
+from prime_rl_kernels.nvfp4.quantize.functional import (
+    quantize_activations,
+    quantize_weights,
+)
+
+__all__ = ["quantize_activations", "quantize_weights"]

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/_extension.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/_extension.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+
+import torch
+
+from prime_rl_kernels.nvfp4._build import load_cuda_extension
+
+_EXTENSION_NAME = "prime_rl_kernels_nvfp4_quantize_sm100"
+_SOURCES = ("bindings.cpp", "quantize.cu")
+_EXTENSION_READY = False
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _quantize_activations_fake(
+    matrix: torch.Tensor,
+    offsets: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    rows, contraction_size = matrix.shape
+    groups = offsets.shape[0]
+    scale_columns = _round_up(contraction_size // 16, 4)
+    padded_scale_rows = _round_up(rows + groups * 127, 128)
+    return (
+        matrix.new_empty((rows, contraction_size // 2), dtype=torch.uint8),
+        matrix.new_empty(
+            (padded_scale_rows, scale_columns),
+            dtype=torch.float8_e4m3fn,
+        ),
+        matrix.new_empty((rows,), dtype=torch.float32),
+    )
+
+
+def _quantize_weights_fake(
+    weight_rows: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    groups, output_size, contraction_size = weight_rows.shape
+    padded_output_size = _round_up(output_size, 128)
+    scale_columns = _round_up(contraction_size // 16, 4)
+    return (
+        weight_rows.new_empty(
+            (groups, output_size, contraction_size // 2),
+            dtype=torch.uint8,
+        ),
+        weight_rows.new_empty(
+            (groups, padded_output_size * scale_columns),
+            dtype=torch.float8_e4m3fn,
+        ),
+        weight_rows.new_empty((groups,), dtype=torch.float32),
+    )
+
+
+def _dequantize_activations_fake(
+    packed: torch.Tensor,
+    block_scales: torch.Tensor,
+    global_scales: torch.Tensor,
+    offsets: torch.Tensor,
+) -> torch.Tensor:
+    del block_scales, global_scales, offsets
+    return packed.new_empty(
+        (packed.shape[0], packed.shape[1] * 2),
+        dtype=torch.bfloat16,
+    )
+
+
+def _dequantize_weights_fake(
+    packed: torch.Tensor,
+    block_scales: torch.Tensor,
+    global_scales: torch.Tensor,
+) -> torch.Tensor:
+    del block_scales, global_scales
+    return packed.new_empty(
+        (packed.shape[0], packed.shape[1], packed.shape[2] * 2),
+        dtype=torch.bfloat16,
+    )
+
+
+@functools.cache
+def _load_extension() -> None:
+    global _EXTENSION_READY
+
+    source_dir = Path(__file__).with_name("csrc")
+    extra_cflags = ["-O3", "-std=c++17"]
+    extra_cuda_cflags = [
+        "-O3",
+        "-std=c++17",
+        "--expt-relaxed-constexpr",
+        "--threads=4",
+        "-gencode=arch=compute_100a,code=sm_100a",
+    ]
+    load_cuda_extension(
+        base_name=_EXTENSION_NAME,
+        sources=[source_dir / source for source in _SOURCES],
+        fingerprint_files=source_dir.glob("*"),
+        extra_cflags=extra_cflags,
+        extra_cuda_cflags=extra_cuda_cflags,
+    )
+    _EXTENSION_READY = True
+
+
+@functools.cache
+def _prepare_extension_for_compile() -> None:
+    _load_extension()
+    torch.library.register_fake(
+        "prime_rl_kernels_nvfp4::quantize_activations",
+        _quantize_activations_fake,
+    )
+    torch.library.register_fake(
+        "prime_rl_kernels_nvfp4::quantize_weights",
+        _quantize_weights_fake,
+    )
+    torch.library.register_fake(
+        "prime_rl_kernels_nvfp4::dequantize_activations",
+        _dequantize_activations_fake,
+    )
+    torch.library.register_fake(
+        "prime_rl_kernels_nvfp4::dequantize_weights",
+        _dequantize_weights_fake,
+    )
+
+
+def _quantize_activations(
+    matrix: torch.Tensor,
+    offsets: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if not _EXTENSION_READY:
+        _load_extension()
+    return torch.ops.prime_rl_kernels_nvfp4.quantize_activations.default(matrix, offsets)
+
+
+def _quantize_weights(
+    weight_rows: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if not _EXTENSION_READY:
+        _load_extension()
+    return torch.ops.prime_rl_kernels_nvfp4.quantize_weights.default(weight_rows)
+
+
+def _dequantize_activations(
+    packed: torch.Tensor,
+    block_scales: torch.Tensor,
+    global_scales: torch.Tensor,
+    offsets: torch.Tensor,
+) -> torch.Tensor:
+    if not _EXTENSION_READY:
+        _load_extension()
+    return torch.ops.prime_rl_kernels_nvfp4.dequantize_activations.default(
+        packed,
+        block_scales,
+        global_scales,
+        offsets,
+    )
+
+
+def _dequantize_weights(
+    packed: torch.Tensor,
+    block_scales: torch.Tensor,
+    global_scales: torch.Tensor,
+) -> torch.Tensor:
+    if not _EXTENSION_READY:
+        _load_extension()
+    return torch.ops.prime_rl_kernels_nvfp4.dequantize_weights.default(
+        packed,
+        block_scales,
+        global_scales,
+    )

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/csrc/bindings.cpp
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/csrc/bindings.cpp
@@ -1,0 +1,49 @@
+#include <ATen/ATen.h>
+#include <torch/library.h>
+
+#include <tuple>
+
+namespace prime_rl_kernels::nvfp4 {
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+quantize_activations_cuda(
+    const at::Tensor& matrix,
+    const at::Tensor& offsets);
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+quantize_weights_cuda(const at::Tensor& weight_rows);
+
+at::Tensor dequantize_activations_cuda(
+    const at::Tensor& packed,
+    const at::Tensor& block_scales,
+    const at::Tensor& global_scales,
+    const at::Tensor& offsets);
+
+at::Tensor dequantize_weights_cuda(
+    const at::Tensor& packed,
+    const at::Tensor& block_scales,
+    const at::Tensor& global_scales);
+
+TORCH_LIBRARY_FRAGMENT(prime_rl_kernels_nvfp4, m) {
+  m.def(
+      "quantize_activations(Tensor matrix, Tensor offsets) -> "
+      "(Tensor, Tensor, Tensor)");
+  m.def(
+      "quantize_weights(Tensor weight_rows) -> "
+      "(Tensor, Tensor, Tensor)");
+  m.def(
+      "dequantize_activations(Tensor packed, Tensor block_scales, "
+      "Tensor global_scales, Tensor offsets) -> Tensor");
+  m.def(
+      "dequantize_weights(Tensor packed, Tensor block_scales, "
+      "Tensor global_scales) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(prime_rl_kernels_nvfp4, CUDA, m) {
+  m.impl("quantize_activations", quantize_activations_cuda);
+  m.impl("quantize_weights", quantize_weights_cuda);
+  m.impl("dequantize_activations", dequantize_activations_cuda);
+  m.impl("dequantize_weights", dequantize_weights_cuda);
+}
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/csrc/quantize.cu
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/csrc/quantize.cu
@@ -1,0 +1,967 @@
+/*
+ * Portions of the Blackwell BF16-to-E2M1 conversion sequence are adapted
+ * from NVIDIA Transformer Engine, Copyright NVIDIA Corporation & affiliates,
+ * under the Apache License 2.0.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+
+#include <cuda_bf16.h>
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <tuple>
+
+namespace prime_rl_kernels::nvfp4 {
+namespace {
+
+constexpr int kSfVectorSize = 16;
+constexpr int kScaleRowTile = 128;
+constexpr int kScaleColTile = 4;
+constexpr int kQuantThreads = 256;
+constexpr int kQuantScaleColsPerCta = 64;
+constexpr int kQuantScaleTilesPerCta =
+    kQuantScaleColsPerCta / kScaleColTile;
+constexpr int kQuantScaleTileElements =
+    kScaleRowTile * kQuantScaleColsPerCta;
+constexpr int kQuantItemsPerThread =
+    kQuantScaleTileElements / kQuantThreads;
+constexpr int kDequantScaleColsPerCta = 32;
+constexpr int kDequantScaleTilesPerCta =
+    kDequantScaleColsPerCta / kScaleColTile;
+constexpr int kDequantScaleTileElements =
+    kScaleRowTile * kDequantScaleColsPerCta;
+constexpr int kDequantItemsPerThread =
+    kDequantScaleTileElements / kQuantThreads;
+constexpr int kReductionThreads = 256;
+constexpr float kGlobalScaleDenominator = 6.0f * 448.0f;
+
+__host__ __device__ __forceinline__ int64_t round_up(
+    int64_t value,
+    int64_t multiple) {
+  return ((value + multiple - 1) / multiple) * multiple;
+}
+
+void check_sm100() {
+  const auto* properties =
+      at::cuda::getDeviceProperties(at::cuda::current_device());
+  TORCH_CHECK(
+      properties->major == 10 && properties->minor == 0,
+      "prime-rl-kernels NVFP4 quantization requires SM100, but the current "
+      "device is SM",
+      properties->major,
+      properties->minor,
+      ".");
+}
+
+void check_bf16_matrix(const at::Tensor& tensor, const char* name) {
+  TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor.");
+  TORCH_CHECK(tensor.scalar_type() == at::kBFloat16, name, " must be BF16.");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous.");
+}
+
+void check_quantized_tensors(
+    const at::Tensor& packed,
+    const at::Tensor& block_scales,
+    const at::Tensor& global_scales) {
+  TORCH_CHECK(packed.is_cuda(), "packed must be a CUDA tensor.");
+  TORCH_CHECK(packed.scalar_type() == at::kByte, "packed must use byte storage.");
+  TORCH_CHECK(packed.is_contiguous(), "packed must be contiguous.");
+  TORCH_CHECK(
+      block_scales.device() == packed.device() &&
+          global_scales.device() == packed.device(),
+      "quantized tensors must be on the same CUDA device.");
+  TORCH_CHECK(
+      block_scales.scalar_type() == at::kFloat8_e4m3fn,
+      "block_scales must be FP8 E4M3.");
+  TORCH_CHECK(
+      global_scales.scalar_type() == at::kFloat,
+      "global_scales must be FP32.");
+  TORCH_CHECK(
+      block_scales.is_contiguous() && global_scales.is_contiguous(),
+      "quantized tensors must be contiguous.");
+}
+
+struct alignas(16) Bf16Block {
+  uint4 vectors[2];
+};
+
+union FP4Block {
+  uint64_t packed;
+  __nv_fp4x4_e2m1 values[4];
+};
+
+__device__ __forceinline__ Bf16Block load_bf16_block(
+    const __nv_bfloat16* input) {
+  Bf16Block block;
+  const auto* vectors = reinterpret_cast<const uint4*>(input);
+  block.vectors[0] = __ldcg(vectors);
+  block.vectors[1] = __ldcg(vectors + 1);
+  return block;
+}
+
+__device__ __forceinline__ float block_amax(const Bf16Block& block) {
+  const auto* pairs = reinterpret_cast<const uint32_t*>(block.vectors);
+  uint32_t maximum = 0;
+#pragma unroll
+  for (int index = 0; index < 8; ++index) {
+    asm volatile(
+        "max.xorsign.abs.bf16x2 %0, %1, %2;"
+        : "=r"(maximum)
+        : "r"(maximum), "r"(pairs[index]));
+  }
+  const float2 values =
+      __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162*>(&maximum));
+  return fmaxf(fabsf(values.x), fabsf(values.y));
+}
+
+__device__ __forceinline__ float warp_max(float value) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value = fmaxf(value, __shfl_down_sync(0xffffffffu, value, offset));
+  }
+  return value;
+}
+
+__device__ __forceinline__ float block_max(
+    float value,
+    float* warp_maxima) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  value = warp_max(value);
+  if (lane == 0) {
+    warp_maxima[warp] = value;
+  }
+  __syncthreads();
+  if (warp == 0) {
+    value = lane < (blockDim.x >> 5) ? warp_maxima[lane] : 0.0f;
+    value = warp_max(value);
+  }
+  return __shfl_sync(0xffffffffu, value, 0);
+}
+
+// Adapted from Transformer Engine's Blackwell BF16-to-E2M1 conversion. Keeping
+// the coefficient in FP32 avoids an extra recipe-changing BF16 rounding.
+__device__ __forceinline__ uint32_t pack_e2m1_8(
+    uint64_t values_03,
+    uint64_t values_47,
+    float coefficient) {
+  uint32_t output;
+  asm volatile(
+      "{\n"
+      ".reg.b64 coefficient_2x;\n\t"
+      "mov.b64 coefficient_2x, {%3, %3};\n\t"
+      ".reg.b16 h0, h1, h2, h3, h4, h5, h6, h7;\n\t"
+      "mov.b64 {h0, h1, h2, h3}, %1;\n\t"
+      "mov.b64 {h4, h5, h6, h7}, %2;\n\t"
+      ".reg.b32 v0, v1, v2, v3, v4, v5, v6, v7;\n\t"
+      "cvt.f32.bf16 v0, h0;\n\t"
+      "cvt.f32.bf16 v1, h1;\n\t"
+      "cvt.f32.bf16 v2, h2;\n\t"
+      "cvt.f32.bf16 v3, h3;\n\t"
+      "cvt.f32.bf16 v4, h4;\n\t"
+      "cvt.f32.bf16 v5, h5;\n\t"
+      "cvt.f32.bf16 v6, h6;\n\t"
+      "cvt.f32.bf16 v7, h7;\n\t"
+      ".reg.b64 v01, v23, v45, v67;\n\t"
+      "mov.b64 v01, {v0, v1};\n\t"
+      "mov.b64 v23, {v2, v3};\n\t"
+      "mov.b64 v45, {v4, v5};\n\t"
+      "mov.b64 v67, {v6, v7};\n\t"
+      "mul.f32x2 v01, v01, coefficient_2x;\n\t"
+      "mul.f32x2 v23, v23, coefficient_2x;\n\t"
+      "mul.f32x2 v45, v45, coefficient_2x;\n\t"
+      "mul.f32x2 v67, v67, coefficient_2x;\n\t"
+      "mov.b64 {v1, v0}, v01;\n\t"
+      "mov.b64 {v3, v2}, v23;\n\t"
+      "mov.b64 {v5, v4}, v45;\n\t"
+      "mov.b64 {v7, v6}, v67;\n\t"
+      ".reg.b8 f0, f1, f2, f3;\n\t"
+      "cvt.rn.satfinite.e2m1x2.f32 f0, v0, v1;\n\t"
+      "cvt.rn.satfinite.e2m1x2.f32 f1, v2, v3;\n\t"
+      "cvt.rn.satfinite.e2m1x2.f32 f2, v4, v5;\n\t"
+      "cvt.rn.satfinite.e2m1x2.f32 f3, v6, v7;\n\t"
+      "mov.b32 %0, {f0, f1, f2, f3};\n\t"
+      "}"
+      : "=r"(output)
+      : "l"(values_03), "l"(values_47), "f"(coefficient));
+  return output;
+}
+
+__device__ __forceinline__ uint64_t pack_e2m1(
+    const Bf16Block& block,
+    float coefficient) {
+  const auto* words = reinterpret_cast<const uint64_t*>(block.vectors);
+  const uint32_t low = pack_e2m1_8(words[0], words[1], coefficient);
+  const uint32_t high = pack_e2m1_8(words[2], words[3], coefficient);
+  return static_cast<uint64_t>(low) |
+      (static_cast<uint64_t>(high) << 32);
+}
+
+__device__ __forceinline__ Bf16Block dequantize_e2m1(
+    uint64_t packed,
+    float decode_scale) {
+  FP4Block input;
+  input.packed = packed;
+  Bf16Block output;
+  auto* output_pairs = reinterpret_cast<__nv_bfloat162*>(output.vectors);
+#pragma unroll
+  for (int index = 0; index < 4; ++index) {
+    const float4 values = static_cast<float4>(input.values[index]);
+    output_pairs[index * 2] = __floats2bfloat162_rn(
+        values.x * decode_scale,
+        values.y * decode_scale);
+    output_pairs[index * 2 + 1] = __floats2bfloat162_rn(
+        values.z * decode_scale,
+        values.w * decode_scale);
+  }
+  return output;
+}
+
+__device__ __forceinline__ float reciprocal_approximate(float value) {
+  float result;
+  asm volatile("rcp.approx.ftz.f32 %0, %1;" : "=f"(result) : "f"(value));
+  return result;
+}
+
+template <int kScaleCols>
+__device__ __forceinline__ int local_scale_offset(
+    int row_in_tile,
+    int scale_column_in_cta) {
+  return (scale_column_in_cta >> 2) * (kScaleRowTile * kScaleColTile) +
+      ((row_in_tile & 31) << 4) |
+      (((row_in_tile >> 5) & 3) << 2) |
+      (scale_column_in_cta & 3);
+}
+
+__device__ __forceinline__ uint8_t quantize_block(
+    const Bf16Block& input,
+    float global_decode_scale,
+    uint64_t* packed) {
+  const float local_amax = block_amax(input);
+  float scale_value = 0.0f;
+  if (global_decode_scale > 0.0f && local_amax > 0.0f) {
+    scale_value =
+        local_amax * reciprocal_approximate(6.0f * global_decode_scale);
+  }
+  const __nv_fp8_e4m3 fp8_scale(scale_value);
+  const float decode_scale =
+      static_cast<float>(fp8_scale) * global_decode_scale;
+  const float coefficient =
+      decode_scale > 0.0f ? reciprocal_approximate(decode_scale) : 0.0f;
+  *packed = pack_e2m1(input, coefficient);
+  return fp8_scale.__x;
+}
+
+__device__ __forceinline__ bool activation_tile_metadata(
+    int tile,
+    const int32_t* offsets,
+    int group_count,
+    int* global_row_start,
+    int* valid_rows) {
+  int group_start = 0;
+  int tile_start = 0;
+  for (int group = 0; group < group_count; ++group) {
+    const int group_end = offsets[group];
+    const int group_rows = group_end - group_start;
+    const int group_tiles =
+        (group_rows + kScaleRowTile - 1) / kScaleRowTile;
+    if (tile < tile_start + group_tiles) {
+      const int tile_in_group = tile - tile_start;
+      *global_row_start =
+          group_start + tile_in_group * kScaleRowTile;
+      *valid_rows = min(
+          kScaleRowTile,
+          group_end - *global_row_start);
+      return true;
+    }
+    group_start = group_end;
+    tile_start += group_tiles;
+  }
+  return false;
+}
+
+__global__ void activation_amax_kernel(
+    const __nv_bfloat16* __restrict__ input,
+    float* __restrict__ global_scales,
+    int rows,
+    int contraction_size) {
+  __shared__ float warp_maxima[kReductionThreads / 32];
+  const int scale_columns = contraction_size / kSfVectorSize;
+  for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+    float local_amax = 0.0f;
+    for (int scale_column = threadIdx.x;
+         scale_column < scale_columns;
+         scale_column += blockDim.x) {
+      const int64_t input_offset =
+          static_cast<int64_t>(row) * contraction_size +
+          scale_column * kSfVectorSize;
+      local_amax = fmaxf(
+          local_amax,
+          block_amax(load_bf16_block(input + input_offset)));
+    }
+    const float maximum = block_max(local_amax, warp_maxima);
+    if (threadIdx.x == 0) {
+      global_scales[row] =
+          maximum > 0.0f ? maximum / kGlobalScaleDenominator : 0.0f;
+    }
+    __syncthreads();
+  }
+}
+
+__global__ void weight_amax_kernel(
+    const __nv_bfloat16* __restrict__ input,
+    float* __restrict__ expert_amax,
+    int64_t elements_per_expert,
+    int blocks_per_expert) {
+  __shared__ float warp_maxima[kReductionThreads / 32];
+  const int expert = blockIdx.x / blocks_per_expert;
+  const int expert_block = blockIdx.x % blocks_per_expert;
+  const int64_t scale_blocks = elements_per_expert / kSfVectorSize;
+  float local_amax = 0.0f;
+  for (int64_t scale_block =
+           static_cast<int64_t>(expert_block) * blockDim.x + threadIdx.x;
+       scale_block < scale_blocks;
+       scale_block += static_cast<int64_t>(blocks_per_expert) * blockDim.x) {
+    const int64_t input_offset =
+        static_cast<int64_t>(expert) * elements_per_expert +
+        scale_block * kSfVectorSize;
+    local_amax = fmaxf(
+        local_amax,
+        block_amax(load_bf16_block(input + input_offset)));
+  }
+  const float maximum = block_max(local_amax, warp_maxima);
+  if (threadIdx.x == 0) {
+    atomicMax(
+        reinterpret_cast<unsigned int*>(expert_amax + expert),
+        __float_as_uint(maximum));
+  }
+}
+
+__global__ void finalize_weight_scales_kernel(
+    const float* __restrict__ expert_amax,
+    float* __restrict__ global_scales,
+    int groups) {
+  const int expert = blockIdx.x * blockDim.x + threadIdx.x;
+  if (expert < groups) {
+    const float maximum = expert_amax[expert];
+    global_scales[expert] =
+        maximum > 0.0f ? maximum / kGlobalScaleDenominator : 0.0f;
+  }
+}
+
+__global__ void quantize_activations_tiled_kernel(
+    const __nv_bfloat16* __restrict__ input,
+    const int32_t* __restrict__ offsets,
+    uint8_t* __restrict__ packed,
+    uint8_t* __restrict__ block_scales,
+    const float* __restrict__ global_scales,
+    int contraction_size,
+    int group_count,
+    int scale_column_tiles) {
+  __shared__ alignas(16) uint8_t scale_tile[kQuantScaleTileElements];
+  __shared__ int global_row_start;
+  __shared__ int valid_rows;
+  __shared__ int active;
+
+  if (threadIdx.x == 0) {
+    active = activation_tile_metadata(
+        blockIdx.x,
+        offsets,
+        group_count,
+        &global_row_start,
+        &valid_rows);
+  }
+  __syncthreads();
+  if (!active) {
+    return;
+  }
+
+#pragma unroll
+  for (int item = 0; item < kQuantItemsPerThread; ++item) {
+    const int tile_index = threadIdx.x + item * kQuantThreads;
+    const int row_in_tile = tile_index / kQuantScaleColsPerCta;
+    const int column_in_tile = tile_index % kQuantScaleColsPerCta;
+    const int scale_column =
+        blockIdx.y * kQuantScaleColsPerCta + column_in_tile;
+    uint8_t scale = 0;
+    if (row_in_tile < valid_rows &&
+        scale_column < contraction_size / kSfVectorSize) {
+      const int row = global_row_start + row_in_tile;
+      const int64_t input_offset =
+          static_cast<int64_t>(row) * contraction_size +
+          scale_column * kSfVectorSize;
+      uint64_t packed_value;
+      scale = quantize_block(
+          load_bf16_block(input + input_offset),
+          global_scales[row],
+          &packed_value);
+      const int64_t packed_offset =
+          static_cast<int64_t>(row) * (contraction_size / 2) +
+          scale_column * 8;
+      *reinterpret_cast<uint64_t*>(packed + packed_offset) =
+          packed_value;
+    }
+    scale_tile[local_scale_offset<kQuantScaleColsPerCta>(
+        row_in_tile,
+        column_in_tile)] =
+        scale;
+  }
+  __syncthreads();
+
+  const int first_scale_tile =
+      blockIdx.y * kQuantScaleTilesPerCta;
+  const int valid_scale_tiles =
+      min(
+          kQuantScaleTilesPerCta,
+          scale_column_tiles - first_scale_tile);
+  const int scale_vectors =
+      valid_scale_tiles * kScaleRowTile * kScaleColTile /
+      static_cast<int>(sizeof(uint4));
+  for (int vector = threadIdx.x;
+       vector < scale_vectors;
+       vector += blockDim.x) {
+    const int64_t tile_offset =
+        (static_cast<int64_t>(blockIdx.x) * scale_column_tiles +
+         first_scale_tile) *
+        (kScaleRowTile * kScaleColTile);
+    reinterpret_cast<uint4*>(block_scales + tile_offset)[vector] =
+        reinterpret_cast<const uint4*>(scale_tile)[vector];
+  }
+}
+
+__global__ void quantize_weights_tiled_kernel(
+    const __nv_bfloat16* __restrict__ input,
+    const float* __restrict__ global_scales,
+    uint8_t* __restrict__ packed,
+    uint8_t* __restrict__ block_scales,
+    int output_size,
+    int contraction_size,
+    int output_row_tiles,
+    int scale_column_tiles) {
+  __shared__ alignas(16) uint8_t scale_tile[kQuantScaleTileElements];
+  const int expert = blockIdx.x / output_row_tiles;
+  const int output_tile = blockIdx.x % output_row_tiles;
+  const int output_row_start = output_tile * kScaleRowTile;
+
+#pragma unroll
+  for (int item = 0; item < kQuantItemsPerThread; ++item) {
+    const int tile_index = threadIdx.x + item * kQuantThreads;
+    const int row_in_tile = tile_index / kQuantScaleColsPerCta;
+    const int column_in_tile = tile_index % kQuantScaleColsPerCta;
+    const int output_row = output_row_start + row_in_tile;
+    const int scale_column =
+        blockIdx.y * kQuantScaleColsPerCta + column_in_tile;
+    uint8_t scale = 0;
+    if (output_row < output_size &&
+        scale_column < contraction_size / kSfVectorSize) {
+      const int64_t row =
+          static_cast<int64_t>(expert) * output_size + output_row;
+      const int64_t input_offset =
+          row * contraction_size + scale_column * kSfVectorSize;
+      uint64_t packed_value;
+      scale = quantize_block(
+          load_bf16_block(input + input_offset),
+          global_scales[expert],
+          &packed_value);
+      const int64_t packed_offset =
+          row * (contraction_size / 2) + scale_column * 8;
+      *reinterpret_cast<uint64_t*>(packed + packed_offset) =
+          packed_value;
+    }
+    scale_tile[local_scale_offset<kQuantScaleColsPerCta>(
+        row_in_tile,
+        column_in_tile)] =
+        scale;
+  }
+  __syncthreads();
+
+  const int first_scale_tile =
+      blockIdx.y * kQuantScaleTilesPerCta;
+  const int valid_scale_tiles =
+      min(
+          kQuantScaleTilesPerCta,
+          scale_column_tiles - first_scale_tile);
+  const int scale_vectors =
+      valid_scale_tiles * kScaleRowTile * kScaleColTile /
+      static_cast<int>(sizeof(uint4));
+  for (int vector = threadIdx.x;
+       vector < scale_vectors;
+       vector += blockDim.x) {
+    const int64_t tile_offset =
+        (static_cast<int64_t>(blockIdx.x) * scale_column_tiles +
+         first_scale_tile) *
+        (kScaleRowTile * kScaleColTile);
+    reinterpret_cast<uint4*>(block_scales + tile_offset)[vector] =
+        reinterpret_cast<const uint4*>(scale_tile)[vector];
+  }
+}
+
+__global__ void dequantize_activations_tiled_kernel(
+    const uint8_t* __restrict__ packed,
+    const uint8_t* __restrict__ block_scales,
+    const float* __restrict__ global_scales,
+    const int32_t* __restrict__ offsets,
+    __nv_bfloat16* __restrict__ output,
+    int contraction_size,
+    int group_count,
+    int scale_column_tiles) {
+  __shared__ alignas(16) uint8_t scale_tile[kDequantScaleTileElements];
+  __shared__ int global_row_start;
+  __shared__ int valid_rows;
+  __shared__ int active;
+
+  if (threadIdx.x == 0) {
+    active = activation_tile_metadata(
+        blockIdx.x,
+        offsets,
+        group_count,
+        &global_row_start,
+        &valid_rows);
+  }
+  const int first_scale_tile =
+      blockIdx.y * kDequantScaleTilesPerCta;
+  const int valid_scale_tiles =
+      min(
+          kDequantScaleTilesPerCta,
+          scale_column_tiles - first_scale_tile);
+  if (threadIdx.x <
+      valid_scale_tiles * kScaleRowTile * kScaleColTile /
+          static_cast<int>(sizeof(uint4))) {
+    const int64_t tile_offset =
+        (static_cast<int64_t>(blockIdx.x) * scale_column_tiles +
+         first_scale_tile) *
+        (kScaleRowTile * kScaleColTile);
+    reinterpret_cast<uint4*>(scale_tile)[threadIdx.x] =
+        reinterpret_cast<const uint4*>(
+            block_scales + tile_offset)[threadIdx.x];
+  }
+  __syncthreads();
+  if (!active) {
+    return;
+  }
+
+#pragma unroll
+  for (int item = 0; item < kDequantItemsPerThread; ++item) {
+    const int tile_index = threadIdx.x + item * kQuantThreads;
+    const int row_in_tile = tile_index / kDequantScaleColsPerCta;
+    const int column_in_tile = tile_index % kDequantScaleColsPerCta;
+    const int scale_column =
+        blockIdx.y * kDequantScaleColsPerCta + column_in_tile;
+    if (row_in_tile < valid_rows &&
+        scale_column < contraction_size / kSfVectorSize) {
+      const int row = global_row_start + row_in_tile;
+      const int64_t packed_offset =
+          static_cast<int64_t>(row) * (contraction_size / 2) +
+          scale_column * 8;
+      const uint64_t packed_value =
+          *reinterpret_cast<const uint64_t*>(packed + packed_offset);
+      const uint8_t scale_bits =
+          scale_tile[local_scale_offset<kDequantScaleColsPerCta>(
+              row_in_tile,
+              column_in_tile)];
+      __nv_fp8_e4m3 scale;
+      scale.__x = scale_bits;
+      const float decode_scale =
+          static_cast<float>(scale) * global_scales[row];
+      const Bf16Block values =
+          dequantize_e2m1(packed_value, decode_scale);
+      const int64_t output_offset =
+          static_cast<int64_t>(row) * contraction_size +
+          scale_column * kSfVectorSize;
+      auto* output_vectors =
+          reinterpret_cast<uint4*>(output + output_offset);
+      output_vectors[0] = values.vectors[0];
+      output_vectors[1] = values.vectors[1];
+    }
+  }
+}
+
+__global__ void dequantize_weights_tiled_kernel(
+    const uint8_t* __restrict__ packed,
+    const uint8_t* __restrict__ block_scales,
+    const float* __restrict__ global_scales,
+    __nv_bfloat16* __restrict__ output,
+    int output_size,
+    int contraction_size,
+    int output_row_tiles,
+    int scale_column_tiles) {
+  __shared__ alignas(16) uint8_t scale_tile[kDequantScaleTileElements];
+  const int expert = blockIdx.x / output_row_tiles;
+  const int output_tile = blockIdx.x % output_row_tiles;
+  const int output_row_start = output_tile * kScaleRowTile;
+
+  const int first_scale_tile =
+      blockIdx.y * kDequantScaleTilesPerCta;
+  const int valid_scale_tiles =
+      min(
+          kDequantScaleTilesPerCta,
+          scale_column_tiles - first_scale_tile);
+  if (threadIdx.x <
+      valid_scale_tiles * kScaleRowTile * kScaleColTile /
+          static_cast<int>(sizeof(uint4))) {
+    const int64_t tile_offset =
+        (static_cast<int64_t>(blockIdx.x) * scale_column_tiles +
+         first_scale_tile) *
+        (kScaleRowTile * kScaleColTile);
+    reinterpret_cast<uint4*>(scale_tile)[threadIdx.x] =
+        reinterpret_cast<const uint4*>(
+            block_scales + tile_offset)[threadIdx.x];
+  }
+  __syncthreads();
+
+#pragma unroll
+  for (int item = 0; item < kDequantItemsPerThread; ++item) {
+    const int tile_index = threadIdx.x + item * kQuantThreads;
+    const int row_in_tile = tile_index / kDequantScaleColsPerCta;
+    const int column_in_tile = tile_index % kDequantScaleColsPerCta;
+    const int output_row = output_row_start + row_in_tile;
+    const int scale_column =
+        blockIdx.y * kDequantScaleColsPerCta + column_in_tile;
+    if (output_row < output_size &&
+        scale_column < contraction_size / kSfVectorSize) {
+      const int64_t row =
+          static_cast<int64_t>(expert) * output_size + output_row;
+      const int64_t packed_offset =
+          row * (contraction_size / 2) + scale_column * 8;
+      const uint64_t packed_value =
+          *reinterpret_cast<const uint64_t*>(packed + packed_offset);
+      const uint8_t scale_bits =
+          scale_tile[local_scale_offset<kDequantScaleColsPerCta>(
+              row_in_tile,
+              column_in_tile)];
+      __nv_fp8_e4m3 scale;
+      scale.__x = scale_bits;
+      const float decode_scale =
+          static_cast<float>(scale) * global_scales[expert];
+      const Bf16Block values =
+          dequantize_e2m1(packed_value, decode_scale);
+      const int64_t output_offset =
+          row * contraction_size + scale_column * kSfVectorSize;
+      auto* output_vectors =
+          reinterpret_cast<uint4*>(output + output_offset);
+      output_vectors[0] = values.vectors[0];
+      output_vectors[1] = values.vectors[1];
+    }
+  }
+}
+
+int weight_amax_blocks_per_expert(
+    int device,
+    int groups,
+    int64_t scale_blocks_per_expert) {
+  const auto* properties = at::cuda::getDeviceProperties(device);
+  const int target = std::max(
+      1,
+      (properties->multiProcessorCount * 4 + groups - 1) / groups);
+  const int available = std::max<int64_t>(
+      1,
+      (scale_blocks_per_expert + kReductionThreads - 1) /
+          kReductionThreads);
+  return std::min(256, std::min(target, available));
+}
+
+int activation_amax_threads(int contraction_size) {
+  const int scale_columns = contraction_size / kSfVectorSize;
+  return std::min(
+      kReductionThreads,
+      std::max(32, static_cast<int>(round_up(scale_columns, 32))));
+}
+
+int activation_amax_blocks(
+    int device,
+    int rows,
+    int threads,
+    int contraction_size) {
+  if (contraction_size >= 2688) {
+    return rows;
+  }
+  const auto* properties = at::cuda::getDeviceProperties(device);
+  const int blocks_per_sm = std::max(1, 1024 / threads);
+  return std::min(rows, properties->multiProcessorCount * blocks_per_sm);
+}
+
+} // namespace
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+quantize_activations_cuda(
+    const at::Tensor& matrix,
+    const at::Tensor& offsets) {
+  check_bf16_matrix(matrix, "matrix");
+  TORCH_CHECK(matrix.dim() == 2, "matrix must be 2D.");
+  TORCH_CHECK(
+      matrix.size(1) > 0 && matrix.size(1) % 32 == 0,
+      "matrix's contraction dimension must be a positive multiple of 32.");
+  TORCH_CHECK(offsets.is_cuda(), "offsets must be a CUDA tensor.");
+  TORCH_CHECK(offsets.scalar_type() == at::kInt, "offsets must be int32.");
+  TORCH_CHECK(
+      offsets.dim() == 1 && offsets.numel() > 0,
+      "offsets must be a non-empty 1D tensor.");
+  TORCH_CHECK(offsets.is_contiguous(), "offsets must be contiguous.");
+  TORCH_CHECK(
+      offsets.device() == matrix.device(),
+      "matrix and offsets must be on the same device.");
+
+  c10::cuda::CUDAGuard device_guard(matrix.device());
+  check_sm100();
+
+  const int64_t rows = matrix.size(0);
+  const int64_t contraction_size = matrix.size(1);
+  const int64_t group_count = offsets.numel();
+  const int64_t scale_columns =
+      round_up(contraction_size / kSfVectorSize, kScaleColTile);
+  const int64_t scale_column_tiles =
+      scale_columns / kScaleColTile;
+  const int64_t scale_column_ctas =
+      round_up(scale_column_tiles, kQuantScaleTilesPerCta) /
+      kQuantScaleTilesPerCta;
+  const int64_t padded_scale_rows =
+      round_up(rows + group_count * (kScaleRowTile - 1), kScaleRowTile);
+  const int64_t scale_row_tiles =
+      padded_scale_rows / kScaleRowTile;
+
+  auto packed = at::empty(
+      {rows, contraction_size / 2},
+      matrix.options().dtype(at::kByte));
+  auto block_scales = at::empty(
+      {padded_scale_rows, scale_columns},
+      matrix.options().dtype(at::kFloat8_e4m3fn));
+  auto global_scales =
+      at::empty({rows}, matrix.options().dtype(at::kFloat));
+
+  if (rows > 0) {
+    const int device = matrix.get_device();
+    const cudaStream_t stream =
+        at::cuda::getCurrentCUDAStream(device);
+    const int amax_threads =
+        activation_amax_threads(contraction_size);
+    const int amax_blocks =
+        activation_amax_blocks(
+            device,
+            rows,
+            amax_threads,
+            contraction_size);
+    activation_amax_kernel<<<amax_blocks, amax_threads, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(matrix.data_ptr()),
+        global_scales.mutable_data_ptr<float>(),
+        rows,
+        contraction_size);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    const dim3 grid(scale_row_tiles, scale_column_ctas);
+    quantize_activations_tiled_kernel
+        <<<grid, kQuantThreads, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(matrix.data_ptr()),
+            offsets.const_data_ptr<int32_t>(),
+            packed.mutable_data_ptr<uint8_t>(),
+            reinterpret_cast<uint8_t*>(block_scales.mutable_data_ptr()),
+            global_scales.const_data_ptr<float>(),
+            contraction_size,
+            group_count,
+            scale_column_tiles);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+  return {packed, block_scales, global_scales};
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+quantize_weights_cuda(const at::Tensor& weight_rows) {
+  check_bf16_matrix(weight_rows, "weight_rows");
+  TORCH_CHECK(weight_rows.dim() == 3, "weight_rows must be 3D.");
+  TORCH_CHECK(weight_rows.size(0) > 0, "weight_rows must contain an expert.");
+  TORCH_CHECK(
+      weight_rows.size(2) > 0 && weight_rows.size(2) % 32 == 0,
+      "weight_rows' contraction dimension must be a positive multiple of 32.");
+
+  c10::cuda::CUDAGuard device_guard(weight_rows.device());
+  check_sm100();
+
+  const int64_t groups = weight_rows.size(0);
+  const int64_t output_size = weight_rows.size(1);
+  const int64_t contraction_size = weight_rows.size(2);
+  const int64_t padded_output_size =
+      round_up(output_size, kScaleRowTile);
+  const int64_t output_row_tiles =
+      padded_output_size / kScaleRowTile;
+  const int64_t scale_columns =
+      round_up(contraction_size / kSfVectorSize, kScaleColTile);
+  const int64_t scale_column_tiles =
+      scale_columns / kScaleColTile;
+  const int64_t scale_column_ctas =
+      round_up(scale_column_tiles, kQuantScaleTilesPerCta) /
+      kQuantScaleTilesPerCta;
+
+  auto packed = at::empty(
+      {groups, output_size, contraction_size / 2},
+      weight_rows.options().dtype(at::kByte));
+  auto block_scales = at::empty(
+      {groups, padded_output_size * scale_columns},
+      weight_rows.options().dtype(at::kFloat8_e4m3fn));
+  auto global_scales =
+      at::empty({groups}, weight_rows.options().dtype(at::kFloat));
+
+  if (output_size > 0) {
+    const int device = weight_rows.get_device();
+    const int64_t scale_blocks_per_expert =
+        output_size * contraction_size / kSfVectorSize;
+    const int blocks_per_expert = weight_amax_blocks_per_expert(
+        device,
+        groups,
+        scale_blocks_per_expert);
+    auto expert_amax =
+        at::zeros({groups}, weight_rows.options().dtype(at::kFloat));
+    const cudaStream_t stream =
+        at::cuda::getCurrentCUDAStream(device);
+    weight_amax_kernel
+        <<<groups * blocks_per_expert, kReductionThreads, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(
+                weight_rows.data_ptr()),
+            expert_amax.mutable_data_ptr<float>(),
+            output_size * contraction_size,
+            blocks_per_expert);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    finalize_weight_scales_kernel<<<1, 256, 0, stream>>>(
+        expert_amax.const_data_ptr<float>(),
+        global_scales.mutable_data_ptr<float>(),
+        groups);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    const dim3 grid(
+        groups * output_row_tiles,
+        scale_column_ctas);
+    quantize_weights_tiled_kernel
+        <<<grid, kQuantThreads, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(
+                weight_rows.data_ptr()),
+            global_scales.const_data_ptr<float>(),
+            packed.mutable_data_ptr<uint8_t>(),
+            reinterpret_cast<uint8_t*>(block_scales.mutable_data_ptr()),
+            output_size,
+            contraction_size,
+            output_row_tiles,
+            scale_column_tiles);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+  return {packed, block_scales, global_scales};
+}
+
+at::Tensor dequantize_activations_cuda(
+    const at::Tensor& packed,
+    const at::Tensor& block_scales,
+    const at::Tensor& global_scales,
+    const at::Tensor& offsets) {
+  check_quantized_tensors(packed, block_scales, global_scales);
+  TORCH_CHECK(packed.dim() == 2, "packed activations must be 2D.");
+  TORCH_CHECK(
+      global_scales.dim() == 1 &&
+          global_scales.size(0) == packed.size(0),
+      "activation global_scales must contain one value per row.");
+  TORCH_CHECK(
+      offsets.is_cuda() && offsets.scalar_type() == at::kInt &&
+          offsets.dim() == 1 && offsets.numel() > 0 &&
+          offsets.is_contiguous() && offsets.device() == packed.device(),
+      "offsets must be a non-empty contiguous CUDA int32 tensor on the "
+      "same device.");
+
+  c10::cuda::CUDAGuard device_guard(packed.device());
+  check_sm100();
+
+  const int64_t rows = packed.size(0);
+  const int64_t contraction_size = packed.size(1) * 2;
+  const int64_t scale_columns =
+      round_up(contraction_size / kSfVectorSize, kScaleColTile);
+  const int64_t scale_column_tiles =
+      scale_columns / kScaleColTile;
+  const int64_t scale_column_ctas =
+      round_up(scale_column_tiles, kDequantScaleTilesPerCta) /
+      kDequantScaleTilesPerCta;
+  TORCH_CHECK(
+      block_scales.numel() % (scale_columns * kScaleRowTile) == 0,
+      "activation block_scales have an invalid swizzled shape.");
+  const int64_t scale_row_tiles =
+      block_scales.numel() / (scale_columns * kScaleRowTile);
+  auto output = at::empty(
+      {rows, contraction_size},
+      packed.options().dtype(at::kBFloat16));
+  if (rows > 0) {
+    const cudaStream_t stream =
+        at::cuda::getCurrentCUDAStream(packed.get_device());
+    const dim3 grid(scale_row_tiles, scale_column_ctas);
+    dequantize_activations_tiled_kernel
+        <<<grid, kQuantThreads, 0, stream>>>(
+            packed.const_data_ptr<uint8_t>(),
+            reinterpret_cast<const uint8_t*>(block_scales.data_ptr()),
+            global_scales.const_data_ptr<float>(),
+            offsets.const_data_ptr<int32_t>(),
+            reinterpret_cast<__nv_bfloat16*>(
+                output.mutable_data_ptr()),
+            contraction_size,
+            offsets.numel(),
+            scale_column_tiles);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+  return output;
+}
+
+at::Tensor dequantize_weights_cuda(
+    const at::Tensor& packed,
+    const at::Tensor& block_scales,
+    const at::Tensor& global_scales) {
+  check_quantized_tensors(packed, block_scales, global_scales);
+  TORCH_CHECK(packed.dim() == 3, "packed weights must be 3D.");
+  TORCH_CHECK(
+      global_scales.dim() == 1 &&
+          global_scales.size(0) == packed.size(0),
+      "weight global_scales must contain one value per expert.");
+
+  c10::cuda::CUDAGuard device_guard(packed.device());
+  check_sm100();
+
+  const int64_t groups = packed.size(0);
+  const int64_t output_size = packed.size(1);
+  const int64_t contraction_size = packed.size(2) * 2;
+  const int64_t padded_output_size =
+      round_up(output_size, kScaleRowTile);
+  const int64_t output_row_tiles =
+      padded_output_size / kScaleRowTile;
+  const int64_t scale_columns =
+      round_up(contraction_size / kSfVectorSize, kScaleColTile);
+  const int64_t scale_column_tiles =
+      scale_columns / kScaleColTile;
+  const int64_t scale_column_ctas =
+      round_up(scale_column_tiles, kDequantScaleTilesPerCta) /
+      kDequantScaleTilesPerCta;
+  TORCH_CHECK(
+      block_scales.numel() ==
+          groups * padded_output_size * scale_columns,
+      "weight block_scales have an invalid swizzled shape.");
+  auto output = at::empty(
+      {groups, output_size, contraction_size},
+      packed.options().dtype(at::kBFloat16));
+  if (output_size > 0) {
+    const cudaStream_t stream =
+        at::cuda::getCurrentCUDAStream(packed.get_device());
+    const dim3 grid(
+        groups * output_row_tiles,
+        scale_column_ctas);
+    dequantize_weights_tiled_kernel
+        <<<grid, kQuantThreads, 0, stream>>>(
+            packed.const_data_ptr<uint8_t>(),
+            reinterpret_cast<const uint8_t*>(block_scales.data_ptr()),
+            global_scales.const_data_ptr<float>(),
+            reinterpret_cast<__nv_bfloat16*>(
+                output.mutable_data_ptr()),
+            output_size,
+            contraction_size,
+            output_row_tiles,
+            scale_column_tiles);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+  return output;
+}
+
+} // namespace prime_rl_kernels::nvfp4

--- a/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/functional.py
+++ b/packages/prime-rl-kernels/src/prime_rl_kernels/nvfp4/quantize/functional.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from prime_rl_kernels.nvfp4.quantize._extension import (
+    _dequantize_activations,
+    _dequantize_weights,
+)
+from prime_rl_kernels.nvfp4.quantize._extension import (
+    _quantize_activations as _quantize_activations_kernel,
+)
+from prime_rl_kernels.nvfp4.quantize._extension import (
+    _quantize_weights as _quantize_weights_kernel,
+)
+
+_NVFP4_GEMM_ALIGNMENT = 32
+
+
+@dataclass(frozen=True)
+class _NVFP4Tensor:
+    data: torch.Tensor
+    block_scales: torch.Tensor
+    global_scales: torch.Tensor
+    offsets: torch.Tensor | None
+
+    def dequantize(self) -> torch.Tensor:
+        packed = self.data.view(torch.uint8)
+        if self.offsets is not None:
+            return _dequantize_activations(
+                packed,
+                self.block_scales,
+                self.global_scales,
+                self.offsets,
+            )
+        return _dequantize_weights(
+            packed,
+            self.block_scales,
+            self.global_scales,
+        ).transpose(-2, -1)
+
+
+def _check_blackwell() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("NVFP4 quantization requires CUDA")
+    capability = torch.cuda.get_device_capability()
+    if capability != (10, 0):
+        raise RuntimeError(
+            f"NVFP4 quantization currently requires SM100, but the current device is SM{capability[0]}{capability[1]}"
+        )
+    if not hasattr(torch, "float4_e2m1fn_x2"):
+        raise RuntimeError("NVFP4 quantization requires PyTorch with float4_e2m1fn_x2 support")
+
+
+def _check_bf16_cuda(tensor: torch.Tensor, name: str) -> None:
+    if tensor.device.type != "cuda" or tensor.dtype != torch.bfloat16:
+        raise ValueError(f"{name} must be a CUDA bfloat16 tensor")
+
+
+def quantize_activations(matrix: torch.Tensor, offsets: torch.Tensor) -> _NVFP4Tensor:
+    """Quantize ``[M, K]`` activations with one FP32 decode scale per token."""
+
+    _check_blackwell()
+    if matrix.ndim != 2:
+        raise ValueError("matrix must be 2D")
+    _check_bf16_cuda(matrix, "matrix")
+    if matrix.shape[1] % _NVFP4_GEMM_ALIGNMENT != 0:
+        raise ValueError(f"matrix's contraction dimension must be divisible by {_NVFP4_GEMM_ALIGNMENT}")
+    if not matrix.is_contiguous():
+        matrix = matrix.contiguous()
+    if offsets.ndim != 1 or offsets.numel() == 0 or offsets.dtype != torch.int32 or offsets.device != matrix.device:
+        raise ValueError("offsets must be a non-empty 1D int32 tensor on the same CUDA device as matrix")
+    if not offsets.is_contiguous():
+        offsets = offsets.contiguous()
+
+    packed, block_scales, global_scales = _quantize_activations_kernel(
+        matrix,
+        offsets,
+    )
+    return _NVFP4Tensor(
+        data=packed.view(torch.float4_e2m1fn_x2),
+        block_scales=block_scales,
+        global_scales=global_scales,
+        offsets=offsets,
+    )
+
+
+def quantize_weights(weight: torch.Tensor) -> _NVFP4Tensor:
+    """Quantize logical ``[G, K, N]`` weights with one FP32 decode scale per expert."""
+
+    _check_blackwell()
+    if weight.ndim != 3:
+        raise ValueError("weight must be 3D")
+    _check_bf16_cuda(weight, "weight")
+
+    _, contraction_size, output_size = weight.shape
+    if contraction_size % _NVFP4_GEMM_ALIGNMENT != 0:
+        raise ValueError(f"weight's contraction dimension must be divisible by {_NVFP4_GEMM_ALIGNMENT}")
+    if output_size % 8 != 0:
+        raise ValueError("weight's output dimension must be divisible by 8")
+
+    weight_rows = weight.transpose(-2, -1)
+    if not weight_rows.is_contiguous():
+        weight_rows = weight_rows.contiguous()
+    packed, block_scales, global_scales = _quantize_weights_kernel(
+        weight_rows,
+    )
+    return _NVFP4Tensor(
+        data=packed.view(torch.float4_e2m1fn_x2),
+        block_scales=block_scales,
+        global_scales=global_scales,
+        offsets=None,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = "~=3.12.0"
 dependencies = [
     "prime-rl-configs",
+    "prime-rl-kernels",
     "prime-pydantic-config",
     "beartype>=0.21.0",
     "datasets>=4.0.0",
@@ -181,6 +182,7 @@ torchao = false
 
 [tool.uv.sources]
 prime-rl-configs = { path = "packages/prime-rl-configs", editable = true }
+prime-rl-kernels = { path = "packages/prime-rl-kernels", editable = true }
 # prime-rl depends on the one `verifiers` package (v0 + v1 + the legacy bridge + the built-in v1
 # harnesses/tasksets, now bundled in verifiers.v1). v0 envs resolve from
 # deps/{verifiers,research-environments}/environments; v1 tasksets (`-v1`) and the `compact`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "torchaudio",
     "torchdata>=0.11.0",
     "transformers==5.6.2",
-    "vllm>=0.24.0",
+    "vllm>=0.25.1",
     "mooncake-transfer-engine>=0.3.10.post2",
     "wandb>=0.26.1",
     "wandb-workspaces>=0.4.3",
@@ -202,8 +202,8 @@ vllm-router = [
     { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
 ]
 vllm = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl", marker = "platform_machine == 'x86_64'" },
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
+    { url = "https://github.com/vllm-project/vllm/releases/download/v0.25.1/vllm-0.25.1+cu129-cp38-abi3-manylinux_2_28_x86_64.whl", marker = "platform_machine == 'x86_64'" },
+    { url = "https://github.com/vllm-project/vllm/releases/download/v0.25.1/vllm-0.25.1+cu129-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
 ]
 deep-ep = [
     { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.2.1+29d31c0-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" },

--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -1,7 +1,7 @@
 """Prime-RL extensions to vLLM's `/inference/v1/generate` handler.
 
-vLLM 0.22 ships a generic tokens-in / tokens-out handler at
-``vllm.entrypoints.serve.disagg.serving.ServingTokens`` that already covers
+vLLM ships a generic tokens-in / tokens-out handler at
+``vllm.entrypoints.scale_out.token_in_token_out.serving.ServingTokens`` that covers
 prefix-cache salting, lora dispatch, multimodal features, prompt logprobs,
 priority, ``data_parallel_rank`` header routing and server-side ``max_tokens``
 defaulting. We subclass it for the bits still missing from the upstream handler:
@@ -37,12 +37,12 @@ from vllm.entrypoints.openai.engine.protocol import (
     RequestResponseMetadata,
     UsageInfo,
 )
-from vllm.entrypoints.serve.disagg.protocol import (
+from vllm.entrypoints.scale_out.token_in_token_out.protocol import (
     GenerateRequest,
     GenerateResponse,
     GenerateResponseChoice,
 )
-from vllm.entrypoints.serve.disagg.serving import ServingTokens
+from vllm.entrypoints.scale_out.token_in_token_out.serving import ServingTokens
 from vllm.entrypoints.serve.utils.api_utils import get_max_tokens
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind, SamplingParams
@@ -200,10 +200,11 @@ class PrimeRlServingTokens(ServingTokens):
         # Build the engine input — features-aware (MM) or text-only fallback.
         # Identical to upstream so we keep tracking it.
         if features := request.features:
-            from vllm.entrypoints.serve.disagg.mm_serde import decode_mm_kwargs_item
+            from vllm.entrypoints.scale_out.token_in_token_out.mm_serde import decode_mm_kwargs_item
             from vllm.inputs import mm_input
             from vllm.multimodal.inputs import (
                 MultiModalKwargsItem,
+                MultiModalKwargsItems,
                 PlaceholderRange,
             )
 
@@ -220,13 +221,13 @@ class PrimeRlServingTokens(ServingTokens):
                     mm_kwargs[modality] = [None] * len(hashes)
             engine_input = mm_input(
                 prompt_token_ids=request.token_ids,
-                mm_kwargs=mm_kwargs,  # type: ignore[arg-type]
+                mm_kwargs=MultiModalKwargsItems(mm_kwargs),
                 mm_hashes=features.mm_hashes,
                 mm_placeholders=mm_placeholders,
                 cache_salt=request.cache_salt,
             )
         else:
-            (engine_input,) = await self.openai_serving_render.preprocess_completion(
+            (engine_input,) = await self.online_renderer.preprocess_completion(
                 request,
                 prompt_input=request.token_ids,
                 prompt_embeds=None,

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -32,6 +32,7 @@ from prime_rl.configs.trainer import (
     FP8Config,
     ModelConfig,
     MXFP8Config,
+    NVFP4Config,
     TokenizerConfig,
 )
 from prime_rl.trainer.distributed import DeepEPExpertParallel, MXFP8AllToAllExpertParallel
@@ -52,9 +53,16 @@ from prime_rl.trainer.models.layers.checkpointing import (
 )
 from prime_rl.trainer.models.layers.fp8_linear import replace_linear_with_fp8_blockwise_linear
 from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
-from prime_rl.trainer.models.layers.moe import MoE, TokenChoiceTopKRouter
+from prime_rl.trainer.models.layers.moe import (
+    FP8MoEQuantizationConfig,
+    MoE,
+    MXFP8MoEQuantizationConfig,
+    NVFP4MoEQuantizationConfig,
+    TokenChoiceTopKRouter,
+)
 from prime_rl.trainer.models.layers.mxfp8_grouped_gemm import apply_mxfp8_moe_grouped_gemm
 from prime_rl.trainer.models.layers.mxfp8_linear import replace_linear_with_mxfp8_linear
+from prime_rl.trainer.models.layers.nvfp4_grouped_gemm import prepare_nvfp4_grouped_gemm
 from prime_rl.trainer.parallel_dims import ParallelDims
 from prime_rl.trainer.weights import (
     load_state_dict,
@@ -585,15 +593,21 @@ def get_model(
             vision_config._attn_implementation = "sdpa"
             if hasattr(vision_config, "_attn_implementation_internal"):
                 vision_config._attn_implementation_internal = "sdpa"
+    moe_quantization = None
+    if isinstance(config.quantization, FP8Config) and config.quantization.enable_grouped_gemm:
+        moe_quantization = FP8MoEQuantizationConfig()
+    elif isinstance(config.quantization, MXFP8Config) and config.quantization.enable_grouped_gemm:
+        moe_quantization = MXFP8MoEQuantizationConfig()
+    elif isinstance(config.quantization, NVFP4Config):
+        moe_quantization = NVFP4MoEQuantizationConfig(backward=config.quantization.backward)
+    model_config.moe_quantization = moe_quantization
+
     for subconfig_key in getattr(model_config, "sub_configs", {}):
         subconfig = getattr(model_config, subconfig_key, None)
         if subconfig is not None and hasattr(subconfig, "use_cache"):
             subconfig.use_cache = False
-    # MoEArgs.fp8 (read via getattr(config, "fp8") in the modeling files) gates the
-    # DeepGEMM FP8 grouped GEMM. MXFP8 grouped GEMM is applied by wrapping the expert
-    # weights with torchao (see apply_quantization), so it leaves this flag False and
-    # the experts keep calling torch._grouped_mm — which the wrapper tensor intercepts.
-    model_config.fp8 = isinstance(config.quantization, FP8Config) and config.quantization.enable_grouped_gemm
+        if subconfig is not None:
+            subconfig.moe_quantization = moe_quantization
 
     if config.index_cache is not None:
         model_config.use_index_cache = True
@@ -1141,10 +1155,7 @@ def apply_quantization(model: nn.Module, config: ModelConfig) -> None:
     """Swap dense linears and MoE expert GEMMs to the configured low-precision path.
 
     Runs after the LM head is injected but before LoRA / EP / FSDP so the swapped
-    modules and wrapped parameters are picked up by the later parallelisms. The
-    FP8 grouped GEMM (DeepGEMM) is gated separately via ``model_config.fp8`` since
-    it lives inside the modeling code; here we only handle the dense-linear swap
-    and the torchao MXFP8 expert-weight wrapping.
+    modules and wrapped parameters are picked up by the later parallelisms.
     """
     quant = config.quantization
     if quant is None:
@@ -1161,6 +1172,13 @@ def apply_quantization(model: nn.Module, config: ModelConfig) -> None:
         replace_linear_with_mxfp8_linear(model, recipe=quant.recipe, ignore_modules=quant.ignore_patterns)
         if quant.enable_grouped_gemm:
             apply_mxfp8_moe_grouped_gemm(model, recipe=quant.recipe)
+    elif isinstance(quant, NVFP4Config):
+        capability = torch.cuda.get_device_capability()
+        if capability != (10, 0):
+            raise ValueError(
+                f"NVFP4 quantization requires SM100 (Blackwell), but device is SM{capability[0]}{capability[1]}."
+            )
+        prepare_nvfp4_grouped_gemm()
 
 
 def apply_ep(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims):

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -257,7 +257,7 @@ class AfmoeDecoderLayer(GradientCheckpointingLayer):
             score_before_experts=getattr(config, "score_before_experts", False),
             top_k=config.num_experts_per_tok,
             load_balance_coeff=config.load_balance_coeff,
-            fp8=getattr(config, "fp8", False),
+            quantization=getattr(config, "moe_quantization", None),
         )
         if self.moe_enabled:
             self.mlp = MoE.from_args(moe_args, dim=config.hidden_size, hidden_dim=config.moe_intermediate_size)

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -62,7 +62,7 @@ class Glm4MoeDecoderLayer(GradientCheckpointingLayer):
             score_before_experts=False,
             top_k=config.num_experts_per_tok,
             load_balance_coeff=1e-3,
-            fp8=getattr(config, "fp8", False),
+            quantization=getattr(config, "moe_quantization", None),
         )
         mlp_config = MLPConfig(
             hidden_size=config.hidden_size,

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -63,7 +63,7 @@ class GlmMoeDsaDecoderLayer(GradientCheckpointingLayer):
             score_before_experts=False,
             top_k=config.num_experts_per_tok,
             load_balance_coeff=1e-3,
-            fp8=getattr(config, "fp8", False),
+            quantization=getattr(config, "moe_quantization", None),
         )
         mlp_config = MLPConfig(
             hidden_size=config.hidden_size,

--- a/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
@@ -39,11 +39,6 @@ class GptOssDecoderLayer(GradientCheckpointingLayer):
         super().__init__()
         self.hidden_size = config.hidden_size
         self.self_attn = GptOssAttention(config=config, layer_idx=layer_idx)
-        grouped_mm_fn = torch._grouped_mm
-        if getattr(config, "fp8", False):
-            from prime_rl.trainer.models.layers.fp8_grouped_gemm import grouped_fp8_gemm
-
-            grouped_mm_fn = grouped_fp8_gemm
         router = TokenChoiceTopKRouter(
             dim=config.hidden_size,
             num_experts=config.num_local_experts,
@@ -66,7 +61,7 @@ class GptOssDecoderLayer(GradientCheckpointingLayer):
             output_bias_name="down_proj_bias",
             transpose_weights_for_state_dict=True,
             activation_fn=interleaved_clamped_swiglu,
-            grouped_mm_fn=grouped_mm_fn,
+            quantization=getattr(config, "moe_quantization", None),
         )
         self.mlp = MoE(
             router=router,

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -164,7 +164,7 @@ class LagunaDecoderLayer(GradientCheckpointingLayer):
                 score_before_experts=False,
                 top_k=config.num_experts_per_tok,
                 load_balance_coeff=config.load_balance_coeff,
-                fp8=getattr(config, "fp8", False),
+                quantization=getattr(config, "moe_quantization", None),
             )
             if config.moe_router_logit_softcapping:
                 raise NotImplementedError("Laguna router logit softcapping is not supported by PrimeRL MoE yet.")

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -4,8 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
+from functools import partial
 from typing import Any, Literal
 
 import torch
@@ -14,6 +16,42 @@ from torch import nn
 
 from prime_rl.configs.trainer import EPCommBackend
 from prime_rl.trainer.distributed.expert_parallel import expert_parallel
+
+NVFP4Backward = Literal["dequant_bf16", "bf16"]
+
+
+class MoEQuantizationConfig(ABC):
+    @property
+    @abstractmethod
+    def grouped_mm(self) -> Callable[..., torch.Tensor]:
+        pass
+
+
+@dataclass(frozen=True)
+class FP8MoEQuantizationConfig(MoEQuantizationConfig):
+    @property
+    def grouped_mm(self) -> Callable[..., torch.Tensor]:
+        from prime_rl.trainer.models.layers.fp8_grouped_gemm import grouped_fp8_gemm
+
+        return grouped_fp8_gemm
+
+
+@dataclass(frozen=True)
+class MXFP8MoEQuantizationConfig(MoEQuantizationConfig):
+    @property
+    def grouped_mm(self) -> Callable[..., torch.Tensor]:
+        return torch._grouped_mm
+
+
+@dataclass(frozen=True)
+class NVFP4MoEQuantizationConfig(MoEQuantizationConfig):
+    backward: NVFP4Backward = "dequant_bf16"
+
+    @property
+    def grouped_mm(self) -> Callable[..., torch.Tensor]:
+        from prime_rl_kernels.nvfp4 import grouped_gemm
+
+        return partial(grouped_gemm, backward=self.backward)
 
 
 @dataclass
@@ -30,7 +68,7 @@ class MoEArgs:
     # token-choice
     top_k: int = 1
     load_balance_coeff: float | None = 1e-3
-    fp8: bool = False  # use FP8 grouped GEMM via DeepGEMM (requires SM90)
+    quantization: MoEQuantizationConfig | None = None
 
 
 def swiglu(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
@@ -231,7 +269,7 @@ class GroupedExperts(nn.Module):
         output_bias_name: str | None = None,
         transpose_weights_for_state_dict: bool = False,
         activation_fn: Callable[[torch.Tensor], torch.Tensor] = fused_swiglu,
-        grouped_mm_fn: Callable[..., torch.Tensor] = torch._grouped_mm,
+        quantization: MoEQuantizationConfig | None = None,
     ):
         super().__init__()
         self.num_experts = num_experts
@@ -251,7 +289,8 @@ class GroupedExperts(nn.Module):
         )
         self.output_bias = nn.Parameter(torch.empty(num_experts, dim)) if output_bias_name is not None else None
         self._activation_fn = activation_fn
-        self._grouped_mm_fn = grouped_mm_fn
+        self.quantization = quantization
+        self.grouped_mm = torch._grouped_mm if quantization is None else quantization.grouped_mm
         self.ep_comm_backend: EPCommBackend = "torch"
         self.register_state_dict_post_hook(self.export_weights_to_state_dict)
         self.register_load_state_dict_pre_hook(self.import_weights_from_state_dict)
@@ -293,7 +332,7 @@ class GroupedExperts(nn.Module):
             self.w2.to_local().transpose(-2, -1),
             x,
             num_tokens_per_expert,
-            grouped_mm_fn=self._grouped_mm_fn,
+            grouped_mm_fn=self.grouped_mm,
             activation_fn=self._activation_fn,
             input_bias=self.input_bias.to_local() if self.input_bias is not None else None,
             output_bias=self.output_bias.to_local() if self.output_bias is not None else None,
@@ -312,7 +351,7 @@ class GroupedExperts(nn.Module):
             self.w2.transpose(-2, -1),
             x,
             num_tokens_per_expert,
-            grouped_mm_fn=self._grouped_mm_fn,
+            grouped_mm_fn=self.grouped_mm,
             activation_fn=self._activation_fn,
             input_bias=self.input_bias,
             output_bias=self.output_bias,
@@ -578,17 +617,11 @@ class MoE(nn.Module):
 
     @classmethod
     def from_args(cls, args: MoEArgs, dim: int, hidden_dim: int) -> "MoE":
-        grouped_mm_fn = torch._grouped_mm
-        if args.fp8:
-            from prime_rl.trainer.models.layers.fp8_grouped_gemm import grouped_fp8_gemm
-
-            grouped_mm_fn = grouped_fp8_gemm
-
         experts = GroupedExperts(
             dim=dim,
             hidden_dim=hidden_dim,
             num_experts=args.num_experts,
-            grouped_mm_fn=grouped_mm_fn,
+            quantization=args.quantization,
         )
         router = TokenChoiceTopKRouter(
             dim=dim,

--- a/src/prime_rl/trainer/models/layers/nvfp4_grouped_gemm.py
+++ b/src/prime_rl/trainer/models/layers/nvfp4_grouped_gemm.py
@@ -1,0 +1,13 @@
+from prime_rl.trainer.distributed.expert_parallel import set_token_group_alignment_size_m
+from prime_rl.utils.logger import get_logger
+
+_NVFP4_TOKEN_GROUP_ALIGNMENT = 32
+
+
+def prepare_nvfp4_grouped_gemm() -> None:
+    from prime_rl_kernels.nvfp4 import prepare_for_compile
+
+    prepare_for_compile()
+    set_token_group_alignment_size_m(_NVFP4_TOKEN_GROUP_ALIGNMENT)
+
+    get_logger().info(f"Prepared NVFP4 grouped GEMM (token_group_alignment={_NVFP4_TOKEN_GROUP_ALIGNMENT})")

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -49,7 +49,7 @@ class MiniMaxM2DecoderLayer(GradientCheckpointingLayer):
             score_before_experts=False,
             top_k=config.num_experts_per_tok,
             load_balance_coeff=1e-3 if config.use_routing_bias else None,
-            fp8=getattr(config, "fp8", False),
+            quantization=getattr(config, "moe_quantization", None),
         )
         self.mlp = MoE.from_args(moe_args, dim=config.hidden_size, hidden_dim=config.intermediate_size)
 

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -256,11 +256,6 @@ class NemotronHMoELayer(GradientCheckpointingLayer):
         super().__init__()
         self.norm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.layer_norm_epsilon))
         effective_latent_dim = config.moe_latent_size if config.moe_latent_size is not None else config.hidden_size
-        grouped_mm_fn = torch._grouped_mm
-        if getattr(config, "fp8", False):
-            from prime_rl.trainer.models.layers.fp8_grouped_gemm import grouped_fp8_gemm
-
-            grouped_mm_fn = grouped_fp8_gemm
 
         router = TokenChoiceTopKRouter(
             dim=config.hidden_size,
@@ -279,7 +274,7 @@ class NemotronHMoELayer(GradientCheckpointingLayer):
             num_experts=config.n_routed_experts,
             input_weight_names=("w1",),
             activation_fn=relu2,
-            grouped_mm_fn=grouped_mm_fn,
+            quantization=getattr(config, "moe_quantization", None),
         )
         shared_expert = FeedForward(
             dim=config.hidden_size,

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -443,7 +443,7 @@ class Qwen3_5MoeDecoderLayer(GradientCheckpointingLayer):
             score_before_experts=False,
             top_k=config.num_experts_per_tok,
             load_balance_coeff=config.load_balance_coeff,
-            fp8=getattr(config, "fp8", False),
+            quantization=getattr(config, "moe_quantization", None),
         )
         self.mlp = MoE.from_args(moe_args, dim=config.hidden_size, hidden_dim=config.moe_intermediate_size)
 

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -67,7 +67,7 @@ class Qwen3MoeDecoderLayer(GradientCheckpointingLayer):
             score_before_experts=False,
             top_k=config.num_experts_per_tok,
             load_balance_coeff=config.load_balance_coeff,
-            fp8=getattr(config, "fp8", False),
+            quantization=getattr(config, "moe_quantization", None),
         )
         mlp_config = MLPConfig(
             hidden_size=config.hidden_size,

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -605,7 +605,7 @@ async def prefill_logprobs(openai: AsyncOpenAI, model: str, token_ids: list[int]
     + ``prompt_logprobs`` (the prime-rl server-side extension in
     ``inference/vllm/serving_tokens.py``). Returns one logprob per token (0.0 for
     the leading token, which has no preceding context)."""
-    from vllm.entrypoints.serve.disagg.protocol import GenerateResponse
+    from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateResponse
 
     # `/inference/v1/generate` is mounted at server root, not under `/v1`: pass an
     # absolute URL so the SDK skips the base-url merge. vLLM's `GenerateResponse`

--- a/tests/unit/inference/test_serving_tokens.py
+++ b/tests/unit/inference/test_serving_tokens.py
@@ -15,7 +15,7 @@ import asyncio
 import numpy as np
 import pybase64
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
-from vllm.entrypoints.serve.disagg.protocol import GenerateResponse, GenerateResponseChoice
+from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateResponse, GenerateResponseChoice
 
 from prime_rl.inference.vllm.routed_experts import serialize_routed_experts
 from prime_rl.inference.vllm.serving_tokens import (

--- a/tests/unit/orchestrator/test_qwen3_vl_e2e.py
+++ b/tests/unit/orchestrator/test_qwen3_vl_e2e.py
@@ -96,8 +96,8 @@ def test_renderer_client_qwen3_vl_e2e_features_payload_roundtrips_through_vllm()
         ClientConfig,
         UserMessage,
     )
-    from vllm.entrypoints.serve.disagg.mm_serde import decode_mm_kwargs_item
-    from vllm.entrypoints.serve.disagg.protocol import GenerateRequest
+    from vllm.entrypoints.scale_out.token_in_token_out.mm_serde import decode_mm_kwargs_item
+    from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateRequest
 
     # ── Build a real Qwen3VLRenderer with a real processor. ─────────────
     tokenizer = load_tokenizer(_MODEL)

--- a/uv.lock
+++ b/uv.lock
@@ -4343,6 +4343,22 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cutlass"
+version = "4.2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-python" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "pydot" },
+    { name = "scipy" },
+    { name = "treelib" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/6b/e86fc2fd536dd4b8bd2209aa31d7002610c501b0802337787eac9c9b328c/nvidia_cutlass-4.2.0.0-py3-none-any.whl", hash = "sha256:f9599ada45c7bcb6bf53f7d3f0a7d154183e53451c01bfa59eecd37dd4a693f6", size = 6440597, upload-time = "2025-09-19T20:57:32.371Z" },
+]
+
+[[package]]
 name = "nvidia-cutlass-dsl"
 version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5142,6 +5158,7 @@ dependencies = [
     { name = "prime" },
     { name = "prime-pydantic-config" },
     { name = "prime-rl-configs" },
+    { name = "prime-rl-kernels" },
     { name = "pyarrow" },
     { name = "pybase64" },
     { name = "pyzmq" },
@@ -5258,6 +5275,7 @@ requires-dist = [
     { name = "prime-rl", extras = ["flash-attn-cute"], marker = "extra == 'all'" },
     { name = "prime-rl", extras = ["quack"], marker = "extra == 'all'" },
     { name = "prime-rl-configs", editable = "packages/prime-rl-configs" },
+    { name = "prime-rl-kernels", editable = "packages/prime-rl-kernels" },
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pybase64", specifier = ">=1.4.2" },
     { name = "pyzmq", specifier = ">=27.1.0" },
@@ -5321,6 +5339,21 @@ requires-dist = [
     { name = "tomli", specifier = ">=2.2.1" },
     { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "verifiers", specifier = ">=0.2.1" },
+]
+
+[[package]]
+name = "prime-rl-kernels"
+version = "0.1.0"
+source = { editable = "packages/prime-rl-kernels" }
+dependencies = [
+    { name = "nvidia-cutlass" },
+    { name = "torch" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "nvidia-cutlass", specifier = "==4.2.0.0" },
+    { name = "torch", specifier = ">=2.11.0" },
 ]
 
 [[package]]
@@ -5682,6 +5715,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
+name = "pydot"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/35/b17cb89ff865484c6a20ef46bf9d95a5f07328292578de0b295f4a6beec2/pydot-4.0.1.tar.gz", hash = "sha256:c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5", size = 162594, upload-time = "2025-06-17T20:09:56.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl", hash = "sha256:869c0efadd2708c0be1f916eb669f3d664ca684bc57ffb7ecc08e70d5e93fee6", size = 37087, upload-time = "2025-06-17T20:09:55.25Z" },
 ]
 
 [[package]]
@@ -7551,6 +7596,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/c8/97da3af4796495e46421e9344738addb3602fa6426ea695be3fcbadbee37/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:199d09985190852e0912da2b8d26c932159be314bc04952cf917ed0e4c633e6b", size = 106072, upload-time = "2025-09-01T07:13:39.798Z" },
     { url = "https://files.pythonhosted.org/packages/13/be/c964e8130be08cc9bd6627d845f0e4460945b158429d39510953bbcb8fcc/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dfcf789064c58dc13c0a4edb550acacfc6f0f280577f1e7a00de3e89fc7f8ddc", size = 104388, upload-time = "2025-09-01T07:13:40.866Z" },
     { url = "https://files.pythonhosted.org/packages/ee/89/9b773dee0f8961d1bb8d7baf0a204ab587618df19897c1ef260916f318ec/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b852d3aee8a36186dbcc32c798b11b4869f9b5041743b63b65c2ef793db7a54", size = 98377, upload-time = "2025-09-01T07:13:41.838Z" },
+]
+
+[[package]]
+name = "treelib"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/31/145bdbee73d7ee4ac4e879c37faa196a32208b288ca4f308c1ad8db3f010/treelib-1.8.0.tar.gz", hash = "sha256:e1be2c6b66ffbfae85079fc4c76fb4909946d01d915ee29ff6795de53aed5d55", size = 28607, upload-time = "2025-06-29T15:06:49.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/24/32361f5d0e2eff7ff1881ac6833b6b090cfe34515b1ee9082636cbe69442/treelib-1.8.0-py3-none-any.whl", hash = "sha256:5235d1ebf988c5026f26ce6e5e0cd470007f16d4978185f5c9b3eee8a25aef81", size = 30728, upload-time = "2025-06-29T15:06:48.248Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -828,7 +828,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "(implementation_name != 'PyPy' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name != 'PyPy' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1097,7 +1097,7 @@ name = "cryptography"
 version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "(platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
 wheels = [
@@ -1885,8 +1885,8 @@ name = "flash-attn"
 version = "2.8.3+cu128torch2.11"
 source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.4/flash_attn-2.8.3+cu128torch2.11-cp312-cp312-linux_x86_64.whl" }
 dependencies = [
-    { name = "einops" },
-    { name = "torch" },
+    { name = "einops", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.4/flash_attn-2.8.3+cu128torch2.11-cp312-cp312-linux_x86_64.whl", hash = "sha256:a16162f436286cc03ebbfb174c0853343ed98ae13c37abf1042947668ec40549" },
@@ -1938,15 +1938,15 @@ dependencies = [
 
 [[package]]
 name = "flashinfer-cubin"
-version = "0.6.12"
+version = "0.6.13"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/c6/63b1bb7b1a7ae612ecf53c0e568312c3d004f9f7558b0ab5edcf7900c360/flashinfer_cubin-0.6.12-py3-none-any.whl", hash = "sha256:01de132c493bb21d5df42ebe6890966cf83b40aa970dae06b2a3c0bed85f13ec", size = 447533460, upload-time = "2026-05-29T23:45:27.579Z" },
+    { url = "https://files.pythonhosted.org/packages/19/43/ce916b4cdec4705173e222ca29c68e09004b47526888746094c5ffb29fca/flashinfer_cubin-0.6.13-py3-none-any.whl", hash = "sha256:41e4848c2d09d220e8394489b2fb6cfec6b6ad09f897b5ab8b39fc23055f6c24", size = 457984995, upload-time = "2026-06-25T00:29:26.08Z" },
 ]
 
 [[package]]
 name = "flashinfer-python"
-version = "0.6.12"
+version = "0.6.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi" },
@@ -1964,9 +1964,9 @@ dependencies = [
     { name = "torch" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/d0/114a64319f5a804def2f307d5ed8f95e6d94a2acdacac4ed5f57525cbf46/flashinfer_python-0.6.12.tar.gz", hash = "sha256:bed67f9c46d81dd22611dfef2787998fc412b2fe2648d9e7d336861dda912694", size = 9453326, upload-time = "2026-05-29T23:45:16.466Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/f7/7f6dd2b03f4277509dfd1e5c7a8ec1de2662fd245d2e663f44a3493882b1/flashinfer_python-0.6.13.tar.gz", hash = "sha256:8a6d7d3708c7c87952390ec4e3aabe6e1c356defa8c7211b26bccaa355a61c59", size = 9638085, upload-time = "2026-06-24T22:46:29.391Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/26/3ca33edbf64906603633cb91904798e427c0ac1c55a13707f8081708f3ae/flashinfer_python-0.6.12-py3-none-any.whl", hash = "sha256:0c7a01e586b4796810d974cbf13a9c0eb2ade6a94d12e3220cf7782a1c09b8d3", size = 13985243, upload-time = "2026-05-29T23:45:13.477Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/50/e8920ed7f68e0116a385e3ab814ac2f0010579852fc483bfb48819d11976/flashinfer_python-0.6.13-py3-none-any.whl", hash = "sha256:239e6ddc3cbbaf0bee251861a8c7c69438b1171830d69ddfa133ddea4494850d", size = 14191198, upload-time = "2026-06-24T22:46:26.565Z" },
 ]
 
 [[package]]
@@ -2573,7 +2573,7 @@ requires-dist = [
 
 [[package]]
 name = "humming-kernels"
-version = "0.1.6"
+version = "0.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings" },
@@ -2587,9 +2587,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "triton" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/5a/fbf574dcd83e9fea6aa3fa96b37bbdec40b8672407b1ed9679efa31fff1d/humming_kernels-0.1.6.tar.gz", hash = "sha256:882b9f382a010165a7cf8eecbad943bfe8d6b17566328fb57611c9a34bdccc9a", size = 214408, upload-time = "2026-06-20T04:04:43.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4f/6977a31451c3f7aa1deaa76506d6cdeb74ef418ad8bcba2e98f7510b26ec/humming_kernels-0.1.10.tar.gz", hash = "sha256:da3e46fb9fc9eba2a9327c2e8135ead68e390c955acd7449f97ee7c71666c8b1", size = 220110, upload-time = "2026-07-02T10:22:57.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/85/490681b9ba24531da91d0bae801d2b26850e5a80bbd02c2efc500756e36b/humming_kernels-0.1.6-py3-none-any.whl", hash = "sha256:e64c0883fca930074bf920f4ba47cbf3acd244d7352f6c74c8d2182439770d8f", size = 178759, upload-time = "2026-06-20T04:04:41.66Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ba/869bc24591d2b4fb0d8da821528072971052a934af077a11f77a0f2b3e79/humming_kernels-0.1.10-py3-none-any.whl", hash = "sha256:4ded0998ff085afeddde70baf93f97c2929969ec3d4a63a52cfec5072bc972b4", size = 184889, upload-time = "2026-07-02T10:22:56.031Z" },
 ]
 
 [package.optional-dependencies]
@@ -3679,7 +3679,7 @@ wheels = [
 
 [[package]]
 name = "mistral-common"
-version = "1.11.3"
+version = "1.11.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
@@ -3691,9 +3691,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/03/3c5d4c9430da406f8444f9a7b058a6aa89c525fb068a57fe2ab8b04a6d08/mistral_common-1.11.3.tar.gz", hash = "sha256:6437e128fc8a307318440839ca14ddf2e8060056b062233ec0db10352651374c", size = 6360629, upload-time = "2026-06-04T09:01:11.131Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/b9/0d7edcc6ff8502e89621a006758a2a36d4972688f521ce584535c5f701ca/mistral_common-1.11.6.tar.gz", hash = "sha256:35ed428e0e886808f0c048adac56843ce77d6cee13c1b54a045ad8d11e77c756", size = 6384808, upload-time = "2026-07-17T13:55:49.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/76/dbfdf9c59e2a4b0116587626a3768c2a3b2ba1758b5756743918c2337fdc/mistral_common-1.11.3-py3-none-any.whl", hash = "sha256:dbfcef9d0c892727ee08a080f0c1039baed5430b291f5425ffd88892bf09e52c", size = 6533154, upload-time = "2026-06-04T09:01:14.186Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9c/ec225d35ae66f212208f78f2b2b48de1bb9597f010363eba66439a934316/mistral_common-1.11.6-py3-none-any.whl", hash = "sha256:d719534ae1079070bc3a37ffb4976862f85db7a6c6549085832357b46ff89f4b", size = 6551801, upload-time = "2026-07-17T13:55:51.556Z" },
 ]
 
 [package.optional-dependencies]
@@ -4041,8 +4041,8 @@ name = "nixl"
 version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nixl-cu12", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "nixl-cu12", version = "0.10.1", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
+    { name = "nixl-cu12", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "nixl-cu12", version = "0.10.1", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/a4/10e80e623790d3fb070e966b36bced009419d483c92ae0df6645230f606f/nixl-0.10.1-py3-none-any.whl", hash = "sha256:616465673dae5180d296525a03237af4cd5f2c00c3228d185bc06dbe621509b7", size = 6680, upload-time = "2026-03-03T19:55:44.848Z" },
@@ -4050,8 +4050,8 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "nixl-cu12", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "nixl-cu12", version = "0.10.1", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
+    { name = "nixl-cu12", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "nixl-cu12", version = "0.10.1", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -4062,8 +4062,8 @@ resolution-markers = [
     "platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "numpy" },
-    { name = "torch" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torch", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/21/c1f34212a3e612b5c0da389c1aa3557588d9cfc2adf864914b32e270847b/nixl_cu12-0.10.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b4712c6e0f18f57fee34cd970faac01480f0caf12da33d4a40ef4e9096a4caf7", size = 50227261, upload-time = "2026-03-03T19:55:17.177Z" },
@@ -4077,8 +4077,8 @@ resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "numpy" },
-    { name = "torch" },
+    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl", hash = "sha256:bd01eb9e52f1affee3330062baa2f3bea7d711664f7cb602bf5d3f694daeb796" },
@@ -4435,6 +4435,16 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/1f/930d63ccc8adcdf27bfc051a24e3e4da2cf6ef987848d6d1d642e29d704b/nvidia_nvvm-13.2.78-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:f5aa433631109bbdec81802c5b5f319bf10bc891fe2f212e4e445845211d6f77", size = 64279462, upload-time = "2026-04-13T10:02:25.719Z" },
     { url = "https://files.pythonhosted.org/packages/8b/fd/db44b7a662a6af75a9a0683ca4580c855a3f5fcfdf1261b0ddb9fce0ee26/nvidia_nvvm-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88075f87a361a1dce95c799cabc028f7093af616a5702dcfb74eba4045dbbd5f", size = 61886055, upload-time = "2026-04-13T10:02:00.345Z" },
+]
+
+[[package]]
+name = "nvtx"
+version = "0.2.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/dd/692765e87de30bae1522cdffaa0f2b52949658a92a0fa6d96b1a01eae9d2/nvtx-0.2.15.tar.gz", hash = "sha256:2287d3be05b85661deb386f878d1f536c2e532774aa9ec7a50c434942ed81ae5", size = 121230, upload-time = "2026-03-18T10:01:25.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/07/698355285a03a366ef63ea9762fc1feef3f9f25483e1655408f72d827090/nvtx-0.2.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2cc530cd0f1a2c14a3a7e683833db509888ac5ed4ead94e5c9e2c7317c6937a7", size = 807159, upload-time = "2026-03-18T10:09:49.232Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d1/08f22448d83481408d663065764ba583df091a7de629ed38fc97e522f1af/nvtx-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3ca8030a6d197952318013dd1c12c22da1d4b9feb76ba72e0fcd449961183c2c", size = 806187, upload-time = "2026-03-18T10:13:32.972Z" },
 ]
 
 [[package]]
@@ -5169,8 +5179,8 @@ dependencies = [
     { name = "tenacity" },
     { name = "tilelang" },
     { name = "torch" },
-    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "torchao", version = "0.17.0+git02105d46c", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.6.0/torchao-0.17.0+git02105d46c-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
+    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torchao", version = "0.17.0+git02105d46c", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.6.0/torchao-0.17.0+git02105d46c-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "torchaudio" },
     { name = "torchdata" },
     { name = "torchtitan" },
@@ -5178,39 +5188,39 @@ dependencies = [
     { name = "transformers" },
     { name = "uvloop" },
     { name = "verifiers", extra = ["harbor"] },
-    { name = "vllm", version = "0.24.0+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64'" },
-    { name = "vllm", version = "0.24.0+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
+    { name = "vllm", version = "0.25.1+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.25.1/vllm-0.25.1+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.25.1+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.25.1/vllm-0.25.1+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "wandb" },
     { name = "wandb-workspaces" },
 ]
 
 [package.optional-dependencies]
 all = [
-    { name = "deep-ep", version = "1.1.0+1fd57b0", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.1.0+1fd57b0-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine != 'x86_64'" },
-    { name = "deep-ep", version = "1.2.1+29d31c0", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.2.1+29d31c0-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
-    { name = "deep-gemm", version = "2.5.0+891d57b", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine != 'x86_64'" },
-    { name = "deep-gemm", version = "2.5.0+891d57b", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
-    { name = "flash-attn", marker = "platform_machine == 'x86_64'" },
+    { name = "deep-ep", version = "1.1.0+1fd57b0", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.1.0+1fd57b0-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "deep-ep", version = "1.2.1+29d31c0", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.2.1+29d31c0-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "deep-gemm", version = "2.5.0+891d57b", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "deep-gemm", version = "2.5.0+891d57b", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "flash-attn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "flash-attn-3" },
     { name = "flash-attn-4" },
     { name = "nixl" },
-    { name = "nixl-cu12", version = "0.10.1", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
+    { name = "nixl-cu12", version = "0.10.1", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "quack-kernels" },
-    { name = "vllm-router", version = "0.1.26", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64'" },
-    { name = "vllm-router", version = "0.1.26", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
+    { name = "vllm-router", version = "0.1.26", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "vllm-router", version = "0.1.26", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 disagg = [
-    { name = "deep-ep", version = "1.1.0+1fd57b0", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.1.0+1fd57b0-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine != 'x86_64'" },
-    { name = "deep-ep", version = "1.2.1+29d31c0", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.2.1+29d31c0-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
-    { name = "deep-gemm", version = "2.5.0+891d57b", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine != 'x86_64'" },
-    { name = "deep-gemm", version = "2.5.0+891d57b", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
+    { name = "deep-ep", version = "1.1.0+1fd57b0", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.1.0+1fd57b0-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "deep-ep", version = "1.2.1+29d31c0", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.2.1+29d31c0-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "deep-gemm", version = "2.5.0+891d57b", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "deep-gemm", version = "2.5.0+891d57b", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nixl" },
-    { name = "nixl-cu12", version = "0.10.1", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
-    { name = "vllm-router", version = "0.1.26", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64'" },
-    { name = "vllm-router", version = "0.1.26", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
+    { name = "nixl-cu12", version = "0.10.1", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "vllm-router", version = "0.1.26", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "vllm-router", version = "0.1.26", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 flash-attn = [
-    { name = "flash-attn", marker = "platform_machine == 'x86_64'" },
+    { name = "flash-attn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 flash-attn-3 = [
     { name = "flash-attn-3" },
@@ -5296,9 +5306,9 @@ requires-dist = [
     { name = "transformers", specifier = "==5.6.2" },
     { name = "uvloop", specifier = ">=0.21.0" },
     { name = "verifiers", extras = ["harbor"], editable = "deps/verifiers" },
-    { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'", specifier = ">=0.24.0" },
-    { name = "vllm", marker = "platform_machine == 'aarch64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" },
-    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" },
+    { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'", specifier = ">=0.25.1" },
+    { name = "vllm", marker = "platform_machine == 'aarch64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.25.1/vllm-0.25.1+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" },
+    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.25.1/vllm-0.25.1+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "vllm-router", marker = "platform_machine == 'aarch64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl" },
     { name = "vllm-router", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'disagg'" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl" },
@@ -5791,7 +5801,7 @@ name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "(platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
 wheels = [
@@ -5803,6 +5813,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
     { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
     { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+]
+
+[[package]]
+name = "pynvvideocodec"
+version = "2.0.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/1c/78f6fdf85133157a6a3405eab5ef4c2bc8048194dbda1c91bb9b8645bb36/pynvvideocodec-2.0.4-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:bad9e25f494abdcfa8f9dffa33a840509eda3ffcdf6e7cf6465d73be307c0c82", size = 28630316, upload-time = "2026-07-08T04:25:54.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/49/98da271686e00676f41b1197ba5431ddc341b96d8efb68ea9d68e2b0d870/pynvvideocodec-2.0.4-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b59cec7a1a3f78fad13fead78cad8b6d9686827f9ff4477080245457675a01d0", size = 43176147, upload-time = "2026-05-27T04:04:08.297Z" },
+    { url = "https://files.pythonhosted.org/packages/42/80/7b13c12fd5f3243b01190130ce098a44ddf62e030e6ed712911cbfe40311/pynvvideocodec-2.0.4-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:a0daa28b09705806c8c6b26326df217c45e60c0a12a673ea3ea6ee5e2e7193b0", size = 35754893, upload-time = "2026-05-27T04:04:43.866Z" },
 ]
 
 [[package]]
@@ -6004,7 +6024,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "(implementation_name == 'pypy' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'pypy' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -7474,6 +7494,15 @@ wheels = [
 ]
 
 [[package]]
+name = "torchcodec"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/de/c00b8d13e3e28de9c76f05b4c25fc4d882b4a3d1451b8d2073d089895684/torchcodec-0.15.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5c62f4257b49c6473b0a1006519274b7daef9ef9c1d66b1a6a025dba9df5daac", size = 2727846, upload-time = "2026-07-15T10:14:08.066Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/05/b7ba7ae04db4afeb1fd32d30ec6290d511c374adc464afe191c8fc8d4e22/torchcodec-0.15.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:fa31e33884829332cc55b301aa9d23ba90bf164aa8576a8c68aed6c0061c2d8c", size = 2988620, upload-time = "2026-07-15T10:14:09.504Z" },
+]
+
+[[package]]
 name = "torchdata"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -7819,7 +7848,7 @@ standard = [
     { name = "httptools" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "uvloop", marker = "(platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
     { name = "watchfiles" },
     { name = "websockets" },
 ]
@@ -7880,7 +7909,7 @@ dependencies = [
     { name = "tenacity" },
     { name = "tomli-w" },
     { name = "typing-extensions" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "uvloop", marker = "(platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
 ]
 
 [package.optional-dependencies]
@@ -7984,87 +8013,90 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.24.0+cu129"
-source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" }
+version = "0.25.1+cu129"
+source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.25.1/vllm-0.25.1+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" }
 resolution-markers = [
     "platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "aiohttp" },
-    { name = "anthropic" },
-    { name = "apache-tvm-ffi" },
-    { name = "blake3" },
-    { name = "cachetools" },
-    { name = "cbor2" },
-    { name = "cloudpickle" },
-    { name = "compressed-tensors" },
-    { name = "depyf" },
-    { name = "diskcache" },
-    { name = "einops" },
-    { name = "fastapi", extra = ["standard"] },
-    { name = "fastsafetensors" },
-    { name = "filelock" },
-    { name = "flashinfer-cubin" },
-    { name = "flashinfer-python" },
-    { name = "humming-kernels", extra = ["cu12"] },
-    { name = "ijson" },
-    { name = "jsonschema" },
-    { name = "lark" },
-    { name = "llguidance" },
-    { name = "lm-format-enforcer" },
-    { name = "mcp" },
-    { name = "mistral-common", extra = ["image"] },
-    { name = "model-hosting-container-standards" },
-    { name = "msgspec" },
-    { name = "ninja" },
-    { name = "numba" },
-    { name = "numpy" },
-    { name = "nvidia-cudnn-frontend" },
-    { name = "nvidia-cutlass-dsl" },
-    { name = "openai" },
-    { name = "openai-harmony" },
-    { name = "opencv-python-headless" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp" },
-    { name = "opentelemetry-sdk" },
-    { name = "opentelemetry-semantic-conventions-ai" },
-    { name = "outlines-core" },
-    { name = "partial-json-parser" },
-    { name = "pillow" },
-    { name = "prometheus-client" },
-    { name = "prometheus-fastapi-instrumentator" },
-    { name = "protobuf" },
-    { name = "psutil" },
-    { name = "py-cpuinfo" },
-    { name = "pybase64" },
-    { name = "pydantic" },
-    { name = "python-json-logger" },
-    { name = "pyyaml" },
-    { name = "pyzmq" },
-    { name = "quack-kernels" },
-    { name = "regex" },
-    { name = "requests" },
-    { name = "safetensors" },
-    { name = "sentencepiece" },
-    { name = "setproctitle" },
-    { name = "setuptools" },
-    { name = "six" },
-    { name = "starlette" },
-    { name = "tiktoken" },
-    { name = "tilelang" },
-    { name = "tokenizers" },
-    { name = "tokenspeed-mla" },
-    { name = "torch" },
-    { name = "torchaudio" },
-    { name = "torchvision" },
-    { name = "tqdm" },
-    { name = "transformers" },
-    { name = "typing-extensions" },
-    { name = "watchfiles" },
-    { name = "xgrammar" },
+    { name = "aiohttp", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "anthropic", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "apache-tvm-ffi", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "blake3", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "cachetools", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "cbor2", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "cloudpickle", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "compressed-tensors", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "depyf", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "diskcache", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "einops", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "fastapi", extra = ["standard"], marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "fastsafetensors", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "filelock", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "flashinfer-cubin", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "flashinfer-python", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "humming-kernels", extra = ["cu12"], marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "ijson", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "jsonschema", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "lark", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "llguidance", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "lm-format-enforcer", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "mcp", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "mistral-common", extra = ["image"], marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "model-hosting-container-standards", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "msgspec", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "ninja", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "numba", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-frontend", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-cutlass-dsl", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvtx", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "openai", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "openai-harmony", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "opencv-python-headless", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-api", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-exporter-otlp", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-sdk", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-semantic-conventions-ai", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "outlines-core", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "partial-json-parser", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pillow", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "prometheus-client", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "prometheus-fastapi-instrumentator", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "protobuf", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "psutil", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "py-cpuinfo", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pybase64", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pynvvideocodec", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "python-json-logger", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pyzmq", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "quack-kernels", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "regex", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "requests", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "safetensors", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "sentencepiece", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "setproctitle", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "six", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "starlette", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "tiktoken", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "tilelang", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "tokenizers", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "tokenspeed-mla", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torch", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torchaudio", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torchcodec", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torchvision", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "tqdm", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "transformers", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "watchfiles", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "xgrammar", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e85edf971a25582993ef3bfd26b0d6ebf498d5ca4ae4944fa8824a734b81ac58" },
+    { url = "https://github.com/vllm-project/vllm/releases/download/v0.25.1/vllm-0.25.1+cu129-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:bdffbe35b2c1ab8f2a9dcc337b657261d9b192c92c217e5a2f98a8835fe78daa" },
 ]
 
 [package.metadata]
@@ -8086,10 +8118,10 @@ requires-dist = [
     { name = "fastsafetensors", specifier = ">=0.3.2" },
     { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.3.2" },
     { name = "filelock", specifier = ">=3.16.1" },
-    { name = "flashinfer-cubin", specifier = "==0.6.12" },
-    { name = "flashinfer-python", specifier = "==0.6.12" },
+    { name = "flashinfer-cubin", specifier = "==0.6.13" },
+    { name = "flashinfer-python", specifier = "==0.6.13" },
     { name = "helion", marker = "extra == 'helion'", specifier = "==1.1.0" },
-    { name = "humming-kernels", extras = ["cu12"], specifier = "==0.1.6" },
+    { name = "humming-kernels", extras = ["cu12"], specifier = "==0.1.10" },
     { name = "ijson" },
     { name = "instanttensor", marker = "extra == 'instanttensor'", specifier = ">=0.1.5" },
     { name = "jsonschema", specifier = ">=4.23.0" },
@@ -8099,7 +8131,7 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'bench'" },
     { name = "mcp" },
     { name = "mistral-common", extras = ["audio"], marker = "extra == 'audio'" },
-    { name = "mistral-common", extras = ["image"], specifier = ">=1.11.3" },
+    { name = "mistral-common", extras = ["image"], specifier = ">=1.11.5" },
     { name = "model-hosting-container-standards", specifier = ">=0.1.14,<1.0.0" },
     { name = "msgspec" },
     { name = "ninja" },
@@ -8107,6 +8139,7 @@ requires-dist = [
     { name = "numpy" },
     { name = "nvidia-cudnn-frontend", specifier = ">=1.19.1" },
     { name = "nvidia-cutlass-dsl", specifier = "==4.5.2" },
+    { name = "nvtx", specifier = "==0.2.15" },
     { name = "openai", specifier = ">=2.0.0" },
     { name = "openai-harmony", specifier = ">=0.0.3" },
     { name = "opencv-python-headless", specifier = ">=4.13.0" },
@@ -8130,6 +8163,7 @@ requires-dist = [
     { name = "py-cpuinfo" },
     { name = "pybase64" },
     { name = "pydantic", specifier = ">=2.12.0" },
+    { name = "pynvvideocodec", specifier = "==2.0.4" },
     { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "pyzmq", specifier = ">=25.0.0" },
@@ -8153,9 +8187,10 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.6.0" },
     { name = "tilelang", specifier = "==0.1.9" },
     { name = "tokenizers", specifier = ">=0.21.1" },
-    { name = "tokenspeed-mla", specifier = "==0.1.2" },
+    { name = "tokenspeed-mla", marker = "sys_platform == 'linux'", specifier = "==0.1.2" },
     { name = "torch", specifier = "==2.11.0" },
     { name = "torchaudio", specifier = "==2.11.0" },
+    { name = "torchcodec", specifier = ">=0.14" },
     { name = "torchvision", specifier = "==0.26.0" },
     { name = "tqdm" },
     { name = "transformers", specifier = ">=5.5.3" },
@@ -8169,87 +8204,90 @@ provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttens
 
 [[package]]
 name = "vllm"
-version = "0.24.0+cu129"
-source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" }
+version = "0.25.1+cu129"
+source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.25.1/vllm-0.25.1+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" }
 resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "aiohttp" },
-    { name = "anthropic" },
-    { name = "apache-tvm-ffi" },
-    { name = "blake3" },
-    { name = "cachetools" },
-    { name = "cbor2" },
-    { name = "cloudpickle" },
-    { name = "compressed-tensors" },
-    { name = "depyf" },
-    { name = "diskcache" },
-    { name = "einops" },
-    { name = "fastapi", extra = ["standard"] },
-    { name = "fastsafetensors" },
-    { name = "filelock" },
-    { name = "flashinfer-cubin" },
-    { name = "flashinfer-python" },
-    { name = "humming-kernels", extra = ["cu12"] },
-    { name = "ijson" },
-    { name = "jsonschema" },
-    { name = "lark" },
-    { name = "llguidance" },
-    { name = "lm-format-enforcer" },
-    { name = "mcp" },
-    { name = "mistral-common", extra = ["image"] },
-    { name = "model-hosting-container-standards" },
-    { name = "msgspec" },
-    { name = "ninja" },
-    { name = "numba" },
-    { name = "numpy" },
-    { name = "nvidia-cudnn-frontend" },
-    { name = "nvidia-cutlass-dsl" },
-    { name = "openai" },
-    { name = "openai-harmony" },
-    { name = "opencv-python-headless" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp" },
-    { name = "opentelemetry-sdk" },
-    { name = "opentelemetry-semantic-conventions-ai" },
-    { name = "outlines-core" },
-    { name = "partial-json-parser" },
-    { name = "pillow" },
-    { name = "prometheus-client" },
-    { name = "prometheus-fastapi-instrumentator" },
-    { name = "protobuf" },
-    { name = "psutil" },
-    { name = "py-cpuinfo" },
-    { name = "pybase64" },
-    { name = "pydantic" },
-    { name = "python-json-logger" },
-    { name = "pyyaml" },
-    { name = "pyzmq" },
-    { name = "quack-kernels" },
-    { name = "regex" },
-    { name = "requests" },
-    { name = "safetensors" },
-    { name = "sentencepiece" },
-    { name = "setproctitle" },
-    { name = "setuptools" },
-    { name = "six" },
-    { name = "starlette" },
-    { name = "tiktoken" },
-    { name = "tilelang" },
-    { name = "tokenizers" },
-    { name = "tokenspeed-mla" },
-    { name = "torch" },
-    { name = "torchaudio" },
-    { name = "torchvision" },
-    { name = "tqdm" },
-    { name = "transformers" },
-    { name = "typing-extensions" },
-    { name = "watchfiles" },
-    { name = "xgrammar" },
+    { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "anthropic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "apache-tvm-ffi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "blake3", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cachetools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cbor2", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cloudpickle", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "compressed-tensors", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "depyf", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "diskcache", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "einops", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "fastapi", extra = ["standard"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "fastsafetensors", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "filelock", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "flashinfer-cubin", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "flashinfer-python", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "humming-kernels", extra = ["cu12"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "ijson", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "jsonschema", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "lark", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "llguidance", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "lm-format-enforcer", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "mcp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "mistral-common", extra = ["image"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "model-hosting-container-standards", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "msgspec", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "ninja", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numba", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-frontend", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cutlass-dsl", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvtx", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "openai", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "openai-harmony", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opencv-python-headless", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-api", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-exporter-otlp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-semantic-conventions-ai", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "outlines-core", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "partial-json-parser", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pillow", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "prometheus-client", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "prometheus-fastapi-instrumentator", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "protobuf", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "psutil", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "py-cpuinfo", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pybase64", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pynvvideocodec", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "python-json-logger", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pyzmq", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "quack-kernels", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "regex", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "safetensors", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "sentencepiece", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setproctitle", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "six", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "tiktoken", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "tilelang", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "tokenizers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "tokenspeed-mla", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torchaudio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torchcodec", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torchvision", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "tqdm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "transformers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "watchfiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "xgrammar", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:597949743f2a00c0539d9e2ff0f67b32c608a378e973f99e7529fd6fa9445f70" },
+    { url = "https://github.com/vllm-project/vllm/releases/download/v0.25.1/vllm-0.25.1+cu129-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9e206f370c934a2d4b6b1f05d3d09708d344e05d80260189ef19f60755709431" },
 ]
 
 [package.metadata]
@@ -8271,10 +8309,10 @@ requires-dist = [
     { name = "fastsafetensors", specifier = ">=0.3.2" },
     { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.3.2" },
     { name = "filelock", specifier = ">=3.16.1" },
-    { name = "flashinfer-cubin", specifier = "==0.6.12" },
-    { name = "flashinfer-python", specifier = "==0.6.12" },
+    { name = "flashinfer-cubin", specifier = "==0.6.13" },
+    { name = "flashinfer-python", specifier = "==0.6.13" },
     { name = "helion", marker = "extra == 'helion'", specifier = "==1.1.0" },
-    { name = "humming-kernels", extras = ["cu12"], specifier = "==0.1.6" },
+    { name = "humming-kernels", extras = ["cu12"], specifier = "==0.1.10" },
     { name = "ijson" },
     { name = "instanttensor", marker = "extra == 'instanttensor'", specifier = ">=0.1.5" },
     { name = "jsonschema", specifier = ">=4.23.0" },
@@ -8284,7 +8322,7 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'bench'" },
     { name = "mcp" },
     { name = "mistral-common", extras = ["audio"], marker = "extra == 'audio'" },
-    { name = "mistral-common", extras = ["image"], specifier = ">=1.11.3" },
+    { name = "mistral-common", extras = ["image"], specifier = ">=1.11.5" },
     { name = "model-hosting-container-standards", specifier = ">=0.1.14,<1.0.0" },
     { name = "msgspec" },
     { name = "ninja" },
@@ -8292,6 +8330,7 @@ requires-dist = [
     { name = "numpy" },
     { name = "nvidia-cudnn-frontend", specifier = ">=1.19.1" },
     { name = "nvidia-cutlass-dsl", specifier = "==4.5.2" },
+    { name = "nvtx", specifier = "==0.2.15" },
     { name = "openai", specifier = ">=2.0.0" },
     { name = "openai-harmony", specifier = ">=0.0.3" },
     { name = "opencv-python-headless", specifier = ">=4.13.0" },
@@ -8315,6 +8354,7 @@ requires-dist = [
     { name = "py-cpuinfo" },
     { name = "pybase64" },
     { name = "pydantic", specifier = ">=2.12.0" },
+    { name = "pynvvideocodec", specifier = "==2.0.4" },
     { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "pyzmq", specifier = ">=25.0.0" },
@@ -8338,9 +8378,10 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.6.0" },
     { name = "tilelang", specifier = "==0.1.9" },
     { name = "tokenizers", specifier = ">=0.21.1" },
-    { name = "tokenspeed-mla", specifier = "==0.1.2" },
+    { name = "tokenspeed-mla", marker = "sys_platform == 'linux'", specifier = "==0.1.2" },
     { name = "torch", specifier = "==2.11.0" },
     { name = "torchaudio", specifier = "==2.11.0" },
+    { name = "torchcodec", specifier = ">=0.14" },
     { name = "torchvision", specifier = "==0.26.0" },
     { name = "tqdm" },
     { name = "transformers", specifier = ">=5.5.3" },
@@ -8360,12 +8401,12 @@ resolution-markers = [
     "platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "aiohttp" },
-    { name = "fastapi" },
-    { name = "orjson" },
-    { name = "requests" },
-    { name = "setproctitle" },
-    { name = "uvicorn" },
+    { name = "aiohttp", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "fastapi", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "orjson", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "requests", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "setproctitle", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "uvicorn", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ab8d0da61faa588fd5a7ed947bd58ddb31f5836cf55518bdd0122cfbc83989f4" },
@@ -8393,12 +8434,12 @@ resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "aiohttp" },
-    { name = "fastapi" },
-    { name = "orjson" },
-    { name = "requests" },
-    { name = "setproctitle" },
-    { name = "uvicorn" },
+    { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "fastapi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "orjson", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setproctitle", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "uvicorn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:db0c9410a4c130da8ffeea22f569faca7c85c58c5e183be1ebf758076361a6ec" },
@@ -8667,7 +8708,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "torch" },
     { name = "transformers" },
-    { name = "triton", marker = "platform_machine == 'x86_64'" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/ea/6394caddd078d33772070eefaaf77cb0a826a3047b908b688dece7d040b5/xgrammar-0.2.1.tar.gz", hash = "sha256:4c48c251b75d211e9ffa7f4f4ac8b5b0164f89fd5f0d1883ad7ff4554922030d", size = 2427065, upload-time = "2026-05-17T21:39:26.576Z" }


### PR DESCRIPTION
## Summary

- add a standalone `prime-rl-kernels` package with owned SM100 NVFP4 activation/weight quantizers and an MSLK-derived CUTLASS grouped GEMM
- add public `quantize_activations` and `quantize_weights` APIs, using per-token activation scales and per-expert fused gate-up weight scales in tcgen05 block-scale layout
- replace the temporary FP8 model flag/callable recipe with an abstract `MoEQuantizationConfig` contract and concrete FP8, MXFP8, and NVFP4 configs directly on the model config; NVFP4 alone owns its backward recipe
- support NVFP4 `backward = "dequant_bf16"` and `backward = "bf16"`; both retain BF16 master parameters, checkpoints, optimizer state, and weight transfer
- persist JIT compilation through `TORCH_EXTENSIONS_DIR` and retain the upstream MSLK license beside the adapted kernel

Depends on #3141.

## Validation

- restacked on #3141; the actual `HuggingFaceStorageReader` DCP fused-load regression and CUDA expert-bias regression pass on GB200
- Ruff format/check on every changed Python file
- runtime construction and backend selection for the FP8, MXFP8, NVFP4-dequant-BF16, and NVFP4-BF16 config subclasses
- bytecode compilation and all MoE backend/config propagation on a GB200 (SM100), including a cached Qwen3-30B-A3B config
- both NVFP4 backward modes compared exactly with grouped BF16 operations over their intended operands
- manual GB200 fused grouped-GEMM forward and fused `GroupedExperts` checkpoint/finite-gradient validation