### PR TITLE
refactor(vllm): delegate token serving to vLLM 0.26

### DIFF
--- a/src/prime_rl/inference/vllm/routed_experts.py
+++ b/src/prime_rl/inference/vllm/routed_experts.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+import io
 from typing import Any
 
 import numpy as np
 import pybase64
-from vllm.outputs import RequestOutput
 
 
 def serialize_routed_experts(routed_experts: Any, start: int = 0) -> dict[str, Any] | None:
@@ -33,16 +32,9 @@ def serialize_routed_experts(routed_experts: Any, start: int = 0) -> dict[str, A
     }
 
 
-class RoutedExpertsCapture:
-    def __init__(self, generator: AsyncIterator[RequestOutput], start: int = 0):
-        self._generator = generator
-        self._start = start
-        self.routed_experts: dict[int, dict[str, Any]] = {}
-
-    async def __aiter__(self):
-        async for request_output in self._generator:
-            for output in request_output.outputs:
-                encoded = serialize_routed_experts(getattr(output, "routed_experts", None), start=self._start)
-                if encoded is not None:
-                    self.routed_experts[output.index] = encoded
-            yield request_output
+def compact_vllm_routed_experts(encoded: str | None, start: int = 0) -> dict[str, Any] | None:
+    """Convert vLLM's base64 ``.npy`` payload to Prime's compact payload."""
+    if encoded is None:
+        return None
+    array = np.load(io.BytesIO(pybase64.b64decode(encoded)), allow_pickle=False)
+    return serialize_routed_experts(array, start=start)

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -158,28 +158,25 @@ async def custom_init_app_state(
     args: Namespace,
     supported_tasks: tuple,
 ):
-    """
-    Modifies init_app_state:
-    1. Call the original init_app_state to set up standard state, including
-       vLLM 0.20's ``serving_tokens`` for ``/inference/v1/generate``.
-    2. Replace ``serving_tokens`` with ``PrimeRlServingTokens`` so DP-rank
-       routing and ``routed_experts`` export survive the migration off the
-       legacy ``/v1/generate`` endpoint.
-    """
+    """Initialize vLLM app state and install Prime's token response adapter."""
     await init_app_state(engine_client, state, args, supported_tasks)
 
     state.liveness_timeout_seconds = args.liveness_timeout_seconds
 
-    # Swap in our ServingTokens subclass for /inference/v1/generate so the
-    # X-data-parallel-rank header and routed_experts response field — both
-    # used by prime-RL's renderer / router-replay paths — keep working.
     if "generate" in supported_tasks and state.serving_tokens is not None:
         from prime_rl.inference.vllm.serving_tokens import PrimeRlServingTokens
 
         upstream = state.serving_tokens
-        prime_serving = object.__new__(PrimeRlServingTokens)
-        prime_serving.__dict__.update(upstream.__dict__)
-        state.serving_tokens = prime_serving
+        state.serving_tokens = PrimeRlServingTokens(
+            upstream.engine_client,
+            upstream.models,
+            upstream.online_renderer,
+            request_logger=upstream.request_logger,
+            return_tokens_as_token_ids=upstream.return_tokens_as_token_ids,
+            force_no_detokenize=upstream.force_no_detokenize,
+            enable_prompt_tokens_details=True,
+            enable_log_outputs=upstream.enable_log_outputs,
+        )
 
 
 import vllm.entrypoints.openai.api_server

--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -1,53 +1,21 @@
-"""Prime-RL extensions to vLLM's `/inference/v1/generate` handler.
-
-vLLM ships a generic tokens-in / tokens-out handler at
-``vllm.entrypoints.scale_out.token_in_token_out.serving.ServingTokens`` that covers
-prefix-cache salting, lora dispatch, multimodal features, prompt logprobs,
-priority, ``data_parallel_rank`` header routing and server-side ``max_tokens``
-defaulting. We subclass it for the bits still missing from the upstream handler:
-
-1. ``data_parallel_rank`` routing — read from the ``X-data-parallel-rank``
-   header and forwarded to ``engine_client.generate``. Upstream ``ServingTokens``
-   now does this too; we keep the equivalent path for the DP-replicated
-   inference servers prime-RL runs.
-
-2. Compact ``routed_experts`` export — when the engine emits routing
-   decisions, surface them as base64 raw-byte payloads without requiring a vLLM
-   source fork.
-
-3. Server-side ``max_tokens`` defaulting — upstream ``ServingTokens`` now applies
-   this itself (via ``GenerateRequest.is_sampling_param_provided`` +
-   ``get_max_tokens``); we keep an equivalent guard so callers that omit
-   ``max_tokens`` don't truncate at vLLM's 16-token ``SamplingParams`` default.
-
-Everything else (request/response schema, sampling params, error handling)
-delegates to upstream so we track future vLLM changes for free.
-"""
+"""Small Prime extensions to vLLM's canonical token-in/token-out handler."""
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, AsyncIterable
-from functools import cached_property
+from collections.abc import AsyncGenerator
 from typing import Any
 
 from fastapi import Request
