### PR TITLE
chore(configs)!: remove every config shim

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,7 +55,7 @@ CLI flags mirror the TOML tree using dots:
 
 > Field names are snake_case in TOML (`max_model_len`) and kebab-case on the CLI (`--max-model-len`).
 
-> Renamed fields keep their old name as a validation alias — e.g. `rollouts_per_example` is still accepted in TOML and CLI after being renamed to `group_size`. Mixing the two names across sources is safe.
+> A renamed field keeps no alias for its old name: the old spelling fails as an unknown key rather than being silently translated.
 
 ## Inspecting and Validating
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -1,9 +1,8 @@
-import warnings
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
 
 import verifiers.v1 as vf
-from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
+from pydantic import Field, SerializeAsAny, model_validator
 from renderers import AutoRendererConfig, RendererConfig
 
 from prime_rl.configs.algorithm import (
@@ -54,9 +53,7 @@ class TrainSamplingConfig(BaseConfig):
     temperature: float = Field(1.0, ge=0, le=2.0)
     """Sampling temperature."""
 
-    max_completion_tokens: int | None = Field(
-        None, validation_alias=AliasChoices("max_completion_tokens", "max_tokens")
-    )
+    max_completion_tokens: int | None = None
     """Maximum output tokens per turn. If None, generates until max context length or EOS."""
 
     # Strictly speaking, extra_body is not a sampling parameter, but it is the
@@ -79,18 +76,6 @@ class TrainSamplingConfig(BaseConfig):
 
         return args
 
-    @model_validator(mode="before")
-    @classmethod
-    def _deprecate_max_tokens(cls, data: Any) -> Any:
-        if isinstance(data, dict) and "max_tokens" in data and "max_completion_tokens" not in data:
-            warnings.warn(
-                "'max_tokens' is deprecated, use 'max_completion_tokens' instead. "
-                "Auto-translating for now, but this will be removed in a future release.",
-                FutureWarning,
-                stacklevel=2,
-            )
-        return data
-
 
 class EvalSamplingConfig(BaseConfig):
     temperature: float | None = Field(None, ge=0, le=2.0)
@@ -105,9 +90,7 @@ class EvalSamplingConfig(BaseConfig):
     min_p: float | None = Field(None, ge=0)
     """Min-p sampling threshold. None defers to the inference server default."""
 
-    max_completion_tokens: int | None = Field(
-        None, validation_alias=AliasChoices("max_completion_tokens", "max_tokens")
-    )
+    max_completion_tokens: int | None = None
     """Maximum output tokens per turn. None defers to the inference server default."""
 
     reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = None
@@ -137,18 +120,6 @@ class EvalSamplingConfig(BaseConfig):
             args["extra_body"] = extra_body
 
         return args
-
-    @model_validator(mode="before")
-    @classmethod
-    def _deprecate_max_tokens(cls, data: Any) -> Any:
-        if isinstance(data, dict) and "max_tokens" in data and "max_completion_tokens" not in data:
-            warnings.warn(
-                "'max_tokens' is deprecated, use 'max_completion_tokens' instead. "
-                "Auto-translating for now, but this will be removed in a future release.",
-                FutureWarning,
-                stacklevel=2,
-            )
-        return data
 
 
 class ServingConfig(vf.ServingConfig):
@@ -250,7 +221,7 @@ class TrainSourceConfig(EnvConfig):
     sampling: TrainSamplingConfig = TrainSamplingConfig()
     """Per-env sampling overrides. Unset fields inherit from the group-level train sampling config."""
 
-    group_size: int = Field(1, ge=1, validation_alias=AliasChoices("group_size", "rollouts_per_example"))
+    group_size: int = Field(1, ge=1)
     """Rollouts generated per example for GRPO group-relative advantages.
     Inherits from ``orchestrator.group_size`` when unset."""
 
@@ -267,7 +238,7 @@ class EvalSourceConfig(EnvConfig):
     num_examples: int = -1
     """Eval examples to sample from the dataset. ``-1`` uses all available examples."""
 
-    group_size: int = Field(1, ge=1, validation_alias=AliasChoices("group_size", "rollouts_per_example"))
+    group_size: int = Field(1, ge=1)
     """Rollouts generated per example. Used for pass@k estimation (e.g. ``group_size=8`` enables pass@1 through pass@8)."""
 
     interval: int = Field(100, ge=1)
@@ -315,7 +286,7 @@ class EvalConfig(BaseConfig):
     num_examples: int = -1
     """Default eval examples per environment. ``-1`` uses all. Can be overridden per env."""
 
-    group_size: int = Field(1, ge=1, validation_alias=AliasChoices("group_size", "rollouts_per_example"))
+    group_size: int = Field(1, ge=1)
     """Default rollouts per example. Can be overridden per env."""
 
     interval: int = Field(100, ge=1)
@@ -567,12 +538,10 @@ class OrchestratorConfig(BaseConfig):
     oversampling_factor: float | None = Field(None, gt=0)
     """Rollout-mode batching only. Multiplier used to derive ``max_inflight_episodes`` from ``batch_size`` when ``max_inflight_episodes`` is unset. Values below 1.0 intentionally cap in-flight episode capacity below ``batch_size``."""
 
-    max_inflight_episodes: int | None = Field(
-        None, ge=1, validation_alias=AliasChoices("max_inflight_episodes", "max_inflight_rollouts")
-    )
+    max_inflight_episodes: int | None = Field(None, ge=1)
     """Maximum number of episodes kept in-flight — one episode is one agent run at a time, whatever the env's agents are. Required for token-based batching. With ``batch_size`` set, defaults to ``batch_size * oversampling_factor`` (or ``batch_size`` when ``oversampling_factor`` is unset)."""
 
-    group_size: int = Field(1, ge=1, validation_alias=AliasChoices("group_size", "rollouts_per_example"))
+    group_size: int = Field(1, ge=1)
     """Output sequences returned per example during training."""
 
     seq_len: int = 2048
@@ -593,24 +562,6 @@ class OrchestratorConfig(BaseConfig):
 
     heartbeat: HeartbeatConfig | None = None
     """BetterStack heartbeat configuration for monitoring training progress."""
-
-    @model_validator(mode="before")
-    @classmethod
-    def _sampling_to_train(cls, data: Any) -> Any:
-        """Allow [sampling] as shorthand for [train.sampling]."""
-        if not isinstance(data, dict):
-            return data
-        if "sampling" in data:
-            train = data.setdefault("train", {})
-            if isinstance(train, dict):
-                warnings.warn(
-                    "'[orchestrator.sampling]' is deprecated, use '[orchestrator.train.sampling]' instead. "
-                    "Auto-translating for now, but this will be removed in a future release.",
-                    FutureWarning,
-                    stacklevel=2,
-                )
-                train.setdefault("sampling", data.pop("sampling"))
-        return data
 
     @model_validator(mode="after")
     def auto_setup_tokenizer(self):

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -30,7 +30,7 @@ uv run rl @ rl.toml --dry-run --output-dir /tmp/x # write resolved TOML to /tmp/
 
 ## Validators
 
-Incompatible combinations (e.g. CP requires flash attention) must raise in a `model_validator` at resolve time, not at runtime. When renaming a field, emit a deprecation warning with a migration hint — never silently drop.
+Incompatible combinations (e.g. CP requires flash attention) must raise in a `model_validator` at resolve time, not at runtime. When renaming a field, remove the old spelling: no `validation_alias`, no auto-translating `mode="before"` validator. The old key then fails as an unknown key, which is the signal. An alias that stays forever is worse than a break — it never gets retired, and a key whose *meaning* changed silently misconfigures the run.
 
 ## Special syntax
 

--- a/tests/unit/train/rl/test_packer.py
+++ b/tests/unit/train/rl/test_packer.py
@@ -32,8 +32,7 @@ def create_run_with_config(output_dir: Path, run_name: str) -> Path:
         "model": {"name": "test-model"},
         "batch_size": 2,
         "group_size": 1,
-        "train": {"source": [{"legacy": {"id": "test-env"}}]},
-        "sampling": {"temperature": 1.0},
+        "train": {"source": [{"legacy": {"id": "test-env"}}], "sampling": {"temperature": 1.0}},
         # test-model isn't in MODEL_RENDERER_MAP; use the explicit default renderer.
         "renderer": {"name": "default"},
     }


