### PR TITLE
chore(orchestrator)!: rename max_inflight_rollouts to max_inflight_episodes

### DIFF
--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -71,7 +71,7 @@ type = "muon"
 batch_size = 256
 group_size = 16
 max_off_policy_steps = 32
-max_inflight_rollouts = 512
+max_inflight_episodes = 512
 
 [orchestrator.renderer]
 name = "glm-4.5"

--- a/examples/advanced/glm-4.5-air/swe.toml
+++ b/examples/advanced/glm-4.5-air/swe.toml
@@ -82,7 +82,7 @@ type = "muon"
 batch_size = 256
 group_size = 16
 max_off_policy_steps = 32
-max_inflight_rollouts = 512
+max_inflight_episodes = 512
 
 [orchestrator.algo]
 type = "grpo"

--- a/examples/advanced/glm-4.5-air/terminal.toml
+++ b/examples/advanced/glm-4.5-air/terminal.toml
@@ -72,7 +72,7 @@ type = "muon"
 batch_size = 256
 group_size = 16
 max_off_policy_steps = 32
-max_inflight_rollouts = 512
+max_inflight_episodes = 512
 
 [orchestrator.renderer]
 name = "glm-4.5"

--- a/examples/advanced/glm-5.2/swe-llmd.toml
+++ b/examples/advanced/glm-5.2/swe-llmd.toml
@@ -81,7 +81,7 @@ weight_decay = 0.0
 [orchestrator]
 batch_size = 256
 group_size = 16
-max_inflight_rollouts = 2048
+max_inflight_episodes = 2048
 max_off_policy_steps = 8 # 16/32 can be better, 8 is more CPU stable
 
 [orchestrator.model]

--- a/examples/advanced/nemotron-3-super/swe.toml
+++ b/examples/advanced/nemotron-3-super/swe.toml
@@ -66,7 +66,7 @@ type = "adamw"
 batch_size = 256
 group_size = 16
 max_off_policy_steps = 32
-max_inflight_rollouts = 1536
+max_inflight_episodes = 1536
 
 [orchestrator.algo]
 type = "grpo"

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -525,10 +525,12 @@ class OrchestratorConfig(BaseConfig):
     """Tokens to train on per step (token-based batching). Set this OR ``batch_size``."""
 
     oversampling_factor: float | None = Field(None, gt=0)
-    """Rollout-mode batching only. Multiplier used to derive ``max_inflight_rollouts`` from ``batch_size`` when ``max_inflight_rollouts`` is unset. Values below 1.0 intentionally cap in-flight rollout capacity below ``batch_size``."""
+    """Rollout-mode batching only. Multiplier used to derive ``max_inflight_episodes`` from ``batch_size`` when ``max_inflight_episodes`` is unset. Values below 1.0 intentionally cap in-flight episode capacity below ``batch_size``."""
 
-    max_inflight_rollouts: int | None = Field(None, ge=1)
-    """Maximum number of rollouts kept in-flight. Required for token-based batching. With ``batch_size`` set, defaults to ``batch_size * oversampling_factor`` (or ``batch_size`` when ``oversampling_factor`` is unset)."""
+    max_inflight_episodes: int | None = Field(
+        None, ge=1, validation_alias=AliasChoices("max_inflight_episodes", "max_inflight_rollouts")
+    )
+    """Maximum number of episodes kept in-flight — one episode is one agent run at a time, whatever the env's agents are. Required for token-based batching. With ``batch_size`` set, defaults to ``batch_size * oversampling_factor`` (or ``batch_size`` when ``oversampling_factor`` is unset)."""
 
     group_size: int = Field(1, ge=1, validation_alias=AliasChoices("group_size", "rollouts_per_example"))
     """Output sequences returned per example during training."""
@@ -682,26 +684,26 @@ class OrchestratorConfig(BaseConfig):
         if has_token_batch:
             if self.oversampling_factor is not None:
                 raise ValueError("oversampling_factor can only be set when batch_size is set")
-            if self.max_inflight_rollouts is None:
-                raise ValueError("max_inflight_rollouts must be set when token_batch_size is set")
+            if self.max_inflight_episodes is None:
+                raise ValueError("max_inflight_episodes must be set when token_batch_size is set")
         else:
             assert self.batch_size is not None
             if self.batch_size % self.group_size != 0:
                 raise ValueError("Batch size must be divisible by the number of samples per problem")
             oversampling_factor = self.oversampling_factor if self.oversampling_factor is not None else 1.0
