### PR TITLE
feat(inference): add minimal Dynamo filesystem integration

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Annotated, Literal, TypeAlias
+from typing import Annotated, Literal, Self, TypeAlias
 
 from pydantic import AfterValidator, Field, model_validator
 
@@ -144,16 +144,37 @@ class ClientConfig(BaseConfig):
     admin_base_url: list[str] | None = None
     """Separate base URLs for admin operations (weight updates, health checks). When set, admin clients bypass routers and hit each server directly — used in disaggregated P/D deployments where the router must not handle admin traffic."""
 
+    dynamo_discovery_url: str | None = None
+    """Dynamo frontend URL used to discover direct vLLM admin endpoints from ``/v1/rl/workers``."""
+
+    dynamo_expected_world_size: int | None = Field(None, ge=1)
+    """Expected total vLLM world size reported by Dynamo discovery."""
+
     elastic: ElasticConfig | None = None
     """Elastic inference pool config for DNS-based service discovery. When set, ``base_url`` is ignored and inference servers are discovered dynamically via DNS."""
 
     router_url: str | None = None
     """vllm-router URL for load-aware inference routing. With elastic mode, inference requests go through the router while admin ops still hit discovered pods directly."""
 
+    @model_validator(mode="after")
+    def validate_pool_mode(self) -> Self:
+        if self.dynamo_discovery_url is not None and self.admin_base_url is not None:
+            raise ValueError("dynamo_discovery_url cannot be combined with admin_base_url")
+        if self.dynamo_discovery_url is not None and self.elastic is not None:
+            raise ValueError("dynamo_discovery_url cannot be combined with elastic discovery")
+        if self.dynamo_discovery_url is not None and self.dynamo_expected_world_size is None:
+            raise ValueError("dynamo_expected_world_size is required with dynamo_discovery_url")
+        return self
+
     @property
     def is_elastic(self) -> bool:
         """Check if elastic mode is enabled."""
         return self.elastic is not None
+
+    @property
+    def is_dynamo(self) -> bool:
+        """Check if Dynamo worker discovery is enabled."""
+        return self.dynamo_discovery_url is not None
 
 
 class LogConfig(BaseConfig):

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -122,6 +122,8 @@ class StaticInferencePool:
         train_client_type: str = "openai_chat_completions",
         eval_client_type: str = "openai_chat_completions",
         renderer_config: RendererConfig | None = None,
+        *,
+        admin_clients: list[AsyncClient] | None = None,
     ):
         renderer_model_name = model_name if train_client_type == "renderer" else None
         self._train_clients = setup_clients(
@@ -131,12 +133,12 @@ class StaticInferencePool:
             renderer_model_name=renderer_model_name,
         )
         self._eval_clients = setup_clients(client_config, client_type=eval_client_type)
-        self._admin_clients = setup_admin_clients(client_config)
+        self._admin_clients = setup_admin_clients(client_config) if admin_clients is None else admin_clients
         # When admin URLs bypass a router, also health-check the client-facing
         # (router) endpoint - it only starts serving once its workers are healthy.
         self._router_clients = (
             setup_admin_clients(client_config.model_copy(update={"admin_base_url": None}))
-            if client_config.admin_base_url
+            if client_config.admin_base_url or admin_clients is not None
             else []
         )
         self._skip_model_check = client_config.skip_model_check
