### PR TITLE
fix: count unscored reward components as zero in rollout metrics

### DIFF
--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -134,22 +134,40 @@ class TimingMetrics(StatGroup):
 
 class CustomMetrics(StatGroup):
     """Per-key ``Stat``s over a dynamic per-rollout dict attribute (env ``@metric``s or reward
-    components), each averaged over the rollouts that report the key. ``value`` extracts the
-    float from each entry (rewards are ``vf.Reward`` records; metrics are plain floats)."""
+    components), each over the rollouts that carry the key. Scoring seeds every expected key
+    with ``None`` before invoking it, so a ``None`` value means the signal never produced a
+    score: with ``unscored_as_zero`` (rewards) it counts as 0.0 — matching the scalar
+    ``reward``, which sums unscored components as 0 — without it (metrics) it is skipped and
+    the key averages over the rollouts that scored it. ``value`` extracts the float from each
+    scored entry (rewards are ``vf.Reward`` records; metrics are plain floats)."""
 
-    def __init__(self, rollouts: list[Rollout], attr: str, value: Callable[[Any], float] = float) -> None:
+    def __init__(
+        self,
+        rollouts: list[Rollout],
+        attr: str,
+        value: Callable[[Any], float] = float,
+        unscored_as_zero: bool = False,
+    ) -> None:
         super().__init__(rollouts)
         self.attr = attr
         self.value = value
+        self.unscored_as_zero = unscored_as_zero
 
     def stats(self) -> dict[str, Stat]:
         names = sorted({name for r in self.rollouts for name in getattr(r, self.attr)})
-        return {
-            name: Stat(
-                [self.value(getattr(r, self.attr)[name]) for r in self.rollouts if name in getattr(r, self.attr)]
-            )
-            for name in names
-        }
+        stats = {}
+        for name in names:
+            values = []
+            for r in self.rollouts:
+                scores = getattr(r, self.attr)
+                if name not in scores:
+                    continue
+                if scores[name] is not None:
+                    values.append(self.value(scores[name]))
+                elif self.unscored_as_zero:
+                    values.append(0.0)
+            stats[name] = Stat(values)
+        return stats
 
 
 class RolloutMetrics:
@@ -193,8 +211,9 @@ class RolloutMetrics:
     @property
     def rewards(self) -> CustomMetrics:
         """Per-component reward breakdown, keyed by name (each entry's weighted ``value``,
-        summed into the scalar ``reward``)."""
-        return CustomMetrics(self.rollouts, "rewards", value=lambda reward: reward.value)
+        summed into the scalar ``reward``). Unscored components count as 0.0 so the breakdown
+        stays consistent with ``reward`` when scoring fails."""
+        return CustomMetrics(self.rollouts, "rewards", value=lambda reward: reward.value, unscored_as_zero=True)
 
     # Boolean rate metrics (0/1 distributions — ``.mean()`` is the rate)
     @property

