### PR TITLE
fix(nccl): preserve checkpoint layer boundaries

### DIFF
--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -78,15 +78,22 @@ class NCCLWeightBroadcastReceiver:
         self.communicator = PyNcclCommunicator(pg, device=device)
 
     @torch.no_grad()
-    def receive_state_dict(self):
-        """Receives the state dict of a model from the trainer master rank using NCCL communicator."""
+    def receive_state_dicts(
+        self,
+    ) -> Generator[Generator[tuple[str, torch.Tensor], None, None], None, None]:
+        """Receive each trainer-broadcast state dict as a separate stream."""
         logger.info("Receiving weights from trainer")
         num_state_dict_to_receive = receive_integer(self.communicator)
         logger.info(f"Receiving {num_state_dict_to_receive} layer state dicts")
         for layer_id in range(num_state_dict_to_receive):
             logger.info(f"Receiving state dict {layer_id + 1}/{num_state_dict_to_receive}")
-            for key, value in receive_state_dict(self.communicator):
-                yield key, value
+            yield receive_state_dict(self.communicator)
+
+    @torch.no_grad()
+    def receive_state_dict(self):
+        """Receive trainer weights as one flat stream for kernel-format loading."""
+        for state_dict in self.receive_state_dicts():
+            yield from state_dict
 
 
 class NCCLWeightUpdateWorker(Worker):
@@ -144,15 +151,14 @@ class NCCLWeightUpdateWorker(Worker):
             model = model_runner.model
         assert isinstance(model, Module)
 
-        state_iter = self.nccl_broadcast_receiver.receive_state_dict()
         if self.quantize_in_weight_transfer:
-            load_weights_kernel(model, state_iter)
+            load_weights_kernel(model, self.nccl_broadcast_receiver.receive_state_dict())
             update_mla_absorbed_weights(model)
-            return
-
-        load_weights_checkpoint_layerwise(
-            model,
-            state_iter,
-            self.model_runner.model_config,
-            self.vllm_config,
-        )
+        else:
+            for state_iter in self.nccl_broadcast_receiver.receive_state_dicts():
+                load_weights_checkpoint_layerwise(
+                    model,
+                    state_iter,
+                    self.model_runner.model_config,
+                    self.vllm_config,
+                )

--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -8,7 +8,7 @@ from vllm.distributed.utils import StatelessProcessGroup
 from vllm.logger import init_logger
 
 from prime_rl.inference.vllm.worker.weight_transfer import (
-    load_weights_checkpoint_layerwise,
+    load_weight_groups_checkpoint_layerwise,
     load_weights_kernel,
     update_mla_absorbed_weights,
 )
@@ -155,10 +155,9 @@ class NCCLWeightUpdateWorker(Worker):
             load_weights_kernel(model, self.nccl_broadcast_receiver.receive_state_dict())
             update_mla_absorbed_weights(model)
         else:
-            for state_iter in self.nccl_broadcast_receiver.receive_state_dicts():
-                load_weights_checkpoint_layerwise(
-                    model,
-                    state_iter,
-                    self.model_runner.model_config,
-                    self.vllm_config,
-                )
+            load_weight_groups_checkpoint_layerwise(
+                model,
+                self.nccl_broadcast_receiver.receive_state_dicts(),
+                self.model_runner.model_config,
+                self.vllm_config,
+            )

--- a/src/prime_rl/inference/vllm/worker/weight_transfer.py
+++ b/src/prime_rl/inference/vllm/worker/weight_transfer.py
@@ -16,11 +16,21 @@ def load_weights_checkpoint_layerwise(
     model_config,
     vllm_config,
 ) -> None:
+    load_weight_groups_checkpoint_layerwise(model, (state_iter,), model_config, vllm_config)
+
+
+def load_weight_groups_checkpoint_layerwise(
+    model: Module,
+    state_iters: Iterable[Iterable[tuple[str, torch.Tensor]]],
+    model_config,
+    vllm_config,
+) -> None:
     logger.info("Reloading checkpoint-format weights with vLLM layerwise processing")
     device = next(model.parameters()).device
     with torch.device(device), set_current_vllm_config(vllm_config):
         initialize_layerwise_reload(model)
-        model.load_weights(state_iter)  # type: ignore
+        for state_iter in state_iters:
+            model.load_weights(state_iter)  # type: ignore
         finalize_layerwise_reload(model, model_config)
 
 

