### PR TITLE
exp: add Laguna XS ScaleSWE training config

### DIFF
--- a/examples/advanced/glm-4.5-air/swe-regular.toml
+++ b/examples/advanced/glm-4.5-air/swe-regular.toml
@@ -1,6 +1,6 @@
-# Five-step reproduction of Mika's regular GLM-4.5-Air ScaleSWE run.
+# Daniel-owned reproduction of Mika's regular GLM-4.5-Air ScaleSWE baseline.
 
-max_steps = 5
+max_steps = 1000
 seq_len = 131072
 
 [env_vars]
@@ -19,7 +19,7 @@ num_infer_replicas = 4
 
 [wandb]
 project = "agentic-judging"
-name = "daniel-glm-air-scaleswe-regular-5step"
+name = "daniel-int5-rl-swe-air-scaleswe-regular"
 
 [weight_broadcast]
 type = "nccl"
@@ -89,6 +89,16 @@ env.agent.runtime = { type = "prime", vm = true, cpu = 1.0, memory = 2.0, disk =
 sampling = { temperature = 1.0, max_completion_tokens = "None", extra_body = { top_k = -1, min_p = 0.0, return_token_ids = true } }
 
 [orchestrator.prime_monitor]
+
+[orchestrator.eval]
+interval = 20
+
+[[orchestrator.eval.env]]
+name = "swebench-verified"
+env.taskset = { id = "swebench-verified-v1" }
+env.agent.harness = { id = "bash" }
+env.agent.runtime = { type = "prime", vm = true, cpu = 1.0, memory = 2.0, disk = 5.0, idle_timeout = "None", labels = ["daniel-air-scaleswe-regular"] }
+env.agent.timeout = { rollout = 3600 }
 
 [inference]
 enable_return_routed_experts = true

--- a/examples/advanced/glm-4.5-air/swe-regular.toml
+++ b/examples/advanced/glm-4.5-air/swe-regular.toml
@@ -1,0 +1,104 @@
+# Five-step reproduction of Mika's regular GLM-4.5-Air ScaleSWE run.
+
+max_steps = 5
+seq_len = 131072
+
+[env_vars]
+TRITON_CACHE_DIR = "/tmp/.triton-cache"
+
+[slurm]
+job_name = "daniel-glm-air-scaleswe-regular"
+partition = "all"
+pre_run_command = 'mkdir -p /tmp/daniel-tmp ; uv sync --all-extras --all-packages ; timeout 120 prime sandbox delete --label "daniel-air-scaleswe-regular" -y || true'
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 2
+num_infer_nodes = 1
+num_infer_replicas = 4
+
+[wandb]
+project = "agentic-judging"
+name = "daniel-glm-air-scaleswe-regular-5step"
+
+[weight_broadcast]
+type = "nccl"
+timeout = 3600
+
+[rollout_transport]
+type = "zmq"
+
+[ckpt]
+interval = 50
+keep_last = 1
+resume_step = -1
+
+[model]
+name = "zai-org/GLM-4.5-Air"
+
+[trainer]
+dist_timeout_seconds = 3600
+enable_router_replay = true
+
+[trainer.model]
+impl = "custom"
+attn = "flash_attention_3"
+cp = 4
+cp_style = "ulysses"
+fused_lm_head_token_chunk_size = 1024
+optim_cpu_offload = true
+
+[trainer.model.ac]
+
+[trainer.model.ac_offloading]
+max_inflight_activations = 1
+
+[trainer.model.compile]
+
+[trainer.ckpt]
+skip_gather_master_weights = true
+skip_optimizer = true
+
+[trainer.optim]
+type = "muon"
+
+[orchestrator]
+batch_size = 256
+group_size = 16
+max_off_policy_steps = 32
+max_inflight_rollouts = 768
+
+[orchestrator.algo]
+type = "grpo"
+
+[orchestrator.algo.length_penalty]
+type = "linear"
+num_output_tokens_weight = 0.0
+num_input_tokens_weight = 0.1
+num_turns_weight = 0.1
+
+[orchestrator.renderer]
+name = "glm-4.5"
+thinking_retention = "all"
+
+[[orchestrator.train.env]]
+name = "scaleswe"
+env.taskset = { id = "scaleswe-v1" }
+env.agent.harness = { id = "bash" }
+env.agent.runtime = { type = "prime", vm = true, cpu = 1.0, memory = 2.0, disk = 5.0, idle_timeout = "None", labels = ["daniel-air-scaleswe-regular"] }
+sampling = { temperature = 1.0, max_completion_tokens = "None", extra_body = { top_k = -1, min_p = 0.0, return_token_ids = true } }
+
+[orchestrator.prime_monitor]
+
+[inference]
+enable_return_routed_experts = true
+
+[inference.env_vars]
+VLLM_CACHE_ROOT = "/tmp/daniel-vllm-cache"
+FLASHINFER_WORKSPACE_BASE = "/tmp/daniel-flashinfer-cache"
+
+[inference.model]
+max_model_len = 131072
+
+[inference.parallel]
+tp = 8

--- a/examples/advanced/laguna-xs-2.1/swe.toml
+++ b/examples/advanced/laguna-xs-2.1/swe.toml
@@ -1,0 +1,134 @@
+# Laguna XS 2.1 on ScaleSWE with the standard bash harness. The startup evaluation
+# uses the model-card sampling settings against the full SWE-Bench Verified set.
+
+max_steps = 1000
+seq_len = 131072
+
+[env_vars]
+TRITON_CACHE_DIR = "/tmp/.triton-cache"
+
+[slurm]
+job_name = "laguna-xs21-scaleswe-bash-pass1-v5"
+partition = "all"
+pre_run_command = 'timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-bash-pass1-v4" -y || true ; timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-bash-pass1-v5" -y || true'
+
+[deployment]
+type = "multi_node"
+# Match Mika's topology: two trainer nodes and four independent TP8 inference
+# replicas, with one client-facing URL per inference engine.
+num_train_nodes = 2
+num_infer_nodes = 1
+num_infer_replicas = 4
+
+[wandb]
+project = "laguna-xs21-scaleswe"
+name = "laguna-xs21-scaleswe-bash-pass1-v5"
+
+[weight_broadcast]
+type = "nccl"
+timeout = 3600
+
+[rollout_transport]
+type = "zmq"
+
+[ckpt]
+interval = 50
+keep_last = 1
+resume_step = -1
+
+[model]
+name = "poolside/Laguna-XS-2.1"
+
+[trainer]
+dist_timeout_seconds = 3600
+enable_router_replay = true
+
+[trainer.model]
+impl = "custom"
+attn = "flash_attention_3"
+cp = 4
+cp_style = "ulysses"
+fused_lm_head_token_chunk_size = 1024
+optim_cpu_offload = true
+
+[trainer.model.ac]
+
+[trainer.model.ac_offloading]
+max_inflight_activations = 1
+
+[trainer.model.compile]
+
+[trainer.ckpt]
+skip_gather_master_weights = true
+skip_optimizer = true
+
+[trainer.optim]
+type = "muon"
+lr = 1e-6
+
+[orchestrator]
+batch_size = 256
+group_size = 16
+max_off_policy_steps = 32
+max_inflight_rollouts = 768
+
+[orchestrator.algo]
+type = "grpo"
+
+[orchestrator.algo.length_penalty]
+type = "linear"
+num_output_tokens_weight = 0.0
+num_input_tokens_weight = 0.1
+num_turns_weight = 0.1
+
+[orchestrator.renderer]
+name = "laguna-xs-2.1"
+enable_thinking = true
+thinking_retention = "all"
+
+[[orchestrator.train.env]]
+name = "scaleswe"
+env.taskset = { id = "scaleswe-v1" }
+env.agent.harness = { id = "bash" }
+env.agent.runtime = { type = "prime", vm = true, cpu = 2.0, memory = 8.0, idle_timeout = "None", labels = ["laguna-xs21-scaleswe-bash-pass1-v5"] }
+env.agent.retries = { max_retries = 3, include = ["ProviderError", "SandboxError"] }
+sampling = { temperature = 1.0, max_completion_tokens = 32768, extra_body = { top_k = 20, min_p = 0.0, return_token_ids = true } }
+
+[orchestrator.prime_monitor]
+
+[orchestrator.eval]
+interval = 20
+skip_first_step = false
+sampling = { temperature = 1.0, top_p = 1.0, top_k = 20, min_p = 0.0, max_completion_tokens = 32768 }
+
+[[orchestrator.eval.env]]
+name = "swebench-verified"
+num_examples = -1
+# Online evaluation reports pass@1 with one attempt per task.
+group_size = 1
+env.taskset = { id = "swebench-verified-v1" }
+env.agent.harness = { id = "bash" }
+env.agent.runtime = { type = "prime", vm = true, cpu = 2.0, memory = 8.0, idle_timeout = "None", labels = ["laguna-xs21-scaleswe-bash-pass1-v5"] }
+env.agent.retries = { max_retries = 3, include = ["ProviderError", "SandboxError"] }
+env.agent.timeout = { rollout = 3600 }
+
+[inference]
+enable_expert_parallel = false
+enable_return_routed_experts = true
+
+[inference.env_vars]
+VLLM_CACHE_ROOT = "/tmp/.vllm-cache"
+FLASHINFER_WORKSPACE_BASE = "/tmp/.flashinfer-cache"
+
+[inference.model]
+max_model_len = 131072
+tool_call_parser = "poolside_xs21"
+reasoning_parser = "poolside_v1"
+
+[inference.parallel]
+tp = 8
+dp = 1
+
+[inference.vllm_extra]
+default_chat_template_kwargs = { enable_thinking = true }
+tool_parser_plugin = "src/prime_rl/inference/vllm/poolside_xs21_tool_parser.py"

--- a/examples/advanced/laguna-xs-2.1/swe.toml
+++ b/examples/advanced/laguna-xs-2.1/swe.toml
@@ -1,5 +1,5 @@
-# Laguna XS 2.1 on ScaleSWE with the standard bash harness. The startup evaluation
-# uses the model-card sampling settings against the full SWE-Bench Verified set.
+# Laguna XS 2.1 on ScaleSWE with the standard bash harness. This follows the
+# tested six-node topology of the regular GLM-4.5-Air SWE run, without a judge.
 
 max_steps = 1000
 seq_len = 131072
@@ -8,21 +8,19 @@ seq_len = 131072
 TRITON_CACHE_DIR = "/tmp/.triton-cache"
 
 [slurm]
-job_name = "laguna-xs21-scaleswe-bash-pass1-v5"
+job_name = "laguna-xs21-scaleswe-regular-v6"
 partition = "all"
-pre_run_command = 'timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-bash-pass1-v4" -y || true ; timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-bash-pass1-v5" -y || true'
+pre_run_command = 'timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-bash-pass1-v5" -y || true ; timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-regular-v6" -y || true'
 
 [deployment]
 type = "multi_node"
-# Match Mika's topology: two trainer nodes and four independent TP8 inference
-# replicas, with one client-facing URL per inference engine.
 num_train_nodes = 2
 num_infer_nodes = 1
 num_infer_replicas = 4
 
 [wandb]
 project = "laguna-xs21-scaleswe"
-name = "laguna-xs21-scaleswe-bash-pass1-v5"
+name = "laguna-xs21-scaleswe-regular-v6"
 
 [weight_broadcast]
 type = "nccl"
@@ -48,6 +46,7 @@ impl = "custom"
 attn = "flash_attention_3"
 cp = 4
 cp_style = "ulysses"
+compile = "None"
 fused_lm_head_token_chunk_size = 1024
 optim_cpu_offload = true
 
@@ -55,8 +54,6 @@ optim_cpu_offload = true
 
 [trainer.model.ac_offloading]
 max_inflight_activations = 1
-
-[trainer.model.compile]
 
 [trainer.ckpt]
 skip_gather_master_weights = true
@@ -90,27 +87,10 @@ thinking_retention = "all"
 name = "scaleswe"
 env.taskset = { id = "scaleswe-v1" }
 env.agent.harness = { id = "bash" }
-env.agent.runtime = { type = "prime", vm = true, cpu = 2.0, memory = 8.0, idle_timeout = "None", labels = ["laguna-xs21-scaleswe-bash-pass1-v5"] }
-env.agent.retries = { max_retries = 3, include = ["ProviderError", "SandboxError"] }
+env.agent.runtime = { type = "prime", vm = true, cpu = 1.0, memory = 2.0, disk = 5.0, idle_timeout = "None", labels = ["laguna-xs21-scaleswe-regular-v6"] }
 sampling = { temperature = 1.0, max_completion_tokens = 32768, extra_body = { top_k = 20, min_p = 0.0, return_token_ids = true } }
 
 [orchestrator.prime_monitor]
-
-[orchestrator.eval]
-interval = 20
-skip_first_step = false
-sampling = { temperature = 1.0, top_p = 1.0, top_k = 20, min_p = 0.0, max_completion_tokens = 32768 }
-
-[[orchestrator.eval.env]]
-name = "swebench-verified"
-num_examples = -1
-# Online evaluation reports pass@1 with one attempt per task.
-group_size = 1
-env.taskset = { id = "swebench-verified-v1" }
-env.agent.harness = { id = "bash" }
-env.agent.runtime = { type = "prime", vm = true, cpu = 2.0, memory = 8.0, idle_timeout = "None", labels = ["laguna-xs21-scaleswe-bash-pass1-v5"] }
-env.agent.retries = { max_retries = 3, include = ["ProviderError", "SandboxError"] }
-env.agent.timeout = { rollout = 3600 }
 
 [inference]
 enable_expert_parallel = false

--- a/examples/advanced/laguna-xs-2.1/swe.toml
+++ b/examples/advanced/laguna-xs-2.1/swe.toml
@@ -1,5 +1,5 @@
 # Laguna XS 2.1 on ScaleSWE with the standard bash harness. This follows the
-# tested six-node topology of the regular GLM-4.5-Air SWE run, without a judge.
+# tested trainer topology of the regular GLM-4.5-Air SWE run, without a judge.
 
 max_steps = 1000
 seq_len = 131072
@@ -16,7 +16,7 @@ pre_run_command = 'timeout 120 prime sandbox delete --label "laguna-xs21-scalesw
 type = "multi_node"
 num_train_nodes = 2
 num_infer_nodes = 1
-num_infer_replicas = 4
+num_infer_replicas = 3
 
 [wandb]
 project = "laguna-xs21-scaleswe"

--- a/examples/advanced/laguna-xs-2.1/swe.toml
+++ b/examples/advanced/laguna-xs-2.1/swe.toml
@@ -8,19 +8,20 @@ seq_len = 131072
 TRITON_CACHE_DIR = "/tmp/.triton-cache"
 
 [slurm]
-job_name = "laguna-xs21-scaleswe-regular-v6"
+job_name = "laguna-xs21-scaleswe-regular-v7-2infer"
 partition = "all"
-pre_run_command = 'timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-bash-pass1-v5" -y || true ; timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-regular-v6" -y || true'
+exclude = "ltc-idc3-hgx8-h200-22"
+pre_run_command = 'timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-bash-pass1-v5" -y || true ; timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-regular-v6" -y || true ; timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-regular-v7-2infer" -y || true'
 
 [deployment]
 type = "multi_node"
 num_train_nodes = 2
 num_infer_nodes = 1
-num_infer_replicas = 3
+num_infer_replicas = 2
 
 [wandb]
 project = "laguna-xs21-scaleswe"
-name = "laguna-xs21-scaleswe-regular-v6"
+name = "laguna-xs21-scaleswe-regular-v7-2infer"
 
 [weight_broadcast]
 type = "nccl"
@@ -87,7 +88,7 @@ thinking_retention = "all"
 name = "scaleswe"
 env.taskset = { id = "scaleswe-v1" }
 env.agent.harness = { id = "bash" }
-env.agent.runtime = { type = "prime", vm = true, cpu = 1.0, memory = 2.0, disk = 5.0, idle_timeout = "None", labels = ["laguna-xs21-scaleswe-regular-v6"] }
+env.agent.runtime = { type = "prime", vm = true, cpu = 1.0, memory = 2.0, disk = 5.0, idle_timeout = "None", labels = ["laguna-xs21-scaleswe-regular-v7-2infer"] }
 sampling = { temperature = 1.0, max_completion_tokens = 32768, extra_body = { top_k = 20, min_p = 0.0, return_token_ids = true } }
 
 [orchestrator.prime_monitor]

--- a/examples/advanced/laguna-xs-2.1/swe.toml
+++ b/examples/advanced/laguna-xs-2.1/swe.toml
@@ -8,20 +8,20 @@ seq_len = 131072
 TRITON_CACHE_DIR = "/tmp/.triton-cache"
 
 [slurm]
-job_name = "laguna-xs21-scaleswe-regular-v7-2infer"
+job_name = "laguna-xs21-scaleswe-regular-v8-4infer-eval"
 partition = "all"
 exclude = "ltc-idc3-hgx8-h200-22"
-pre_run_command = 'timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-bash-pass1-v5" -y || true ; timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-regular-v6" -y || true ; timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-regular-v7-2infer" -y || true'
+pre_run_command = 'timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-regular-v7-2infer" -y || true ; timeout 120 prime sandbox delete --label "laguna-xs21-scaleswe-regular-v8-4infer-eval" -y || true'
 
 [deployment]
 type = "multi_node"
 num_train_nodes = 2
 num_infer_nodes = 1
-num_infer_replicas = 2
+num_infer_replicas = 4
 
 [wandb]
 project = "laguna-xs21-scaleswe"
-name = "laguna-xs21-scaleswe-regular-v7-2infer"
+name = "laguna-xs21-scaleswe-regular-v8-4infer-eval"
 
 [weight_broadcast]
 type = "nccl"
@@ -31,7 +31,7 @@ timeout = 3600
 type = "zmq"
 
 [ckpt]
-interval = 50
+interval = 25
 keep_last = 1
 resume_step = -1
 
@@ -88,10 +88,20 @@ thinking_retention = "all"
 name = "scaleswe"
 env.taskset = { id = "scaleswe-v1" }
 env.agent.harness = { id = "bash" }
-env.agent.runtime = { type = "prime", vm = true, cpu = 1.0, memory = 2.0, disk = 5.0, idle_timeout = "None", labels = ["laguna-xs21-scaleswe-regular-v7-2infer"] }
+env.agent.runtime = { type = "prime", vm = true, cpu = 1.0, memory = 2.0, disk = 5.0, idle_timeout = "None", labels = ["laguna-xs21-scaleswe-regular-v8-4infer-eval"] }
 sampling = { temperature = 1.0, max_completion_tokens = 32768, extra_body = { top_k = 20, min_p = 0.0, return_token_ids = true } }
 
 [orchestrator.prime_monitor]
+
+[orchestrator.eval]
+interval = 20
+
+[[orchestrator.eval.env]]
+name = "swebench-verified"
+env.taskset = { id = "swebench-verified-v1" }
+env.agent.harness = { id = "bash" }
+env.agent.runtime = { type = "prime", vm = true, cpu = 1.0, memory = 2.0, disk = 5.0, idle_timeout = "None", labels = ["laguna-xs21-scaleswe-regular-v8-4infer-eval"] }
+env.agent.timeout = { rollout = 3600 }
 
 [inference]
 enable_expert_parallel = false

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -40,6 +40,17 @@ uv run rl @ examples/basic/reverse-text/rl.toml --dry-run                       
   `deps/verifiers/environments/` but does not import, install the env workspace
   members with `uv sync --all-packages` (all) or `uv sync --package prime-rl
   --package <env>` (one) — they're auto-discovered, no `pyproject.toml` edit needed.
+- Laguna XS-2.1 with the standard `bash` harness needs the repository's
+  `poolside_xs21` vLLM tool-parser plugin. The upstream `poolside_v1` non-streaming
+  parser requires a newline between the tool name and first `<arg_key>`, while
+  XS-2.1 emits the packed form. Set `inference.model.tool_call_parser =
+  "poolside_xs21"` and point `inference.vllm_extra.tool_parser_plugin` at
+  `src/prime_rl/inference/vllm/poolside_xs21_tool_parser.py`. Verify an initial
+  trace contains structured tool calls and more than one turn; `ok=true` alone
+  can hide a one-turn, zero-reward parser failure. Large Prime-runtime launches
+  can dispatch before the elastic interception tunnel pool finishes expanding;
+  set targeted agent retries for `ProviderError` and `SandboxError` when infra
+  failures must not contaminate a pass@1 baseline.
 
 ## `sft` — SFT training
 

--- a/src/prime_rl/inference/vllm/poolside_xs21_tool_parser.py
+++ b/src/prime_rl/inference/vllm/poolside_xs21_tool_parser.py
@@ -1,0 +1,17 @@
+import regex as re
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParserManager
+from vllm.tool_parsers.poolside_v1_tool_parser import PoolsideV1ToolParser
+
+
+@ToolParserManager.register_module("poolside_xs21")
+class PoolsideXS21ToolParser(PoolsideV1ToolParser):
+    """Parse Laguna XS-2.1 tool calls whose name and first argument are adjacent."""
+
+    def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
+        super().__init__(tokenizer, tools)
+        self.func_detail_regex = re.compile(
+            r"<tool_call>\s*([^\n<]*?)(?:\n|(?=<arg_key>)|(?=</tool_call>))"
+            r"(.*?)</tool_call>",
+            re.DOTALL,
+        )


### PR DESCRIPTION
## What changed

- add the Laguna XS-2.1 ScaleSWE training configuration with a full pass@1 SWE-Bench Verified startup eval
- use the standard bash harness with a Laguna-specific packed tool-call parser
- configure the v5 run with four independent TP8 inference replicas and a two-node CP4 trainer
- document the Laguna parser and targeted sandbox retry requirements in the training workflow

## Why

The previous TP4/DP2 inference layout developed severe per-engine routing and prefix-cache imbalance, while the single-node CP8 trainer repeatedly stalled in reduce-scatter. The v5 topology mirrors the healthy GLM ScaleSWE deployment shape: four independently routed inference engines and a trainer mesh with a real data-shard dimension.

## Validation

- `uv run python -m py_compile src/prime_rl/inference/vllm/poolside_xs21_tool_parser.py`
- `uv run rl @ examples/advanced/laguna-xs-2.1/swe.toml --dry-run --output-dir /tmp/laguna-v5-dryrun.015u4h`

The dry run resolved six nodes, 32 inference GPUs, TP8/DP1 inference, 131072-token context, and CP4 training.
