### PR TITLE
fix: read overview quality metrics from effective subset

### DIFF
--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -89,7 +89,7 @@ grep -E "WARNING|ERROR" {output_dir}/logs/envs/{train,eval}/*.log
 
 All metrics print to the console log (and W&B when configured).
 
-**Progress** — orchestrator log. Rollout metrics are keyed `{scope}/{subset}/<metric>/<stat>`: `scope` is `train/agg` (all train envs) or `train/<env>` (`eval/<env>` for eval); `subset` is `all` (every rollout) or `effective` (post-filter). Prefer the `effective` subset for quality metrics — on `all`, errored rollouts contribute zeros.
+**Progress** — orchestrator log. Rollout metrics are keyed `{scope}/{subset}/<metric>/<stat>`: `scope` is `train/agg` (all train envs) or `train/<env>` (`eval/<env>` for eval); `subset` is `all` (every rollout) or `effective` (post-filter).
 
 | Metric | Description |
 |--------|-------------|

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -89,17 +89,17 @@ grep -E "WARNING|ERROR" {output_dir}/logs/envs/{train,eval}/*.log
 
 All metrics print to the console log (and W&B when configured).
 
-**Progress** — orchestrator log. Rollout metrics are keyed `{scope}/{subset}/<metric>/<stat>`: `scope` is `train/agg` (all train envs) or `train/<env>` (`eval/<env>` for eval); `subset` is `all` (every rollout) or `effective` (post-filter).
+**Progress** — orchestrator log. Rollout metrics are keyed `{scope}/{subset}/<metric>/<stat>`: `scope` is `train/agg` (all train envs) or `train/<env>` (`eval/<env>` for eval); `subset` is `all` (every rollout) or `effective` (post-filter). Prefer the `effective` subset for quality metrics — on `all`, errored rollouts contribute zeros.
 
 | Metric | Description |
 |--------|-------------|
-| `train/agg/all/reward/mean` | mean training reward (per env: `train/<env>/all/reward/mean`) |
-| `train/agg/all/num_total_tokens/mean` | avg tokens per rollout (also `num_input_tokens`, `num_output_tokens`) |
-| `train/agg/all/num_turns/mean` | avg turns per rollout (multi-turn only) |
-| `train/agg/all/is_truncated/mean` | fraction truncated |
+| `train/agg/effective/reward/mean` | mean training reward (per env: `train/<env>/effective/reward/mean`) |
+| `train/agg/effective/num_total_tokens/mean` | avg tokens per rollout (also `num_input_tokens`, `num_output_tokens`) |
+| `train/agg/effective/num_turns/mean` | avg turns per rollout (multi-turn only) |
+| `train/agg/effective/is_truncated/mean` | fraction truncated |
 | `train/agg/all/has_error/mean` | fraction errored (per-type under `train/agg/all/error/<type>`; also `dispatcher/errored/{train,eval}`) |
-| `train/<env>/all/metrics/<name>/mean` | env-specific metrics (e.g. pass rate) |
-| `eval/<env>/all/{avg@k,pass@k}` | eval scores when configured |
+| `train/<env>/effective/metrics/<name>/mean` | env-specific metrics (e.g. pass rate) |
+| `eval/<env>/effective/{avg@k,pass@k}` | eval scores when configured |
 
 **Stability** — trainer log:
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -875,15 +875,15 @@ class Orchestrator:
         metrics["step"] = float(batch.step)
         self.monitor.log(metrics, step=batch.step)
 
-        # Success line — reward / turns / truncation over the effective set, error rate + branches
-        # over the full returned cohort. ``Stat.mean()`` is 0.0 for an empty set.
+        # Success line — quality metrics over the effective set, error rate over the full returned
+        # cohort. ``Stat.mean()`` is 0.0 for an empty set.
         eff, full = effective.metrics, rollouts.metrics
         triggered_at = self.eval_triggered_at.pop((batch.env_name, batch.step), None)
         elapsed = (time.perf_counter() - triggered_at) if triggered_at is not None else 0.0
         get_logger().success(
             f"Evaluated {batch.env_name} (Step {batch.step}) | "
             f"Policy v{policy_version} | {format_time(elapsed):>7} | Reward {eff.reward.mean():.4f} | "
-            f"Turns {eff.num_turns.mean():.1f} | Branches {full.num_branches.mean():.1f} | "
+            f"Turns {eff.num_turns.mean():.1f} | Branches {eff.num_branches.mean():.1f} | "
             f"Error {full.has_error.mean():.1%} | Truncation {eff.is_truncated.mean():.1%}"
         )
 

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -299,8 +299,8 @@ class WandbMonitor(Monitor):
 OVERVIEW_NAME = "overview"
 
 # Per-rollout metrics (as "<subset>/<metric>" under "<scope>/") shown for BOTH train and eval.
-# Quality metrics read the effective subset — on the all subset, errored rollouts contribute
-# zeros that skew the distributions. has_error only exists on all (effective drops errors by
+# Quality metrics read the effective subset — the all subset includes errored rollouts, whose
+# zero values skew the distributions. has_error only exists on all (effective drops errors by
 # construction). Only the reward metrics differ — train uses "reward/mean", eval uses "avg@k",
 # each shown for the all and effective subsets — and each section builder prepends its own.
 COMMON_METRICS = [

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -298,15 +298,17 @@ class WandbMonitor(Monitor):
 
 OVERVIEW_NAME = "overview"
 
-# Per-rollout metrics (under "<scope>/all/") shown for BOTH train and eval. Only the reward metrics
-# differ — train uses "reward/mean", eval uses "avg@k", each shown for the all and effective
-# subsets — and each section builder prepends its own.
+# Per-rollout metrics (as "<subset>/<metric>" under "<scope>/") shown for BOTH train and eval.
+# Quality metrics read the effective subset — on the all subset, errored rollouts contribute
+# zeros that skew the distributions. has_error only exists on all (effective drops errors by
+# construction). Only the reward metrics differ — train uses "reward/mean", eval uses "avg@k",
+# each shown for the all and effective subsets — and each section builder prepends its own.
 COMMON_METRICS = [
-    "has_error/mean",
-    "is_truncated/mean",
-    "num_total_tokens/mean",
-    "num_turns/mean",
-    "num_branches/mean",
+    "all/has_error/mean",
+    "effective/is_truncated/mean",
+    "effective/num_total_tokens/mean",
+    "effective/num_turns/mean",
+    "effective/num_branches/mean",
 ]
 
 STABILITY_METRICS = ["optim/grad_norm", "entropy/all/mean", "mismatch_kl/all/mean", "kl_ent_ratio/mean"]
@@ -351,7 +353,7 @@ def train_section(name: str, scope: str) -> ws.Section:
     return section(
         name,
         metrics=[f"{scope}/all/reward/mean", f"{scope}/effective/reward/mean"]
-        + [f"{scope}/all/{m}" for m in COMMON_METRICS],
+        + [f"{scope}/{m}" for m in COMMON_METRICS],
     )
 
 
@@ -361,7 +363,7 @@ def eval_section(name: str, env_pattern: str) -> ws.Section:
     return section(
         name,
         regexes=[f"eval/{env_pattern}/all/avg@.*", f"eval/{env_pattern}/effective/avg@.*"]
-        + [f"eval/{env_pattern}/all/{m}" for m in COMMON_METRICS],
+        + [f"eval/{env_pattern}/{m}" for m in COMMON_METRICS],
     )
 
 


### PR DESCRIPTION
## Summary

- Point the curated wandb overview panels at the `effective` subset for the per-rollout quality metrics (`num_branches`, `num_turns`, `num_total_tokens`, `is_truncated`). The `all` subset includes errored rollouts, whose zero values (e.g. 0 branches) skew the distributions and make the panels uninterpretable. `has_error` stays on `all` since the effective subset drops errors by construction.
- Switch the eval success log line's `Branches` to the effective subset, matching the train success line and the rest of the line's quality metrics.
- Update the monitor-run skill's metric-key examples to the `effective` subset accordingly.

Both subsets are still emitted to wandb unchanged — this only changes which one the overview panels and log lines read. The changed panel set changes the overview `view_signature`, so existing projects get a new versioned `overview` view on the next run instead of an in-place edit.