### PR DESCRIPTION
Every config back-compat path in the repo, removed in one cut. Each old spelling now fails as an unknown key.

This is deliberately posted as an **overview to decide from** — the four are independent, and reverting any one is a two-line change. Nothing here is load-bearing for the repo itself.

## The inventory

| # | old spelling | new name | shape | warned? | sites |
| --- | --- | --- | --- | --- | --- |
| 1 | `max_tokens` | `max_completion_tokens` | `validation_alias` + `mode="before"` warner | ✅ FutureWarning | `TrainSamplingConfig`, `EvalSamplingConfig` |
| 2 | `[orchestrator.sampling]` | `[orchestrator.train.sampling]` | auto-translating validator | ✅ FutureWarning | `_sampling_to_train` |
| 3 | `rollouts_per_example` | `group_size` | `validation_alias` | ❌ **silent** | 4 classes |
| 4 | `max_inflight_rollouts` | `max_inflight_episodes` | `validation_alias` | ❌ **silent** | `OrchestratorConfig` |

\#2 dates from [#2193](https://github.com/PrimeIntellect-ai/prime-rl/pull/2193) (Apr 9), which introduced the `[train]` / `[eval]` groups, and promised removal in its own warning text — "Auto-translating for now, but this will be removed in a future release." \#4 is four hours old, added by [#3150](https://github.com/PrimeIntellect-ai/prime-rl/pull/3150).

