### PR TITLE
fix: flush stale eval epochs when a newer one finishes first

### DIFF
--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -657,6 +657,27 @@ class RolloutDispatcher:
             await safe_cancel_all(tasks_to_cancel)
         return cancelled
 
+    async def cancel_eval_step(self, env_name: str, eval_step: int) -> int:
+        """Cancel all in-flight rollouts of one eval epoch and drop its group
+        state. No markers are emitted — the sink has already closed the
+        epoch's bucket, so late arrivals are dropped rather than counted."""
+        for group_id, group in list(self.groups.items()):
+            if group.kind == "eval" and group.env_name == env_name and group.eval_step == eval_step:
+                self.groups.pop(group_id, None)
+        tasks: list[asyncio.Task] = []
+        cancelled = 0
+        for task, meta in list(self.inflight.items()):
+            if meta.kind == "eval" and meta.env_name == env_name and meta.eval_step == eval_step:
+                del self.inflight[task]
+                self.release(meta.rollout_count)
+                cancelled += meta.rollout_count
+                tasks.append(task)
+        if cancelled:
+            self.metrics.record_cancellation(kind="eval", env_name=env_name, n=cancelled)
+        if tasks:
+            await safe_cancel_all(tasks)
+        return cancelled
+
     async def cancel_inflight_rollouts(self) -> None:
         """Cancel all in-flight rollouts. Used on shutdown — doesn't emit
         markers since the sinks are being torn down anyway."""

--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -33,12 +33,20 @@ class EvalSink:
         self.pending_group_episodes: dict[uuid.UUID, int] = defaultdict(int)
         self.pending_batches: dict[tuple[str, int], list[Rollout]] = defaultdict(list)
         self.pending_batch_episodes: dict[tuple[str, int], int] = defaultdict(int)
+        # Epochs force-finalized by ``flush_before`` — straggler episodes
+        # arriving for them are dropped instead of re-opening the bucket.
+        self.closed_batches: set[tuple[str, int]] = set()
 
     def add(self, episode: list[Rollout]) -> EvalBatch | None:
         """Process one episode arrival; finalize the group on the ``group_size``-th
         episode and the per-env epoch on the ``num_examples × group_size``-th."""
         env_name = episode[0].env_name
         group_id = episode[0].group_id
+        if (env_name, episode[0].eval_step) in self.closed_batches:
+            get_logger().debug(
+                f"Dropping straggler eval episode for closed epoch | env={env_name} eval_step={episode[0].eval_step}"
+            )
+            return None
         for rollout in episode:
             self.process_rollout(rollout)
         bkey = (env_name, episode[0].eval_step)
@@ -116,6 +124,29 @@ class EvalSink:
             f"Finished group | env={env_name} task_idx={task_idx} eval_step={eval_step} | "
             f"rollouts={len(group)} (errored={num_errored}) | reward={avg_reward:.4f}"
         )