-from vllm.entrypoints.openai.engine.protocol import (
-    ErrorResponse,
-    PromptTokenUsageInfo,
-    RequestResponseMetadata,
-    UsageInfo,
-)
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse, RequestResponseMetadata
 from vllm.entrypoints.scale_out.token_in_token_out.protocol import (
     GenerateRequest,
     GenerateResponse,
     GenerateResponseChoice,
 )
 from vllm.entrypoints.scale_out.token_in_token_out.serving import ServingTokens
-from vllm.entrypoints.serve.utils.api_utils import get_max_tokens
 from vllm.outputs import RequestOutput
-from vllm.sampling_params import RequestOutputKind, SamplingParams
 
-from prime_rl.inference.vllm.routed_experts import RoutedExpertsCapture
+from prime_rl.inference.vllm.routed_experts import compact_vllm_routed_experts
 
 
 class PrimeRlGenerateResponseChoice(GenerateResponseChoice):
@@ -56,255 +24,26 @@ class PrimeRlGenerateResponseChoice(GenerateResponseChoice):
 
 class PrimeRlGenerateResponse(GenerateResponse):
     choices: list[PrimeRlGenerateResponseChoice]
-    # Upstream ``GenerateResponse`` doesn't declare a ``usage`` field, so the
-    # parent ``ServingTokens.serve_tokens_full_generator`` constructs it and
-    # Pydantic silently drops it on serialization. Declare it here so the
-    # router can extract per-run token counts (and cached-prefix tokens) for
-    # platform billing — see https://github.com/PrimeIntellect-ai/router/pull/43.
-    usage: UsageInfo | None = None
-
-
-class _GenerateRoutedExpertsCapture(RoutedExpertsCapture):
-    def post_process(self, response: GenerateResponse) -> PrimeRlGenerateResponse:
-        choices = [
-            PrimeRlGenerateResponseChoice(
-                **choice.model_dump(exclude={"routed_experts"}),
-                routed_experts=self.routed_experts.get(choice.index),
-            )
-            for choice in response.choices
-        ]
-        return PrimeRlGenerateResponse(
-            request_id=response.request_id,
-            choices=choices,
-            prompt_logprobs=response.prompt_logprobs,
-            kv_transfer_params=response.kv_transfer_params,
-        )
-
-
-class _FinalOutputCapture:
-    """Wraps a ``RequestOutput`` async generator to record the last yielded item.
-
-    Needed so the response builder can construct a ``usage`` block from
-    ``final_res.prompt_token_ids`` / ``output.token_ids`` / ``num_cached_tokens``
-    after delegating iteration to upstream.
-    """
-
-    def __init__(self, source: AsyncIterable[RequestOutput]) -> None:
-        # ``source`` may be any async-iterable — including
-        # ``_GenerateRoutedExpertsCapture``, which exposes the protocol via
-        # ``async def __aiter__`` (an async generator function) and has no
-        # ``__anext__`` method. Drive it through ``async for`` rather than
-        # poking ``__anext__`` directly so both shapes work.
-        self._source = source
-        self.final_res: RequestOutput | None = None
-
-    async def __aiter__(self) -> AsyncGenerator[RequestOutput, None]:
-        async for item in self._source:
-            self.final_res = item
-            yield item
-
-
-def _build_usage(final_res: RequestOutput) -> UsageInfo:
-    assert final_res.prompt_token_ids is not None
-    num_prompt_tokens = len(final_res.prompt_token_ids)
-    if final_res.encoder_prompt_token_ids is not None:
-        num_prompt_tokens += len(final_res.encoder_prompt_token_ids)
-    num_generated_tokens = sum(len(output.token_ids) for output in final_res.outputs)
-    usage = UsageInfo(
-        prompt_tokens=num_prompt_tokens,
-        completion_tokens=num_generated_tokens,
-        total_tokens=num_prompt_tokens + num_generated_tokens,
-    )
-    # Always emit cached tokens when vLLM reports any. Upstream gates this on
-    # ``enable_prompt_tokens_details`` (default False) for OpenAI-API compat,
-    # but ``/inference/v1/generate`` is prime-rl internal — the cache-discount
-    # billing pipeline always wants the cached subset surfaced.
-    if final_res.num_cached_tokens:
-        usage.prompt_tokens_details = PromptTokenUsageInfo(cached_tokens=final_res.num_cached_tokens)
-    return usage
-
-
-async def _client_set_max_tokens(raw_request: Request | None) -> bool:
-    """Whether the inbound JSON body carried ``sampling_params.max_tokens``.
-
-    ``GenerateRequest.sampling_params`` is parsed into a ``SamplingParams``
-    instance, which means an unset ``max_tokens`` is indistinguishable from
-    an explicit ``max_tokens=16`` once the request reaches the handler —
-    both surface as ``sampling_params.max_tokens == 16``. We re-read the
-    cached body to recover that distinction. When we can't (no raw_request,
-    non-JSON body, or read error), pessimistically assume the client did
-    set it so we never clobber an explicit value.
-    """
-    if raw_request is None:
-        return True
-    try:
-        body = await raw_request.json()
-    except Exception:
-        return True
-    if not isinstance(body, dict):
-        return True
-    sp = body.get("sampling_params")
-    return isinstance(sp, dict) and "max_tokens" in sp
 
 
 class PrimeRlServingTokens(ServingTokens):
