### PR TITLE
chore: expand inline TOML tables to sections in configs and examples

### DIFF
--- a/configs/basic/alphabet-sort/rl.toml
+++ b/configs/basic/alphabet-sort/rl.toml
@@ -34,9 +34,20 @@ max_completion_tokens = 768
 
 [[orchestrator.train.source]]
 name = "alphabet-sort"
-env.taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "alphabet-sort-v1"
+min_turns = 3
+max_turns = 5
+
+[orchestrator.train.source.env.taskset.task]
+power_per_turn = false
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [ckpt] # Checkpoint at the end of training
 

--- a/configs/basic/hendrycks-sanity/rl.toml
+++ b/configs/basic/hendrycks-sanity/rl.toml
@@ -21,9 +21,17 @@ seq_len = 8192
 
 [[orchestrator.train.source]]
 name = "hendrycks-math"
-env.taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "math-env-v1"
+dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B"
+dataset_subset = "default"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.model]
 seq_len = 16384

--- a/configs/basic/reverse-text/rl.toml
+++ b/configs/basic/reverse-text/rl.toml
@@ -24,9 +24,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/basic/wiki-search/rl.toml
+++ b/configs/basic/wiki-search/rl.toml
@@ -42,9 +42,15 @@ max_completion_tokens = 512
 
 [[orchestrator.train.source]]
 name = "wiki-search"
