### PR TITLE
feat(orchestrator): per-agent metric slices, and keep reward metrics to the policy

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -117,6 +117,7 @@ Pulled from the console logs and mirrored to W&B.
 - `num_turns/{all,env}/mean` — for multi-turn envs.
 - `empty_rollouts/{all,env}`, `errored_rollouts/{all,env}` — non-zero is fine in small numbers; sustained > 5% is a smell.
 - `eval/{env}/{avg@k,pass@k}` — eval scores when `[orchestrator.eval]` is set.
+- `{train,eval}/{env}/agent/{name}/...` — the same metrics per agent, emitted only for a multi-agent env. Read these rather than the env-level ones: agents' rewards aren't comparable, so averaging them together can cancel out entirely (a two-agent zero-sum env reports reward ≈ 0 no matter how either agent plays).
 
 **Stability** (trainer):
 
@@ -317,7 +318,7 @@ uv run rl @ rl.toml --wandb \
   --no-trainer.wandb.log-extras.distributions
 ```
 
-prime-rl deliberately logs a **large number of metrics** for maximum observability: every rollout metric is emitted per subset (`all`/`effective`), per statistic (`mean`/`max`/`min`/`p10`/`p90`), and per environment alongside a cross-env aggregate, so a multi-env run can emit thousands of series. To keep that navigable, W&B mode **auto-creates an `overview` saved view** on the first run into a project — curating the handful of metrics that matter into `train`, `eval`, `stability`, and `performance` sections (with per-env breakdowns). The view is created once per project and adapts to the run's environments; if a later run uses a different set of environments, a new versioned view (`overview-v2`, …) is created instead of overwriting the first.
+prime-rl deliberately logs a **large number of metrics** for maximum observability: every rollout metric is emitted per subset (`all`/`effective`), per statistic (`mean`/`max`/`min`/`p10`/`p90`), and per environment alongside a cross-env aggregate — plus per agent for a multi-agent env — so a multi-env run can emit thousands of series. To keep that navigable, W&B mode **auto-creates an `overview` saved view** on the first run into a project — curating the handful of metrics that matter into `train`, `eval`, `stability`, and `performance` sections (with per-env breakdowns). The view is created once per project and adapts to the run's environments; if a later run uses a different set of environments, a new versioned view (`overview-v2`, …) is created instead of overwriting the first.
 
 ### Platform Monitoring
 

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -108,7 +108,7 @@ zero-sum self-play env (`kuhn-poker-v1`) they cancel, so `train/<env>/*/reward/m
 however each agent is actually doing. Reward-derived metrics (`reward`, `rewards/<name>`,
 `solved_*`, `avg@k`, `pass@k`) cover the run's *trainable* agents only, so a frozen judge or a
 pinned user sim can't drag them toward its structural zero; token, turn, timing and error metrics
-still cover every agent.
+cover every agent.
 
 **Stability** — trainer log:
 

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -89,7 +89,7 @@ grep -E "WARNING|ERROR" {output_dir}/logs/envs/{train,eval}/*.log
 
 All metrics print to the console log (and W&B when configured).
 
-**Progress** — orchestrator log. Rollout metrics are keyed `{scope}/{subset}/<metric>/<stat>`: `scope` is `train/agg` (all train envs) or `train/<env>` (`eval/<env>` for eval); `subset` is `all` (every rollout) or `effective` (post-filter).
+**Progress** — orchestrator log. Rollout metrics are keyed `{scope}/{subset}/<metric>/<stat>`: `scope` is `train/agg` (all train envs), `train/<env>`, or `train/<env>/agent/<name>` (`eval/<env>` for eval); `subset` is `all` (every rollout) or `effective` (post-filter).
 
 | Metric | Description |
 |--------|-------------|
@@ -99,7 +99,16 @@ All metrics print to the console log (and W&B when configured).
 | `train/agg/effective/is_truncated/mean` | fraction truncated |
 | `train/agg/all/has_error/mean` | fraction errored (per-type under `train/agg/all/error/<type>`; also `dispatcher/errored/{train,eval}`) |
 | `train/<env>/effective/metrics/<name>/mean` | env-specific metrics (e.g. pass rate) |
+| `train/<env>/agent/<name>/effective/reward/mean` | per-agent reward, multi-agent envs only (see below) |
 | `eval/<env>/effective/{avg@k,pass@k}` | eval scores when configured |
+
+**Multi-agent envs**: the `agent/<name>` scope appears only when an env ran more than one agent, and
+it's the one to watch. The env-level reward averages agents whose rewards aren't comparable — for a
+zero-sum self-play env (`kuhn-poker-v1`) they cancel, so `train/<env>/*/reward/mean` sits at ~0.0
+however each agent is actually doing. Reward-derived metrics (`reward`, `rewards/<name>`,
+`solved_*`, `avg@k`, `pass@k`) cover the run's *trainable* agents only, so a frozen judge or a
+pinned user sim can't drag them toward its structural zero; token, turn, timing and error metrics
+still cover every agent.
 
 **Stability** — trainer log:
 

--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -121,8 +121,13 @@ class EvalSink:
         """Pop the finished ``(env, eval_step)`` epoch and return the ``EvalBatch`` with its full
         returned cohort (errored rollouts included — the ``all`` set). Metrics are computed
         downstream via ``EvalBatch.rollouts.metrics`` over the all/effective subsets, so the sink
-        does no aggregation."""
+        does no aggregation.
+
+        The epoch's ``group_size`` (the ``avg@k`` k) is the env's configured one, passed in rather
+        than derived: the sink is what scheduled the episodes, so it knows the intended k even for
+        an epoch that lost rollouts to errors."""
         env_name, step = key
         rollouts = self.pending_batches.pop(key, [])
         self.pending_batch_episodes.pop(key, None)
-        return EvalBatch(env_name=env_name, step=step, rollouts=EvalRollouts(rollouts))
+        cohort = EvalRollouts(rollouts, group_size=self.group_size_for(env_name))
+        return EvalBatch(env_name=env_name, step=step, rollouts=cohort)

--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -123,9 +123,8 @@ class EvalSink:
         downstream via ``EvalBatch.rollouts.metrics`` over the all/effective subsets, so the sink
         does no aggregation.
 
-        The epoch's ``group_size`` (the ``avg@k`` k) is the env's configured one, passed in rather
-        than derived: the sink is what scheduled the episodes, so it knows the intended k even for
-        an epoch that lost rollouts to errors."""
+        The epoch carries the env's configured ``group_size`` (the ``avg@k`` k): the sink scheduled
+        the episodes, so it knows the intended k even for an epoch that lost rollouts to errors."""
         env_name, step = key
         rollouts = self.pending_batches.pop(key, [])
         self.pending_batch_episodes.pop(key, None)

--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -1,13 +1,19 @@
 """Train and eval rollout metrics.
 
 A rollout container (``TrainRollouts`` / ``EvalRollouts``) owns the rollout list and exposes
-``.effective`` (the clean subset, as the same container type) and ``.metrics`` (``TrainMetrics`` /
-``EvalMetrics``). The metrics object exposes each distributional / rate metric as a ``Stat`` — so
+``.effective`` (the clean subset, as the same container type), ``.by_env()`` / ``.by_agent()``
+(slices of the same type) and ``.metrics`` (``TrainMetrics`` / ``EvalMetrics``). The metrics object
+exposes each distributional / rate metric as a ``Stat`` — so
 ``rollouts.metrics.num_input_tokens.mean()`` works — and assembles the full
 ``{prefix}/{subset}/<metric>/<stat>`` wandb dict via ``.to_wandb(...)``.
 
 No I/O, no pandas — plain Python over the ``vf.Trace`` properties each rollout exposes. Aggregation
-is flat over the rollout list except the solve rates, which group by ``group_id``.
+is flat over the rollout list except the solve rates and pass@k, which group by
+``(group_id, agent_name)``.
+
+Reward-derived metrics (the reward distribution, its per-component breakdown, the solve rates,
+pass@k, ``avg@k``) read the *policy view* of their pool — see :func:`_scored`. Cost, shape and
+error metrics still cover every rollout: an untrainable agent's tokens and failures are real.
 """
 
 from __future__ import annotations
@@ -20,6 +26,34 @@ if TYPE_CHECKING:
     from prime_rl.orchestrator.types import Rollout
 
 Subset = Literal["all", "effective"]
+
+DEFAULT_AGENT_NAME = "agent"
+"""Slice key for a rollout with no agent info (the legacy v0 bridge); matches
+``vf.AgentInfo.name``'s own default."""
+
+
+def _scored(rollouts: list[Rollout]) -> list[Rollout]:
+    """The policy view of a blended pool: its trainable rollouts, else all of them.
+
+    Untrainable agents (a frozen judge, a pinned user sim) are not the policy, so their rewards
+    don't belong in a reward metric — and they usually carry none at all, which would drag every
+    mean toward a structural zero. Falling back to the full list keeps an all-untrainable pool
+    (a frozen-model eval) reporting its own rewards instead of nothing. Same rule verifiers
+    applies in ``v1/push.py`` and the eval dashboard.
+
+    A no-op on the ``effective`` subset, which is already trainable-only."""
+    return [r for r in rollouts if r.trainable] or rollouts
+
+
+def _by_group_and_agent(rollouts: list[Rollout]) -> dict[tuple, list[Rollout]]:
+    """Group rollouts into the units a solve rate / pass@k is defined over: one example as seen
+    by one agent. Keying on ``group_id`` alone would pool agents whose rewards aren't comparable
+    — in a zero-sum game the pooled group sums to 0 no matter how the policy plays, which reads
+    as "nobody scored". Identical to keying on ``group_id`` for a single-agent env."""
+    groups: dict[tuple, list[Rollout]] = {}
+    for r in rollouts:
+        groups.setdefault((r.group_id, r.agent_name), []).append(r)
+    return groups
 
 
 class Stat:
@@ -192,9 +226,9 @@ class RolloutMetrics:
 
     @property
     def rewards(self) -> CustomMetrics:
-        """Per-component reward breakdown, keyed by name (each entry's weighted ``value``,
-        summed into the scalar ``reward``)."""
-        return CustomMetrics(self.rollouts, "rewards", value=lambda reward: reward.value)
+        """Per-component reward breakdown over the policy view, keyed by name (each entry's
+        weighted ``value``, summed into the scalar ``reward``)."""
+        return CustomMetrics(_scored(self.rollouts), "rewards", value=lambda reward: reward.value)
 
     # Boolean rate metrics (0/1 distributions — ``.mean()`` is the rate)
     @property
@@ -230,12 +264,11 @@ class RolloutMetrics:
         return {t: types.count(t) for t in sorted(set(types))}
 
     def solve_rates(self) -> dict[str, float]:
-        """Per-group solve rates, assuming binary 0/1 rewards (unspecified for other reward ranges):
-        ``solved_none`` (the group earned no reward), ``solved_all`` (every rollout scored 1.0), and
-        ``solved_some`` (the mixed remainder — the GRPO-signal groups)."""
-        groups: dict = {}
-        for r in self.rollouts:
-            groups.setdefault(r.group_id, []).append(r)
+        """Per-(example, agent) solve rates over the policy view, assuming binary 0/1 rewards
+        (unspecified for other reward ranges): ``solved_none`` (the group earned no reward),
+        ``solved_all`` (every rollout scored 1.0), and ``solved_some`` (the mixed remainder — the
+        GRPO-signal groups)."""
+        groups = _by_group_and_agent(_scored(self.rollouts))
         n_groups = len(groups)
         solved_none = sum(1 for g in groups.values() if sum(r.reward for r in g) == 0)
         solved_all = sum(1 for g in groups.values() if all(r.reward == 1.0 for r in g))
@@ -276,7 +309,8 @@ class TrainMetrics(RolloutMetrics):
 
     @property
     def reward(self) -> Stat:
-        return Stat([float(r.reward) for r in self.rollouts])
+        """The policy's reward distribution (untrainable agents excluded — see :func:`_scored`)."""
+        return Stat([float(r.reward) for r in _scored(self.rollouts)])
 
     @property
     def is_trainable(self) -> Stat:
@@ -316,17 +350,16 @@ class EvalMetrics(RolloutMetrics):
 
     @property
     def reward(self) -> Stat:
-        return Stat([float(r.reward) for r in self.rollouts])
+        """The policy's reward distribution (untrainable agents excluded — see :func:`_scored`)."""
+        return Stat([float(r.reward) for r in _scored(self.rollouts)])
 
     def pass_at_k(self) -> dict[str, float]:
-        """pass@k / pass^k averaged over examples; ``{}`` for non-binary rewards."""
-        rewards = [r.reward for r in self.rollouts]
-        if not set(rewards).issubset({0.0, 1.0}):
+        """pass@k / pass^k averaged over (example, agent) over the policy view; ``{}`` for
+        non-binary rewards."""
+        scored = _scored(self.rollouts)
+        if not {r.reward for r in scored}.issubset({0.0, 1.0}):
             return {}
-        by_example: dict = {}
-        for r in self.rollouts:
-            by_example.setdefault(r.group_id, []).append(r.reward)
-        per_example = [compute_pass_metrics(rs) for rs in by_example.values()]
+        per_example = [compute_pass_metrics([r.reward for r in g]) for g in _by_group_and_agent(scored).values()]
         keys = sorted({k for d in per_example for k in d})
         return {k: sum(d[k] for d in per_example if k in d) / sum(1 for d in per_example if k in d) for k in keys}
 
@@ -368,6 +401,14 @@ class TrainRollouts:
             grouped.setdefault(r.env_name, []).append(r)
         return {env: TrainRollouts(rs) for env, rs in grouped.items()}
 
+    def by_agent(self) -> dict[str, TrainRollouts]:
+        """Per-agent slices, keyed by ``agent_name``. One key for a single-agent env; callers
+        emit the slices only when there are several (see ``Orchestrator``)."""
+        grouped: dict[str, list[Rollout]] = {}
+        for r in self.rollouts:
+            grouped.setdefault(r.agent_name or DEFAULT_AGENT_NAME, []).append(r)
+        return {name: TrainRollouts(rs) for name, rs in grouped.items()}
+
     @property
     def metrics(self) -> TrainMetrics:
         return TrainMetrics(self.rollouts)
@@ -391,22 +432,51 @@ class EvalRollouts:
 
     @property
     def group_size(self) -> int:
-        """The largest group in trainable (policy) traces — equals the configured group size
-        whenever one example kept all its rollouts; untrainable traces don't count, so a
-        multi-agent episode doesn't inflate ``k``. A subview carries its parent's value so
-        ``avg@k`` doesn't drift across subsets."""
+        """The ``avg@k`` k. ``EvalSink`` supplies the env's configured group size, and a subview
+        carries its parent's value, so ``k`` is stable across subsets and across epochs that lost
+        rollouts to errors.
+
+        Derived only when nothing was supplied: the largest number of *episodes* one example was
+        rolled out for. Episodes, not traces — a multi-agent episode is one attempt at the example
+        however many agents it takes, so a two-agent env at ``group_size=4`` reports ``avg@4``
+        rather than ``avg@8``."""
         if self._group_size is not None:
             return self._group_size
-        counts: dict = {}
+        episodes: dict = {}
         for r in self.rollouts:
-            if r.trainable:
-                counts[r.group_id] = counts.get(r.group_id, 0) + 1
-        return max(counts.values(), default=0)
+            episodes.setdefault(r.group_id, set()).add(r.episode_id)
+        return max((len(e) for e in episodes.values()), default=0)
 
     @property
     def effective(self) -> EvalRollouts:
         return EvalRollouts([r for r in self.rollouts if not r.has_error and r.trainable], group_size=self.group_size)
 
+    def by_agent(self) -> dict[str, EvalRollouts]:
+        """Per-agent slices, keyed by ``agent_name``, each carrying this pool's ``group_size`` so
+        ``avg@k`` stays comparable across slices."""
+        grouped: dict[str, list[Rollout]] = {}
+        for r in self.rollouts:
+            grouped.setdefault(r.agent_name or DEFAULT_AGENT_NAME, []).append(r)
+        return {name: EvalRollouts(rs, group_size=self.group_size) for name, rs in grouped.items()}
+
     @property
     def metrics(self) -> EvalMetrics:
         return EvalMetrics(self.rollouts, self.group_size)
+
+
+def agent_metrics(pool: TrainRollouts | EvalRollouts, *, prefix: str, subset: Subset) -> dict[str, float]:
+    """The ``{prefix}/agent/{name}/{subset}/...`` slices for one pool — the per-agent view that the
+    ``{agg,<env>}`` axes average away (a two-agent zero-sum env reports reward 0.0 whatever each
+    agent is doing).
+
+    ``{}`` unless the pool holds more than one agent, so single-agent runs (nearly all of them)
+    gain no keys and the slices never just restate the env's own. That also means the ``effective``
+    subset of a frozen-judge env emits nothing here: dropping the untrainable agent leaves one, and
+    the env's own ``effective`` keys already are it."""
+    pools = pool.by_agent()
+    if len(pools) < 2:
+        return {}
+    out: dict[str, float] = {}
+    for name, agent_pool in sorted(pools.items()):
+        out |= agent_pool.metrics.to_wandb(prefix=f"{prefix}/agent/{name}", subset=subset)
+    return out

--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -13,7 +13,7 @@ is flat over the rollout list except the solve rates and pass@k, which group by
 
 Reward-derived metrics (the reward distribution, its per-component breakdown, the solve rates,
 pass@k, ``avg@k``) read the *policy view* of their pool — see :func:`_scored`. Cost, shape and
-error metrics still cover every rollout: an untrainable agent's tokens and failures are real.
+error metrics cover every rollout: an untrainable agent's tokens and failures are real.
 """
 
 from __future__ import annotations
@@ -33,23 +33,19 @@ DEFAULT_AGENT_NAME = "agent"
 
 
 def _scored(rollouts: list[Rollout]) -> list[Rollout]:
-    """The policy view of a blended pool: its trainable rollouts, else all of them.
+    """The policy view of a pool: its trainable rollouts, or all of them when none is trainable.
 
-    Untrainable agents (a frozen judge, a pinned user sim) are not the policy, so their rewards
-    don't belong in a reward metric — and they usually carry none at all, which would drag every
-    mean toward a structural zero. Falling back to the full list keeps an all-untrainable pool
-    (a frozen-model eval) reporting its own rewards instead of nothing. Same rule verifiers
-    applies in ``v1/push.py`` and the eval dashboard.
-
-    A no-op on the ``effective`` subset, which is already trainable-only."""
+    A reward metric is about the policy, and an untrainable agent (a frozen judge, a pinned user
+    sim) isn't it — usually carrying no rewards at all, so its traces score a structural zero. The
+    fallback keeps an all-frozen pool reporting its own rewards rather than nothing. Same rule
+    verifiers applies in ``v1/push.py`` and the eval dashboard."""
     return [r for r in rollouts if r.trainable] or rollouts
 
 
 def _by_group_and_agent(rollouts: list[Rollout]) -> dict[tuple, list[Rollout]]:
-    """Group rollouts into the units a solve rate / pass@k is defined over: one example as seen
-    by one agent. Keying on ``group_id`` alone would pool agents whose rewards aren't comparable
-    — in a zero-sum game the pooled group sums to 0 no matter how the policy plays, which reads
-    as "nobody scored". Identical to keying on ``group_id`` for a single-agent env."""
+    """Group rollouts into the unit a solve rate / pass@k is defined over: one example as attempted
+    by one agent. Agents' rewards aren't comparable — a zero-sum pair sums to 0 whatever the policy
+    does — so each gets its own group. One group per ``group_id`` for a single-agent env."""
     groups: dict[tuple, list[Rollout]] = {}
     for r in rollouts:
         groups.setdefault((r.group_id, r.agent_name), []).append(r)
@@ -432,14 +428,12 @@ class EvalRollouts:
 
     @property
     def group_size(self) -> int:
-        """The ``avg@k`` k. ``EvalSink`` supplies the env's configured group size, and a subview
-        carries its parent's value, so ``k`` is stable across subsets and across epochs that lost
-        rollouts to errors.
+        """The ``avg@k`` k. ``EvalSink`` supplies the env's configured group size and a subview
+        carries its parent's, so ``k`` holds across subsets and across epochs that lost rollouts.
 
-        Derived only when nothing was supplied: the largest number of *episodes* one example was
-        rolled out for. Episodes, not traces — a multi-agent episode is one attempt at the example
-        however many agents it takes, so a two-agent env at ``group_size=4`` reports ``avg@4``
-        rather than ``avg@8``."""
+        Derived when nothing was supplied: the most *episodes* one example was rolled out for.
+        Episodes, not traces — one attempt at an example is one episode however many agents it
+        takes, so a two-agent env at ``group_size=4`` stays ``avg@4``."""
         if self._group_size is not None:
             return self._group_size
         episodes: dict = {}
@@ -465,14 +459,13 @@ class EvalRollouts:
 
 
 def agent_metrics(pool: TrainRollouts | EvalRollouts, *, prefix: str, subset: Subset) -> dict[str, float]:
-    """The ``{prefix}/agent/{name}/{subset}/...`` slices for one pool — the per-agent view that the
-    ``{agg,<env>}`` axes average away (a two-agent zero-sum env reports reward 0.0 whatever each
-    agent is doing).
+    """The ``{prefix}/agent/{name}/{subset}/...`` slices for one pool: the per-agent breakdown the
+    ``{agg,<env>}`` axes average over. A two-agent zero-sum env reports reward 0.0 at env level
+    whatever each agent is doing, so for those envs this is the signal.
 
-    ``{}`` unless the pool holds more than one agent, so single-agent runs (nearly all of them)
-    gain no keys and the slices never just restate the env's own. That also means the ``effective``
-    subset of a frozen-judge env emits nothing here: dropping the untrainable agent leaves one, and
-    the env's own ``effective`` keys already are it."""
+    ``{}`` unless the pool holds more than one agent — a single-agent slice would only restate the
+    env's own keys. So a frozen-judge env emits slices on ``all`` but not on ``effective``, where
+    dropping the untrainable agent leaves one."""
     pools = pool.by_agent()
     if len(pools) < 2:
         return {}

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -27,9 +27,10 @@ import time
 from typing import TYPE_CHECKING
 
 import tomli_w
-import verifiers.v1 as vf
 from modelexpress import p2p_pb2
 from modelexpress.client import MxClient
+
+import verifiers.v1 as vf
 
 if TYPE_CHECKING:
     from renderers.base import Renderer
@@ -48,6 +49,7 @@ from prime_rl.orchestrator.eval_sink import EvalSink
 from prime_rl.orchestrator.eval_source import EvalSource
 from prime_rl.orchestrator.filters import setup_filters
 from prime_rl.orchestrator.inference_metrics import InferenceMetricsCollector
+from prime_rl.orchestrator.metrics import agent_metrics
 from prime_rl.orchestrator.patches import (
     monkey_patch_chat_completion_logprobs,
     monkey_patch_oai_iterable_types,
@@ -648,13 +650,15 @@ class Orchestrator:
         save_ckpt_time = await self.maybe_save_ckpt(step)
         trim_process_memory()
 
-        # Rollout metrics over the {agg,<env>} × {all,effective} matrix. ``batch.rollouts`` is the
-        # full arrival window (errored + filtered included); ``.effective`` is the clean subset.
+        # Rollout metrics over the {agg,<env>,<env>/agent/<name>} × {all,effective} matrix.
+        # ``batch.rollouts`` is the full arrival window (errored + filtered included);
+        # ``.effective`` is the clean subset.
         metrics: dict[str, float] = {}
         for subset, pool in (("all", batch.rollouts), ("effective", effective)):
             metrics |= pool.metrics.to_wandb(prefix="train/agg", subset=subset)
             for env_name, env_pool in pool.by_env().items():
                 metrics |= env_pool.metrics.to_wandb(prefix=f"train/{env_name}", subset=subset)
+                metrics |= agent_metrics(env_pool, prefix=f"train/{env_name}", subset=subset)
 
         # Progress / timing / env-share / pre-filter accounting (assembled here, not in the metrics
         # objects). ``num_tokens`` is over the full arrival window; the input/output breakdown is over
@@ -864,13 +868,15 @@ class Orchestrator:
             get_logger().warning(
                 f"Eval {batch.env_name} step {batch.step} had mixed policy versions: {sorted(policy_versions)}"
             )
-        # Rollout metrics over {all,effective} (eval batches are per-env, so no `agg` axis).
-        # ``effective`` = non-errored; pass@k / pass^k only over the effective set.
+        # Rollout metrics over {all,effective} (eval batches are per-env, so no `agg` axis), plus
+        # the per-agent slices for a multi-agent env. ``effective`` = non-errored; pass@k / pass^k
+        # only over the effective set.
         rollouts = batch.rollouts
         effective = rollouts.effective
         metrics: dict[str, float] = {}
         for subset, pool in (("all", rollouts), ("effective", effective)):
             metrics |= pool.metrics.to_wandb(prefix=f"eval/{batch.env_name}", subset=subset)
+            metrics |= agent_metrics(pool, prefix=f"eval/{batch.env_name}", subset=subset)
         metrics[f"eval/{batch.env_name}/policy_version"] = float(policy_version)
         metrics["step"] = float(batch.step)
         self.monitor.log(metrics, step=batch.step)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -27,10 +27,9 @@ import time
 from typing import TYPE_CHECKING
 
 import tomli_w
+import verifiers.v1 as vf
 from modelexpress import p2p_pb2
 from modelexpress.client import MxClient
-
-import verifiers.v1 as vf
 
 if TYPE_CHECKING:
     from renderers.base import Renderer

--- a/tests/unit/orchestrator/test_metrics.py
+++ b/tests/unit/orchestrator/test_metrics.py
@@ -1,11 +1,14 @@
 import math
+from itertools import count
 from types import SimpleNamespace
 
 import pytest
-import verifiers.v1 as vf
 
-from prime_rl.orchestrator.metrics import EvalRollouts, Stat, TrainRollouts
+import verifiers.v1 as vf
+from prime_rl.orchestrator.metrics import EvalRollouts, Stat, TrainRollouts, agent_metrics
 from prime_rl.orchestrator.utils import compute_pass_metrics
+
+_episodes = count()
 
 
 def mk(
@@ -25,6 +28,8 @@ def mk(
     rewards: dict | None = None,
     env_name: str = "env",
     group_id: str = "g0",
+    agent_name: str | None = "agent",
+    episode_id: str | None = None,
     trainable: bool = True,
     is_trainable: bool = True,
     is_filtered: bool = False,
@@ -53,6 +58,10 @@ def mk(
         metrics=metrics or {},
         env_name=env_name,
         group_id=group_id,
+        agent_name=agent_name,
+        # Distinct per rollout unless pinned: one episode per rollout is the single-agent shape,
+        # and ``EvalRollouts.group_size`` counts episodes.
+        episode_id=episode_id if episode_id is not None else f"e{next(_episodes)}",
         trainable=trainable,
         is_trainable=is_trainable,
         is_filtered=is_filtered,
@@ -132,6 +141,26 @@ def test_solve_rates():
     assert rates == (0.25, 0.25, 0.5)
 
 
+def test_solve_rates_split_per_agent_not_pooled_across_them():
+    # One group, two agents, each solving one of its two rollouts: per agent that's solved_some.
+    # Pooling them under group_id alone would collapse it to a single mixed group.
+    rollouts = [mk(reward=r, group_id="g0", agent_name=a) for a in ("player0", "player1") for r in (1.0, 0.0)]
+    out = train_wandb(rollouts)
+    assert out["train/agg/all/solved_some"] == 1.0  # 2 (example, agent) groups, both mixed
+    assert out["train/agg/all/solved_all"] == 0.0 and out["train/agg/all/solved_none"] == 0.0
+
+
+def test_solve_rates_zero_sum_group_is_not_reported_as_unsolved():
+    # A zero-sum pair sums to 0 for every group, which used to trip `solved_none` on every group
+    # and read as "no GRPO signal" when both agents in fact have spread.
+    rollouts = [mk(reward=r, group_id="g0", agent_name="player0") for r in (1.0, 0.0)] + [
+        mk(reward=-r, group_id="g0", agent_name="player1") for r in (1.0, 0.0)
+    ]
+    out = train_wandb(rollouts)
+    assert out["train/agg/all/solved_none"] == 0.0
+    assert out["train/agg/all/solved_some"] == 1.0
+
+
 def test_stop_condition_breakdown():
     truncated = [mk(is_truncated=True, stop_condition=c) for c in ("length", "max_turns", "prompt_too_long")]
     out = train_wandb(truncated + [mk(stop_condition=None)])
@@ -190,6 +219,67 @@ def test_eval_avg_at_k_and_pass_k():
     assert not any("pass@" in k or "pass^" in k for k in all_out)  # pass@k effective-only
     non_binary = EvalRollouts([mk(reward=0.5, group_id="g0"), mk(reward=1.0, group_id="g0")])
     assert not any("pass@" in k for k in non_binary.effective.metrics.to_wandb(prefix="eval/x", subset="effective"))
+
+
+def test_reward_metrics_read_the_policy_view_of_a_blended_pool():
+    # A frozen judge carries no reward; on `all` its structural zero used to halve the mean.
+    rollouts = [
+        mk(reward=1.0, rewards={"correct": vf.Reward(score=1.0)}, agent_name="solver"),
+        mk(reward=0.0, agent_name="judge", trainable=False),
+    ]
+    out = train_wandb(rollouts)
+    assert out["train/agg/all/reward/mean"] == 1.0  # the solver's reward, not (1.0 + 0.0) / 2
+    assert out["train/agg/all/rewards/correct/mean"] == 1.0
+    assert out["train/agg/all/num_total_tokens/mean"] == 10.0  # cost still covers both agents
+    assert out["train/agg/all/is_completed/mean"] == 1.0
+
+
+def test_reward_metrics_fall_back_when_no_rollout_is_trainable():
+    out = train_wandb([mk(reward=1.0, trainable=False), mk(reward=0.0, trainable=False)])
+    assert out["train/agg/all/reward/mean"] == 0.5  # an all-frozen pool reports its own rewards
+
+
+def test_by_agent_slices_emitted_only_for_multi_agent_pools():
+    kuhn = TrainRollouts(
+        [mk(reward=1.0, group_id="g0", agent_name="player0"), mk(reward=-1.0, group_id="g0", agent_name="player1")]
+    )
+    assert set(kuhn.by_agent()) == {"player0", "player1"}
+    assert isinstance(kuhn.by_agent()["player0"], TrainRollouts)
+    out = agent_metrics(kuhn, prefix="train/kuhn", subset="all")
+    # the env-level mean is 0.0 by construction; the slices are where the signal lives
+    assert kuhn.metrics.to_wandb(prefix="train/kuhn", subset="all")["train/kuhn/all/reward/mean"] == 0.0
+    assert out["train/kuhn/agent/player0/all/reward/mean"] == 1.0
+    assert out["train/kuhn/agent/player1/all/reward/mean"] == -1.0
+    # single-agent pools gain nothing — the slice would restate the env's own keys
+    assert agent_metrics(TrainRollouts([mk(), mk()]), prefix="train/x", subset="all") == {}
+
+
+def test_by_agent_slices_on_eval_carry_the_parent_group_size():
+    pool = EvalRollouts(
+        [
+            mk(reward=r, group_id="g0", episode_id=e, agent_name=a)
+            for e in ("e0", "e1")
+            for a, r in (("player0", 1.0), ("player1", 0.0))
+        ]
+    )
+    assert pool.group_size == 2  # two episodes, not the four traces they produced
+    out = agent_metrics(pool, prefix="eval/kuhn", subset="all")
+    assert out["eval/kuhn/agent/player0/all/avg@2"] == 1.0
+    assert out["eval/kuhn/agent/player1/all/avg@2"] == 0.0
+
+
+def test_eval_group_size_counts_episodes_not_traces():
+    # Same example rolled out twice, each episode producing one trace per agent: k is 2, not 4.
+    multi = EvalRollouts(
+        [
+            mk(reward=1.0, group_id="g0", episode_id=e, agent_name=a)
+            for e in ("e0", "e1")
+            for a in ("player0", "player1")
+        ]
+    )
+    assert multi.group_size == 2
+    assert "eval/x/all/avg@2" in multi.metrics.to_wandb(prefix="eval/x", subset="all")
+    assert multi.effective.group_size == 2  # subview carries the parent's k
 
 
 def test_compute_pass_metrics_matches_closed_form():

--- a/tests/unit/orchestrator/test_metrics.py
+++ b/tests/unit/orchestrator/test_metrics.py
@@ -3,8 +3,8 @@ from itertools import count
 from types import SimpleNamespace
 
 import pytest
-
 import verifiers.v1 as vf
+
 from prime_rl.orchestrator.metrics import EvalRollouts, Stat, TrainRollouts, agent_metrics
 from prime_rl.orchestrator.utils import compute_pass_metrics
 

--- a/tests/unit/orchestrator/test_metrics.py
+++ b/tests/unit/orchestrator/test_metrics.py
@@ -141,18 +141,16 @@ def test_solve_rates():
     assert rates == (0.25, 0.25, 0.5)
 
 
-def test_solve_rates_split_per_agent_not_pooled_across_them():
-    # One group, two agents, each solving one of its two rollouts: per agent that's solved_some.
-    # Pooling them under group_id alone would collapse it to a single mixed group.
+def test_solve_rates_group_per_agent():
+    # One example, two agents, each solving one of its two rollouts: one solved_some group per agent
     rollouts = [mk(reward=r, group_id="g0", agent_name=a) for a in ("player0", "player1") for r in (1.0, 0.0)]
     out = train_wandb(rollouts)
-    assert out["train/agg/all/solved_some"] == 1.0  # 2 (example, agent) groups, both mixed
+    assert out["train/agg/all/solved_some"] == 1.0
     assert out["train/agg/all/solved_all"] == 0.0 and out["train/agg/all/solved_none"] == 0.0
 
 
-def test_solve_rates_zero_sum_group_is_not_reported_as_unsolved():
-    # A zero-sum pair sums to 0 for every group, which used to trip `solved_none` on every group
-    # and read as "no GRPO signal" when both agents in fact have spread.
+def test_solve_rates_zero_sum_agents_still_report_signal():
+    # The pair's rewards cancel, so the reward sum can't decide whether the example went unsolved
     rollouts = [mk(reward=r, group_id="g0", agent_name="player0") for r in (1.0, 0.0)] + [
         mk(reward=-r, group_id="g0", agent_name="player1") for r in (1.0, 0.0)
     ]
@@ -221,16 +219,15 @@ def test_eval_avg_at_k_and_pass_k():
     assert not any("pass@" in k for k in non_binary.effective.metrics.to_wandb(prefix="eval/x", subset="effective"))
 
 
-def test_reward_metrics_read_the_policy_view_of_a_blended_pool():
-    # A frozen judge carries no reward; on `all` its structural zero used to halve the mean.
+def test_reward_metrics_cover_the_trainable_agents_only():
     rollouts = [
         mk(reward=1.0, rewards={"correct": vf.Reward(score=1.0)}, agent_name="solver"),
-        mk(reward=0.0, agent_name="judge", trainable=False),
+        mk(reward=0.0, agent_name="judge", trainable=False),  # a frozen judge, carrying no reward
     ]
     out = train_wandb(rollouts)
     assert out["train/agg/all/reward/mean"] == 1.0  # the solver's reward, not (1.0 + 0.0) / 2
     assert out["train/agg/all/rewards/correct/mean"] == 1.0
-    assert out["train/agg/all/num_total_tokens/mean"] == 10.0  # cost still covers both agents
+    assert out["train/agg/all/num_total_tokens/mean"] == 10.0  # cost covers both agents
     assert out["train/agg/all/is_completed/mean"] == 1.0
 
 
@@ -246,11 +243,10 @@ def test_by_agent_slices_emitted_only_for_multi_agent_pools():
     assert set(kuhn.by_agent()) == {"player0", "player1"}
     assert isinstance(kuhn.by_agent()["player0"], TrainRollouts)
     out = agent_metrics(kuhn, prefix="train/kuhn", subset="all")
-    # the env-level mean is 0.0 by construction; the slices are where the signal lives
+    # the two agents cancel at env level, so the slices carry the signal
     assert kuhn.metrics.to_wandb(prefix="train/kuhn", subset="all")["train/kuhn/all/reward/mean"] == 0.0
     assert out["train/kuhn/agent/player0/all/reward/mean"] == 1.0
     assert out["train/kuhn/agent/player1/all/reward/mean"] == -1.0
-    # single-agent pools gain nothing — the slice would restate the env's own keys
     assert agent_metrics(TrainRollouts([mk(), mk()]), prefix="train/x", subset="all") == {}
 
 
@@ -262,14 +258,14 @@ def test_by_agent_slices_on_eval_carry_the_parent_group_size():
             for a, r in (("player0", 1.0), ("player1", 0.0))
         ]
     )
-    assert pool.group_size == 2  # two episodes, not the four traces they produced
+    assert pool.group_size == 2
     out = agent_metrics(pool, prefix="eval/kuhn", subset="all")
     assert out["eval/kuhn/agent/player0/all/avg@2"] == 1.0
     assert out["eval/kuhn/agent/player1/all/avg@2"] == 0.0
 
 
 def test_eval_group_size_counts_episodes_not_traces():
-    # Same example rolled out twice, each episode producing one trace per agent: k is 2, not 4.
+    # One example, two episodes, each episode producing a trace per agent: k is the 2 episodes
     multi = EvalRollouts(
         [
             mk(reward=1.0, group_id="g0", episode_id=e, agent_name=a)


### PR DESCRIPTION
## Summary

Multi-agent envs are metric-blind: the axes are `{agg,<env>} × {all,effective}`, so two agents inside one env get averaged together, and because their rewards aren't comparable the average can cancel outright. On a `kuhn-poker-v1` self-play run, `train/kuhn/*/reward/mean` logged exactly `+0.0000` at every step while the two seats were 1.6 chips a hand apart.

- **`by_agent()` on `TrainRollouts` / `EvalRollouts`**, parallel to `by_env()`, emitted as `{train,eval}/{env}/agent/{name}/{subset}/...` through a new `agent_metrics()` helper. Gated on the pool holding more than one agent, so single-agent runs gain no keys. Eval slices carry the parent's `group_size` so `avg@k` stays comparable across them.
- **Reward-derived metrics cover the trainable agents only.** `reward`, `rewards/<name>`, `solved_*`, `avg@k` and `pass@k` aggregate over `_scored(pool)` — the trainable rollouts, or all of them when none is trainable. Token, turn, timing and error metrics still cover every agent.
- **`solve_rates()` and `pass_at_k()` group by `(group_id, agent_name)`.** A no-op for single-agent envs.
- **`avg@k` counts episodes, not traces**, and `EvalSink` passes its configured `group_size` rather than leaving it derived.
- `docs/training.md` and the monitor-run skill document the new scope; `test_metrics.py` gains 6 tests and its `mk` fixture gains `agent_name` / `episode_id`.

No change to GRPO's cross-agent baseline — this is metrics only.

## Why

Every saved trace record already carries `agent.name`, `agent.trainable` and `info.episode_id`; only the metrics layer discarded them. `RAEAlgorithm` was the sole agent-aware consumer, and its docstring already names the zero-sum problem the metrics ignored.

**The trainable filter is a live defect, not just a blind spot.** `train_sink.py:184-185` puts every rollout of a finalized group into the observation window including untrainable ones, and `TrainMetrics.reward` applied no filter, so a frozen judge's structural zero landed in the headline reward. `effective` already filtered `r.trainable` and was correct. This matches verifiers' own rule in `v1/push.py:127` and `v1/cli/dashboard/eval.py:305`.

**`solved_none` was inverted for zero-sum envs.** Its test is `sum(r.reward for r in g) == 0`, which a zero-sum pair satisfies for *every* group — so it fired on 100% of groups and `solved_some`, the GRPO-signal diagnostic, read `0.00` while every group in fact had reward spread. Broken on `effective` too, since both kuhn agents are trainable, so the trainable filter alone doesn't fix it.

**`avg@k` double-counted agents.** One attempt at an example is one episode however many agents it takes; counting trainable traces per `group_id` doubled `k`, so an eval configured `group_size = 4` emitted `avg@8`.

## Measured

Two 4-step runs of the same config (Qwen3-1.7B, 2 GPUs, `kuhn-poker-v1` + `proposer-solver-v1` with `train_solver=false`), before and after. 0% error, 0% truncation.

| | before | after |
| --- | --- | --- |
| metric keys / with an agent axis | 524 / **0** | 1189 / 665 |
| `train/kuhn/all/reward/mean` | `0.0` | `0.0` (unchanged — correct at env level) |
| `train/kuhn/agent/player0/all/reward/mean` | — | `[-1.625, -1.75, 0.0, 1.25]` |
| `train/kuhn/agent/player1/all/reward/mean` | — | `[1.625, 1.75, 0.0, -1.25]` |
| `train/kuhn/all/solved_none` | `1.00` | `0.00` |
| `train/kuhn/all/solved_some` | `0.00` | `[1.0, 1.0, 1.0, 0.75]` |
| eval key | `avg@8` | `avg@4` |

For the untrainable case, propsolve didn't reach a shipped batch's window in the verification run, so its real saved traces were replayed through the new code instead:

| step | window | untrainable share | `all/reward/mean` before | after | proposer (trainable) |
| --- | --- | --- | --- | --- | --- |
| 3 | 14 traces | 57% | `+0.4286` | `+0.0000` | `+0.0000` |
| 4 | 16 traces | 50% | `+0.1250` | `+0.0000` | `+0.0000` |

`uv run pytest tests/unit` — 477 passed, 8 skipped. Deselected `test_qwen3_vl_e2e` (fails identically on `main` here), `test_load_configs` and `nemotron_h` (environmental, sm_120).

## Notes for review

- **Deviation from verifiers**: it restricts env `@metric` outputs to trainable traces alongside rewards; this PR leaves `metrics/<name>` blended, since an untrainable agent's metric (a judge's confidence, say) can be exactly what you want to watch. Easy to align if you'd rather match upstream.
- The slices roughly double a multi-agent env's key count. Gated so single-agent runs are unaffected.
- If an agent's traces all error in a step, `effective` drops to one agent and that step emits no slices — a one-step gap, with the env-level keys still showing the collapse.
- **Heads-up for anyone touching a file that imports `verifiers` here**: the pre-commit hook and CI disagree. CI checks out with `submodules: false`, so `deps/verifiers` is empty and ruff classifies `verifiers` as third-party; a local checkout with the submodule populated classifies it as first-party, so the hook moves the import into the `prime_rl` block and CI's `I001` then fires. `main`'s ordering is the CI-correct one. Reproducing CI locally needs a tree without the submodule content — `git archive HEAD | tar -x -C <tmp>` then `ruff check --config=pyproject.toml .` there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
