### PR TITLE
fix: standalone inference at dp=1 EP (template) + poolside_v1 tool-call regex

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -15,7 +15,6 @@ def apply_shared_vllm_patches():
     _patch_qwen35_moe_lora_format()
     monkey_patch_nano_v3_reasoning_parser()
     monkey_patch_qwen3_coder_param_newline_trim()
-    monkey_patch_poolside_v1_tool_call_name_boundary()
     monkey_patch_minimax_m2_think_end_passthrough()
     monkey_patch_vllm_padded_input_scrub()
     monkey_patch_return_routed_experts_with_nixl_connector()
@@ -123,37 +122,6 @@ def monkey_patch_nano_v3_reasoning_parser():
             return reasoning_content, final_content
 
     ReasoningParserManager.register_module("nano_v3", module=NanoV3ReasoningParser)
-
-
-def monkey_patch_poolside_v1_tool_call_name_boundary():
-    """Accept ``<tool_call>name<arg_key>`` without a newline in poolside_v1.
-
-    Laguna S 2.1 emits tool calls with no newline between the function name
-    and the first ``<arg_key>``; this vLLM's non-streaming
-    ``func_detail_regex`` requires ``name\\n`` (upstream vLLM >=0.25 accepts
-    both), so every tool call fails detail parsing and leaks verbatim into
-    ``content``. The streaming path already treats ``<arg_key>`` and
-    ``</tool_call>`` as name terminators. Only the regex changes: the name
-    group stops at ``<`` or a newline, and ``\\s*`` covers the optional
-    newline.
-    """
-    import re
-
-    from vllm.tool_parsers import poolside_v1_tool_parser as poolside
-
-    parser_cls = poolside.PoolsideV1ToolParser
-    original_init = parser_cls.__init__
-    if getattr(original_init, "_prime_rl_name_boundary", False):
-        return
-
-    def _patched_init(self, *args, **kwargs):
-        original_init(self, *args, **kwargs)
-        ## START PATCHED CODE (upstream: r"<tool_call>([^\n]*)\n(.*)</tool_call>")
-        self.func_detail_regex = re.compile(r"<tool_call>\s*([^\n<]*)\s*(.*)</tool_call>", re.DOTALL)
-        ## END PATCHED CODE
-
-    _patched_init._prime_rl_name_boundary = True
-    parser_cls.__init__ = _patched_init
 
 
 def monkey_patch_qwen3_coder_param_newline_trim():

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -15,6 +15,7 @@ def apply_shared_vllm_patches():
     _patch_qwen35_moe_lora_format()
     monkey_patch_nano_v3_reasoning_parser()
     monkey_patch_qwen3_coder_param_newline_trim()
+    monkey_patch_poolside_v1_tool_call_name_boundary()
     monkey_patch_minimax_m2_think_end_passthrough()
     monkey_patch_vllm_padded_input_scrub()
     monkey_patch_return_routed_experts_with_nixl_connector()
@@ -122,6 +123,37 @@ def monkey_patch_nano_v3_reasoning_parser():
             return reasoning_content, final_content
 
     ReasoningParserManager.register_module("nano_v3", module=NanoV3ReasoningParser)
+
+
+def monkey_patch_poolside_v1_tool_call_name_boundary():
+    """Accept ``<tool_call>name<arg_key>`` without a newline in poolside_v1.
+
+    Laguna S 2.1 emits tool calls with no newline between the function name
+    and the first ``<arg_key>``; this vLLM's non-streaming
+    ``func_detail_regex`` requires ``name\\n`` (upstream vLLM >=0.25 accepts
+    both), so every tool call fails detail parsing and leaks verbatim into
+    ``content``. The streaming path already treats ``<arg_key>`` and
+    ``</tool_call>`` as name terminators. Only the regex changes: the name
+    group stops at ``<`` or a newline, and ``\\s*`` covers the optional
+    newline.
+    """
+    import re
+
+    from vllm.tool_parsers import poolside_v1_tool_parser as poolside
+
+    parser_cls = poolside.PoolsideV1ToolParser
+    original_init = parser_cls.__init__
+    if getattr(original_init, "_prime_rl_name_boundary", False):
+        return
+
+    def _patched_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        ## START PATCHED CODE (upstream: r"<tool_call>([^\n]*)\n(.*)</tool_call>")
+        self.func_detail_regex = re.compile(r"<tool_call>\s*([^\n<]*)\s*(.*)</tool_call>", re.DOTALL)
+        ## END PATCHED CODE
+
+    _patched_init._prime_rl_name_boundary = True
+    parser_cls.__init__ = _patched_init
 
 
 def monkey_patch_qwen3_coder_param_newline_trim():

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -329,10 +329,14 @@ srun --kill-on-bad-exit=1 bash -c '
     for ((d=0; d<DP_PER_NODE; d++)); do
         RANK_GPUS=$(seq -s, $((d * TP)) $((d * TP + TP - 1)))
         RANK_LOG=$(rank_log "$INFER_NODE_RANK" "$d")
-        if [ "$EP" -eq 1 ]; then
+        if [ "$EP" -eq 1 ] && [ "$DP_PER_NODE" -gt 1 ]; then
             RANK_EXTRA="{\"data_parallel_rank\": $d, \"data_parallel_address\": \"$LOCAL_IP\"}"
             launch_inference_rank "$((BACKEND_PORT + d))" "$RANK_GPUS" "$DP_PER_NODE" "$RPC_PORT" "$RANK_EXTRA" "" "$RANK_LOG"
         else
+            # Dense or single-DP-rank EP (dp=1, e.g. EP within one tp=8 group):
+            # independent single-engine servers. vLLM rejects the external-LB DP
+            # args when data_parallel_size == 1; enable_expert_parallel in the
+            # inference config alone shards experts across the TP group.
             launch_inference_rank "$((BACKEND_PORT + d))" "$RANK_GPUS" 1 "" "" "" "$RANK_LOG"
         fi
     done


### PR DESCRIPTION
Same bug as #3094, same fix, in the sibling template: the multi-node branch of `inference.sbatch.j2` still passes the external-LB DP args (`data_parallel_rank`/`data_parallel_address`) when `dp_per_node == 1` (e.g. `tp = 8` on 8-GPU nodes), which vLLM ≥0.24 rejects at startup with `data_parallel_external_lb can only be set when data_parallel_size > 1`. #3094 guarded this in `multi_node_rl.sbatch.j2` only.

Hit in practice by the research-prod `int5/inference/{super,ultra}.toml` deployments (PrimeIntellect-ai/research-prod#158) at `num_nodes > 1`: every replica crash-looped on the ValidationError. With this guard, dp=1 EP replicas launch dense-style (EP shards experts across the TP group; no DP linkage needed), matching the RL template's behavior. Verified by relaunching both deployments at 2 and 4 replicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only launch-path change; aligns inference with the RL template and fixes crash-loops without altering training or auth paths.
> 
> **Overview**
> **Fixes multi-node standalone inference crash** when expert parallel is on but each node runs a single DP rank (`dp_per_node == 1`, e.g. `tp=8` on 8 GPUs).
> 
> The multi-node branch in `inference.sbatch.j2` now only passes `data_parallel_rank` / `data_parallel_address` when **both** `EP=1` and `DP_PER_NODE > 1`. Otherwise it launches a single-engine server with `data_parallel_size=1` and no external-LB JSON—matching the guard already added in `multi_node_rl.sbatch.j2` (#3094). vLLM ≥0.24 rejects external-LB when `data_parallel_size == 1`; EP within one TP group still comes from `enable_expert_parallel` in config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0620f22d571681ef318ee8e2389c0121fcd15fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->