### PR TITLE
feat: effective reward and eval score as second panel in W&B overview

### DIFF
--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -298,8 +298,9 @@ class WandbMonitor(Monitor):
 
 OVERVIEW_NAME = "overview"
 
-# Per-rollout metrics (under "<scope>/all/") shown for BOTH train and eval. Only the reward metric
-# differs — train uses "reward/mean", eval uses "avg@k" — and each section builder prepends its own.
+# Per-rollout metrics (under "<scope>/all/") shown for BOTH train and eval. Only the reward metrics
+# differ — train uses "reward/mean", eval uses "avg@k", each shown for the all and effective
+# subsets — and each section builder prepends its own.
 COMMON_METRICS = [
     "has_error/mean",
     "is_truncated/mean",
@@ -347,15 +348,20 @@ def section(name: str, metrics: Sequence[str] = (), regexes: Sequence[str] = ())
 
 
 def train_section(name: str, scope: str) -> ws.Section:
-    return section(name, metrics=[f"{scope}/all/reward/mean"] + [f"{scope}/all/{m}" for m in COMMON_METRICS])
+    return section(
+        name,
+        metrics=[f"{scope}/all/reward/mean", f"{scope}/effective/reward/mean"]
+        + [f"{scope}/all/{m}" for m in COMMON_METRICS],
+    )
 
 
 def eval_section(name: str, env_pattern: str) -> ws.Section:
     # Same metrics as train, but eval's reward is "avg@k" (dynamic k → regex). Everything is a regex so
-    # one section can also serve any env (env_pattern=".*"). Only the "all" subset, like train.
+    # one section can also serve any env (env_pattern=".*").
     return section(
         name,
-        regexes=[f"eval/{env_pattern}/all/avg@.*"] + [f"eval/{env_pattern}/all/{m}" for m in COMMON_METRICS],
+        regexes=[f"eval/{env_pattern}/all/avg@.*", f"eval/{env_pattern}/effective/avg@.*"]
+        + [f"eval/{env_pattern}/all/{m}" for m in COMMON_METRICS],
     )
 
 
@@ -399,8 +405,13 @@ def list_views(entity: str, project: str) -> list[tuple[str, str]]:
 def view_signature(sections: Sequence[ws.Section]) -> tuple:
     train = sorted(s.name[len("train/") :] for s in sections if s.name.startswith("train/") and s.name != "train/agg")
     evals = sorted(s.name[len("eval/") :] for s in sections if s.name.startswith("eval/"))
-    axes = {getattr(p.x, "name", p.x) for s in sections for p in s.panels if isinstance(p, wr.LinePlot)}
-    return (tuple(train), tuple(evals), tuple(sorted(axes)))
+    panels = {
+        (getattr(p.x, "name", p.x), tuple(getattr(m, "name", m) for m in p.y or ()), p.metric_regex)
+        for s in sections
+        for p in s.panels
+        if isinstance(p, wr.LinePlot)
+    }
+    return (tuple(train), tuple(evals), tuple(sorted(panels, key=str)))
 
 
 def next_overview_name(base: str, existing: Sequence[str]) -> str:


### PR DESCRIPTION
## Summary

- Show the effective-subset reward metrics as the second panel in each W&B overview section: train sections now plot `<scope>/effective/reward/mean` right after `<scope>/all/reward/mean`, and eval sections plot `eval/<env>/effective/avg@k` right after `eval/<env>/all/avg@k`.
- Extend `view_signature` to include the panel set (x-axis, y-metrics, metric regex per panel), so any future panel change — not just env-set or axis changes — versions the overview instead of silently reusing a stale view. Existing projects get an `overview-vN` with the new layout on their next run.

## Verification

Ran against a scratch W&B project (deleted afterwards):

- Save → reload round-trip: `view_signature` of the reloaded view equals the locally built one, so reuse detection keeps working.
- Upgrade path: seeded an old-layout `overview` (no effective panels), then `ensure_overview_view` created `overview-v2` with the new panels on the first call and returned `None` (reuse) on the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only W&B workspace overview construction and view reuse detection; training and metric logging are untouched.
> 
> **Overview**
> The curated W&B **overview** saved view now surfaces **effective-subset** reward alongside the existing **all** metrics. Train sections add a second line panel for `{scope}/effective/reward/mean` next to `{scope}/all/reward/mean`; eval sections add `eval/{env}/effective/avg@.*` next to the matching **all** `avg@k` regex.
> 
> **`view_signature`** no longer keys reuse only on train/eval env names and x-axes. It fingerprints the full set of line panels (x-axis, y-metrics, and `metric_regex`), so layout changes like these trigger a new versioned overview (`overview-v2`, …) instead of reusing a stale saved view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca95646f279f5dfdffe05e1f26c0258718c69152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->