--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -136,38 +136,27 @@ class CustomMetrics(StatGroup):
     """Per-key ``Stat``s over a dynamic per-rollout dict attribute (env ``@metric``s or reward
     components), each over the rollouts that carry the key. Scoring seeds every expected key
     with ``None`` before invoking it, so a ``None`` value means the signal never produced a
-    score: with ``unscored_as_zero`` (rewards) it counts as 0.0 — matching the scalar
-    ``reward``, which sums unscored components as 0 — without it (metrics) it is skipped and
-    the key averages over the rollouts that scored it. ``value`` extracts the float from each
-    scored entry (rewards are ``vf.Reward`` records; metrics are plain floats)."""
+    score and counts as 0.0 — the ``effective`` subset excludes errored rollouts and gives the
+    clean means. ``value`` extracts the float from each scored entry (rewards are ``vf.Reward``
+    records; metrics are plain floats)."""
 
-    def __init__(
-        self,
-        rollouts: list[Rollout],
-        attr: str,
-        value: Callable[[Any], float] = float,
-        unscored_as_zero: bool = False,
-    ) -> None:
+    def __init__(self, rollouts: list[Rollout], attr: str, value: Callable[[Any], float] = float) -> None:
         super().__init__(rollouts)
         self.attr = attr
         self.value = value
-        self.unscored_as_zero = unscored_as_zero
 
     def stats(self) -> dict[str, Stat]:
         names = sorted({name for r in self.rollouts for name in getattr(r, self.attr)})
-        stats = {}
-        for name in names:
-            values = []
-            for r in self.rollouts:
-                scores = getattr(r, self.attr)
-                if name not in scores:
-                    continue
-                if scores[name] is not None:
-                    values.append(self.value(scores[name]))
-                elif self.unscored_as_zero:
-                    values.append(0.0)
-            stats[name] = Stat(values)
-        return stats
+        return {
+            name: Stat(
+                [
+                    self.value(scores[name]) if scores[name] is not None else 0.0
+                    for r in self.rollouts
+                    if name in (scores := getattr(r, self.attr))
+                ]
+            )
+            for name in names
+        }
 
 
 class RolloutMetrics:
@@ -211,9 +200,8 @@ class RolloutMetrics:
     @property
     def rewards(self) -> CustomMetrics:
         """Per-component reward breakdown, keyed by name (each entry's weighted ``value``,
-        summed into the scalar ``reward``). Unscored components count as 0.0 so the breakdown
-        stays consistent with ``reward`` when scoring fails."""
-        return CustomMetrics(self.rollouts, "rewards", value=lambda reward: reward.value, unscored_as_zero=True)
+        summed into the scalar ``reward``)."""
+        return CustomMetrics(self.rollouts, "rewards", value=lambda reward: reward.value)
 
     # Boolean rate metrics (0/1 distributions — ``.mean()`` is the rate)
     @property

--- a/tests/unit/orchestrator/test_metrics.py
+++ b/tests/unit/orchestrator/test_metrics.py
@@ -144,18 +144,19 @@ def test_nested_metrics_and_rewards():
     rollouts = [
         mk(metrics={"acc": 1.0}, rewards={"correct": vf.Reward(score=1.0), "format": vf.Reward(score=0.0)}),
         mk(metrics={"acc": 3.0, "fmt": 5.0}, rewards={"correct": vf.Reward(score=0.0), "format": vf.Reward(score=1.0)}),
-        # scoring failed after seeding: rewards count as 0.0, metrics stay averaged over scorers
+        # scoring failed after seeding: unscored (None) entries count as 0.0 on `all`
         mk(has_error=True, metrics={"acc": None}, rewards={"correct": None, "format": None}),
     ]
     rc = TrainRollouts(rollouts)
     m = rc.metrics
-    assert m.metrics["acc"].mean() == 2.0 and m.rewards["correct"].mean() == pytest.approx(1 / 3)
+    assert m.metrics["acc"].mean() == pytest.approx(4 / 3) and m.rewards["correct"].mean() == pytest.approx(1 / 3)
     out = m.to_wandb(prefix="train/agg", subset="all")
-    assert out["train/agg/all/metrics/acc/mean"] == 2.0  # unscored seed skipped, averaged over scorers
+    assert out["train/agg/all/metrics/acc/mean"] == pytest.approx(4 / 3)
     assert out["train/agg/all/metrics/fmt/mean"] == 5.0  # single reporter
-    assert out["train/agg/all/rewards/format/mean"] == pytest.approx(1 / 3)  # unscored seed counts as 0.0
+    assert out["train/agg/all/rewards/format/mean"] == pytest.approx(1 / 3)
     # effective drops the errored rollout, so its seeds don't dilute the effective means
     eff = rc.effective.metrics.to_wandb(prefix="train/agg", subset="effective")
+    assert eff["train/agg/effective/metrics/acc/mean"] == 2.0
     assert eff["train/agg/effective/rewards/format/mean"] == 0.5
     # cross-env agg: another env's unscored trace carries different keys, so it can't dilute these
     other = mk(env_name="other", has_error=True, rewards={"solved": None})

--- a/tests/unit/orchestrator/test_metrics.py
+++ b/tests/unit/orchestrator/test_metrics.py
@@ -144,13 +144,24 @@ def test_nested_metrics_and_rewards():
     rollouts = [
         mk(metrics={"acc": 1.0}, rewards={"correct": vf.Reward(score=1.0), "format": vf.Reward(score=0.0)}),
         mk(metrics={"acc": 3.0, "fmt": 5.0}, rewards={"correct": vf.Reward(score=0.0), "format": vf.Reward(score=1.0)}),
+        # scoring failed after seeding: rewards count as 0.0, metrics stay averaged over scorers
+        mk(has_error=True, metrics={"acc": None}, rewards={"correct": None, "format": None}),
     ]