-env.taskset = { id = "wiki-search-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "wiki-search-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [ckpt] # Checkpoint at the end of training
 

--- a/configs/basic/wordle/rl.toml
+++ b/configs/basic/wordle/rl.toml
@@ -23,9 +23,15 @@ group_size = 8
 
 [[orchestrator.train.source]]
 name = "wordle"
-env.taskset = { id = "wordle-v1" }
-env.player.harness = { id = "null" }
-env.player.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "wordle-v1"
+
+[orchestrator.train.source.env.player.harness]
+id = "null"
+
+[orchestrator.train.source.env.player.runtime]
+type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 1024

--- a/configs/ci/integration/alphabet_sort.toml
+++ b/configs/ci/integration/alphabet_sort.toml
@@ -24,9 +24,23 @@ max_completion_tokens = 384
 
 [[orchestrator.train.source]]
 name = "alphabet-sort"
-env.taskset = { id = "alphabet-sort-v1", min_turns = 2, max_turns = 2, min_names_per_turn = 1, max_names_per_turn = 3, task = { similarity_power = 4, power_per_turn = false } }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "alphabet-sort-v1"
+min_turns = 2
+max_turns = 2
+min_names_per_turn = 1
+max_names_per_turn = 3
+
+[orchestrator.train.source.env.taskset.task]
+similarity_power = 4
+power_per_turn = false
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [inference]
 

--- a/configs/ci/integration/reverse-text-lora/resume.toml
+++ b/configs/ci/integration/reverse-text-lora/resume.toml
@@ -28,9 +28,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [inference]
 enable_lora = true

--- a/configs/ci/integration/reverse-text-lora/start.toml
+++ b/configs/ci/integration/reverse-text-lora/start.toml
@@ -27,9 +27,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [inference]
 enable_lora = true

--- a/configs/ci/integration/reverse-text-moe/start.toml
+++ b/configs/ci/integration/reverse-text-moe/start.toml
@@ -27,9 +27,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [inference]
 gpu_memory_utilization = 0.7

--- a/configs/ci/integration/reverse-text-multi-run/orchestrator.toml
+++ b/configs/ci/integration/reverse-text-multi-run/orchestrator.toml
@@ -16,9 +16,15 @@ max_completion_tokens = 128
 
 [[train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[train.source.env.taskset]
+id = "reverse-text-v1"
+
+[train.source.env.agent.harness]
+id = "null"
+
+[train.source.env.agent.runtime]
+type = "subprocess"
 
 [ckpt]
 interval = 10

--- a/configs/ci/integration/reverse-text-rl-opd/start.toml
+++ b/configs/ci/integration/reverse-text-rl-opd/start.toml
@@ -39,9 +39,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -52,9 +58,15 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/ci/integration/reverse-text-rl-sft/start.toml
+++ b/configs/ci/integration/reverse-text-rl-sft/start.toml
@@ -45,9 +45,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -58,9 +64,15 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/ci/integration/reverse-text/resume.toml
+++ b/configs/ci/integration/reverse-text/resume.toml
@@ -25,9 +25,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [inference]
 

--- a/configs/ci/integration/reverse-text/start.toml
+++ b/configs/ci/integration/reverse-text/start.toml
@@ -24,9 +24,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [inference]
 

--- a/configs/ci/nightly-fft/alphabet-sort.toml
+++ b/configs/ci/nightly-fft/alphabet-sort.toml
@@ -20,9 +20,20 @@ group_size = 16
 
 [[orchestrator.train.source]]
 name = "alphabet-sort"
-env.taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "alphabet-sort-v1"
+min_turns = 3
+max_turns = 5
+
+[orchestrator.train.source.env.taskset.task]
+power_per_turn = false
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 768

--- a/configs/ci/nightly-fft/hendrycks-sanity.toml
+++ b/configs/ci/nightly-fft/hendrycks-sanity.toml
@@ -20,19 +20,33 @@ seq_len = 8192
 
 [[orchestrator.train.source]]
 name = "hendrycks-math"
-env.taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "math-env-v1"
+dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B"
+dataset_subset = "default"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.eval]
 interval = 50
 
 [[orchestrator.eval.source]]
 name = "aime2024"
-env.taskset = { id = "aime24-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
 group_size = 32
+
+[orchestrator.eval.source.env.taskset]
+id = "aime24-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer]
 

--- a/configs/ci/nightly-fft/reverse-text.toml
+++ b/configs/ci/nightly-fft/reverse-text.toml
@@ -20,9 +20,15 @@ group_size = 16
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 128

--- a/configs/ci/nightly-fft/wiki-search.toml
+++ b/configs/ci/nightly-fft/wiki-search.toml
@@ -25,9 +25,15 @@ enforce = true
 
 [[orchestrator.train.source]]
 name = "wiki-search"
-env.taskset = { id = "wiki-search-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "wiki-search-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 512

--- a/configs/ci/nightly-fft/wordle.toml
+++ b/configs/ci/nightly-fft/wordle.toml
@@ -20,9 +20,15 @@ group_size = 16
 
 [[orchestrator.train.source]]
 name = "wordle"
-env.taskset = { id = "wordle-v1" }
-env.player.harness = { id = "null" }
-env.player.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "wordle-v1"
+
+[orchestrator.train.source.env.player.harness]
+id = "null"
+
+[orchestrator.train.source.env.player.runtime]
+type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 1024

--- a/configs/ci/nightly/multimodal_color_codeword.toml
+++ b/configs/ci/nightly/multimodal_color_codeword.toml
@@ -22,9 +22,16 @@ max_completion_tokens = 64
 
 [[orchestrator.train.source]]
 name = "color-codeword"
-env.taskset = { id = "color-codeword-v1", images_per_turn = 1 }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "color-codeword-v1"
+images_per_turn = 1
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer]
 

--- a/configs/debug/algo/echo.toml
+++ b/configs/debug/algo/echo.toml
@@ -26,9 +26,20 @@ alpha = 0.1
 
 [[orchestrator.train.source]]
 name = "alphabet-sort"
-env.taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "alphabet-sort-v1"
+min_turns = 3
+max_turns = 5
+
+[orchestrator.train.source.env.taskset.task]
+power_per_turn = false
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 512

--- a/configs/debug/algo/grpo.toml
+++ b/configs/debug/algo/grpo.toml
@@ -23,9 +23,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -36,9 +42,15 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/max_rl.toml
+++ b/configs/debug/algo/max_rl.toml
@@ -23,9 +23,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -36,9 +42,15 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/mixed_grpo_opd.toml
+++ b/configs/debug/algo/mixed_grpo_opd.toml
@@ -33,15 +33,27 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text-grpo"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [[orchestrator.train.source]]
 name = "reverse-text-opd"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.train.source.algo]
 type = "opd"
@@ -59,9 +71,15 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/opd.toml
+++ b/configs/debug/algo/opd.toml
@@ -35,9 +35,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -48,9 +54,15 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/opd_lora.toml
+++ b/configs/debug/algo/opd_lora.toml
@@ -35,9 +35,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -48,9 +54,15 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.optim]
 lr = 1e-4

--- a/configs/debug/algo/rae.toml
+++ b/configs/debug/algo/rae.toml
@@ -23,11 +23,21 @@ max_completion_tokens = 512
 
 [[orchestrator.train.source]]
 name = "kuhn-poker"
-env.taskset = { id = "kuhn-poker-v1" }
-env.player0.harness = { id = "null" }
-env.player0.runtime = { type = "subprocess" }
-env.player1.harness = { id = "null" }
-env.player1.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "kuhn-poker-v1"
+
+[orchestrator.train.source.env.player0.harness]
+id = "null"
+
+[orchestrator.train.source.env.player0.runtime]
+type = "subprocess"
+
+[orchestrator.train.source.env.player1.harness]
+id = "null"
+
+[orchestrator.train.source.env.player1.runtime]
+type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -38,11 +48,21 @@ max_completion_tokens = 512
 
 [[orchestrator.eval.source]]
 name = "kuhn-poker"
-env.taskset = { id = "kuhn-poker-v1" }
-env.player0.harness = { id = "null" }
-env.player0.runtime = { type = "subprocess" }
-env.player1.harness = { id = "null" }
-env.player1.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "kuhn-poker-v1"
+
+[orchestrator.eval.source.env.player0.harness]
+id = "null"
+
+[orchestrator.eval.source.env.player0.runtime]
+type = "subprocess"
+
+[orchestrator.eval.source.env.player1.harness]
+id = "null"
+
+[orchestrator.eval.source.env.player1.runtime]
+type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/self_distill.toml
+++ b/configs/debug/algo/self_distill.toml
@@ -31,9 +31,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -44,9 +50,15 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/sft_distill.toml
+++ b/configs/debug/algo/sft_distill.toml
@@ -40,9 +40,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -53,9 +59,15 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/sft_distill_lora.toml
+++ b/configs/debug/algo/sft_distill_lora.toml
@@ -40,9 +40,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -53,9 +59,15 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.optim]
 lr = 1e-4

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -100,7 +100,9 @@ Echo also takes an optional user-supplied token filter that narrows the role sel
 ```toml
 [orchestrator.algo.filter]
 import_path = "my_module.drop_warnings"
-kwargs = { patterns = ["WARNING"] }
+
+[orchestrator.algo.filter.kwargs]
+patterns = ["WARNING"]
 ```
 
 ```python
@@ -121,18 +123,32 @@ Both components resolve per environment. Each env inherits `[orchestrator.algo]`
 type = "grpo"
 
 [[orchestrator.train.source]]
-name = "math"
-env.taskset = { id = "math-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
-# inherits the top-level grpo
+name = "math"  # inherits the top-level grpo
+
+[orchestrator.train.source.env.taskset]
+id = "math-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [[orchestrator.train.source]]
 name = "terminal"
-env.taskset = { id = "terminal-v1" }
-env.agent.harness = { id = "bash" }
-env.agent.runtime = { type = "subprocess" }
-algo = { type = "echo" }   # this env runs its own algorithm
+
+[orchestrator.train.source.env.taskset]
+id = "terminal-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "bash"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
+
+# this env runs its own algorithm
+[orchestrator.train.source.algo]
+type = "echo"
 ```
 
 ### The Algorithm Classes
