### PR TITLE
add Laguna XS-2.1 SWE example

### DIFF
--- a/examples/advanced/laguna-xs-2.1/swe.toml
+++ b/examples/advanced/laguna-xs-2.1/swe.toml
@@ -1,0 +1,159 @@
+# Laguna XS-2.1 on ScaleSWE with the standard bash harness and pass@1
+# evaluation on SWE-Bench Verified.
+
+max_steps = 1000
+seq_len = 131072
+
+[env_vars]
+TRITON_CACHE_DIR = "/tmp/.triton-cache"
+
+[slurm]
+job_name = "laguna-xs21-swe"
+partition = "all"
+pre_run_command = 'timeout 120 prime sandbox delete --label "laguna-xs21-swe" -y || true'
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 2
+num_infer_nodes = 1
+num_infer_replicas = 4
+
+[wandb]
+project = "laguna-xs21-swe"
+name = "laguna-xs21-scaleswe"
+
+[weight_broadcast]
+type = "nccl"
+timeout = 3600
+
+[ckpt]
+interval = 25
+keep_last = 1
+resume_step = -1
+
+[model]
+name = "poolside/Laguna-XS-2.1"
+
+[trainer]
+dist_timeout_seconds = 3600
+enable_router_replay = true
+
+[trainer.model]
+impl = "custom"
+attn = "flash_attention_3"
+cp = 4
+cp_style = "ulysses"
+# torch.compile caused trainer ranks to enter mismatched MoE collectives and time out in NCCL.
+compile = "None"
+fused_lm_head_token_chunk_size = 1024
+optim_cpu_offload = true
+
+[trainer.model.ac]
+
+[trainer.model.ac_offloading]
+max_inflight_activations = 1
+
+[trainer.ckpt]
+skip_gather_master_weights = true
+skip_optimizer = true
+
+[trainer.optim]
+type = "muon"
+lr = 1e-6
+
+[orchestrator]
+batch_size = 256
+group_size = 16
+max_off_policy_steps = 32
+max_inflight_episodes = 768
+
+[orchestrator.algo]
+type = "grpo"
+
+[orchestrator.algo.length_penalty]
+type = "linear"
+num_output_tokens_weight = 0.0
+num_input_tokens_weight = 0.1
+num_turns_weight = 0.1
+
+[orchestrator.renderer]
+name = "laguna-xs-2.1"
+enable_thinking = true
+thinking_retention = "all"
+
+[orchestrator.train.sampling]
+temperature = 1.0
+max_completion_tokens = 32768
+extra_body = { top_k = 20, min_p = 0.0 }
+
+[[orchestrator.train.source]]
+name = "scaleswe"
+
+[orchestrator.train.source.env.taskset]
+id = "scaleswe-v1"
+
+[orchestrator.train.source.env.agent.harness]
+id = "bash"
+
+[orchestrator.train.source.env.agent.runtime]
+type = "prime"
+vm = true
+cpu = 1.0
+memory = 2.0
+disk = 5.0
+idle_timeout = "None"
+labels = ["laguna-xs21-swe"]
+
+[orchestrator.prime_monitor]
+
+[orchestrator.eval]
+interval = 20
+group_size = 1
+
+[orchestrator.eval.sampling]
+temperature = 1.0
+top_p = 1.0
+top_k = 20
+min_p = 0.0
+max_completion_tokens = 32768
+
+[[orchestrator.eval.source]]
+name = "swebench-verified"
+
+[orchestrator.eval.source.env.taskset]
+id = "swebench-verified-v1"
+
+[orchestrator.eval.source.env.agent.harness]
+id = "bash"
+
+[orchestrator.eval.source.env.agent.runtime]
+type = "prime"
+vm = true
+cpu = 1.0
+memory = 2.0
+disk = 5.0
+idle_timeout = "None"
+labels = ["laguna-xs21-swe"]
+
+[orchestrator.eval.source.env.agent.timeout]
+rollout = 3600
+
+[inference]
+enable_expert_parallel = false
+enable_return_routed_experts = true
+
+[inference.env_vars]
+VLLM_CACHE_ROOT = "/tmp/.vllm-cache"
+FLASHINFER_WORKSPACE_BASE = "/tmp/.flashinfer-cache"
+
+[inference.model]
+max_model_len = 131072
+tool_call_parser = "poolside_v1"
+reasoning_parser = "poolside_v1"
+
+[inference.parallel]
+tp = 8
+dp = 1
+
+[inference.vllm_extra]
+default_chat_template_kwargs = { enable_thinking = true }

