### PR TITLE
fix: report crash exit code in platform finalize

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 import time
 import uuid
 from typing import TYPE_CHECKING
@@ -493,7 +494,11 @@ class Orchestrator:
                 get_logger().success(f"Orchestrator step loop done in {elapsed}")
             else:
                 get_logger().warning(f"Orchestrator interrupted after {elapsed} — forcing cleanup (not a clean exit)")
-            self.monitor.save_final_summary()
+            # Report the real outcome: a finalize without it defaults to
+            # exit_code=0 on the platform and a crashed run lands as COMPLETED.
+            exc = sys.exc_info()[1]
+            error_message = f"{type(exc).__name__}: {exc}" if exc is not None and not clean_exit else None
+            self.monitor.save_final_summary(success=clean_exit, error_message=error_message)
             # ``progress.step`` points at the next (unshipped) step; the last finished step is
             # ``progress.step - 1``. Checkpoint it as ``step_{progress.step - 1}`` (no-op before the
             # first ship).

--- a/src/prime_rl/utils/monitor/base.py
+++ b/src/prime_rl/utils/monitor/base.py
@@ -93,7 +93,9 @@ class Monitor(ABC):
         pass
 
     @abstractmethod
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(
+        self, filename: str = "final_summary.json", success: bool = True, error_message: str | None = None
+    ) -> None:
         pass
 
     @abstractmethod
@@ -124,7 +126,9 @@ class NoOpMonitor(Monitor):
     def log_eval_samples(self, rollouts: list[Rollout], env_name: str, step: int) -> None:
         pass
 
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(
+        self, filename: str = "final_summary.json", success: bool = True, error_message: str | None = None
+    ) -> None:
         pass
 
     def log_distributions(self, distributions: dict[str, list[float]], step: int) -> None:

--- a/src/prime_rl/utils/monitor/file.py
+++ b/src/prime_rl/utils/monitor/file.py
@@ -88,7 +88,9 @@ class FileMonitor(Monitor):
     def log_distributions(self, distributions: dict[str, list[float]], step: int) -> None:
         pass
 
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(
+        self, filename: str = "final_summary.json", success: bool = True, error_message: str | None = None
+    ) -> None:
         if not self.is_master or not self.enabled or self.output_dir is None:
             return
         summary = self.history[-1] if self.history else {}

--- a/src/prime_rl/utils/monitor/multi.py
+++ b/src/prime_rl/utils/monitor/multi.py
@@ -47,10 +47,12 @@ class MultiMonitor(Monitor):
             except Exception as e:
                 self.logger.warning(f"Failed to log eval samples to {monitor.__class__.__name__}: {e}")
 
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(
+        self, filename: str = "final_summary.json", success: bool = True, error_message: str | None = None
+    ) -> None:
         for monitor in self.monitors:
             try:
-                monitor.save_final_summary(filename=filename)
+                monitor.save_final_summary(filename=filename, success=success, error_message=error_message)
             except Exception as e:
                 self.logger.warning(f"Failed to save final summary to {monitor.__class__.__name__}: {e}")
 

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -485,11 +485,21 @@ class PrimeMonitor(Monitor):
             f"Logged distributions at step {step} to Prime Intellect API in {time.perf_counter() - start_time:.2f}s"
         )
 
-    def _submit_final_summary(self, summary: dict[str, Any]) -> bool:
-        """Submit the final summary/finalize request synchronously."""
+    def _submit_final_summary(self, summary: dict[str, Any], success: bool, error_message: str | None) -> bool:
+        """Submit the final summary/finalize request synchronously.
+
+        ``exit_code`` must reflect whether the orchestrator actually finished:
+        the platform routes 0 to COMPLETED and non-zero to FAILED. Omitting it
+        made every crash land as COMPLETED (the API defaults the field to 0).
+        """
         payload = self._sanitize_json_payload(
             "finalize",
-            {"run_id": self.run_id, "summary": summary},
+            {
+                "run_id": self.run_id,
+                "summary": summary,
+                "exit_code": 0 if success else 1,
+                "error_message": error_message,
+            },
         )
 
         try:
@@ -512,14 +522,16 @@ class PrimeMonitor(Monitor):
 
         return True
 
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(
+        self, filename: str = "final_summary.json", success: bool = True, error_message: str | None = None
+    ) -> None:
         """Save final summary to Prime Intellect API."""
         if not self.is_master or not self.enabled:
             return
 
         self.logger.info("Saving final summary to Prime Intellect API")
         summary = self.history[-1] if self.history else {}
-        finalized_via_summary = self._submit_final_summary(summary)
+        finalized_via_summary = self._submit_final_summary(summary, success, error_message)
 
         if os.getpid() != self._owner_pid:
             return
@@ -528,7 +540,7 @@ class PrimeMonitor(Monitor):
             self._finalized = True
             return
 
-        self._finalize_run(success=True)
+        self._finalize_run(success=success)
         self._finalized = True
 
     def close(self) -> None:

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -277,7 +277,9 @@ class WandbMonitor(Monitor):
         """Log distributions (no-op for W&B)."""
         pass
 
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(
+        self, filename: str = "final_summary.json", success: bool = True, error_message: str | None = None
+    ) -> None:
         """Save final summary to W&B table."""
         if not self.is_master or not self.enabled:
             return

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -117,3 +117,30 @@ def test_sanitize_json_payload_drops_non_finite_values_and_logs_paths():
     monitor.logger.warning.assert_called_once_with(
         "Dropping 2 non-finite value(s) from Prime monitor metrics payload: metrics.nan, distributions[1]"
     )
+
+
+def test_submit_final_summary_reports_crash_exit_code(monkeypatch):
+    monitor = _new_monitor()
+    monitor.logger = Mock()
+    monitor.run_id = "run-123"
+    monitor.base_url = "https://api.example.com/monitoring"
+    monitor._headers = {}
+
+    captured = {}
+
+    def fake_post(url, headers, json, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        return Mock(status_code=200)
+
+    monkeypatch.setattr("prime_rl.utils.monitor.prime.httpx.post", fake_post)
+
+    assert monitor._submit_final_summary({"reward": 0.5}, success=False, error_message="OSError: ENOSPC")
+
+    assert captured["url"].endswith("/finalize")
+    assert captured["json"]["exit_code"] == 1
+    assert captured["json"]["error_message"] == "OSError: ENOSPC"
+
+    assert monitor._submit_final_summary({"reward": 0.5}, success=True, error_message=None)
+    assert captured["json"]["exit_code"] == 0
+    assert captured["json"]["error_message"] is None


### PR DESCRIPTION
Crashed orchestrators were landing as COMPLETED on the platform (e.g. run atu3ef6jd6p43dyobjqlhfen died with ENOSPC at step 20/1000 but shows Completed).

- the finalize POST never carried an exit_code, and the platform defaults it to 0 → COMPLETED
- pass clean_exit from orchestrator teardown into save_final_summary
- send exit_code 1 + the exception as error_message on crash

https://claude.ai/code/session_01DRBktHFbsLakKa7TUCiVfs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized monitoring/teardown change with a unit test; no training or auth logic changes beyond correct platform run status reporting.
> 
> **Overview**
> Fixes training runs that **crashed** still showing as **COMPLETED** on the platform because the `/finalize` request never sent `exit_code` (the API defaults it to 0).
> 
> On orchestrator teardown, **`save_final_summary`** now receives **`success=clean_exit`** and, when the main loop did not finish cleanly, an **`error_message`** built from the active exception (`sys.exc_info`). **`PrimeMonitor`** includes **`exit_code`** (0 vs 1) and **`error_message`** in the finalize payload and passes **`success`** through to the status fallback (`_finalize_run`) when finalize via summary fails. The monitor API is updated across **`MultiMonitor`**, file/W&B/no-op stubs for the new parameters.
> 
> A unit test asserts crash vs success finalize payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a28a9a4cc8bbe4b6c5daa1557ee33a78ecd7a30a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->