-    """ServingTokens + DP-rank routing + compact routed experts + max_tokens defaulting."""
-
-    @cached_property
-    def _max_tokens_defaults(self) -> tuple[dict, int | None]:
-        """Server-side ``max_tokens`` defaulting inputs, mirroring upstream ``ServingTokens``.
-
-        Computed lazily because ``custom_init_app_state`` swaps in this
-        subclass via ``object.__new__`` + ``__dict__.update`` (so our
-        ``__init__`` never runs).
-        """
-        diff = self.model_config.get_diff_sampling_param()
-        mc = self.model_config
-        override = (
-            diff.get("max_tokens")
-            if mc.generation_config not in ("auto", "vllm")
-            # Upstream uses ``getattr(..., {})`` directly. Defensive ``or {}``
-            # in case a downstream caller ever sets the attribute to ``None``
-            # (``getattr``'s default only fires when the attribute is missing,
-            # not when it exists with a ``None`` value).
-            else (getattr(mc, "override_generation_config", None) or {}).get("max_new_tokens")
-        )
-        return diff, override
+    """Add KV handoff and Prime's compact routed-expert response encoding."""
 
     async def serve_tokens(
         self,
         request: GenerateRequest,
         raw_request: Request | None = None,
-    ) -> PrimeRlGenerateResponse | ErrorResponse | AsyncGenerator[str, None]:
-        # Mirrors upstream ``ServingTokens.serve_tokens``. Diffs:
-        # (a) inject ``data_parallel_rank`` from the inbound header into
-        # ``engine_client.generate``; (b) default ``sampling_params.max_tokens``
-        # to ``max_model_len - prompt_len`` when the caller didn't set it; and
-        # (c) dispatch to our overridden response builder so ``routed_experts``
-        # makes it into the JSON.
-        error_check_ret = await self._check_model(request)
-        if error_check_ret is not None:
-            return error_check_ret
+    ) -> GenerateResponse | ErrorResponse | AsyncGenerator[str, None]:
+        if request.kv_transfer_params is None:
+            return await super().serve_tokens(request, raw_request)
 
-        if self.engine_client.errored:
-            raise self.engine_client.dead_error
+        forwarded = request.model_copy(deep=True)
+        extra_args = dict(forwarded.sampling_params.extra_args or {})
+        extra_args["kv_transfer_params"] = forwarded.kv_transfer_params
+        forwarded.sampling_params.extra_args = extra_args
+        return await super().serve_tokens(forwarded, raw_request)
 