--- a/examples/advanced/laguna-xs-2.1/swe.toml
+++ b/examples/advanced/laguna-xs-2.1/swe.toml
@@ -139,7 +139,7 @@ labels = ["laguna-xs21-swe"]
 rollout = 3600
 
 [inference]
-enable_expert_parallel = false
+enable_expert_parallel = true
 enable_return_routed_experts = true
 
 [inference.env_vars]

--- a/examples/advanced/laguna-xs-2.1/swe.toml
+++ b/examples/advanced/laguna-xs-2.1/swe.toml
@@ -43,10 +43,10 @@ impl = "custom"
 attn = "flash_attention_3"
 cp = 4
 cp_style = "ulysses"
-# torch.compile caused trainer ranks to enter mismatched MoE collectives and time out in NCCL.
-compile = "None"
 fused_lm_head_token_chunk_size = 1024
 optim_cpu_offload = true
+
+[trainer.model.compile]
 
 [trainer.model.ac]
 

--- a/examples/advanced/laguna-xs-2.1/swe.toml
+++ b/examples/advanced/laguna-xs-2.1/swe.toml
@@ -20,7 +20,7 @@ num_infer_replicas = 4
 
 [wandb]
 project = "laguna-xs21-swe"
-name = "laguna-xs21-scaleswe"
+name = "laguna-xs21-scaleswe-dep8"
 
 [weight_broadcast]
 type = "nccl"
@@ -152,8 +152,8 @@ tool_call_parser = "poolside_v1"
 reasoning_parser = "poolside_v1"
 
 [inference.parallel]
-tp = 8
-dp = 1
+tp = 1
+dp = 8
 
 [inference.vllm_extra]
 default_chat_template_kwargs = { enable_thinking = true }


### PR DESCRIPTION
## Summary

Add a standalone `poolside/Laguna-XS-2.1` RL example for ScaleSWE with online pass@1 evaluation on SWE-Bench Verified.

The example captures the tested setup:

- two trainer nodes and four single-node DEP8 inference groups (TP1, DP8, EP8)
- the Laguna XS-2.1 renderer and vLLM's built-in `poolside_v1` parsers
- vLLM expert parallel inference and routed-expert replay for MoE training
- the standard bash harness without a judge
- checkpointing every 25 steps and startup/every-20-step SWE-Bench Verified evaluation
- trainer compilation enabled following a successful five-step, two-node compiled trainer validation
- labeled Prime sandboxes with startup cleanup

This is based directly on current `main`, so it does not carry the earlier local parser workaround, old dependency pins, GLM configs, or cluster-specific node exclusions.

## Validation

- `uv run rl @ examples/advanced/laguna-xs-2.1/swe.toml --dry-run --output-dir <temp-dir>`
- `uv lock --check`
- built and installed the standalone `prime-rl-configs` wheel outside the workspace
- verified the slim install imports against `verifiers==0.2.2.dev76` and `vf.ServeConfig`
- `git diff --check`

The dry run generated trainer, orchestrator, inference, and Slurm configs successfully with throughput-oriented DEP8 inference and the 10,000-step CLI override. The external slim-wheel import reproducing the previous CI failure also passes. A compiled two-node, 16-GPU trainer run completed five steps on current main; step 1 took 2m17s and subsequent steps took 19–22s without NCCL errors.

## Historical trainer compilation failure

An earlier compiled trainer failed in Slurm job `1578` on 2026-08-01. The current config restores compilation after the two-node five-step validation described above. At sequence 3750, rank 0 entered FSDP `_REDUCE_SCATTER_BASE` while rank 1 (and ranks 2–7) entered Ulysses `ALLTOALL_BASE`. After the 3,600-second watchdog timeout, NCCL terminated the process group. The relevant rank-0 and rank-1 stderr is reproduced verbatim below.

<details>
<summary>Full NCCL collective-mismatch trace (job 1578)</summary>