-    m = TrainRollouts(rollouts).metrics
-    assert m.metrics["acc"].mean() == 2.0 and m.rewards["correct"].mean() == 0.5  # nested group access
+    rc = TrainRollouts(rollouts)
+    m = rc.metrics
+    assert m.metrics["acc"].mean() == 2.0 and m.rewards["correct"].mean() == pytest.approx(1 / 3)
     out = m.to_wandb(prefix="train/agg", subset="all")
-    assert out["train/agg/all/metrics/acc/mean"] == 2.0  # averaged over reporters
+    assert out["train/agg/all/metrics/acc/mean"] == 2.0  # unscored seed skipped, averaged over scorers
     assert out["train/agg/all/metrics/fmt/mean"] == 5.0  # single reporter
-    assert out["train/agg/all/rewards/format/mean"] == 0.5
+    assert out["train/agg/all/rewards/format/mean"] == pytest.approx(1 / 3)  # unscored seed counts as 0.0
+    # effective drops the errored rollout, so its seeds don't dilute the effective means
+    eff = rc.effective.metrics.to_wandb(prefix="train/agg", subset="effective")
+    assert eff["train/agg/effective/rewards/format/mean"] == 0.5
+    # cross-env agg: another env's unscored trace carries different keys, so it can't dilute these
+    other = mk(env_name="other", has_error=True, rewards={"solved": None})
+    agg = TrainRollouts(rollouts + [other]).metrics.to_wandb(prefix="train/agg", subset="all")
+    assert agg["train/agg/all/rewards/format/mean"] == pytest.approx(1 / 3)
+    assert agg["train/agg/all/rewards/solved/mean"] == 0.0
 
 
 def test_nested_timing():


### PR DESCRIPTION
## Summary

- Companion to PrimeIntellect-ai/verifiers#2235: scoring now seeds every expected reward/metric name with `None` before invoking it, so a scoring failure leaves seeded-unscored entries (`{"solved": null}`) instead of an empty dict.
- `CustomMetrics` counts unscored (`None`) reward and metric entries as 0.0. Previously scoring-failed traces silently dropped out of `all/rewards/<name>/mean` and `all/metrics/<name>/mean`, making the `all` subset collapse onto `effective` — while `all/reward/mean` counted the same traces as 0, so the views couldn't be reconciled. Now `all` is the raw view including failures as zeros, and `effective` (which excludes errored rollouts) is the clean view.
- Cross-env `agg` pools need no special handling: another env's unscored traces carry their own env's keys, so they can't dilute a different env's means.
- Bumps `deps/verifiers` to the seeding commit.

Uncovered on scaleswe_v1 SWE-bench Verified evals. Linear: [RES-1210](https://linear.app/primeintellect/issue/RES-1210/handle-empty-rewardmetric-traces-when-scoring-errors-occur)

## Breaking

- `{train,eval}/*/all/{rewards,metrics}/<name>/*` wandb series change meaning: traces whose scoring failed after seeding now count as 0.0 for each expected key (previously they were silently excluded, so `all` matched `effective`). `effective` subsets are unchanged.

## Verification

`uv run pytest tests/unit` passes against the bumped submodule; `test_nested_metrics_and_rewards` covers the new semantics (unscored entries → 0.0 in `all`, dropped from `effective`; cross-env isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the meaning of existing `all/{metrics,rewards}/<name>` wandb series (breaking for dashboards); logic is localized to aggregation but affects how eval/train metrics are interpreted.
> 
> **Overview**
> **`CustomMetrics`** now treats seeded-but-unscored entries (`None` in per-rollout `metrics` / `rewards` dicts) as **0.0** when building per-key means, instead of skipping those rollouts for that key.
> 
> That makes the **`all`** wandb slice include scoring-failed traces as zeros for each expected component, aligning with scalar **`all/reward/mean`** behavior. The **`effective`** subset is unchanged (errored rollouts are still excluded there).
> 
> Unit tests in **`test_nested_metrics_and_rewards`** were extended for errored rollouts with `None` seeds, **`effective`** means, and cross-env aggregation so unrelated env keys do not dilute another env’s component means.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc41c585d7b82e6bef5d8b467fa8296ceb1bdba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->