### PR TITLE
fix: checkpoint and resume the orchestrator train data position

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -217,7 +217,7 @@ Checkpointing is split across processes because the orchestrator and trainer can
 | Process | What's saved | Where |
 |---|---|---|
 | Trainer | FSDP-sharded model (DCP), optimizer, scheduler, progress | `<output_dir>/checkpoints/step_N/trainer/` |
-| Orchestrator | Step counter, total tokens / samples / problems, per-env data position (epoch + cursor) | `<output_dir>/checkpoints/step_N/orchestrator/` |
+| Orchestrator | Progress, per-env data state | `<output_dir>/checkpoints/step_N/orchestrator/` |
 | Inference | _nothing_ — re-pushed from the latest checkpoint on restart | n/a |
 | Trainer (HF weights) | HF-compatible weight snapshot for serving | `<output_dir>/weights/step_N/` |
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -217,7 +217,7 @@ Checkpointing is split across processes because the orchestrator and trainer can
 | Process | What's saved | Where |
 |---|---|---|
 | Trainer | FSDP-sharded model (DCP), optimizer, scheduler, progress | `<output_dir>/checkpoints/step_N/trainer/` |
-| Orchestrator | Step counter, total tokens / samples / problems | `<output_dir>/checkpoints/step_N/orchestrator/` |
+| Orchestrator | Step counter, total tokens / samples / problems, per-env data position (epoch + cursor) | `<output_dir>/checkpoints/step_N/orchestrator/` |
 | Inference | _nothing_ — re-pushed from the latest checkpoint on restart | n/a |
 | Trainer (HF weights) | HF-compatible weight snapshot for serving | `<output_dir>/weights/step_N/` |
 

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -7,7 +7,6 @@ import contextlib
 import os
 import tempfile
 import time
-from dataclasses import asdict
 from pathlib import Path
 
 import torch
@@ -58,7 +57,9 @@ class CheckpointManager:
             with open(state_file, "rb") as f:
                 state = torch.load(f, weights_only=False)
             saved: Progress = state["progress"]
-            for key, value in asdict(saved).items():
+            # vars() instead of asdict(): a checkpoint pickled before a field
+            # existed simply omits it, keeping the in-memory default
+            for key, value in vars(saved).items():
                 if hasattr(progress, key):
                     setattr(progress, key, value)
         get_logger().debug(f"Orchestrator checkpoint loaded in {format_time(time.perf_counter() - start)}")

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -64,7 +64,7 @@ class CheckpointManager:
                 if hasattr(progress, key):
                     setattr(progress, key, value)
             train_source.load_state_dict(state["train_source"])
-            for name, position in state["train_source"].items():
+            for name, position in state["train_source"]["envs"].items():
                 if name not in train_source.base_rows:
                     continue
                 rows = train_source.base_rows[name]

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -64,6 +64,15 @@ class CheckpointManager:
                 if hasattr(progress, key):
                     setattr(progress, key, value)
             train_source.load_state_dict(state["train_source"])
+            for name, position in state["train_source"].items():
+                if name not in train_source.base_rows:
+                    continue
+                rows = train_source.base_rows[name]
+                num_tasks = len(rows) if rows is not None else "infinite"
+                get_logger().info(
+                    f"Resumed data position for env {name} - epoch={position['epoch']}, "
+                    f"cursor={position['cursor']}/{num_tasks}"
+                )
         get_logger().debug(f"Orchestrator checkpoint loaded in {format_time(time.perf_counter() - start)}")
 
 

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -7,6 +7,7 @@ import contextlib
 import os
 import tempfile
 import time
+from dataclasses import asdict
 from pathlib import Path
 
 import torch
@@ -57,9 +58,7 @@ class CheckpointManager:
             with open(state_file, "rb") as f:
                 state = torch.load(f, weights_only=False)
             saved: Progress = state["progress"]