-        lora_request = self._maybe_get_adapters(request, supports_default_mm_loras=True)
-        model_name = self.models.model_name(lora_request)
-
-        request_id = f"generate-tokens-{self._base_request_id(raw_request, request.request_id)}"
-        request_metadata = RequestResponseMetadata(request_id=request_id)
-        if raw_request:
-            raw_request.state.request_metadata = request_metadata
-
-        # Build the engine input — features-aware (MM) or text-only fallback.
-        # Identical to upstream so we keep tracking it.
-        if features := request.features:
-            from vllm.entrypoints.scale_out.token_in_token_out.mm_serde import decode_mm_kwargs_item
-            from vllm.inputs import mm_input
-            from vllm.multimodal.inputs import (
-                MultiModalKwargsItem,
-                MultiModalKwargsItems,
-                PlaceholderRange,
-            )
-
-            mm_placeholders = {
-                modality: [PlaceholderRange(offset=p.offset, length=p.length) for p in ranges]
-                for modality, ranges in features.mm_placeholders.items()
-            }
-            mm_kwargs: dict[str, list[MultiModalKwargsItem | None]] = {}
-            if features.kwargs_data is not None:
-                for modality, items in features.kwargs_data.items():
-                    mm_kwargs[modality] = [decode_mm_kwargs_item(item) if item is not None else None for item in items]
-            else:
-                for modality, hashes in features.mm_hashes.items():
-                    mm_kwargs[modality] = [None] * len(hashes)
-            engine_input = mm_input(
-                prompt_token_ids=request.token_ids,
-                mm_kwargs=MultiModalKwargsItems(mm_kwargs),
-                mm_hashes=features.mm_hashes,
-                mm_placeholders=mm_placeholders,
-                cache_salt=request.cache_salt,
-            )
-        else:
-            (engine_input,) = await self.online_renderer.preprocess_completion(
-                request,
-                prompt_input=request.token_ids,
-                prompt_embeds=None,
-                skip_mm_cache=True,
-            )
-
-        sampling_params: SamplingParams = request.sampling_params
-
-        # Upstream ``ServingTokens.serve_tokens`` parses ``request.kv_transfer_params``
-        # but never threads it into the engine, so PD disagg never fires on
-        # ``/inference/v1/generate`` — decode receives an empty NIXL handshake
-        # and ends up re-prefilling the prompt locally (~100× slower under
-        # concurrency). Bridge it through ``sampling_params.extra_args`` so the
-        # engine's KV connector picks the params up.
-        #
-        # Upstream fix: https://github.com/vllm-project/vllm/pull/42644 — drop
-        # this block once we pin a vLLM version that includes it.
-        if request.kv_transfer_params is not None:
-            extra = sampling_params.extra_args or {}
-            extra["kv_transfer_params"] = request.kv_transfer_params
-            sampling_params.extra_args = extra
-
-        # Server-side ``max_tokens`` defaulting — see module docstring. Upstream
-        # ``ServingTokens`` now does this too; kept here so callers that omit
-        # ``max_tokens`` don't get capped at vLLM's 16-token ``SamplingParams``
-        # default.
-        if not await _client_set_max_tokens(raw_request):
-            diff_sp, override = self._max_tokens_defaults
-            sampling_params.max_tokens = get_max_tokens(
-                max_model_len=self.model_config.max_model_len,
-                max_tokens=None,
-                input_length=len(request.token_ids),
-                default_sampling_params=diff_sp,
-                override_max_tokens=override,
-            )
-
-        if self.force_no_detokenize:
-            sampling_params.detokenize = False
-        if request.stream:
-            sampling_params.output_kind = RequestOutputKind.DELTA
-
-        self._log_inputs(
-            request_id,
-            engine_input,
-            params=sampling_params,
-            lora_request=lora_request,
-        )
-
-        trace_headers = None if raw_request is None else await self._get_trace_headers(raw_request.headers)
-
-        result_generator = self.engine_client.generate(
-            engine_input,
-            sampling_params,
-            request_id,
-            lora_request=lora_request,
-            trace_headers=trace_headers,
-            priority=request.priority,
-            data_parallel_rank=self._get_data_parallel_rank(raw_request),
-        )
-
-        if request.stream:
-            # Streaming path: defer to upstream — prime-RL's renderer client
-            # only consumes the full response, so adding routed_experts to the
-            # streaming choice schema is unnecessary churn.
-            return self.serve_tokens_stream_generator(
-                request,
-                result_generator,
-                request_id,
-                model_name,
-                request_metadata,
-            )
-
-        return await self.serve_tokens_full_generator(
-            request, result_generator, request_id, model_name, request_metadata
-        )
-
-    async def serve_tokens_full_generator(  # type: ignore[override]
+    async def serve_tokens_full_generator(
         self,
         request: GenerateRequest,
         result_generator: AsyncGenerator[RequestOutput, None],
@@ -312,45 +51,25 @@ class PrimeRlServingTokens(ServingTokens):
         model_name: str,
         request_metadata: RequestResponseMetadata,
     ) -> ErrorResponse | GenerateResponse:
-        # Capture routed_experts as vLLM streams request outputs, then post-process
-        # the final response into our GenerateResponse subclass so the encoded
-        # experts surface in the JSON.
-        capture: _GenerateRoutedExpertsCapture | None = None
-        if self.model_config.enable_return_routed_experts:
-            start = request.sampling_params.routed_experts_prompt_start
-            capture = _GenerateRoutedExpertsCapture(
-                result_generator,
-                start=start,
-            )
-            result_generator = capture
-
-        # Always capture the final ``RequestOutput`` so we can attach a
-        # ``usage`` block to the response. The router parses ``usage`` for
-        # per-run billing metrics; without it the cache-discount counter
-        # (``vllm_router_run_cached_prompt_tokens_total``) stays at zero.
-        final_capture = _FinalOutputCapture(result_generator)
-        result_generator = final_capture
-
         response = await super().serve_tokens_full_generator(
-            request, result_generator, request_id, model_name, request_metadata
+            request,
+            result_generator,
+            request_id,
+            model_name,
+            request_metadata,
         )
-
-        if not isinstance(response, GenerateResponse):
+        if not isinstance(response, GenerateResponse) or not any(
+            choice.routed_experts is not None for choice in response.choices
+        ):
             return response
-
-        if capture is not None:
-            response = capture.post_process(response)
-        elif not isinstance(response, PrimeRlGenerateResponse):
-            # Upgrade to the prime-rl subclass so the declared ``usage`` field
-            # actually surfaces in JSON (the parent class would drop it).
-            response = PrimeRlGenerateResponse(
-                request_id=response.request_id,
-                choices=[PrimeRlGenerateResponseChoice(**choice.model_dump()) for choice in response.choices],
-                prompt_logprobs=response.prompt_logprobs,
-                kv_transfer_params=response.kv_transfer_params,
-            )
-
-        if final_capture.final_res is not None:
-            response.usage = _build_usage(final_capture.final_res)
-
-        return response
+        start = request.sampling_params.routed_experts_prompt_start or 0
+        return PrimeRlGenerateResponse(
+            **response.model_dump(exclude={"choices"}),
+            choices=[
+                PrimeRlGenerateResponseChoice(
+                    **choice.model_dump(exclude={"routed_experts"}),
+                    routed_experts=compact_vllm_routed_experts(choice.routed_experts, start=start),
+                )
+                for choice in response.choices
+            ],
+        )

--- a/tests/unit/inference/test_serving_tokens.py
+++ b/tests/unit/inference/test_serving_tokens.py
@@ -1,66 +1,40 @@
-"""Sanity tests for the prime-RL ``ServingTokens`` subclass.
-
-The full happy-path is owned upstream by vLLM's
-``vllm/entrypoints/serve/disagg`` test suite. We only cover the prime-RL
-deltas here:
-    * ``serialize_routed_experts`` round-trips a compact raw-byte payload.
-    * The subclass attaches its overrides without monkey-patching the parent.
-    * ``_client_set_max_tokens`` distinguishes raw-body shapes correctly.
-"""
-
 from __future__ import annotations
 
 import asyncio
+import io
 
 import numpy as np
 import pybase64
-from vllm.entrypoints.openai.engine.protocol import UsageInfo
-from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateResponse, GenerateResponseChoice
-
-from prime_rl.inference.vllm.routed_experts import serialize_routed_experts
-from prime_rl.inference.vllm.serving_tokens import (
-    PrimeRlGenerateResponse,
-    PrimeRlGenerateResponseChoice,
-    PrimeRlServingTokens,
-    _build_usage,
-    _client_set_max_tokens,
-    _FinalOutputCapture,
-    _GenerateRoutedExpertsCapture,
+from vllm.entrypoints.openai.engine.protocol import RequestResponseMetadata, UsageInfo
+from vllm.entrypoints.scale_out.token_in_token_out.protocol import (
+    GenerateRequest,
+    GenerateResponse,
+    GenerateResponseChoice,
 )
+from vllm.entrypoints.scale_out.token_in_token_out.serving import ServingTokens
+from vllm.sampling_params import SamplingParams
+
+from prime_rl.inference.vllm.routed_experts import (
+    compact_vllm_routed_experts,
+    serialize_routed_experts,
+)
+from prime_rl.inference.vllm.serving_tokens import PrimeRlServingTokens
 
 
-def _decode_routed_experts(encoded: dict) -> np.ndarray:
+def _decode_compact(encoded: dict) -> np.ndarray:
     return np.frombuffer(
         pybase64.b64decode_as_bytearray(encoded["data"]),
         dtype=np.uint8,
     ).reshape(encoded["shape"])
 
 
-class _FakeRawRequest:
-    def __init__(self, body):
-        self._body = body
-        self._raise = isinstance(body, Exception)
-
-    async def json(self):
-        if self._raise:
-            raise self._body
-        return self._body
+def _encode_vllm(array: np.ndarray) -> str:
+    buffer = io.BytesIO()
+    np.save(buffer, array)
+    return pybase64.b64encode(buffer.getvalue()).decode("ascii")
 
 
-async def _empty_request_outputs():
-    if False:
-        yield
-
-
-def test_subclass_only_overrides_serve_tokens():
-    assert PrimeRlServingTokens.serve_tokens is not PrimeRlServingTokens.__mro__[1].serve_tokens
-    assert (
-        PrimeRlServingTokens.serve_tokens_full_generator
-        is not PrimeRlServingTokens.__mro__[1].serve_tokens_full_generator
-    )
-
-
-def test_serialize_routed_experts_uses_compact_raw_payload():
+def test_routed_experts_round_trip_both_wire_formats():
     routed_experts = np.array(
         [
             [[1, 2], [3, 4]],
@@ -69,201 +43,96 @@ def test_serialize_routed_experts_uses_compact_raw_payload():
         dtype=np.int64,
     )
 
-    encoded = serialize_routed_experts(routed_experts)
-    assert encoded is not None
+    compact = serialize_routed_experts(routed_experts, start=2)
+    converted = compact_vllm_routed_experts(_encode_vllm(routed_experts), start=2)
 
-    decoded = _decode_routed_experts(encoded)
-    assert decoded.dtype == np.uint8
-    np.testing.assert_array_equal(decoded, routed_experts)
+    assert compact is not None
+    assert converted is not None
+    assert converted["start"] == 2
+    np.testing.assert_array_equal(_decode_compact(compact), routed_experts)
+    np.testing.assert_array_equal(_decode_compact(converted), routed_experts)
 
 
-def test_generate_response_post_process_replaces_upstream_routed_experts():
-    compact_routed_experts = {"data": "AQID", "shape": [1, 1, 3], "start": 0}
-    capture = _GenerateRoutedExpertsCapture(_empty_request_outputs())
-    capture.routed_experts[0] = compact_routed_experts
-    response = GenerateResponse(
-        request_id="request-id",
+def test_serve_tokens_forwards_kv_transfer_params_without_mutating_request(monkeypatch):
+    expected = object()
+    observed_request = None
+
+    async def upstream(_self, request, _raw_request=None):
+        nonlocal observed_request
+        observed_request = request
+        assert request.sampling_params.extra_args == {
+            "existing": True,
+            "kv_transfer_params": {"remote": "metadata"},
+        }
+        return expected
+
+    monkeypatch.setattr(ServingTokens, "serve_tokens", upstream)
+    server = object.__new__(PrimeRlServingTokens)
+    request = GenerateRequest(
+        token_ids=[1],
+        sampling_params=SamplingParams(max_tokens=1, extra_args={"existing": True}),
+        kv_transfer_params={"remote": "metadata"},
+    )
+
+    assert asyncio.run(server.serve_tokens(request)) is expected
+    assert observed_request is not request
+    assert request.sampling_params.extra_args == {"existing": True}
+
+
+def test_full_generator_preserves_all_upstream_response_fields(monkeypatch):
+    routed_experts = np.array([[[1, 2, 3]]], dtype=np.uint8)
+    usage = UsageInfo(
+        prompt_tokens=3,
+        completion_tokens=2,
+        total_tokens=5,
+        prompt_tokens_details={"cached_tokens": 2},
+    )
+    upstream_response = GenerateResponse(
+        request_id="canonical-request-id",
+        model="served-model",
+        created=123456789,
+        usage=usage,
         choices=[
             GenerateResponseChoice(
                 index=0,
-                token_ids=[1, 2, 3],
-                routed_experts="upstream-npy-payload",
+                token_ids=[10, 11],
+                routed_experts=_encode_vllm(routed_experts),
             )
         ],
     )
 
-    processed = capture.post_process(response)
-
-    assert processed.choices[0].routed_experts == compact_routed_experts
-
-
-def test_client_set_max_tokens_recognizes_explicit_value():
-    body = {"token_ids": [1, 2, 3], "sampling_params": {"max_tokens": 256}}
-    assert asyncio.run(_client_set_max_tokens(_FakeRawRequest(body))) is True
-
-
-def test_client_set_max_tokens_detects_unset():
-    body = {"token_ids": [1, 2, 3], "sampling_params": {}}
-    assert asyncio.run(_client_set_max_tokens(_FakeRawRequest(body))) is False
-
-    body_without_sp = {"token_ids": [1, 2, 3]}
-    assert asyncio.run(_client_set_max_tokens(_FakeRawRequest(body_without_sp))) is False
-
-
-class _FakeOutput:
-    def __init__(self, token_ids):
-        self.token_ids = token_ids
-
-
-class _FakeRequestOutput:
-    """Minimal stand-in for ``vllm.outputs.RequestOutput``.
-
-    ``_build_usage`` only touches four attributes; constructing a real
-    ``RequestOutput`` would require a full ``CompletionOutput`` graph and
-    isn't worth it for a serialization-shape test.
-    """
-
-    def __init__(self, prompt_token_ids, output_token_ids_list, num_cached_tokens=0, encoder_prompt_token_ids=None):
-        self.prompt_token_ids = prompt_token_ids
-        self.encoder_prompt_token_ids = encoder_prompt_token_ids
-        self.outputs = [_FakeOutput(t) for t in output_token_ids_list]
-        self.num_cached_tokens = num_cached_tokens
-
-
-def test_prime_rl_generate_response_serializes_usage_block():
-    # Regression for prime-rl PR #2408: parent ``GenerateResponse`` doesn't
-    # declare ``usage``, so the field must be declared on the subclass for
-    # Pydantic to emit it in JSON. Without this the router can't extract
-    # per-run token / cache counts for billing.
-    response = PrimeRlGenerateResponse(
-        request_id="req-1",
-        choices=[PrimeRlGenerateResponseChoice(index=0, token_ids=[1, 2, 3])],
-        usage=UsageInfo(prompt_tokens=4, completion_tokens=3, total_tokens=7),
-    )
-    payload = response.model_dump(mode="json")
-    assert payload["usage"] == {
-        "prompt_tokens": 4,
-        "completion_tokens": 3,
-        "total_tokens": 7,
-        "prompt_tokens_details": None,
-    }
-
-
-def test_build_usage_sums_prompt_and_completion_tokens():
-    final_res = _FakeRequestOutput(
-        prompt_token_ids=[1, 2, 3, 4, 5],
-        output_token_ids_list=[[10, 11], [20, 21, 22]],
-    )
-    usage = _build_usage(final_res)
-    assert usage.prompt_tokens == 5
-    assert usage.completion_tokens == 5  # 2 + 3
-    assert usage.total_tokens == 10
-    assert usage.prompt_tokens_details is None
-
-
-def test_build_usage_includes_encoder_prompt_tokens():
-    final_res = _FakeRequestOutput(
-        prompt_token_ids=[1, 2, 3],
-        output_token_ids_list=[[10]],
-        encoder_prompt_token_ids=[100, 101],
-    )
-    usage = _build_usage(final_res)
-    assert usage.prompt_tokens == 5  # 3 + 2
-    assert usage.total_tokens == 6
-
-
-def test_build_usage_reports_cached_tokens_unconditionally():
-    # Unlike upstream's ``enable_prompt_tokens_details`` gate, prime-rl always
-    # surfaces cached tokens — the cache-discount billing pipeline needs them.
-    final_res = _FakeRequestOutput(
-        prompt_token_ids=[1, 2, 3, 4],
-        output_token_ids_list=[[10, 11]],
-        num_cached_tokens=3,
-    )
-    usage = _build_usage(final_res)
-    assert usage.prompt_tokens_details is not None
-    assert usage.prompt_tokens_details.cached_tokens == 3
-
-
-def test_build_usage_skips_cached_tokens_when_zero():
-    # Don't emit a details block with cached=0, which would be misleading
-    # to the router's billing extractor.
-    final_res = _FakeRequestOutput(
-        prompt_token_ids=[1, 2, 3, 4],
-        output_token_ids_list=[[10, 11]],
-        num_cached_tokens=0,
-    )
-    usage = _build_usage(final_res)
-    assert usage.prompt_tokens_details is None
-
-
-def test_final_output_capture_records_last_item():
-    async def _gen():
-        for r in [
-            _FakeRequestOutput(prompt_token_ids=[1], output_token_ids_list=[[1]]),
-            _FakeRequestOutput(prompt_token_ids=[1, 2], output_token_ids_list=[[1, 2]]),
-            _FakeRequestOutput(prompt_token_ids=[1, 2, 3], output_token_ids_list=[[1, 2, 3]]),
-        ]:
-            yield r
-
-    async def _drain(capture):
-        async for _ in capture:
+    async def upstream(_self, _request, result_generator, *_args):
+        async for _ in result_generator:
             pass
+        return upstream_response
 
-    capture = _FinalOutputCapture(_gen())
-    asyncio.run(_drain(capture))
-    assert capture.final_res is not None
-    assert capture.final_res.prompt_token_ids == [1, 2, 3]
+    monkeypatch.setattr(ServingTokens, "serve_tokens_full_generator", upstream)
+    server = object.__new__(PrimeRlServingTokens)
+    server.enable_prompt_tokens_details = True
+    request = GenerateRequest(
+        token_ids=[1, 2, 3],
+        sampling_params=SamplingParams(max_tokens=2, routed_experts_prompt_start=1),
+    )
 
+    async def outputs():
+        if False:
+            yield
 
-def test_final_output_capture_works_over_async_def_aiter_source():
-    # ``_GenerateRoutedExpertsCapture`` exposes the async-iterator protocol
-    # via ``async def __aiter__`` (an async generator function) and has no
-    # ``__anext__``. The wrapper must drive it through ``async for`` rather
-    # than poking ``__anext__`` directly, or routed-experts runs raise
-    # AttributeError before the response is built.
+    response = asyncio.run(
+        server.serve_tokens_full_generator(
+            request,
+            outputs(),
+            "input-request-id",
+            "input-model",
+            RequestResponseMetadata(request_id="input-request-id"),
+        )
+    )
 
-    class _AsyncGenAiterSource:
-        def __init__(self, items):
-            self._items = items
-
-        async def __aiter__(self):
-            for item in self._items:
-                yield item
-
-    items = [
-        _FakeRequestOutput(prompt_token_ids=[1], output_token_ids_list=[[1]]),
-        _FakeRequestOutput(prompt_token_ids=[1, 2], output_token_ids_list=[[1, 2]]),
-    ]
-    capture = _FinalOutputCapture(_AsyncGenAiterSource(items))
-
-    async def _drain():
-        async for _ in capture:
-            pass
-
-    asyncio.run(_drain())
-    assert capture.final_res is not None
-    assert capture.final_res.prompt_token_ids == [1, 2]
-
-
-def test_final_output_capture_handles_empty_stream():
-    capture = _FinalOutputCapture(_empty_request_outputs())
-
-    async def _drain():
-        async for _ in capture:
-            pass
-
-    asyncio.run(_drain())
-    assert capture.final_res is None
-
-
-def test_client_set_max_tokens_assumes_set_when_body_unreadable():
-    # No raw_request → can't tell, don't override.
-    assert asyncio.run(_client_set_max_tokens(None)) is True
-
-    # body read raises → can't tell, don't override.
-    err = ValueError("bad json")
-    assert asyncio.run(_client_set_max_tokens(_FakeRawRequest(err))) is True
-
-    # non-dict body → can't tell, don't override.
-    assert asyncio.run(_client_set_max_tokens(_FakeRawRequest([1, 2, 3]))) is True
+    assert response.request_id == "canonical-request-id"
+    assert response.model == "served-model"
+    assert response.created == 123456789
+    assert response.usage == usage
+    encoded = response.choices[0].routed_experts
+    assert isinstance(encoded, dict)
+    assert encoded["start"] == 1
+    np.testing.assert_array_equal(_decode_compact(encoded), routed_experts)


### PR DESCRIPTION
## Summary

- adapt Prime-RL token serving to the vLLM 0.26 serving interfaces
- delegate request preprocessing and response construction to native vLLM helpers
- preserve Prime-RL routed-expert capture and the legacy Python vLLM server path

## Scope

This is an independent compatibility refactor. It does not enable Dynamo and does not change deployment configuration.

## Test plan

- `ruff check` on the changed inference and test files
- `pytest -q tests/unit/inference/test_serving_tokens.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the inference generate path and billing-related response fields now depend on upstream vLLM behavior; misalignment could affect rollouts, PD KV transfer, or router replay until parity is verified on the pinned version.
> 
> **Overview**
> **Refactors** `/inference/v1/generate` so Prime-RL rides vLLM 0.26’s native `ServingTokens` instead of reimplementing the full request/response pipeline.
> 
> `PrimeRlServingTokens` is now a thin layer: it **bridges** `kv_transfer_params` into `sampling_params.extra_args` (deep-copied request) when PD KV handoff is needed, and **post-processes** choices that include upstream `routed_experts` by converting vLLM’s base64 `.npy` strings into Prime’s compact `{data, shape, start, dtype}` via new `compact_vllm_routed_experts`. The async `RoutedExpertsCapture` path and custom usage / `max_tokens` / DP-rank / multimodal handling in the subclass are **removed**, assuming upstream covers those behaviors.
> 
> App bootstrap **constructs** `PrimeRlServingTokens` explicitly (with `enable_prompt_tokens_details=True`) rather than swapping instances with `object.__new__`. Unit tests are **narrowed** to wire-format round-trips, KV forwarding without mutating the caller’s request, and preserving upstream response fields when re-encoding experts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e755863f7f0b2aa6aad48ecadc00fd6cd268ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->