-            resolved_max_inflight_rollouts = max(
+            resolved_max_inflight_episodes = max(
                 self.group_size,
                 int(self.batch_size * oversampling_factor),
             )
-            if self.max_inflight_rollouts is not None and self.oversampling_factor is not None:
-                expected_max_inflight_rollouts = resolved_max_inflight_rollouts
-                if self.max_inflight_rollouts != expected_max_inflight_rollouts:
-                    raise ValueError("max_inflight_rollouts conflicts with oversampling_factor * batch_size")
-            if self.max_inflight_rollouts is None:
-                self.max_inflight_rollouts = resolved_max_inflight_rollouts
+            if self.max_inflight_episodes is not None and self.oversampling_factor is not None:
+                expected_max_inflight_episodes = resolved_max_inflight_episodes
+                if self.max_inflight_episodes != expected_max_inflight_episodes:
+                    raise ValueError("max_inflight_episodes conflicts with oversampling_factor * batch_size")
+            if self.max_inflight_episodes is None:
+                self.max_inflight_episodes = resolved_max_inflight_episodes
 
-        if self.max_inflight_rollouts is not None and self.max_inflight_rollouts < self.group_size:
-            raise ValueError("max_inflight_rollouts must be at least the number of rollouts per example")
+        if self.max_inflight_episodes is not None and self.max_inflight_episodes < self.group_size:
+            raise ValueError("max_inflight_episodes must be at least the number of rollouts per example")
 
         # Propagate the top-level ``group_size`` into each train env that didn't set its own.
         for env_cfg in self.train.source:

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -1,7 +1,9 @@
 """RolloutDispatcher: schedules rollouts under a shared permit counter.
 
-- Capacity (``max_inflight_rollouts``) is shared across train + eval.
-  A group-scoring task that runs N rollouts in one call reserves N permits.
+- Capacity (``max_inflight_episodes``) is shared across train + eval. One permit is
+  one episode: for a v1 env one ``run`` request, and a group-scoring task that runs
+  N rollouts in one call reserves N permits (each bridged v0 rollout is its own
+  single-agent episode).
 - Optional rate limiting via ``AsyncLimiter(tasks_per_minute, 60)``.
 - Emit-everything invariant: every dispatched env-rollout eventually reaches
   ``out_q`` exactly once, as one episode (a ``list[Rollout]``). Failures
@@ -129,7 +131,7 @@ class RolloutDispatcher:
         eval_source: EvalSource | None,
         policy_pool: InferencePool,
         policy: Policy,
-        max_inflight_rollouts: int,
+        max_inflight_episodes: int,
         tasks_per_minute: float | None,
         max_off_policy_steps: int,
     ) -> None:
@@ -143,7 +145,7 @@ class RolloutDispatcher:
         self.eval_source = eval_source
         self.max_off_policy_steps = max_off_policy_steps
 
-        self.max_inflight = max_inflight_rollouts
+        self.max_inflight = max_inflight_episodes
         self.inflight_permits = 0
         self.rate_limiter: AsyncLimiter | None = (
             AsyncLimiter(tasks_per_minute, time_period=60) if tasks_per_minute else None

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -391,7 +391,7 @@ class Orchestrator:
             else None
         )
 
-        assert config.max_inflight_rollouts is not None, "max_inflight_rollouts must be resolved before dispatcher init"
+        assert config.max_inflight_episodes is not None, "max_inflight_episodes must be resolved before dispatcher init"
         log_interval = config.log.interval
         wandb_enabled = config.wandb is not None
         self.dispatcher = RolloutDispatcher(
@@ -401,7 +401,7 @@ class Orchestrator:
             eval_source=self.eval_source,
             policy_pool=self.policy_inference,
             policy=self.policy,
-            max_inflight_rollouts=config.max_inflight_rollouts,
+            max_inflight_episodes=config.max_inflight_episodes,
             tasks_per_minute=config.tasks_per_minute,
             max_off_policy_steps=config.max_off_policy_steps,
         )


### PR DESCRIPTION
A dispatcher permit has always bought one **episode**, not one rollout: for a v1 env one `run` request is one episode however many agents play it, and a legacy group-scoring call reserves one permit per bridged v0 rollout — each of which is its own single-agent episode. Name the knob what it counts.

`orchestrator.max_inflight_rollouts` → `orchestrator.max_inflight_episodes`, with `max_inflight_rollouts` kept as a `validation_alias` (the same treatment `rollouts_per_example` gets for `group_size`), so existing TOMLs and `--max-inflight-rollouts` overrides keep working. The five example configs that set it are updated to the new name.

Together with PrimeIntellect-ai/verifiers#2157 (`-c`/`max_concurrent` bounds episodes, `env.max_concurrent_agents` bounds agent runs inside one, default 1), an episode permit is also one live agent run — so `max_inflight_episodes` bounds real load instead of being multiplied by whatever an env fans out to internally.

This PR is only the rename: it says nothing that isn't already true of the pinned verifiers, so it can land in either order. The two things that *do* need the bump land with it — the "one permit is one live agent run" guarantee in the dispatcher docstring, and forwarding the new serve-level `max_concurrent` (which prime-rl's `EnvConfig` inherits from `vf.EnvServerConfig`) to the env-server worker.

### Verified

- `pytest tests/unit -k "config or dispatcher"` — 55 passed (`test_load_configs` deselected: it fails on `main` in this environment too, missing hub env packages like `alphabet-sort-v1`).
- Throwaway probe: the new name, the old alias, `--max-inflight-episodes` / `--max_inflight_episodes` / `--max-inflight-rollouts` CLI forms, `batch_size * oversampling_factor` derivation, and the token-batching guard all resolve as expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Naming and alias-only change with no scheduling logic changes; old config keys still accepted via Pydantic alias.
> 
> **Overview**
> Renames **`orchestrator.max_inflight_rollouts`** to **`max_inflight_episodes`** so the config matches what the dispatcher actually limits (one permit per episode, not per rollout). **`max_inflight_rollouts`** remains a **`validation_alias`**, so existing TOMLs and CLI overrides keep working; **`resolve_batching`** and related validation/error strings use the new name.
> 
> Five advanced example TOMLs switch to **`max_inflight_episodes`**. **`RolloutDispatcher`** and **`Orchestrator`** take **`max_inflight_episodes`**; the dispatcher module docstring clarifies that capacity is episode-based (v1 `run`, legacy group-scoring as N single-agent episodes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aef4f8f9745b78b5bc07060deb9ee54916522cb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->