Two more were in scope when this branch was first written and have since landed via #3150, which is why the diff shrank on rebase: `[[orchestrator.env]]` → `[[orchestrator.train.env]]`, and the silent `num_workers` → `pool` migration.

## Why now

The two silent ones are the argument. `rollouts_per_example` and `max_inflight_rollouts` translate with no warning, no docs entry, and no removal trigger — nothing will ever prompt anyone to delete them, so they are permanent by construction.

The loud two are at least retirable, but #2 is four months past a warning that said it would go.

\#4 is worth a moment on its own: #3150 renamed the field because a permit buys an *episode*, not a rollout — and then kept the old name silently accepted. That's the shape this PR argues against, added by the PR that argued for the rename.

## Blast radius: nothing in this repo

A `tomllib` walk over every checked-in TOML under `examples/`, `configs/` and `k8s/` finds **zero** uses of any of the four.

The repo's own **tests** did rely on one: `test_packer.py`'s fixture set `[sampling]` at the top level rather than under `[train]`, so it's migrated here. (#3150 already migrated the four `[[orchestrator.env]]` fixtures for its own rename.)

## Docs and the agent skill

Two places asserted the policy this reverses:

- `docs/configuration.md` — "Renamed fields keep their old name as a validation alias — e.g. `rollouts_per_example` is still accepted" → now says a rename keeps no alias and the old spelling fails.
- `skills/configs/SKILL.md` — told agents "when renaming a field, emit a deprecation warning with a migration hint — never silently drop" → now says to break, with the reasoning.

That skill line is the most consequential edit here, since it's the standing instruction for future renames. If you'd rather keep the warn-then-remove policy and only drop the *silent* aliases (#3, #4), that's the natural middle position and it's the line to revert.

## What a user sees now

```
train.source.0.rollouts_per_example
  Extra inputs are not permitted [type=extra_forbidden]
```

No pointer to the new key. Adding pointers back is possible but is its own decision — pointer tables are what [verifiers#2157](https://github.com/PrimeIntellect-ai/verifiers/pull/2157) deleted for being cruft, so this matches that call.

## Checks

- `uv run pytest tests/unit -m "not gpu"` — **48 failed / 435 passed**, identical to the same command on unmodified `origin/main` in this environment. 47 are `test_configs.py` hitting missing hub env packages (`No module named '<taskset>_v1'`); the 48th is `test_qwen3_vl_e2e.py`'s renderer payload test, which fails from `deps/renderers/renderers/client.py` on plain `main` too (verified by detaching to `origin/main` and running it alone).
- All four shims verified rejected via `OrchestratorConfig.model_validate`, and a canonical config verified still loading.
- `ruff check`, `ruff format --check` clean.

## Not touched

Two other `backward compatibility` mentions are runtime, not config, and out of scope: `trainer/rl/loss.py`'s `pad_value` default and the vendored `nemotron_h` HF config's `hybrid_override_pattern`. The four other `warnings.warn` sites (`rl.py`, `sft.py`, `trainer.py`) are advisory config-conflict notices — "LoRA is enabled but inference is not configured", "gradient clipping is incompatible with DeepEP" — not deprecations.
