### PR TITLE
fix: compute trainable rate over effective rollouts

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -597,11 +597,15 @@ class Orchestrator:
                 )
             return
         self.consecutive_empty_batches = 0
-        n_trainable = sum(1 for r in batch.rollouts if r.is_trainable)
-        if n_trainable / len(batch.rollouts) <= 0.1:
+        # The clean, trained-on subset — the only pool where "carries a gradient" is meaningful.
+        # Errored, filtered and payload-less rollouts never reach the trainer, so counting them
+        # would make the rate track error/filter volume instead of task difficulty.
+        effective = batch.rollouts.effective
+        n_trainable = sum(1 for r in effective if r.is_trainable)
+        if effective and n_trainable / len(effective) <= 0.1:
             get_logger().warning(
-                f"Only {n_trainable}/{len(batch.rollouts)} generated rollouts are trainable "
-                f"({n_trainable / len(batch.rollouts):.1%}) — consider reviewing task difficulty / filter config"
+                f"Only {n_trainable}/{len(effective)} effective rollouts are trainable "
+                f"({n_trainable / len(effective):.1%}) — consider reviewing task difficulty / filter config"
             )
 
         # Ship batch ``step`` only once the trainer has published v{step-1-TARGET_LAG}.
@@ -637,7 +641,6 @@ class Orchestrator:
         # at ship time; the full arrival window already streamed into ``all`` on arrival.
         # to_record drops the per-node training tensors — they're for training, not the rollout
         # record, and can't round-trip json (raw numpy bytes).
-        effective = batch.rollouts.effective
         records = [r.to_record() for r in effective]
         await asyncio.to_thread(save_rollouts, records, get_trace_path(config.output_dir, step, "train", "effective"))
 
@@ -805,19 +808,19 @@ class Orchestrator:
     def log_train_batch(self, batch: TrainBatch, *, step: int, step_time: float) -> None:
         """Per-step ``Step …`` success line. Multi-env runs append an indented ``╰─`` line per env.
         ``Error`` is the sink-level rate (errored arrivals / total arrivals, over the full window);
-        the quality metrics are over the effective (clean, trained-on) subset; ``Trainable`` is
-        relative to all generated rollouts."""
+        the quality metrics are over the effective (clean, trained-on) subset, as is ``Trainable``."""
         rollouts = batch.rollouts
         effective = rollouts.effective
         eff = effective.metrics
         n_generated = len(rollouts)
-        n_trainable = sum(1 for r in rollouts if r.is_trainable)
-        trainable_rate = (n_trainable / n_generated) if n_generated else 0.0
+        n_effective = len(effective)
+        n_trainable = sum(1 for r in effective if r.is_trainable)
+        trainable_rate = (n_trainable / n_effective) if n_effective else 0.0
         max_off_policy = max((r.off_policy_steps for r in effective), default=0)
 
         head = (
             f"Step {step} | {format_time(step_time):>7} | Reward {eff.reward.mean():.4f} | "
-            f"Trainable {n_trainable}/{n_generated} ({trainable_rate:.1%}) | "
+            f"Trainable {n_trainable}/{n_effective} ({trainable_rate:.1%}) | "
             f"Turns {eff.num_turns.mean():.1f} | Branches {eff.num_branches.mean():.1f} | "
             f"Max Off-Policy {max_off_policy} | "
             f"Error {rollouts.metrics.has_error.mean():.1%} | Truncation {eff.is_truncated.mean():.1%}"

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -597,9 +597,6 @@ class Orchestrator:
                 )
             return
         self.consecutive_empty_batches = 0
-        # The clean, trained-on subset — the only pool where "carries a gradient" is meaningful.
-        # Errored, filtered and payload-less rollouts never reach the trainer, so counting them
-        # would make the rate track error/filter volume instead of task difficulty.
         effective = batch.rollouts.effective
         n_trainable = sum(1 for r in effective if r.is_trainable)
         if effective and n_trainable / len(effective) <= 0.1:

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -146,7 +146,7 @@ class TrainBatch:
     finalized in that span (errored + filtered included; rollouts of still-incomplete groups wait
     for a later window). Its ``.effective`` / ``.metrics`` views drive logging. ``samples`` is the
     trainer-bound payload (the shipped cohort's post-filter survivors) — an empty list means nothing
-    ships, which would stall the trainer. Trainable counts derive from ``rollouts``
+    ships, which would stall the trainer. Trainable counts derive from ``rollouts.effective``
     (``r.is_trainable``) and token totals from ``samples``, so neither is carried as a field."""
 
     rollouts: TrainRollouts


### PR DESCRIPTION
## Summary

Observed in a live run:

```
Only 260/296944 generated rollouts are trainable (0.1%) — consider reviewing task difficulty / filter config
```

The denominator was the full arrival window (`batch.rollouts` — errored, filtered and payload-less rollouts included), so the rate tracked error/filter volume rather than task difficulty, and the warning fired on healthy runs.

- Compute `Trainable` (the `Step …` line) and the low-trainable warning over `batch.rollouts.effective`, the clean trained-on subset — the only pool where "carries a gradient" is meaningful.
- Hoist `effective = batch.rollouts.effective` in `finalize_train_batch` so the warning and the downstream record/metrics paths share one view.
- Guard the warning against an empty effective window (a batch shipping only overflow from a previous window divides by zero today).

The per-env `Ratio` in the multi-env lines still uses the full window, unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging and warning logic only; no changes to training payloads, filters, or shipping behavior.
> 
> **Overview**
> **Trainable** metrics and the low-trainable warning now use `batch.rollouts.effective` (the clean, trained-on cohort) instead of the full arrival window, so rates reflect gradient-bearing rollouts rather than error/filter volume.
> 
> In `finalize_train_batch`, `effective` is computed once and reused for the warning, trace save, and related paths. The warning is skipped when `effective` is empty to avoid divide-by-zero. The per-step **Step …** log’s **Trainable** fraction matches this definition; multi-env **Ratio** lines still use the full window. `TrainBatch` docstring notes trainable counts come from `rollouts.effective`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32f1579eb8fd91aa251ca41e3d2c5d2adf025d2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->