-            # vars() instead of asdict(): a checkpoint pickled before a field
-            # existed simply omits it, keeping the in-memory default
-            for key, value in vars(saved).items():
+            for key, value in asdict(saved).items():
                 if hasattr(progress, key):
                     setattr(progress, key, value)
         get_logger().debug(f"Orchestrator checkpoint loaded in {format_time(time.perf_counter() - start)}")

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -1,4 +1,5 @@
-"""Checkpoint manager for ``Progress``. Layout:
+"""Checkpoint manager for the orchestrator state (``Progress`` counters +
+``TrainSource`` data position). Layout:
 ``<output_dir>/checkpoints/step_N/orchestrator/progress.pt``."""
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ from pathlib import Path
 import torch
 
 from prime_rl.configs.orchestrator import CheckpointConfig
+from prime_rl.orchestrator.train_source import TrainSource
 from prime_rl.orchestrator.types import Progress
 from prime_rl.utils.logger import format_time, get_logger
 from prime_rl.utils.pathing import get_ckpt_dir, get_step_path
@@ -26,7 +28,7 @@ class CheckpointManager:
     def get_ckpt_path(self, step: int) -> Path:
         return get_step_path(self.ckpt_dir, step) / "orchestrator"
 
-    def save(self, progress: Progress, step: int) -> None:
+    def save(self, progress: Progress, train_source: TrainSource, step: int) -> None:
         ckpt_path = self.get_ckpt_path(step)
         ckpt_path.mkdir(parents=True, exist_ok=True)
         start = time.perf_counter()
@@ -35,7 +37,7 @@ class CheckpointManager:
         fd, tmp_name = tempfile.mkstemp(dir=ckpt_path, prefix="progress.pt.", suffix=".tmp")
         try:
             with os.fdopen(fd, "wb") as f:
-                torch.save({"progress": progress}, f)
+                torch.save({"progress": progress, "train_source": train_source.state_dict()}, f)
             os.replace(tmp_name, ckpt_path / "progress.pt")
         except BaseException:
             with contextlib.suppress(OSError):
@@ -45,7 +47,7 @@ class CheckpointManager:
             f"Orchestrator checkpoint saved to {ckpt_path} in {format_time(time.perf_counter() - start)}"
         )
 
-    def load(self, progress: Progress, step: int) -> None:
+    def load(self, progress: Progress, train_source: TrainSource, step: int) -> None:
         ckpt_path = self.get_ckpt_path(step)
         state_file = ckpt_path / "progress.pt"
         if not state_file.exists():
@@ -53,7 +55,7 @@ class CheckpointManager:
         get_logger().debug(f"Loading checkpoint from {state_file}")
         start = time.perf_counter()
         if self.config.skip_progress:
-            get_logger().info("Skipping progress loading from checkpoint")
+            get_logger().info("Skipping progress and data position loading from checkpoint")
         else:
             with open(state_file, "rb") as f:
                 state = torch.load(f, weights_only=False)
@@ -61,6 +63,7 @@ class CheckpointManager:
             for key, value in asdict(saved).items():
                 if hasattr(progress, key):
                     setattr(progress, key, value)
+            train_source.load_state_dict(state["train_source"])
         get_logger().debug(f"Orchestrator checkpoint loaded in {format_time(time.perf_counter() - start)}")
 
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -388,12 +388,13 @@ class Orchestrator:
         if self.progress.data_positions:
             self.train_source.load_state(self.progress.data_positions)
             for name, position in self.progress.data_positions.items():
-                rows = self.train_source.base_rows.get(name)
-                if rows is None:
+                if name not in self.train_source.base_rows:
                     continue
+                rows = self.train_source.base_rows[name]
+                num_tasks = len(rows) if rows is not None else "infinite"
                 get_logger().info(
                     f"Resumed data position for env {name} - epoch={position['epoch']}, "
-                    f"cursor={position['cursor']}/{len(rows)}"
+                    f"cursor={position['cursor']}/{num_tasks}"
                 )
         self.eval_source: EvalSource | None = (
             EvalSource(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -343,13 +343,23 @@ class Orchestrator:
 
         self.lora_name = config.model.lora.name if config.model.lora else None
 
+        self.train_source = TrainSource(self.train_envs, seed=42)
+
         if self.resume_step is not None and self.ckpt_manager is not None:
-            self.ckpt_manager.load(self.progress, step=self.resume_step)
+            self.ckpt_manager.load(self.progress, self.train_source, step=self.resume_step)
             # The checkpoint finished step ``resume_step``; resume at the next step. Derive the step
             # from ``resume_step`` (not the loaded progress.step) so it stays coordinated with the
             # trainer even when ``ckpt.skip_progress`` left the counter unrestored.
             self.progress.step = self.resume_step + 1
             get_logger().info(f"Resuming orchestrator from checkpoint step {self.resume_step}")
+            if not config.ckpt.skip_progress:
+                for name, position in self.train_source.state_dict().items():
+                    rows = self.train_source.base_rows[name]
+                    num_tasks = len(rows) if rows is not None else "infinite"
+                    get_logger().info(
+                        f"Resumed data position for env {name} - epoch={position['epoch']}, "
+                        f"cursor={position['cursor']}/{num_tasks}"
+                    )
         else:
             get_logger().info("Training from scratch")
 
@@ -384,18 +394,6 @@ class Orchestrator:
                 self.policy.model_name = self.lora_name
             self.policy.version = sync_version
 
-        self.train_source = TrainSource(self.train_envs, seed=42)
-        if self.progress.data_positions:
-            self.train_source.load_state(self.progress.data_positions)
-            for name, position in self.progress.data_positions.items():
-                if name not in self.train_source.base_rows:
-                    continue
-                rows = self.train_source.base_rows[name]
-                num_tasks = len(rows) if rows is not None else "infinite"
-                get_logger().info(
-                    f"Resumed data position for env {name} - epoch={position['epoch']}, "
-                    f"cursor={position['cursor']}/{num_tasks}"
-                )
         self.eval_source: EvalSource | None = (
             EvalSource(
                 self.eval_envs,
@@ -510,9 +508,8 @@ class Orchestrator:
             # first ship).
             if self.ckpt_manager is not None and self.progress.step > 1:
                 self.progress.step -= 1
-                self.progress.data_positions = self.train_source.get_state()
                 get_logger().info("Writing final checkpoint")
-                self.ckpt_manager.save(self.progress, step=self.progress.step)
+                self.ckpt_manager.save(self.progress, self.train_source, step=self.progress.step)
             await self.stop()
             if clean_exit:
                 get_logger().success("Orchestrator finished.")
@@ -916,9 +913,7 @@ class Orchestrator:
             return 0.0
         get_logger().info(f"Saving checkpoint at step {step}")
         t = time.perf_counter()
-        # Snapshot on the event loop so the dispatcher can't advance cursors mid-save
-        self.progress.data_positions = self.train_source.get_state()
-        await asyncio.to_thread(self.ckpt_manager.save, self.progress, step)
+        await asyncio.to_thread(self.ckpt_manager.save, self.progress, self.train_source, step)
         return time.perf_counter() - t
 
     def update_dispatch_gate(self) -> None:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -343,7 +343,7 @@ class Orchestrator:
 
         self.lora_name = config.model.lora.name if config.model.lora else None
 
-        self.train_source = TrainSource(self.train_envs, seed=42)
+        self.train_source = TrainSource(self.train_envs)
 
         if self.resume_step is not None and self.ckpt_manager is not None:
             self.ckpt_manager.load(self.progress, self.train_source, step=self.resume_step)
@@ -352,14 +352,6 @@ class Orchestrator:
             # trainer even when ``ckpt.skip_progress`` left the counter unrestored.
             self.progress.step = self.resume_step + 1
             get_logger().info(f"Resuming orchestrator from checkpoint step {self.resume_step}")
-            if not config.ckpt.skip_progress:
-                for name, position in self.train_source.state_dict().items():
-                    rows = self.train_source.base_rows[name]
-                    num_tasks = len(rows) if rows is not None else "infinite"
-                    get_logger().info(
-                        f"Resumed data position for env {name} - epoch={position['epoch']}, "
-                        f"cursor={position['cursor']}/{num_tasks}"
-                    )
         else:
             get_logger().info("Training from scratch")
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -385,6 +385,16 @@ class Orchestrator:
             self.policy.version = sync_version
 
         self.train_source = TrainSource(self.train_envs, seed=42)
+        if self.progress.data_positions:
+            self.train_source.load_state(self.progress.data_positions)
+            for name, position in self.progress.data_positions.items():
+                rows = self.train_source.base_rows.get(name)
+                if rows is None:
+                    continue
+                get_logger().info(
+                    f"Resumed data position for env {name} - epoch={position['epoch']}, "
+                    f"cursor={position['cursor']}/{len(rows)}"
+                )
         self.eval_source: EvalSource | None = (
             EvalSource(
                 self.eval_envs,
@@ -499,6 +509,7 @@ class Orchestrator:
             # first ship).
             if self.ckpt_manager is not None and self.progress.step > 1:
                 self.progress.step -= 1
+                self.progress.data_positions = self.train_source.get_state()
                 get_logger().info("Writing final checkpoint")
                 self.ckpt_manager.save(self.progress, step=self.progress.step)
             await self.stop()
@@ -904,6 +915,8 @@ class Orchestrator:
             return 0.0
         get_logger().info(f"Saving checkpoint at step {step}")
         t = time.perf_counter()
+        # Snapshot on the event loop so the dispatcher can't advance cursors mid-save
+        self.progress.data_positions = self.train_source.get_state()
         await asyncio.to_thread(self.ckpt_manager.save, self.progress, step)
         return time.perf_counter() - t
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -905,7 +905,9 @@ class Orchestrator:
             return 0.0
         get_logger().info(f"Saving checkpoint at step {step}")
         t = time.perf_counter()
-        await asyncio.to_thread(self.ckpt_manager.save, self.progress, self.train_source, step)
+        # Synchronous on purpose: the payload is tiny, and snapshotting on the
+        # event loop keeps the dispatcher from mutating TrainSource mid-save
+        self.ckpt_manager.save(self.progress, self.train_source, step)
         return time.perf_counter() - t
 
     def update_dispatch_gate(self) -> None:

--- a/src/prime_rl/orchestrator/train_source.py
+++ b/src/prime_rl/orchestrator/train_source.py
@@ -14,11 +14,12 @@ import random
 from collections.abc import Iterator
 
 import verifiers.v1 as vf
+from torch.distributed.checkpoint.stateful import Stateful
 
 from prime_rl.orchestrator.envs import TrainEnvs
 
 
-class TrainSource:
+class TrainSource(Stateful):
     """``next_example(available_permits)`` picks a weighted-RR env and
     returns its next example (or ``None`` when the env's per-call permit
     cost doesn't fit — the dispatch loop retries when permits free up).
@@ -26,7 +27,7 @@ class TrainSource:
     whose data is shipped to the env server at dispatch).
 
     An env's data position is ``{epoch, cursor}``, round-tripped through a