@@ -199,6 +201,17 @@ async def setup_inference_pool(
         from prime_rl.utils.elastic import ElasticInferencePool
 
         return await ElasticInferencePool.from_config(
+            client_config,
+            model_name=model_name,
+            train_client_type=train_client_type,
+            eval_client_type=eval_client_type,
+            renderer_config=renderer_config,
+        )
+
+    if client_config.is_dynamo:
+        from prime_rl.utils.dynamo import DynamoInferencePool
+
+        return await DynamoInferencePool.from_config(
             client_config,
             model_name=model_name,
             train_client_type=train_client_type,
@@ -396,6 +409,8 @@ async def update_weights(
     weight_dir: Path | None,
     lora_name: str | None = None,
     step: int = 0,
+    *,
+    use_native_collective_rpc: bool = False,
 ) -> None:
     """Update weights on static inference servers.
 
@@ -425,12 +440,18 @@ async def update_weights(
                 nccl_ready_file.touch()
                 logger.debug(f"Created NCCL_READY marker at {nccl_ready_file}")
 
+            update_path = "/collective_rpc" if use_native_collective_rpc else "/update_weights"
+            payload = (
+                {"method": "update_weights_from_path", "args": [weight_dir_posix]}
+                if use_native_collective_rpc
+                else {"weight_dir": weight_dir_posix}
+            )
             await asyncio.gather(
                 *[
                     _admin_post(
                         admin_client,
-                        "/update_weights",
-                        json={"weight_dir": weight_dir_posix},
+                        update_path,
+                        json=payload,
                         timeout_s=UPDATE_WEIGHTS_TIMEOUT_S,
                     )
                     for admin_client in admin_clients

--- a/src/prime_rl/utils/dynamo.py
+++ b/src/prime_rl/utils/dynamo.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from tenacity import AsyncRetrying, retry_if_exception, stop_after_delay, wait_exponential
+
+from prime_rl.configs.shared import ClientConfig
+from prime_rl.utils.client import StaticInferencePool, setup_admin_clients, update_weights
+
+DYNAMO_RL_DISCOVERY_PROTOCOL_VERSION = 1
+DYNAMO_REQUEST_TIMEOUT_S = 30.0
+
+
+class DiscoveredDynamoWorker(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    component: str = Field(min_length=1)
+    instance_id: int = Field(ge=0, strict=True)
+    model: str
+    admin_base_url: str = Field(min_length=1)
+    world_size: int = Field(gt=0, strict=True)
+
+    @field_validator("admin_base_url")
+    @classmethod
+    def validate_admin_url(cls, value: str) -> str:
+        url = httpx.URL(value)
+        if url.scheme not in ("http", "https") or not url.host:
+            raise ValueError("admin_base_url must be an HTTP URL")
+        return value.rstrip("/")
+
+
+class DynamoDiscoverySnapshot(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    protocol_version: int = Field(
+        strict=True,
+        ge=DYNAMO_RL_DISCOVERY_PROTOCOL_VERSION,
+        le=DYNAMO_RL_DISCOVERY_PROTOCOL_VERSION,
+    )
+    workers: list[dict[str, Any]]
+
+
+class DynamoDiscoveryPending(ValueError):
+    """A valid discovery snapshot that is not complete yet."""
+
+
+def _is_retryable_dynamo_error(exception: BaseException) -> bool:
+    if isinstance(exception, httpx.HTTPStatusError):
+        return exception.response.status_code == 429 or exception.response.status_code >= 500
+    return isinstance(exception, (DynamoDiscoveryPending, httpx.TransportError))
+
+
+def _parse_dynamo_workers(payload: object, model_name: str) -> tuple[DiscoveredDynamoWorker, ...]:
+    snapshot = DynamoDiscoverySnapshot.model_validate(payload)
+    workers = []
+    for raw_worker in snapshot.workers:
+        if raw_worker.get("model") != model_name:
+            continue
+        if error := raw_worker.get("error"):
+            raise DynamoDiscoveryPending(f"Dynamo worker is not ready: {error}")
+        workers.append(DiscoveredDynamoWorker.model_validate(raw_worker))
+    if not workers:
+        raise DynamoDiscoveryPending(f"Dynamo has not discovered a worker for {model_name!r}")
+
+    identities = [(worker.component, worker.instance_id) for worker in workers]
+    admin_urls = [worker.admin_base_url for worker in workers]
+    if len(set(identities)) != len(identities):
+        raise ValueError("Dynamo discovery returned duplicate worker identities")
+    if len(set(admin_urls)) != len(admin_urls):
+        raise ValueError("Dynamo discovery returned duplicate admin endpoints")
+    return tuple(sorted(workers, key=lambda worker: (worker.component, worker.instance_id)))
+
+
+def _setup_control_clients(urls: list[str]) -> list[httpx.AsyncClient]:
+    return [
+        httpx.AsyncClient(
+            base_url=url,
+            limits=httpx.Limits(max_connections=4, max_keepalive_connections=1),
+            timeout=httpx.Timeout(None),
+        )
+        for url in urls
+    ]
+
+
+async def _wait_for_model(clients: list[httpx.AsyncClient], model_name: str, timeout: float) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    async with asyncio.timeout(timeout):
+        async for attempt in AsyncRetrying(
+            stop=stop_after_delay(timeout),
+            wait=wait_exponential(multiplier=0.1, min=0.1, max=1),
+            retry=retry_if_exception(_is_retryable_dynamo_error),
+            reraise=True,
+        ):
+            with attempt:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    raise TimeoutError
+                responses = await asyncio.gather(
+                    *(client.get("/v1/models", timeout=min(DYNAMO_REQUEST_TIMEOUT_S, remaining)) for client in clients)
+                )
+                for response in responses:
+                    response.raise_for_status()
+                    models = response.json().get("data", [])
+                    if not any(model.get("id") == model_name for model in models):
+                        raise DynamoDiscoveryPending(f"Dynamo frontend has not published {model_name!r}")
+
+
+class DynamoInferencePool(StaticInferencePool):
+    """Static request pool with direct vLLM admin endpoints discovered from Dynamo."""
+
+    def __init__(self, client_config: ClientConfig, workers: tuple[DiscoveredDynamoWorker, ...], **kwargs):
+        admin_clients = _setup_control_clients([worker.admin_base_url for worker in workers])
+        super().__init__(client_config, admin_clients=admin_clients, **kwargs)
+        self._readiness_deadline: float | None = None
+
+    async def wait_for_ready(self, model_name: str, timeout: int | None = None) -> None:
+        effective_timeout = self._wait_for_ready_timeout if timeout is None else timeout
+        loop = asyncio.get_running_loop()
+        deadline = (
+            self._readiness_deadline
+            if timeout is None and self._readiness_deadline is not None
+            else loop.time() + effective_timeout
+        )
+        remaining = max(0.0, deadline - loop.time())
+        try:
+            async with asyncio.timeout(remaining):
+                await super().wait_for_ready(model_name, timeout=remaining)
+                if not self._skip_model_check:
+                    await _wait_for_model(self._router_clients, model_name, max(0.0, deadline - loop.time()))
+        finally:
+            self._readiness_deadline = None
+
+    async def update_weights(self, weight_dir: Path | None, lora_name: str | None = None, step: int = 0) -> None:
+        await update_weights(
+            self._admin_clients,
+            weight_dir,
+            lora_name=lora_name,
+            step=step,
+            use_native_collective_rpc=True,
+        )
+
+    async def stop(self) -> None:
+        await super().stop()
+        await asyncio.gather(*(client.aclose() for client in [*self._admin_clients, *self._router_clients]))
+
+    @classmethod
+    async def from_config(cls, client_config: ClientConfig, model_name: str, **kwargs) -> DynamoInferencePool:
+        discovery_url = cast(str, client_config.dynamo_discovery_url).rstrip("/").removesuffix("/v1")
+        discovery_config = client_config.model_copy(
+            update={
+                "base_url": [discovery_url],
+                "admin_base_url": None,
+                "dynamo_discovery_url": None,
+            }
+        )
+        discovery_client = setup_admin_clients(discovery_config)[0]
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + client_config.wait_for_ready_timeout
+        expected_world_size = cast(int, client_config.dynamo_expected_world_size)
+        try:
+            async with asyncio.timeout(client_config.wait_for_ready_timeout):
+                async for attempt in AsyncRetrying(
+                    stop=stop_after_delay(client_config.wait_for_ready_timeout),
+                    wait=wait_exponential(multiplier=0.1, min=0.1, max=1),
+                    retry=retry_if_exception(_is_retryable_dynamo_error),
+                    reraise=True,
+                ):
+                    with attempt:
+                        remaining = deadline - loop.time()
+                        if remaining <= 0:
+                            raise TimeoutError
+                        response = await discovery_client.get(
+                            "/v1/rl/workers",
+                            timeout=min(DYNAMO_REQUEST_TIMEOUT_S, remaining),
+                        )
+                        response.raise_for_status()
+                        workers = _parse_dynamo_workers(response.json(), model_name)
+                        world_size = sum(worker.world_size for worker in workers)
+                        if world_size < expected_world_size:
+                            raise DynamoDiscoveryPending(
+                                f"Dynamo reported world_size={world_size}; waiting for world_size={expected_world_size}"
+                            )
+                        if world_size > expected_world_size:
+                            raise ValueError(
+                                f"Dynamo reported world_size={world_size}, expected world_size={expected_world_size}"
+                            )
+        finally:
+            await discovery_client.aclose()
+
+        pool = cls(client_config, workers, model_name=model_name, **kwargs)
+        pool._readiness_deadline = deadline
+        return pool

--- a/tests/unit/utils/test_client.py
+++ b/tests/unit/utils/test_client.py
@@ -1,12 +1,19 @@
 import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx
+import pytest
 from verifiers.v1.configs.client import EvalClientConfig
 
 from prime_rl.configs.shared import ClientConfig
-from prime_rl.utils.client import _is_retryable_lora_error, check_health, load_lora_adapter, setup_clients
+from prime_rl.utils.client import (
+    _is_retryable_lora_error,
+    check_health,
+    load_lora_adapter,
+    setup_clients,
+    update_weights,
+)
 
 
 def test_is_retryable_lora_error_returns_true_for_404():
@@ -122,4 +129,51 @@ def test_setup_clients_preserves_chat_client_defaults():
             base_url="http://worker-a:8000/v1",
             headers={},
         )
+    ]
+
+
+def test_update_weights_uses_native_collective_rpc_and_always_resumes(tmp_path):
+    admin_client = AsyncMock()
+    weight_dir = tmp_path / "weights"
+    post = AsyncMock()
+
+    async def fail_update(_client, path, **_kwargs):
+        if path == "/collective_rpc":
+            raise RuntimeError("update failed")
+
+    post.side_effect = fail_update
+    with patch("prime_rl.utils.client._admin_post", post):
+        with pytest.raises(RuntimeError, match="update failed"):
+            asyncio.run(update_weights([admin_client], weight_dir, step=2, use_native_collective_rpc=True))
+
+    assert (weight_dir / "NCCL_READY").is_file()
+    assert post.await_args_list == [
+        call(admin_client, "/pause", params={"mode": "keep", "clear_cache": "false"}),
+        call(
+            admin_client,
+            "/collective_rpc",
+            json={"method": "update_weights_from_path", "args": [weight_dir.as_posix()]},
+            timeout_s=720.0,
+        ),
+        call(admin_client, "/resume"),
+    ]
+
+
+def test_update_weights_preserves_legacy_endpoint(tmp_path):
+    admin_client = AsyncMock()
+    weight_dir = tmp_path / "weights"
+    post = AsyncMock()
+
+    with patch("prime_rl.utils.client._admin_post", post):
+        asyncio.run(update_weights([admin_client], weight_dir, step=2))
+
+    assert post.await_args_list == [
+        call(admin_client, "/pause", params={"mode": "keep", "clear_cache": "false"}),
+        call(
+            admin_client,
+            "/update_weights",
+            json={"weight_dir": weight_dir.as_posix()},
+            timeout_s=720.0,
+        ),
+        call(admin_client, "/resume"),
     ]

--- a/tests/unit/utils/test_dynamo.py
+++ b/tests/unit/utils/test_dynamo.py
@@ -1,0 +1,122 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from prime_rl.configs.shared import ClientConfig, ElasticConfig
+from prime_rl.utils.client import setup_inference_pool
+from prime_rl.utils.dynamo import DynamoDiscoveryPending, DynamoInferencePool, _parse_dynamo_workers
+
+MODEL = "Qwen/Qwen3-0.6B"
+
+
+def worker(**updates):
+    value = {
+        "component": "backend",
+        "instance_id": 10,
+        "model": MODEL,
+        "admin_base_url": "http://worker:8120",
+        "world_size": 1,
+    }
+    return {**value, **updates}
+
+
+def payload(*workers):
+    return {"protocol_version": 1, "workers": list(workers)}
+
+
+def response(body):
+    result = MagicMock()
+    result.raise_for_status = MagicMock()
+    result.json.return_value = body
+    return result
+
+
+def test_parse_workers_accepts_complete_snapshot_and_rejects_duplicates():
+    workers = _parse_dynamo_workers(payload(worker()), MODEL)
+    assert [(item.admin_base_url, item.world_size) for item in workers] == [("http://worker:8120", 1)]
+
+    with pytest.raises(ValueError, match="duplicate"):
+        _parse_dynamo_workers(payload(worker(), worker(instance_id=11)), MODEL)
+
+
+def test_parse_workers_treats_missing_model_as_pending():
+    with pytest.raises(DynamoDiscoveryPending):
+        _parse_dynamo_workers(payload(worker(model=None)), MODEL)
+
+
+@pytest.mark.parametrize(
+    "conflict",
+    [
+        {"admin_base_url": ["http://worker:8120"]},
+        {"elastic": ElasticConfig(hostname="workers")},
+    ],
+)
+def test_discovery_config_rejects_other_pool_modes(conflict):
+    with pytest.raises(ValueError, match="dynamo_discovery_url"):
+        ClientConfig(dynamo_discovery_url="http://frontend:8001", dynamo_expected_world_size=1, **conflict)
+
+
+def test_discovery_config_requires_expected_world_size():
+    with pytest.raises(ValueError, match="dynamo_expected_world_size"):
+        ClientConfig(dynamo_discovery_url="http://frontend:8001")
+
+
+def test_discovery_retries_until_expected_world_size_is_complete():
+    discovery_client = AsyncMock()
+    discovery_client.get.side_effect = [
+        response(payload()),
+        response(payload(worker())),
+    ]
+
+    class DiscoveryOnlyPool(DynamoInferencePool):
+        def __init__(self, _config, workers, **_kwargs):
+            self.workers = workers
+
+    with patch("prime_rl.utils.dynamo.setup_admin_clients", return_value=[discovery_client]):
+        pool = asyncio.run(
+            DiscoveryOnlyPool.from_config(
+                ClientConfig(
+                    base_url=["http://frontend:8000/v1"],
+                    dynamo_discovery_url="http://frontend:8001",
+                    dynamo_expected_world_size=1,
+                    wait_for_ready_timeout=1,
+                ),
+                model_name=MODEL,
+            )
+        )
+
+    assert discovery_client.get.await_count == 2
+    assert pool.workers[0].admin_base_url == "http://worker:8120"
+
+
+def test_setup_inference_pool_selects_dynamo_pool():
+    config = ClientConfig(
+        base_url=["http://frontend:8000/v1"],
+        dynamo_discovery_url="http://frontend:8001",
+        dynamo_expected_world_size=1,
+    )
+    expected = MagicMock()
+    with patch("prime_rl.utils.dynamo.DynamoInferencePool.from_config", new=AsyncMock(return_value=expected)):
+        pool = asyncio.run(setup_inference_pool(config, model_name=MODEL))
+
+    assert pool is expected
+
+
+def test_discovered_admin_clients_do_not_inherit_frontend_credentials(monkeypatch):
+    monkeypatch.setenv("PRIME_API_KEY", "frontend-token")
+    config = ClientConfig(
+        base_url=["http://frontend:8000/v1"],
+        api_key_var="PRIME_API_KEY",
+        headers={"X-Frontend-Secret": "secret"},
+        dynamo_discovery_url="http://frontend:8001",
+        dynamo_expected_world_size=1,
+    )
+    pool = DynamoInferencePool(config, _parse_dynamo_workers(payload(worker()), MODEL), model_name=MODEL)
+
+    assert "X-Frontend-Secret" not in pool.admin_clients[0].headers
+    assert "Authorization" not in pool.admin_clients[0].headers
+    assert pool._router_clients[0].headers["X-Frontend-Secret"] == "secret"
+    assert pool._router_clients[0].headers["Authorization"] == "Bearer frontend-token"
+
+    asyncio.run(pool.stop())


### PR DESCRIPTION
## Summary

- add an opt-in Dynamo discovery URL and an expected-world-size startup fence
- discover native vLLM admin endpoints through /v1/rl/workers while generation continues through the configured frontend
- verify worker and frontend model readiness before the inference pool becomes ready
- translate filesystem weight updates to native vLLM collective_rpc update_weights_from_path calls
- preserve the existing static, elastic, and Python-vLLM request paths when Dynamo discovery is not configured

## Why

Prime-RL already owns filesystem checkpoint publication and pause/update/resume ordering. A sidecar deployment therefore only needs a small adapter that discovers worker control endpoints and selects the native filesystem update request. Keeping this at the existing inference-client boundary avoids new trainer, orchestrator, deployment, and vLLM-plugin abstractions.

## Deliberate scope

This PR supports one aggregated DP1 worker with full shared-filesystem weight updates. NCCL, NIXL, TP/PP/DP/EP rank mapping, LoRA lifecycle, Helm changes, and model recipes are intentionally separate follow-ups.

## Validation

- 19 focused client/discovery tests pass on CPU and in the GPU image
- Ruff and git diff checks pass
- signed commit is based directly on current upstream main 756f217f
- local two-GPU Qwen3-0.6B Math run completed three steps, native reloads, and post-update generation
- bis-rl-3 Kubernetes run q06min-0804t0214 completed three steps; DGD successful, trainer exit 0, zero restarts, three native reloads, and post-update generation through the frontend Service

The repository-wide config-loader matrix was not used as a patch gate because this environment does not contain its external taskset packages; directly affected tests and both end-to-end gates passed.