+
+    def flush_before(self, env_name: str, step: int) -> list[EvalBatch]:
+        """Force-finalize every pending epoch of ``env_name`` older than ``step``:
+        move partial groups into their batch bucket, pop the (incomplete) batches
+        in ascending step order, and mark the epochs closed so stragglers arriving
+        later are dropped. Called when a newer epoch of the same env completes
+        first — the stale epochs are logged as-is instead of waiting."""
+        stale_group_ids: dict[int, list[uuid.UUID]] = defaultdict(list)
+        for group_id, rollouts in self.pending_groups.items():
+            if not rollouts:
+                continue
+            eval_step = rollouts[0].eval_step
+            assert eval_step is not None
+            if rollouts[0].env_name == env_name and eval_step < step:
+                stale_group_ids[eval_step].append(group_id)
+        stale_steps = {s for (env, s) in self.pending_batches if env == env_name and s < step} | set(stale_group_ids)
+        batches: list[EvalBatch] = []
+        for stale_step in sorted(stale_steps):
+            for group_id in stale_group_ids.get(stale_step, []):
+                self.process_group(group_id)
+            batches.append(self.process_batch((env_name, stale_step)))
+            self.closed_batches.add((env_name, stale_step))
+        return batches
 
     def process_batch(self, key: tuple[str, int]) -> EvalBatch:
         """Pop the finished ``(env, eval_step)`` epoch and return the ``EvalBatch`` with its full

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -549,6 +549,17 @@ class Orchestrator:
                 assert self.eval_sink is not None  # eval rollouts only emitted when eval is configured
                 eval_batch = self.eval_sink.add(episode)
                 if eval_batch is not None:
+                    # A newer epoch finishing first means the older ones are
+                    # straggling — cancel their tail and log them as-is, before
+                    # the newer epoch, so metrics stay monotone in ``step``.
+                    for stale_batch in self.eval_sink.flush_before(eval_batch.env_name, eval_batch.step):
+                        cancelled = await self.dispatcher.cancel_eval_step(stale_batch.env_name, stale_batch.step)
+                        get_logger().warning(
+                            f"Eval {eval_batch.env_name} @ step={eval_batch.step} finished before "
+                            f"step={stale_batch.step} - cancelled its {cancelled} remaining rollouts and logging "
+                            f"step {stale_batch.step} as-is ({len(stale_batch.rollouts)} rollouts)"
+                        )
+                        await self.finalize_eval_batch(stale_batch)
                     await self.finalize_eval_batch(eval_batch)
                 continue
 


### PR DESCRIPTION
## Summary

When eval epochs of the same env overlap (eval faster than `interval` allows, or a straggling rollout), an epoch triggered at step `y` can finish before the epoch at step `x < y`. Today the older epoch just keeps waiting: its cohort sits in the sink, a single stuck rollout holds the final drain hostage, and if the run is interrupted meanwhile the step-`x` scores are lost without a trace. The out-of-order completion also logs eval metrics with a regressing `step`, which leaves the W&B run summary (what run tables and reports display) stuck on the older epoch's scores.

This PR makes a newer epoch's completion a completion barrier for older epochs of the same env:

- `EvalSink.flush_before(env, step)` force-finalizes every pending epoch of `env` older than `step` (partial groups included) and marks it closed; straggler episodes arriving for a closed epoch are dropped.
- `RolloutDispatcher.cancel_eval_step(env, step)` cancels the stale epoch's in-flight rollouts and drops its group state without emitting markers (the sink already closed the bucket).
- The orchestrator logs a warning (`Eval {env} @ step=y finished before step=x - cancelled its N remaining rollouts and logging step x as-is`) and finalizes the stale epochs **before** the newer one, so eval metrics are logged monotonically in `step` and the W&B summary stays fresh.

Epochs of *different* envs are left alone — independent per-env cadences finishing at different times is normal and W&B keys them separately.

## Verification

Toy repro on reverse-text (2 GPUs, `Qwen3-0.6B-Reverse-Text-SFT`, eval `interval=1`, 16 examples × 2 rollouts), with a temporary injection delaying eval step 2's task-0 rollouts by 90s:

**Before** ([run](https://wandb.ai/primeintellect/oor-step-repro/runs/bd594a19070241f0b9a49b4013022dc9)): evals finalize in order 3, 4, 5, 6, then 2 (91s late). All points do reach W&B history correctly positioned (the `define_metric("*", step_metric="step")` custom x-axis handles out-of-order data), but the run summary ends on step 2's scores (`eval/reverse-text/all/avg@2 = 0.099` instead of step 6's `0.317`, `summary["step"] = 2`), and the final drain blocks on the straggler for the full 90s.

**After** ([run](https://wandb.ai/primeintellect/oor-step-repro/runs/23e8e94a55e04120bb95835f709df20b)): when step 3's epoch completes, the orchestrator warns (`Eval reverse-text @ step=3 finished before step=2 - cancelled its 2 remaining rollouts and logging step 2 as-is (30 rollouts)`), and logs step 2 before step 3. All epochs land in ascending step order, the summary reflects the newest epoch (`avg@2 = 0.258`, `step = 6`), and the step loop finishes in 31.5s instead of blocking 90s on the straggler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