@@ -253,7 +269,9 @@ Wire it up:
 [trainer.loss]
 type = "custom"
 import_path = "my_module.ppo_clip_loss"
-kwargs = { clip_eps = 0.2 }
+
+[trainer.loss.kwargs]
+clip_eps = 0.2
 ```
 
 The dataclasses:
@@ -346,12 +364,22 @@ episode_agents = ["solver"]
 [[orchestrator.train.source]]
 name = "proposer-solver"
 group_size = 4  # proposed problems per source task
-env.taskset = { id = "proposer-solver-v1" }
 env.n = 4  # solver attempts per proposed problem
-env.proposer.harness = { id = "null" }
-env.proposer.runtime = { type = "subprocess" }
-env.solver.harness = { id = "null" }
-env.solver.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "proposer-solver-v1"
+
+[orchestrator.train.source.env.proposer.harness]
+id = "null"
+
+[orchestrator.train.source.env.proposer.runtime]
+type = "subprocess"
+
+[orchestrator.train.source.env.solver.harness]
+id = "null"
+
+[orchestrator.train.source.env.solver.runtime]
+type = "subprocess"
 ```
 
 `group_size` controls how many problems are proposed from each source task. `env.n` controls how many solvers attempt each proposed problem. If a comparison contains only one trace—for example, a solver when `env.n = 1`—its advantage is zero and the zero-advantage filter removes it.
@@ -371,11 +399,21 @@ decay = 0.95
 
 [[orchestrator.train.source]]
 name = "kuhn-poker"
-env.taskset = { id = "kuhn-poker-v1" }
-env.player0.harness = { id = "null" }
-env.player0.runtime = { type = "subprocess" }
-env.player1.harness = { id = "null" }
-env.player1.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "kuhn-poker-v1"
+
+[orchestrator.train.source.env.player0.harness]
+id = "null"
+
+[orchestrator.train.source.env.player0.runtime]
+type = "subprocess"
+
+[orchestrator.train.source.env.player1.harness]
+id = "null"
+
+[orchestrator.train.source.env.player1.runtime]
+type = "subprocess"
 ```
 
 Both of `kuhn-poker-v1`'s agents late-bind to the run's own model — shared-policy self-play against a continuously improving opponent. Pin one agent to a frozen endpoint (`env.player1.model = ...`) for asymmetric play; its traces are marked untrainable by the env and never reach the advantage computation. A single-agent env under `rae` degrades to REINFORCE with an EMA baseline.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,7 +97,7 @@ Overlay TOMLs **replace** lists wholesale — an overlay that wants to add one i
 
 ### Dicts
 
-CLI takes a JSON literal. TOML uses a table or inline-table. CLI dicts deep-merge with TOML dicts — CLI keys win on conflict but don't wipe the file's keys:
+CLI takes a JSON literal. TOML uses a table. CLI dicts deep-merge with TOML dicts — CLI keys win on conflict but don't wipe the file's keys:
 
 ```bash
 uv run rl @ rl.toml --orchestrator.train.source.0.args \
@@ -106,7 +106,10 @@ uv run rl @ rl.toml --orchestrator.train.source.0.args \
 
 ```toml
 [[orchestrator.train.source]]
-args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }
+
+[orchestrator.train.source.args]
+dataset_name = "openai/gsm8k"
+dataset_subset = "main"
 ```
 
 ### Optional Sub-Configs