-    checkpoint via ``get_state()`` / ``load_state()``. For a finite env,
+    checkpoint via ``state_dict()`` / ``load_state_dict()``. For a finite env,
     epochs are 1-indexed and seed that epoch's shuffle; for an infinite env
     the epoch stays 1 and the cursor counts generator pulls, replayed on
     restore by fast-forwarding the generator (exact iff it's deterministic).
@@ -78,12 +79,12 @@ class TrainSource:
         random.Random(self.epochs[env_name]).shuffle(rows)
         return rows
 
-    def get_state(self) -> dict[str, dict[str, int]]:
+    def state_dict(self) -> dict[str, dict[str, int]]:
         """Per-env data position ``{epoch, cursor}``."""
         return {name: {"epoch": self.epochs[name], "cursor": self.cursors[name]} for name in self.epochs}
 
-    def load_state(self, state: dict[str, dict[str, int]]) -> None:
-        for name, position in state.items():
+    def load_state_dict(self, state_dict: dict[str, dict[str, int]]) -> None:
+        for name, position in state_dict.items():
             if name not in self.base_rows:
                 continue
             self.epochs[name] = position["epoch"]

--- a/src/prime_rl/orchestrator/train_source.py
+++ b/src/prime_rl/orchestrator/train_source.py
@@ -25,18 +25,22 @@ class TrainSource:
     Returned dicts carry ``env_name`` + ``task_idx`` (+ ``task`` for v1 envs,
     whose data is shipped to the env server at dispatch).
 
-    An env's data position is ``{epoch, cursor}``, round-tripped through a
-    checkpoint via ``state_dict()`` / ``load_state_dict()``. For a finite env,
-    epochs are 1-indexed and seed that epoch's shuffle; for an infinite env
-    the epoch stays 1 and the cursor counts generator pulls, replayed on
-    restore by fast-forwarding the generator (exact iff it's deterministic).
-    The cursor advances at dispatch time (ahead of shipped batches), so a
-    resume skips the tasks that were in flight at checkpoint time."""
+    The data position round-trips through a checkpoint via ``state_dict()``
+    / ``load_state_dict()``: per-env ``{epoch, cursor}`` plus the env-choice
+    RNG state, making the dispatch sequence reproducible across resumes. For
+    a finite env, epochs are 1-indexed and seed that epoch's shuffle; for an
+    infinite env the epoch stays 1 and the cursor counts generator pulls,
+    replayed on restore by fast-forwarding the generator (exact iff it's
+    deterministic). Cursors advance at dispatch time (ahead of shipped
+    batches), so a resume skips the tasks that were in flight at checkpoint
+    time."""
 
     def __init__(self, train_envs: TrainEnvs) -> None:
-        # Env-choice RNG; not checkpointed (i.i.d. sampling, restarting the
-        # stream re-randomizes the interleave without repeating data)
         self.rng = random.Random(42)
+        # The drawn-but-undispatched env. A draw whose permit cost doesn't fit
+        # is held here (head-of-line) rather than redrawn, so the choice stream
+        # advances exactly once per dispatched example and stays reproducible.
+        self.pending_env: str | None = None
         self.envs = list(train_envs)
         if not self.envs:
             raise ValueError("TrainSource needs at least one train env")
@@ -80,12 +84,19 @@ class TrainSource:
         random.Random(self.epochs[env_name]).shuffle(rows)
         return rows
 
-    def state_dict(self) -> dict[str, dict[str, int]]:
-        """Per-env data position ``{epoch, cursor}``."""
-        return {name: {"epoch": self.epochs[name], "cursor": self.cursors[name]} for name in self.epochs}
+    def state_dict(self) -> dict:
+        """Env-choice RNG state + pending draw + per-env ``{epoch, cursor}``."""
+        return {
+            "rng": self.rng.getstate(),
+            "pending_env": self.pending_env,
+            "envs": {name: {"epoch": self.epochs[name], "cursor": self.cursors[name]} for name in self.epochs},
+        }
 
-    def load_state_dict(self, state_dict: dict[str, dict[str, int]]) -> None:
-        for name, position in state_dict.items():
+    def load_state_dict(self, state_dict: dict) -> None:
+        self.rng.setstate(state_dict["rng"])
+        pending = state_dict["pending_env"]
+        self.pending_env = pending if pending in self.env_costs else None
+        for name, position in state_dict["envs"].items():
             if name not in self.base_rows:
                 continue
             self.epochs[name] = position["epoch"]
@@ -97,9 +108,12 @@ class TrainSource:
                 self.examples[name] = self._shuffle(name)
 
     def next_example(self, available_permits: int) -> dict | None:
-        env_name = self.rng.choices(self.env_names, weights=self.weights, k=1)[0]
+        if self.pending_env is None:
+            self.pending_env = self.rng.choices(self.env_names, weights=self.weights, k=1)[0]
+        env_name = self.pending_env
         if self.env_costs[env_name] > available_permits:
             return None
+        self.pending_env = None
         rows = self.examples[env_name]
         cursor = self.cursors[env_name]
         if rows is None:  # infinite env: pull the next generated task

--- a/src/prime_rl/orchestrator/train_source.py
+++ b/src/prime_rl/orchestrator/train_source.py
@@ -25,11 +25,13 @@ class TrainSource:
     Returned dicts carry ``env_name`` + ``task_idx`` (+ ``task`` for v1 envs,
     whose data is shipped to the env server at dispatch).
 
-    A finite env's data position is ``{epoch, cursor}``: epochs are 1-indexed
-    and seed that epoch's shuffle, so ``get_state()`` / ``load_state()`` can
-    round-trip the position through a checkpoint. The cursor advances at
-    dispatch time (ahead of shipped batches), so a resume skips the tasks
-    that were in flight at checkpoint time."""
+    An env's data position is ``{epoch, cursor}``, round-tripped through a
+    checkpoint via ``get_state()`` / ``load_state()``. For a finite env,
+    epochs are 1-indexed and seed that epoch's shuffle; for an infinite env
+    the epoch stays 1 and the cursor counts generator pulls, replayed on
+    restore by fast-forwarding the generator (exact iff it's deterministic).
+    The cursor advances at dispatch time (ahead of shipped batches), so a
+    resume skips the tasks that were in flight at checkpoint time."""
 
     def __init__(self, train_envs: TrainEnvs, *, seed: int | None) -> None:
         self.rng = random.Random(seed)
@@ -77,21 +79,20 @@ class TrainSource:
         return rows
 
     def get_state(self) -> dict[str, dict[str, int]]:
-        """Per-env data position for finite envs (an infinite env's generator
-        has no restorable position)."""
-        return {
-            name: {"epoch": self.epochs[name], "cursor": self.cursors[name]}
-            for name in self.epochs
-            if self.base_rows[name] is not None
-        }
+        """Per-env data position ``{epoch, cursor}``."""
+        return {name: {"epoch": self.epochs[name], "cursor": self.cursors[name]} for name in self.epochs}
 
     def load_state(self, state: dict[str, dict[str, int]]) -> None:
         for name, position in state.items():
-            if self.base_rows.get(name) is None:
+            if name not in self.base_rows:
                 continue
             self.epochs[name] = position["epoch"]
             self.cursors[name] = position["cursor"]
-            self.examples[name] = self._shuffled(name)
+            if self.base_rows[name] is None:
+                for _ in range(position["cursor"]):
+                    next(self.iters[name])
+            else:
+                self.examples[name] = self._shuffled(name)
 
     def next_example(self, available_permits: int) -> dict | None:
         env_name = self.rng.choices(self.env_names, weights=self.weights, k=1)[0]
@@ -101,6 +102,7 @@ class TrainSource:
         cursor = self.cursors[env_name]
         if rows is None:  # infinite env: pull the next generated task
             task = next(self.iters[env_name])
+            self.cursors[env_name] = cursor + 1
             return {"task_idx": task.data.idx, "task": task, "env_name": env_name}
         if cursor >= len(rows):
             self.epochs[env_name] += 1

--- a/src/prime_rl/orchestrator/train_source.py
+++ b/src/prime_rl/orchestrator/train_source.py
@@ -14,12 +14,11 @@ import random
 from collections.abc import Iterator
 
 import verifiers.v1 as vf
-from torch.distributed.checkpoint.stateful import Stateful
 
 from prime_rl.orchestrator.envs import TrainEnvs
 
 
-class TrainSource(Stateful):
+class TrainSource:
     """``next_example(available_permits)`` picks a weighted-RR env and
     returns its next example (or ``None`` when the env's per-call permit
     cost doesn't fit — the dispatch loop retries when permits free up).
@@ -34,8 +33,10 @@ class TrainSource(Stateful):
     The cursor advances at dispatch time (ahead of shipped batches), so a
     resume skips the tasks that were in flight at checkpoint time."""
 
-    def __init__(self, train_envs: TrainEnvs, *, seed: int | None) -> None:
-        self.rng = random.Random(seed)
+    def __init__(self, train_envs: TrainEnvs) -> None:
+        # Env-choice RNG; not checkpointed (i.i.d. sampling, restarting the
+        # stream re-randomizes the interleave without repeating data)
+        self.rng = random.Random(42)
         self.envs = list(train_envs)
         if not self.envs:
             raise ValueError("TrainSource needs at least one train env")
@@ -62,13 +63,13 @@ class TrainSource(Stateful):
             self.base_rows[env.name] = rows
             self.epochs[env.name] = 1
             self.cursors[env.name] = 0
-            self.examples[env.name] = self._shuffled(env.name)
+            self.examples[env.name] = self._shuffle(env.name)
             self.env_costs[env.name] = env.config.group_size if env.requires_group_scoring else 1
 
         self.env_names = [e.name for e in self.envs]
         self.weights: list[float] = [float(e.config.ratio) for e in self.envs]
 
-    def _shuffled(self, env_name: str) -> list[dict] | None:
+    def _shuffle(self, env_name: str) -> list[dict] | None:
         """The env's example table shuffled for its current epoch — a pure
         function of (canonical order, epoch), so a restored position replays
         the exact epoch permutation."""
@@ -93,7 +94,7 @@ class TrainSource(Stateful):
                 for _ in range(position["cursor"]):
                     next(self.iters[name])
             else:
-                self.examples[name] = self._shuffled(name)
+                self.examples[name] = self._shuffle(name)
 
     def next_example(self, available_permits: int) -> dict | None:
         env_name = self.rng.choices(self.env_names, weights=self.weights, k=1)[0]
@@ -107,7 +108,7 @@ class TrainSource(Stateful):
             return {"task_idx": task.data.idx, "task": task, "env_name": env_name}
         if cursor >= len(rows):
             self.epochs[env_name] += 1
-            rows = self._shuffled(env_name)
+            rows = self._shuffle(env_name)
             self.examples[env_name] = rows
             cursor = 0
         example = rows[cursor]

--- a/src/prime_rl/orchestrator/train_source.py
+++ b/src/prime_rl/orchestrator/train_source.py
@@ -2,10 +2,11 @@
 
 Weights are each env's configured ``ratio`` (default 1, i.e. equal weight
 per env). A v1 env serves the tasks the orchestrator loaded client-side: a
-finite one as a shuffled table (reshuffled on cursor exhaustion), an
-infinite one (``num_tasks is None``) straight off its generator — every
-pull is a fresh task and there are no epochs to shuffle. A legacy env's
-dataset lives on its server, so it serves shuffled task *indices*."""
+finite one as a shuffled table (reshuffled with ``seed=epoch`` on cursor
+exhaustion), an infinite one (``num_tasks is None``) straight off its
+generator — every pull is a fresh task and there are no epochs to shuffle.
+A legacy env's dataset lives on its server, so it serves shuffled task
+*indices*."""
 
 from __future__ import annotations
 
@@ -22,7 +23,13 @@ class TrainSource:
     returns its next example (or ``None`` when the env's per-call permit
     cost doesn't fit — the dispatch loop retries when permits free up).
     Returned dicts carry ``env_name`` + ``task_idx`` (+ ``task`` for v1 envs,
-    whose data is shipped to the env server at dispatch)."""
+    whose data is shipped to the env server at dispatch).
+
+    A finite env's data position is ``{epoch, cursor}``: epochs are 1-indexed
+    and seed that epoch's shuffle, so ``get_state()`` / ``load_state()`` can
+    round-trip the position through a checkpoint. The cursor advances at
+    dispatch time (ahead of shipped batches), so a resume skips the tasks
+    that were in flight at checkpoint time."""
 
     def __init__(self, train_envs: TrainEnvs, *, seed: int | None) -> None:
         self.rng = random.Random(seed)
@@ -30,31 +37,61 @@ class TrainSource:
         if not self.envs:
             raise ValueError("TrainSource needs at least one train env")
 
-        # A finite env's shuffled example table; ``None`` for an infinite env,
-        # whose generator (``self.iters``) is pulled per example.
+        # A finite env's example table in canonical order (each epoch's shuffle
+        # starts from this); ``None`` for an infinite env, whose generator
+        # (``self.iters``) is pulled per example.
+        self.base_rows: dict[str, list[dict] | None] = {}
         self.examples: dict[str, list[dict] | None] = {}
         self.iters: dict[str, Iterator[vf.Task]] = {}
+        self.epochs: dict[str, int] = {}
         self.cursors: dict[str, int] = {}
         # Group-scoring envs reserve ``group_size`` permits up front;
         # per-rollout envs need 1
         self.env_costs: dict[str, int] = {}
         for env in self.envs:
             if env.tasks is None:  # legacy: sample over the index range from info()
-                rows: list[dict] = [{"task_idx": i, "env_name": env.name} for i in range(env.num_tasks)]
-                self.rng.shuffle(rows)
-                self.examples[env.name] = rows
+                rows: list[dict] | None = [{"task_idx": i, "env_name": env.name} for i in range(env.num_tasks)]
             elif env.num_tasks is None:  # infinite: pull the generator per example
-                self.examples[env.name] = None
+                rows = None
                 self.iters[env.name] = env.tasks
             else:
                 rows = [{"task_idx": task.data.idx, "task": task, "env_name": env.name} for task in env.tasks]
-                self.rng.shuffle(rows)
-                self.examples[env.name] = rows
+            self.base_rows[env.name] = rows
+            self.epochs[env.name] = 1
             self.cursors[env.name] = 0
+            self.examples[env.name] = self._shuffled(env.name)
             self.env_costs[env.name] = env.config.group_size if env.requires_group_scoring else 1
 
         self.env_names = [e.name for e in self.envs]
         self.weights: list[float] = [float(e.config.ratio) for e in self.envs]
+
+    def _shuffled(self, env_name: str) -> list[dict] | None:
+        """The env's example table shuffled for its current epoch — a pure
+        function of (canonical order, epoch), so a restored position replays
+        the exact epoch permutation."""
+        rows = self.base_rows[env_name]
+        if rows is None:
+            return None
+        rows = rows.copy()
+        random.Random(self.epochs[env_name]).shuffle(rows)
+        return rows
+
+    def get_state(self) -> dict[str, dict[str, int]]:
+        """Per-env data position for finite envs (an infinite env's generator
+        has no restorable position)."""
+        return {
+            name: {"epoch": self.epochs[name], "cursor": self.cursors[name]}
+            for name in self.epochs
+            if self.base_rows[name] is not None
+        }
+
+    def load_state(self, state: dict[str, dict[str, int]]) -> None:
+        for name, position in state.items():
+            if self.base_rows.get(name) is None:
+                continue
+            self.epochs[name] = position["epoch"]
+            self.cursors[name] = position["cursor"]
+            self.examples[name] = self._shuffled(name)
 
     def next_example(self, available_permits: int) -> dict | None:
         env_name = self.rng.choices(self.env_names, weights=self.weights, k=1)[0]
@@ -66,7 +103,9 @@ class TrainSource:
             task = next(self.iters[env_name])
             return {"task_idx": task.data.idx, "task": task, "env_name": env_name}
         if cursor >= len(rows):
-            self.rng.shuffle(rows)
+            self.epochs[env_name] += 1
+            rows = self._shuffled(env_name)
+            self.examples[env_name] = rows
             cursor = 0
         example = rows[cursor]
         self.cursors[env_name] = cursor + 1

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, Literal, Protocol
 
 import verifiers.v1 as vf
@@ -27,15 +27,12 @@ class Policy:
 
 @dataclass
 class Progress:
-    """Persistent counters; ``step`` is the trainer-aligned step (1-indexed).
-    ``data_positions`` is the ``TrainSource`` per-env ``{epoch, cursor}``
-    snapshot, keyed by env name."""
+    """Persistent counters; ``step`` is the trainer-aligned step (1-indexed)."""
 
     step: int = 1
     total_tokens: int = 0
     total_samples: int = 0
     total_problems: int = 0
-    data_positions: dict[str, dict[str, int]] = field(default_factory=dict)
 
 
 RolloutKind = Literal["train", "eval"]

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Generic, Literal, Protocol
 
 import verifiers.v1 as vf
@@ -27,12 +27,15 @@ class Policy:
 
 @dataclass
 class Progress:
-    """Persistent counters; ``step`` is the trainer-aligned step (1-indexed)."""
+    """Persistent counters; ``step`` is the trainer-aligned step (1-indexed).
+    ``data_positions`` is the ``TrainSource`` per-env ``{epoch, cursor}``
+    snapshot, keyed by env name."""
 
     step: int = 1
     total_tokens: int = 0
     total_samples: int = 0
     total_problems: int = 0
+    data_positions: dict[str, dict[str, int]] = field(default_factory=dict)
 
 
 RolloutKind = Literal["train", "eval"]


### PR DESCRIPTION
## Summary

- Data loading on the orchestrator was stateless across restarts: `TrainSource` shuffled once with a fixed seed and its cursors lived only in memory, so a resumed run restarted every finite taskset from the top of the same permutation, re-sampling tasks the previous run already saw.
- `TrainSource` now tracks a per-env data position `{epoch, cursor}`, exposed via `state_dict()` / `load_state_dict()` — mirroring how the SFT dataloader checkpoints its position. For finite tasksets, epochs are 1-indexed and each epoch's shuffle is seeded with the epoch number from the canonical table order, so a permutation is a pure function of the epoch and can be replayed on resume. Legacy server-side datasets get the same treatment over their index table.
- For infinite (generator-backed) tasksets the epoch stays 1 and the cursor counts generator pulls; restore fast-forwards the generator by that many pulls — an exact replay when the generator is deterministic, a harmless discard when it isn't.
- The data position is a first-class part of the orchestrator checkpoint: `CheckpointManager.save/load` take the `TrainSource` alongside `Progress` and store its state under its own `train_source` key in `progress.pt` (`Progress` itself is unchanged). On resume, `load` restores it and logs one line per env: `Resumed data position for env <name> - epoch=E, cursor=C/N` (`N` is `infinite` for generator-backed tasksets). `--ckpt.skip-progress` skips both the counters and the data position.
- The interval save runs synchronously on the event loop (no `asyncio.to_thread`): the payload is tiny, and snapshotting inline keeps the dispatcher from mutating `TrainSource` mid-save, which would tear the snapshot.
- The cross-env dispatch sequence is reproducible too: the env-choice RNG advances exactly once per dispatched example — a draw whose permit cost doesn't fit is held as `pending_env` (head-of-line) instead of being redrawn — and the RNG state + pending draw are part of the `TrainSource` state. Without the hold, permit-rejected attempts would consume draws at timing-dependent points, making the interleave irreproducible even within a single run. The trade-off is head-of-line blocking: a pending group draw waits for `group_size` permits rather than letting a cheaper env slip through. (`TrainSource` also no longer takes a `seed` — the RNG only drives env choice now that shuffles are epoch-seeded, so the previously hardcoded call-site value moved inside.)

Known approximation: cursors advance when the dispatcher pulls an example, ahead of batch shipping, so tasks in flight at checkpoint time are counted as consumed — a resume skips them for that epoch (up to ~`max_inflight_episodes`). Trading that for duplicates would need shipped-task tracking; not worth the complexity. (Completion order and batch composition also stay timing-dependent — what's reproducible is the dispatch sequence, not the training batches.)

## Breaking

- Orchestrator checkpoints written before this PR can't be resumed: their `progress.pt` has no `train_source` key, so `CheckpointManager.load` fails with `KeyError: 'train_source'`. Migration: finish (or restart) in-flight runs rather than resuming them across this change, or resume with `--ckpt.skip-progress` (which skips loading the counters and the data position).

## Verification

reverse-text RL (`examples/basic/reverse-text/rl.toml`, 1000 tasks, batch 128 / group 16 → 8 tasks per step), 10 steps + resume for 10 more:

```
# run 1: uv run rl @ examples/basic/reverse-text/rl.toml --max-steps 10 --no-wandb --ckpt
step-10 checkpoint: progress=Progress(step=10, ...)
                    train_source={'rng': <625-word MT state>, 'pending_env': None,
                                  'envs': {'reverse-text': {'epoch': 1, 'cursor': 100}}}

# run 2: … --max-steps 20 --ckpt.resume-step 10
INFO  Resumed data position for env reverse-text - epoch=1, cursor=100/1000
step-20 checkpoint: envs={'reverse-text': {'epoch': 1, 'cursor': 199}}
```

Cross-checking `task.data.idx` in the saved traces: steps 1–10 dispatched 85 distinct tasks, steps 11–20 dispatched 84, with **zero overlap** — the resumed run continued the epoch-1 permutation instead of restarting it (before this change, run 2 restarted from cursor 0 and re-sampled run 1's tasks). Unit round-trips additionally cover the multi-env interleave (an interrupted+resumed source replays the uninterrupted dispatch sequence exactly, including a pending draw held across a checkpoint), infinite-generator fast-forward, and stale env names in old state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