--- a/tests/unit/inference/test_nccl_weight_update.py
+++ b/tests/unit/inference/test_nccl_weight_update.py
@@ -1,0 +1,15 @@
+from prime_rl.inference.vllm.worker import nccl
+
+
+def test_receiver_preserves_state_dict_boundaries(monkeypatch):
+    receiver = object.__new__(nccl.NCCLWeightBroadcastReceiver)
+    receiver.communicator = object()
+    streams = [iter([("layer.0", 0)]), iter([("layer.1", 1)])]
+
+    monkeypatch.setattr(nccl, "receive_integer", lambda _communicator: len(streams))
+    monkeypatch.setattr(nccl, "receive_state_dict", lambda _communicator: streams.pop(0))
+
+    assert [list(stream) for stream in receiver.receive_state_dicts()] == [
+        [("layer.0", 0)],
+        [("layer.1", 1)],
+    ]

--- a/tests/unit/inference/test_nccl_weight_update.py
+++ b/tests/unit/inference/test_nccl_weight_update.py
@@ -1,4 +1,8 @@
-from prime_rl.inference.vllm.worker import nccl
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from prime_rl.inference.vllm.worker import nccl, weight_transfer
 
 
 def test_receiver_preserves_state_dict_boundaries(monkeypatch):
@@ -12,4 +16,33 @@ def test_receiver_preserves_state_dict_boundaries(monkeypatch):
     assert [list(stream) for stream in receiver.receive_state_dicts()] == [
         [("layer.0", 0)],
         [("layer.1", 1)],
+    ]
+
+
+def test_layerwise_reload_brackets_all_state_dict_groups(monkeypatch):
+    events = []
+    model = Mock()
+    model.parameters.return_value = iter([SimpleNamespace(device="cpu")])
+    model.load_weights.side_effect = lambda state_iter: events.append(("load", list(state_iter)))
+
+    monkeypatch.setattr(weight_transfer, "set_current_vllm_config", lambda _config: nullcontext())
+    monkeypatch.setattr(weight_transfer, "initialize_layerwise_reload", lambda _model: events.append("initialize"))
+    monkeypatch.setattr(
+        weight_transfer,
+        "finalize_layerwise_reload",
+        lambda _model, _model_config: events.append("finalize"),
+    )
+
+    weight_transfer.load_weight_groups_checkpoint_layerwise(
+        model,
+        [iter([("layer.0", 0)]), iter([("layer.1", 1)])],
+        model_config=object(),
+        vllm_config=object(),
+    )
+
+    assert events == [
+        "initialize",
+        ("load", [("layer.0", 0)]),
+        ("load", [("layer.1", 1)]),
+        "finalize",
     ]


### PR DESCRIPTION
## Summary

**Why:** Prime-RL broadcasts checkpoint weights in layer/state-dict groups. Flattening those groups before vLLM reloads them loses the checkpoint boundaries needed for correct reconstruction and can apply weights incorrectly.

**Changes:**

- preserve each received checkpoint state dict as a separate stream
- initialize and finalize vLLM's layerwise reload once while loading each group independently
- retain the existing flattened stream for kernel-format updates
- add regression coverage for grouped and ungrouped weight loading

## Scope

This is an independent correctness fix shared by native Prime-RL and external inference backends.

## Test plan

- `ruff check` on the changed NCCL worker and test
- `pytest -q tests/unit/inference/test_nccl_weight_update.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live inference weight-update paths over NCCL; the change is narrow and regression-tested but incorrect grouping would break model weights.
> 
> **Overview**
> Fixes checkpoint-format NCCL weight reloads by **not flattening** multiple trainer broadcasts into one tensor stream.
> 
> `NCCLWeightBroadcastReceiver` now exposes **`receive_state_dicts()`**, yielding one generator per layer broadcast, while **`receive_state_dict()`** still flattens streams for kernel-format loading. Non-quantized updates call **`load_weight_groups_checkpoint_layerwise`**, which runs vLLM’s **`initialize_layerwise_reload` / `finalize_layerwise_reload`** once and invokes **`model.load_weights`** separately for each group.
> 
> Adds unit tests that assert per-layer streams stay separate and that grouped reload runs init → multiple loads → finalize in order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cca92c5724bf8d29e4940ff93698e6f254a4bbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

