### PR TITLE
fix: token_id-formatted logprob tokens in the qwen3-vl fake engine

### DIFF
--- a/tests/unit/orchestrator/test_qwen3_vl_e2e.py
+++ b/tests/unit/orchestrator/test_qwen3_vl_e2e.py
@@ -64,9 +64,9 @@ class _FakeOpenAI:
                     "token_ids": [50, 60, 151645],
                     "logprobs": {
                         "content": [
-                            {"token": "t1", "logprob": -0.1},
-                            {"token": "t2", "logprob": -0.2},
-                            {"token": "t3", "logprob": -0.3},
+                            {"token": "token_id:50", "logprob": -0.1},
+                            {"token": "token_id:60", "logprob": -0.2},
+                            {"token": "token_id:151645", "logprob": -0.3},
                         ]
                     },
                     "finish_reason": "stop",


### PR DESCRIPTION
## Summary

- The `_FakeOpenAI` engine response in `test_qwen3_vl_e2e.py` emits `token: "t1"`-style logprob entries; renderers 0.1.9.dev9 (PrimeIntellect-ai/renderers#108, pulled in by #3158) rejects sampled-token evidence whose logprob token is not `token_id:<id>`, so the test fails on `main`.
- CI never catches it: the test skips unless the Qwen3-VL HF snapshot is cached locally.

## Verification

- Before (main + synced venv): `MalformedGenerateResponseError: Engine response choice.logprobs.content[0].token must be 'token_id:50'.`
- After: `1 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