@@ -149,23 +152,43 @@ Training and evaluation sources are arrays of tables. Set one source per environ
 ```toml
 [[orchestrator.train.source]]
 name = "gsm8k"
-env.taskset = { id = "gsm8k-v1", split = "train" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
 ratio = 3  # 75% of batches
+
+[orchestrator.train.source.env.taskset]
+id = "gsm8k-v1"
+split = "train"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
 ratio = 1  # default — 25% of batches
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [[orchestrator.eval.source]]
 name = "gsm8k-eval"
-env.taskset = { id = "gsm8k-v1", split = "test" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "gsm8k-v1"
+split = "test"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 ```
 
 `ratio` defaults to `1` (equal weight per env); values are relative weights normalized to probabilities across envs.

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -174,11 +174,17 @@ Every deployment fronts its vLLM engines with a single global router — it list
 ```toml
 [inference.router]              # or [router] for the standalone inference entrypoint
 type = "llm-d"                  # "vllm-router" (default) or "llm-d"
-# llm-d-only knobs (all optional):
-scorers = { "prefix-cache-scorer" = 3.0, "active-request-scorer" = 2.0 }   # base, applied to every profile
-prefill_scorer_overrides = { "queue-scorer" = 2.0, "kv-cache-utilization-scorer" = 2.0 }  # merged onto the P/D prefill profile
-decode_scorer_overrides = {}    # merged onto the P/D decode profile
-non_cached_tokens = 16          # below this many non-cached prompt tokens, skip remote prefill (P/D)
+non_cached_tokens = 16          # llm-d only: below this many non-cached prompt tokens, skip remote prefill (P/D)
+
+# llm-d only: base scorer weights, applied to every profile
+[inference.router.scorers]
+"prefix-cache-scorer" = 3.0
+"active-request-scorer" = 2.0
+
+# llm-d only: merged onto the P/D prefill profile (decode_scorer_overrides for decode)
+[inference.router.prefill_scorer_overrides]
+"queue-scorer" = 2.0
+"kv-cache-utilization-scorer" = 2.0
 ```
 
 - **`vllm-router`** (default) — our fork of [vllm-router](https://github.com/PrimeIntellect-ai/router). Knob: `policy`. The only backend supported for single-node (local) deployments.
@@ -255,8 +261,12 @@ For configuring various knobs with environment variables, we enable you to confi
 [inference.deployment]
 type = "disaggregated"
 
-prefill_env_vars = {"VLLM_ENABLE_MOE_DP_CHUNK"="0", "VLLM_DEEP_GEMM_WARMUP"="skip"}
-decode_env_vars = {"VLLM_DEEP_GEMM_WARMUP"="skip"}
+[inference.deployment.prefill_env_vars]
+"VLLM_ENABLE_MOE_DP_CHUNK" = "0"
+"VLLM_DEEP_GEMM_WARMUP" = "skip"
+
+[inference.deployment.decode_env_vars]
+"VLLM_DEEP_GEMM_WARMUP" = "skip"
 ```
 
 These are role-specific and layer on top of [`env_vars`](configuration.md#environment-variables) shared by all inference processes regardless of role.

--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -95,8 +95,18 @@ num_turns_weight = 0.0
 # the plugged BC-style prompt is replaced by the reference judge's stock prompt).
 [[orchestrator.train.source]]
 name = "openseeker"
-env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = [65536, 131072] }
-env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] }
+
+[orchestrator.train.source.env.agent.harness]
+id = "rlm"
+skills = ["search"]
+forward_env = ["SERPER_API_KEY"]
+summarize_at_tokens = [65536, 131072]
+
+[orchestrator.train.source.env.agent.runtime]
+type = "prime"
+vm = true
+idle_timeout = "None"
+labels = ["glm45air-search"]
 
 [orchestrator.train.source.env.taskset]
 id = "openseeker-v1"
@@ -118,8 +128,18 @@ choices = ["A", "B"]
 
 [[orchestrator.train.source]]
 name = "redsearcher"
-env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = [65536, 131072] }
-env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] }
+
+[orchestrator.train.source.env.agent.harness]
+id = "rlm"
+skills = ["search"]
+forward_env = ["SERPER_API_KEY"]
+summarize_at_tokens = [65536, 131072]
+
+[orchestrator.train.source.env.agent.runtime]
+type = "prime"
+vm = true
+idle_timeout = "None"
+labels = ["glm45air-search"]
 
 [orchestrator.train.source.env.taskset]
 id = "redsearcher-v1" # optional `difficulty` filter (easy/medium/hard)
@@ -147,13 +167,27 @@ interval = 20
 [[orchestrator.eval.source]]
 name = "browsecomp"
 num_examples = 500 # full set is 1266; cap eval at 500
-env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"], summarize_at_tokens = 98304 }
-env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-search"] }
-env.agent.timeout = { rollout = 3600 }
+
+[orchestrator.eval.source.env.agent.harness]
+id = "rlm"
+skills = ["search"]
+forward_env = ["SERPER_API_KEY"]
+summarize_at_tokens = 98304
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "prime"
+vm = true
+idle_timeout = "None"
+labels = ["glm45air-search"]
+
+[orchestrator.eval.source.env.agent.timeout]
+rollout = 3600
 
 [orchestrator.eval.source.env.taskset]
 id = "browsecomp-v1"
-task = { judge = { model = "Qwen/Qwen3-235B-A22B-Instruct-2507" } }
+
+[orchestrator.eval.source.env.taskset.task.judge]
+model = "Qwen/Qwen3-235B-A22B-Instruct-2507"
 
 # # Metric-only monitor (weight 0): rlm harness-mechanics rubric, judged by GLM-5.2.
 # [[orchestrator.eval.source.env.taskset.task.judges]]

--- a/examples/advanced/glm-4.5-air/swe.toml
+++ b/examples/advanced/glm-4.5-air/swe.toml
@@ -99,9 +99,19 @@ thinking_retention = "all"
 
 [[orchestrator.train.source]]
 name = "scaleswe"
-env.taskset = { id = "scaleswe-v1" }
-env.agent.harness = { id = "rlm", summarize_at_tokens = [65536, 131072] }
-env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe"] }
+
+[orchestrator.train.source.env.taskset]
+id = "scaleswe-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "rlm"
+summarize_at_tokens = [65536, 131072]
+
+[orchestrator.train.source.env.agent.runtime]
+type = "prime"
+vm = true
+idle_timeout = "None"
+labels = ["glm45air-swe"]
 
 [orchestrator.prime_monitor]
 
@@ -112,10 +122,22 @@ interval = 20
 
 [[orchestrator.eval.source]]
 name = "swebench-verified"
-env.taskset = { id = "swebench-verified-v1" }
-env.agent.harness = { id = "rlm", summarize_at_tokens = 98304 }
-env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-swe"] }
-env.agent.timeout = { rollout = 3600 }
+
+[orchestrator.eval.source.env.taskset]
+id = "swebench-verified-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "rlm"
+summarize_at_tokens = 98304
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "prime"
+vm = true
+idle_timeout = "None"
+labels = ["glm45air-swe"]
+
+[orchestrator.eval.source.env.agent.timeout]
+rollout = 3600
 
 # --- Inference ---
 

--- a/examples/advanced/glm-4.5-air/terminal.toml
+++ b/examples/advanced/glm-4.5-air/terminal.toml
@@ -93,8 +93,16 @@ num_turns_weight = 0.1
 
 [[orchestrator.train.source]]
 name = "tmax"
-env.agent.harness = { id = "rlm", summarize_at_tokens = [65536, 131072] }
-env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] }
+
+[orchestrator.train.source.env.agent.harness]
+id = "rlm"
+summarize_at_tokens = [65536, 131072]
+
+[orchestrator.train.source.env.agent.runtime]
+type = "prime"
+vm = true
+idle_timeout = "None"
+labels = ["glm45air-terminal"]
 
 [orchestrator.train.source.env.taskset]
 id = "tmax-v1"
@@ -121,9 +129,19 @@ interval = 20
 
 [[orchestrator.eval.source]]
 name = "swebench-verified"
-env.agent.harness = { id = "rlm", summarize_at_tokens = 98304 }
-env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] }
-env.agent.timeout = { rollout = 3600 }
+
+[orchestrator.eval.source.env.agent.harness]
+id = "rlm"
+summarize_at_tokens = 98304
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "prime"
+vm = true
+idle_timeout = "None"
+labels = ["glm45air-terminal"]
+
+[orchestrator.eval.source.env.agent.timeout]
+rollout = 3600
 
 [orchestrator.eval.source.env.taskset]
 id = "swebench-verified-v1"
@@ -145,9 +163,19 @@ id = "swebench-verified-v1"
 [[orchestrator.eval.source]]
 name = "terminal-bench-2"
 group_size = 4 # avg@4
-env.agent.harness = { id = "rlm", summarize_at_tokens = 98304 }
-env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["glm45air-terminal"] }
-env.agent.timeout = { rollout = 3600 }
+
+[orchestrator.eval.source.env.agent.harness]
+id = "rlm"
+summarize_at_tokens = 98304
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "prime"
+vm = true
+idle_timeout = "None"
+labels = ["glm45air-terminal"]
+
+[orchestrator.eval.source.env.agent.timeout]
+rollout = 3600
 
 [orchestrator.eval.source.env.taskset]
 id = "terminal-bench-2-v1"

--- a/examples/advanced/glm-5.2/infer/pd-llmd.toml
+++ b/examples/advanced/glm-5.2/infer/pd-llmd.toml
@@ -35,15 +35,31 @@ prefill_nodes_per_replica = 2
 num_prefill_replicas = 4
 decode_nodes_per_replica = 8
 num_decode_replicas = 1
-prefill_env_vars = {"VLLM_ENABLE_MOE_DP_CHUNK"="0", "VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
-decode_env_vars = {"VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
+
+[deployment.prefill_env_vars]
+"VLLM_ENABLE_MOE_DP_CHUNK" = "0"
+"VLLM_DEEP_GEMM_WARMUP" = "skip"
+"UCX_RCACHE_MAX_UNRELEASED" = "1024"
+
+[deployment.decode_env_vars]
+"VLLM_DEEP_GEMM_WARMUP" = "skip"
+"UCX_RCACHE_MAX_UNRELEASED" = "1024"
 
 [router]
 type = "llm-d"
-scorers = { "prefix-cache-scorer" = 3.0 }
-prefill_scorer_overrides = { "queue-scorer" = 4.0, "active-request-scorer" = 5.0 }
-decode_scorer_overrides = { "active-request-scorer" = 5.0, "kv-cache-utilization-scorer" = 4.0, "queue-scorer" = 3.0 }
 non_cached_tokens = 128
+
+[router.scorers]
+"prefix-cache-scorer" = 3.0
+
+[router.prefill_scorer_overrides]
+"queue-scorer" = 4.0
+"active-request-scorer" = 5.0
+
+[router.decode_scorer_overrides]
+"active-request-scorer" = 5.0
+"kv-cache-utilization-scorer" = 4.0
+"queue-scorer" = 3.0
 
 [slurm]
 job_name = "glm5.2-16node-llmd"

--- a/examples/advanced/glm-5.2/swe-llmd.toml
+++ b/examples/advanced/glm-5.2/swe-llmd.toml
@@ -28,22 +28,43 @@ prefill_nodes_per_replica = 2
 num_prefill_replicas = 4
 decode_nodes_per_replica = 8
 num_decode_replicas = 1
+
 # skip warmup for faster start in cost of some jit overhead early
 # ucx needs to be set else random segfaults, vllm can't autoset before importing for some reason
-prefill_env_vars = {"VLLM_ENABLE_MOE_DP_CHUNK"="0", "VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
-decode_env_vars = {"VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
+[inference.deployment.prefill_env_vars]
+"VLLM_ENABLE_MOE_DP_CHUNK" = "0"
+"VLLM_DEEP_GEMM_WARMUP" = "skip"
+"UCX_RCACHE_MAX_UNRELEASED" = "1024"
+
+[inference.deployment.decode_env_vars]
+"VLLM_DEEP_GEMM_WARMUP" = "skip"
+"UCX_RCACHE_MAX_UNRELEASED" = "1024"
 
 # gives the most KV cache while keeping decent throughput, KV cache increase comes in from lower deep-ep LL static buffers
-prefill_vllm_overrides = {"enable_dbo"=true}
-decode_vllm_overrides = {"max_num_batched_tokens"=96, "max_num_seqs"=96}
+[inference.deployment.prefill_vllm_overrides]
+"enable_dbo" = true
+
+[inference.deployment.decode_vllm_overrides]
+"max_num_batched_tokens" = 96
+"max_num_seqs" = 96
+
 
 [inference.router]
 type = "llm-d"
-scorers = { "prefix-cache-scorer" = 3.0 } # need some prefix-cache routing, however due to shared mooncake pool do low prio
 
-prefill_scorer_overrides = { "queue-scorer" = 4.0, "active-request-scorer" = 5.0 } # prefill creates queues quite heavily, queue scorer to 4.0, active request at 5.0 is needed due to burstiness of early pipeline RL fill
-decode_scorer_overrides = { "active-request-scorer" = 5.0, "kv-cache-utilization-scorer" = 4.0, "queue-scorer" = 3.0 } # decode doesn't really create queue, it fills in KV cache fast, give 4.0
 non_cached_tokens = 128 # if <128 tokens, skip prefill go to decode immediately
+
+[inference.router.scorers] # need some prefix-cache routing, however due to shared mooncake pool do low prio
+"prefix-cache-scorer" = 3.0
+
+[inference.router.prefill_scorer_overrides] # prefill creates queues quite heavily, queue scorer to 4.0, active request at 5.0 is needed due to burstiness of early pipeline RL fill
+"queue-scorer" = 4.0
+"active-request-scorer" = 5.0
+
+[inference.router.decode_scorer_overrides] # decode doesn't really create queue, it fills in KV cache fast, give 4.0
+"active-request-scorer" = 5.0
+"kv-cache-utilization-scorer" = 4.0
+"queue-scorer" = 3.0
 
 [slurm]
 job_name = "glm5-llmd"
@@ -93,14 +114,23 @@ clear_thinking = false
 
 [orchestrator.train.sampling]
 temperature = 1.0
-extra_body = {chat_template_kwargs = {clear_thinking = false}}
+
+[orchestrator.train.sampling.extra_body.chat_template_kwargs]
+clear_thinking = false
 
 
 [[orchestrator.train.source]]
 name = "r2e"
-env.taskset = { id = "r2e-gym-v1" }
-env.agent.harness = { id = "rlm" }
-env.agent.runtime = { type = "prime", labels = ["glm5-llmd"] }
+
+[orchestrator.train.source.env.taskset]
+id = "r2e-gym-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "rlm"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "prime"
+labels = ["glm5-llmd"]
 
 [inference]
 enable_expert_parallel = true

--- a/examples/advanced/glm-5.2/swe.toml
+++ b/examples/advanced/glm-5.2/swe.toml
@@ -73,9 +73,16 @@ interval = 20
 
 [[orchestrator.eval.source]]
 name = "swe-bench-verified"
-env.taskset = { id = "swebench-verified-v1" }
-env.agent.harness = { id = "bash" }
-env.agent.runtime = { type = "prime", labels = ["glm5-pd-disag", "swe-bench-verified"] }
+
+[orchestrator.eval.source.env.taskset]
+id = "swebench-verified-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "bash"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "prime"
+labels = ["glm5-pd-disag", "swe-bench-verified"]
 
 [[orchestrator.post_batch_filters]]
 type = "gibberish"

--- a/examples/advanced/intellect-3.1/rl.toml
+++ b/examples/advanced/intellect-3.1/rl.toml
@@ -50,37 +50,74 @@ oversampling_factor = 2
 [[orchestrator.train.source]]
 name = "swe"
 ratio = 0.3
-env.taskset = { id = "r2e-gym-v1" }
-env.agent.harness = { id = "bash" }
-env.agent.runtime = { type = "prime", labels = ["intellect-3.1", "swe"] }
+
+[orchestrator.train.source.env.taskset]
+id = "r2e-gym-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "bash"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "prime"
+labels = ["intellect-3.1", "swe"]
 
 [[orchestrator.train.source]]
 name = "deepdive"
 ratio = 0.2
-env.taskset = { id = "deepdive-v1" }
-env.agent.harness = { id = "rlm", skills = ["search"], forward_env = ["SERPER_API_KEY"] }
-env.agent.runtime = { type = "prime", labels = ["intellect-3.1", "deepdive"] }
+
+[orchestrator.train.source.env.taskset]
+id = "deepdive-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "rlm"
+skills = ["search"]
+forward_env = ["SERPER_API_KEY"]
+
+[orchestrator.train.source.env.agent.runtime]
+type = "prime"
+labels = ["intellect-3.1", "deepdive"]
 
 [[orchestrator.train.source]]
 name = "math"
 ratio = 0.3
-env.taskset = { id = "i3_math_v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "i3_math_v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [[orchestrator.train.source]]
 name = "logic"
 ratio = 0.2
-env.taskset = { id = "i3_logic_v1", filter = { max = 0.874 } }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "i3_logic_v1"
+
+[orchestrator.train.source.env.taskset.filter]
+max = 0.874
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [[orchestrator.train.source]]
 name = "code"
 ratio = 0.2
-env.taskset = { id = "i3_code_v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "i3_code_v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [[orchestrator.pre_batch_filters]]
 type = "zero_advantage"
@@ -91,15 +128,28 @@ interval = 25
 
 [[orchestrator.eval.source]]
 name = "swe-bench-verified"
-env.taskset = { id = "swebench-verified-v1" }
-env.agent.harness = { id = "bash" }
-env.agent.runtime = { type = "prime", labels = ["intellect-3.1", "swe-bench-verified"] }
+
+[orchestrator.eval.source.env.taskset]
+id = "swebench-verified-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "bash"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "prime"
+labels = ["intellect-3.1", "swe-bench-verified"]
 
 [[orchestrator.eval.source]]
 name = "aime2025"
-env.taskset = { id = "aime25-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "aime25-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [inference.parallel]
 tp = 8

--- a/examples/advanced/minimax-m2.5/swe.toml
+++ b/examples/advanced/minimax-m2.5/swe.toml
@@ -51,18 +51,32 @@ max_off_policy_steps = 16
 
 [[orchestrator.train.source]]
 name = "swe"
-env.taskset = { id = "r2e-gym-v1" }
-env.agent.harness = { id = "bash" }
-env.agent.runtime = { type = "prime", labels = ["minimax-swe", "swe"] }
+
+[orchestrator.train.source.env.taskset]
+id = "r2e-gym-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "bash"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "prime"
+labels = ["minimax-swe", "swe"]
 
 [orchestrator.eval]
 interval = 25
 
 [[orchestrator.eval.source]]
 name = "swe-bench-verified"
-env.taskset = { id = "swebench-verified-v1" }
-env.agent.harness = { id = "bash" }
-env.agent.runtime = { type = "prime", labels = ["minimax-swe", "swe-bench-verified"] }
+
+[orchestrator.eval.source.env.taskset]
+id = "swebench-verified-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "bash"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "prime"
+labels = ["minimax-swe", "swe-bench-verified"]
 
 [inference.parallel]
 tp = 8

--- a/examples/advanced/nemotron-3-super/swe.toml
+++ b/examples/advanced/nemotron-3-super/swe.toml
@@ -83,9 +83,19 @@ truncate_history_thinking = false
 
 [[orchestrator.train.source]]
 name = "scaleswe"
-env.taskset = { id = "scaleswe-v1" }
-env.agent.harness = { id = "rlm", summarize_at_tokens = [65536, 131072] }
-env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["nemotron-3-super-swe"] }
+
+[orchestrator.train.source.env.taskset]
+id = "scaleswe-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "rlm"
+summarize_at_tokens = [65536, 131072]
+
+[orchestrator.train.source.env.agent.runtime]
+type = "prime"
+vm = true
+idle_timeout = "None"
+labels = ["nemotron-3-super-swe"]
 
 [orchestrator.prime_monitor]
 
@@ -94,10 +104,22 @@ interval = 20
 
 [[orchestrator.eval.source]]
 name = "swebench-verified"
-env.taskset = { id = "swebench-verified-v1" }
-env.agent.harness = { id = "rlm", summarize_at_tokens = 98304 }
-env.agent.runtime = { type = "prime", vm = true, idle_timeout = "None", labels = ["nemotron-3-super-swe"] }
-env.agent.timeout = { rollout = 3600 }
+
+[orchestrator.eval.source.env.taskset]
+id = "swebench-verified-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "rlm"
+summarize_at_tokens = 98304
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "prime"
+vm = true
+idle_timeout = "None"
+labels = ["nemotron-3-super-swe"]
+
+[orchestrator.eval.source.env.agent.timeout]
+rollout = 3600
 
 [inference]
 enable_expert_parallel = true

--- a/examples/advanced/qwen3-30b-a3b/math.toml
+++ b/examples/advanced/qwen3-30b-a3b/math.toml
@@ -50,18 +50,30 @@ max_completion_tokens = 32768
 
 [[orchestrator.train.source]]
 name = "math"
-env.taskset = { id = "i3_math_v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "i3_math_v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.eval]
 interval = 25
 
 [[orchestrator.eval.source]]
 name = "aime2025"
-env.taskset = { id = "aime25-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "aime25-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [inference.parallel]
 tp = 8

--- a/examples/advanced/qwen3-30b-a3b/swe.toml
+++ b/examples/advanced/qwen3-30b-a3b/swe.toml
@@ -48,18 +48,32 @@ max_off_policy_steps = 16
 
 [[orchestrator.train.source]]
 name = "swe"
-env.taskset = { id = "r2e-gym-v1" }
-env.agent.harness = { id = "bash" }
-env.agent.runtime = { type = "prime", labels = ["qwen30b-swe", "swe"] }
+
+[orchestrator.train.source.env.taskset]
+id = "r2e-gym-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "bash"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "prime"
+labels = ["qwen30b-swe", "swe"]
 
 [orchestrator.eval]
 interval = 25
 
 [[orchestrator.eval.source]]
 name = "swe-bench-verified"
-env.taskset = { id = "swebench-verified-v1" }
-env.agent.harness = { id = "bash" }
-env.agent.runtime = { type = "prime", labels = ["qwen30b-swe", "swe-bench-verified"] }
+
+[orchestrator.eval.source.env.taskset]
+id = "swebench-verified-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "bash"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "prime"
+labels = ["qwen30b-swe", "swe-bench-verified"]
 
 [inference.parallel]
 tp = 8

--- a/examples/advanced/qwen3-30b-a3b/tool.toml
+++ b/examples/advanced/qwen3-30b-a3b/tool.toml
@@ -36,9 +36,19 @@ group_size = 16
 max_off_policy_steps = 32
 
 [[orchestrator.train.source]]
-env.taskset = { id = "general-agent-v1", task = { tools = { colocated = true } }, min_tier = 1 }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "modal" }
+
+[orchestrator.train.source.env.taskset]
+id = "general-agent-v1"
+min_tier = 1
+
+[orchestrator.train.source.env.taskset.task.tools]
+colocated = true
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "modal"
 
 [inference]
 gpu_memory_utilization = 0.85

--- a/examples/basic/alphabet-sort/rl.toml
+++ b/examples/basic/alphabet-sort/rl.toml
@@ -33,8 +33,19 @@ max_completion_tokens = 768
 
 [[orchestrator.train.source]]
 name = "alphabet-sort"
-env.taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, task = { power_per_turn = false } }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "alphabet-sort-v1"
+min_turns = 3
+max_turns = 5
+
+[orchestrator.train.source.env.taskset.task]
+power_per_turn = false
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [inference] # Default inference config

--- a/examples/basic/hendrycks-sanity/rl.toml
+++ b/examples/basic/hendrycks-sanity/rl.toml
@@ -18,19 +18,33 @@ seq_len = 8192
 
 [[orchestrator.train.source]]
 name = "hendrycks-math"
-env.taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "math-env-v1"
+dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B"
+dataset_subset = "default"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [orchestrator.eval]
 interval = 50
 
 [[orchestrator.eval.source]]
 name = "aime2024"
-env.taskset = { id = "aime24-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
 group_size = 32
+
+[orchestrator.eval.source.env.taskset]
+id = "aime24-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.model]
 seq_len = 16384

--- a/examples/basic/reverse-text/rl.toml
+++ b/examples/basic/reverse-text/rl.toml
@@ -17,9 +17,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/examples/basic/wiki-search/rl.toml
+++ b/examples/basic/wiki-search/rl.toml
@@ -46,9 +46,15 @@ enforce = true
 
 [[orchestrator.train.source]]
 name = "wiki-search"
-env.taskset = { id = "wiki-search-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "wiki-search-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [ckpt] # Checkpoint at the end of training
 

--- a/examples/basic/wordle/rl.toml
+++ b/examples/basic/wordle/rl.toml
@@ -20,9 +20,15 @@ group_size = 16
 
 [[orchestrator.train.source]]
 name = "wordle"
-env.taskset = { id = "wordle-v1" }
-env.player.harness = { id = "null" }
-env.player.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "wordle-v1"
+
+[orchestrator.train.source.env.player.harness]
+id = "null"
+
+[orchestrator.train.source.env.player.runtime]
+type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 1024

--- a/k8s/prime-rl/examples/reverse-text/orch.toml
+++ b/k8s/prime-rl/examples/reverse-text/orch.toml
@@ -15,9 +15,15 @@ max_completion_tokens = 128
 
 [[train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[train.source.env.taskset]
+id = "reverse-text-v1"
+
+[train.source.env.agent.harness]
+id = "null"
+
+[train.source.env.agent.runtime]
+type = "subprocess"
 
 [renderer]
 name = "prime-qwen3"

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -34,6 +34,8 @@ Incompatible combinations (e.g. CP requires flash attention) must raise in a `mo
 
 ## Special syntax
 
+**No inline tables** — checked-in configs use `[section]` headers, never `key = { ... }`. Expand `env.taskset = { id = "..." }` to a full-path header (`[orchestrator.train.source.env.taskset]` — subtable headers after a `[[...]]` entry attach to that entry).
+
 **Booleans** — CLI `--flag` / `--no-flag`; TOML must be explicit (`enforce_eager = true`).
 
 **None** — TOML has no null, use the string `"None"` (`max_model_len = "None"`); CLI: `--model.max-model-len None`.
@@ -43,15 +45,28 @@ Incompatible combinations (e.g. CP requires flash attention) must raise in a `mo
 ```toml
 [[orchestrator.train.source]]
 name = "reverse-text"
-env.taskset = { id = "reverse-text-v1" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.train.source.env.taskset]
+id = "reverse-text-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "null"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "subprocess"
 
 [[orchestrator.eval.source]]
 name = "reverse-text-eval"
-env.taskset = { id = "reverse-text-v1", split = "test" }
-env.agent.harness = { id = "null" }
-env.agent.runtime = { type = "subprocess" }
+
+[orchestrator.eval.source.env.taskset]
+id = "reverse-text-v1"
+split = "test"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "null"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "subprocess"
 ```
 
 CLI: `--orchestrator.train.source.0.env.taskset.id reverse-text-v1` or `--orchestrator.eval.source.0.env.taskset.id reverse-text-v1`.


### PR DESCRIPTION
## Summary

- Rewrites every checked-in TOML config (`configs/`, `examples/`, `k8s/` — 48 files) to use `[section]` headers instead of `key = { ... }` inline tables, e.g. `env.taskset = { id = "reverse-text-v1" }` becomes a `[orchestrator.train.source.env.taskset]` block.
- Nested inline tables expand to nested sections (`task = { judge = { ... } }` → `[...taskset.task.judge]`); dict-valued fields (`scorers`, `prefill_env_vars`, …) become sections too. Keyless intermediate tables are left implicit.
- Updates the TOML snippets in `docs/configuration.md`, `docs/algorithms.md`, `docs/inference.md` and the `configs` skill to match, and adds the no-inline-tables rule to the skill.

## Verification

Purely stylistic — no config changes semantics:

- Every rewritten file was asserted `tomllib`-parse-identical to its version on `main` (all 66 TOML files under `configs/`, `examples/`, `k8s/` checked).
- `tests/unit/test_configs.py` passes (108 tests): all files still load through their config classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Style-only TOML rewrites with parse-equivalence checks; no runtime or config-schema changes.
> 
> **Overview**
> **Replaces inline TOML tables with `[section]` headers** across checked-in configs (`configs/`, `examples/`, `k8s/`) and documentation. Environment blocks like `env.taskset = { id = "..." }` become paths such as `[orchestrator.train.source.env.taskset]`; nested structs and dict fields (`scorers`, `prefill_env_vars`, `kwargs`, etc.) follow the same pattern.
> 
> **Docs and agent guidance** in `docs/configuration.md`, `docs/algorithms.md`, `docs/inference.md`, and `skills/configs/SKILL.md` are updated to show section-style dicts and to **forbid inline tables** in repo configs.
> 
> No training or inference behavior changes—semantics are unchanged; this is formatting and convention only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d6e15183f352ddf25d9a8df34f0e0168e0e0a1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->