```text
[rank0]:[E801 01:01:39.260111354 ProcessGroupNCCL.cpp:1849] [PG ID 0 PG GUID 0(default_pg) Rank 0] Observed flight recorder dump signal from another rank via TCPStore.
[rank0]:[E801 01:01:39.261254230 ProcessGroupNCCL.cpp:1914] [PG ID 0 PG GUID 0(default_pg) Rank 0] Received a dump signal due to a collective timeout from  rank 3 and we will try our best to dump the debug info. Last enqueued NCCL work: 3751, last completed NCCL work: 3749.This is most likely caused by incorrect usages of collectives, e.g., wrong sizes used across ranks, the order of collectives is not same for all ranks or the scheduled collective, for some reason, didn't run. Additionally, this can be caused by GIL deadlock or other reasons such as network errors or bugs in the communications library (e.g. NCCL), etc.
[rank0]:[E801 01:01:39.262164320 ProcessGroupNCCL.cpp:1628] [PG ID 0 PG GUID 0(default_pg) Rank 0] ProcessGroupNCCL preparing to dump debug info. Include stack trace: 1, only active collectives: 0
[rank0]:[E801 01:01:40.633196518 ProcessGroupNCCL.cpp:689] [Rank 0] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=3750, OpType=_REDUCE_SCATTER_BASE, NumelIn=79794432, NumelOut=9974304, Timeout(ms)=3600000) ran for 3600097 milliseconds before timing out.
[rank0]:[E801 01:01:40.633637525 ProcessGroupNCCL.cpp:2303] [PG ID 0 PG GUID 0(default_pg) Rank 0]  failure detected by watchdog at work sequence id: 3750 PG status: last enqueued work: 3751, last completed work: 3749
[rank0]:[E801 01:01:40.634292450 ProcessGroupNCCL.cpp:733] Stack trace of the failed collective:
#0 reduce_scatter_tensor from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py:4652
#1 wrapper from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/distributed/c10d_logger.py:83
#2 __call__ from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py:125
#3 foreach_reduce from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py:544
#4 decorate_context from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py:124
#5 post_backward from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py:567
#6 backward from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py:902
#7 apply from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/autograd/function.py:317

[rank1]:[E801 01:01:39.674967915 ProcessGroupNCCL.cpp:689] [Rank 1] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=3750, OpType=ALLTOALL_BASE, NumelIn=201222144, NumelOut=201222144, Timeout(ms)=3600000) ran for 3600041 milliseconds before timing out.
[rank1]:[E801 01:01:39.675356666 ProcessGroupNCCL.cpp:2303] [PG ID 0 PG GUID 0(default_pg) Rank 1]  failure detected by watchdog at work sequence id: 3750 PG status: last enqueued work: 3755, last completed work: 3749
[rank1]:[E801 01:01:39.676667143 ProcessGroupNCCL.cpp:733] Stack trace of the failed collective:
#0 all_to_all_single from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py:4829
#1 wrapper from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/distributed/c10d_logger.py:83
#2 forward from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/distributed/nn/functional.py:430
#3 apply from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/autograd/function.py:596
#4 backward from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/distributed/nn/functional.py:446
#5 apply from /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/autograd/function.py:317

[rank1]:[E801 01:01:39.677080285 ProcessGroupNCCL.cpp:2636] [PG ID 0 PG GUID 0(default_pg) Rank 1] First PG on this rank to signal dumping.
[rank1]:[E801 01:01:39.254662130 ProcessGroupNCCL.cpp:1914] [PG ID 0 PG GUID 0(default_pg) Rank 1] Received a dump signal due to a collective timeout from this local rank and we will try our best to dump the debug info. Last enqueued NCCL work: 3755, last completed NCCL work: 3749.This is most likely caused by incorrect usages of collectives, e.g., wrong sizes used across ranks, the order of collectives is not same for all ranks or the scheduled collective, for some reason, didn't run. Additionally, this can be caused by GIL deadlock or other reasons such as network errors or bugs in the communications library (e.g. NCCL), etc.
[rank1]:[E801 01:01:39.255294610 ProcessGroupNCCL.cpp:1628] [PG ID 0 PG GUID 0(default_pg) Rank 1] ProcessGroupNCCL preparing to dump debug info. Include stack trace: 1, only active collectives: 0
[rank1]:[E801 01:02:40.569782119 ProcessGroupNCCL.cpp:750] [Rank 1] Some NCCL operations have failed or timed out. Due to the asynchronous nature of CUDA kernels, subsequent GPU operations might run on corrupted/incomplete data.
[rank1]:[E801 01:02:40.569994989 ProcessGroupNCCL.cpp:764] [Rank 1] To avoid data inconsistency, we are taking the entire process down.
[rank1]:[E801 01:02:40.571318176 ProcessGroupNCCL.cpp:2119] [PG ID 0 PG GUID 0(default_pg) Rank 1] Process group watchdog thread terminated with exception: [Rank 1] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=3750, OpType=ALLTOALL_BASE, NumelIn=201222144, NumelOut=201222144, Timeout(ms)=3600000) ran for 3600041 milliseconds before timing out.
Exception raised from checkTimeout at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:692 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x9d (0x738bc797205d in /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/lib/libc10.so)
frame #1: c10d::ProcessGroupNCCL::WorkNCCL::checkTimeout(std::optional<std::chrono::duration<long, std::ratio<1l, 1000l> > >) + 0x2a7 (0x738af353fd87 in /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so)
frame #2: c10d::ProcessGroupNCCL::Watchdog::runLoop() + 0x17b1 (0x738af35451a1 in /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so)
frame #3: c10d::ProcessGroupNCCL::Watchdog::run() + 0x157 (0x738af3546597 in /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so)
frame #4: <unknown function> + 0xecdb4 (0x738c0c376db4 in /lib/x86_64-linux-gnu/libstdc++.so.6)
frame #5: <unknown function> + 0x9caa4 (0x738c0ee54aa4 in /lib/x86_64-linux-gnu/libc.so.6)
frame #6: <unknown function> + 0x129c6c (0x738c0eee1c6c in /lib/x86_64-linux-gnu/libc.so.6)

terminate called after throwing an instance of 'c10::DistBackendError'
  what():  [PG ID 0 PG GUID 0(default_pg) Rank 1] Process group watchdog thread terminated with exception: [Rank 1] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=3750, OpType=ALLTOALL_BASE, NumelIn=201222144, NumelOut=201222144, Timeout(ms)=3600000) ran for 3600041 milliseconds before timing out.
Exception raised from checkTimeout at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:692 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x9d (0x738bc797205d in /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/lib/libc10.so)
frame #1: c10d::ProcessGroupNCCL::WorkNCCL::checkTimeout(std::optional<std::chrono::duration<long, std::ratio<1l, 1000l> > >) + 0x2a7 (0x738af353fd87 in /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so)
frame #2: c10d::ProcessGroupNCCL::Watchdog::runLoop() + 0x17b1 (0x738af35451a1 in /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so)
frame #3: c10d::ProcessGroupNCCL::Watchdog::run() + 0x157 (0x738af3546597 in /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so)
frame #4: <unknown function> + 0xecdb4 (0x738c0c376db4 in /lib/x86_64-linux-gnu/libstdc++.so.6)
frame #5: <unknown function> + 0x9caa4 (0x738c0ee54aa4 in /lib/x86_64-linux-gnu/libc.so.6)
frame #6: <unknown function> + 0x129c6c (0x738c0eee1c6c in /lib/x86_64-linux-gnu/libc.so.6)

Exception raised from run at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:2125 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x9d (0x738bc797205d in /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/lib/libc10.so)
frame #1: <unknown function> + 0x9b5d75 (0x738af2da6d75 in /home/daniel/git/prime-rl-laguna-xs21/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so)
frame #2: <unknown function> + 0xecdb4 (0x738c0c376db4 in /lib/x86_64-linux-gnu/libstdc++.so.6)
frame #3: <unknown function> + 0x9caa4 (0x738c0ee54aa4 in /lib/x86_64-linux-gnu/libc.so.6)
frame #4: <unknown function> + 0x129c6c (0x738c0eee1c6c in /lib/x86_64-linux-gnu/libc.so.6)
```

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition of an example TOML; no runtime, library, or training code paths change.
> 
> **Overview**
> Adds **`examples/advanced/laguna-xs-2.1/swe.toml`**, a runnable recipe for **GRPO** on **ScaleSWE** with **`poolside/Laguna-XS-2.1`**, using the **bash** harness and **pass@1** eval on **SWE-Bench Verified** every 20 steps.
> 
> The config wires a **2-node trainer** (Ulysses CP=4, Muon, router replay, compile + activation checkpointing/offload) to **four inference replicas** at **DP8** with **expert parallel** and **routed-expert return** for MoE training. Orchestration uses the **laguna-xs-2.1** renderer with thinking enabled, Prime sandboxes labeled **`laguna-xs21-swe`** (with Slurm pre-run cleanup), and vLLM **`poolside_v1`** tool/reasoning parsers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5e6abfab9f2479efc6c82220525d1348bb3db3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

