### PR TITLE
feat(trainer): add Bradley-Terry reward-model training

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ End-to-end usage examples for prime-rl, referenced from the top-level [README](.
   - `wiki-search` — multi-turn tool calling, LoRA
   - `wordle` — multi-turn (~6-turn games)
   - `hendrycks-sanity` — single-turn math, long-running
+- **[`reward_model/`](reward_model)** — Bradley–Terry pairwise reward-model training, including a Qwen3-0.6B capitalization sanity check.
 - **[`advanced/`](advanced)** — larger, mostly multi-node runs on frontier models, one folder
   per model: `qwen3-30b-a3b` (math/swe/tool), `glm-4.5-air` (search/swe/terminal), `glm-5.2`
   (large-scale + PD-disaggregated inference), `minimax-m2.5` (swe), `nemotron-3-super` (swe),

--- a/examples/reward_model/capitalization/README.md
+++ b/examples/reward_model/capitalization/README.md
@@ -1,0 +1,18 @@
+# Bradley–Terry reward-model sanity check
+
+This example verifies that the reward-model trainer can learn an intentionally trivial preference: capitalized audit labels are chosen over otherwise identical fully lowercase responses.
+
+Generate the deterministic local JSONL files and train Qwen3-0.6B:
+
+```bash
+uv run python examples/reward_model/capitalization/make_data.py
+uv run reward-model @ examples/reward_model/capitalization/reward_model.toml
+```
+
+Bradley–Terry datasets use three fields. Each value may be a string or an OpenAI-style message list:
+
+```json
+{"prompt": [{"role": "user", "content": "State the label."}], "chosen": [{"role": "assistant", "content": "PASS"}], "rejected": [{"role": "assistant", "content": "pass"}]}
+```
+
+The trainer renders the chosen and rejected conversations independently, obtains one scalar reward per sequence, and minimizes `-log sigmoid(reward_chosen - reward_rejected)`. Validation reports loss, pairwise accuracy, and mean reward margin.

--- a/examples/reward_model/capitalization/make_data.py
+++ b/examples/reward_model/capitalization/make_data.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+LABELS = [
+    "SITUATIONAL GROUNDING",
+    "CONCRETE TASK PROGRESS",
+    "EVIDENCE DISCIPLINE",
+    "NO OBVIOUS ISSUES",
+    "NEEDS REVIEW",
+    "PASS",
+    "FAIL",
+    "TRUE",
+    "FALSE",
+    "SUPPORTED",
+    "UNSUPPORTED",
+    "INCONCLUSIVE",
+]
+TEMPLATES = [
+    "Audit label: {label}",
+    "Final judgment: {label}",
+    "Selected category: {label}",
+    "Rubric result: {label}",
+    "The applicable label is {label}.",
+    "My determination is {label}.",
+    "Recorded outcome: {label}",
+    "Classification: {label}",
+]
+
+
+def rows(offset: int, count: int):
+    for index in range(offset, offset + count):
+        label = LABELS[index % len(LABELS)]
+        response = TEMPLATES[(index // len(LABELS)) % len(TEMPLATES)].format(label=label)
+        yield {
+            "prompt": [{"role": "user", "content": "State the selected audit label exactly."}],
+            "chosen": [{"role": "assistant", "content": response}],
+            "rejected": [{"role": "assistant", "content": response.lower()}],
+        }
+
+
+root = Path(__file__).parent
+for name, offset, count in (("train", 0, 96), ("validation", 96, 48)):
+    with (root / f"{name}.jsonl").open("w") as file:
+        for row in rows(offset, count):
+            file.write(json.dumps(row) + "\n")

--- a/examples/reward_model/capitalization/reward_model.toml
+++ b/examples/reward_model/capitalization/reward_model.toml
@@ -1,0 +1,56 @@
+output_dir = "outputs/qwen3-0.6b-capitalization-rm"
+clean_output_dir = true
+max_steps = 30
+
+[model]
+name = "Qwen/Qwen3-0.6B"
+impl = "hf"
+attn = "flash_attention_2"
+
+[tokenizer]
+name = "Qwen/Qwen3-0.6B"
+
+[renderer]
+name = "qwen3"
+
+[data]
+type = "bradley_terry"
+name = "examples/reward_model/capitalization/train.jsonl"
+seq_len = 96
+batch_size = 16
+micro_batch_size = 4
+shuffle = true
+seed = 42
+
+[val]
+interval = 5
+eval_on_start = true
+
+[val.data]
+type = "bradley_terry"
+name = "examples/reward_model/capitalization/validation.jsonl"
+seq_len = 96
+batch_size = 16
+micro_batch_size = 8
+shuffle = false
+
+[optim]
+type = "adamw"
+lr = 2e-5
+weight_decay = 0.0
+max_norm = 1.0
+
+[scheduler]
+type = "constant"
+
+[deployment]
+type = "single_node"
+num_gpus = 1
+
+[ckpt]
+weights_only = true
+keep_last = 1
+
+[ckpt.weights]
+save_sharded = false
+save_format = "safetensors"

--- a/packages/prime-rl-configs/src/prime_rl/configs/reward_model.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/reward_model.py
@@ -1,0 +1,66 @@
+from typing import Literal
+
+from pydantic import Field, model_validator
+from renderers import AutoRendererConfig, RendererConfig
+
+from prime_rl.configs.sft import SFTConfig, SingleNodeDeploymentConfig
+from prime_rl.configs.trainer import AdamWConfig, ConstantSchedulerConfig, ModelConfig, OptimizerConfig, SchedulerConfig
+from prime_rl.utils.config import BaseConfig
+
+
+class BradleyTerryDataConfig(BaseConfig):
+    type: Literal["bradley_terry"] = "bradley_terry"
+    name: str
+    """Hugging Face dataset name or local JSON/JSONL path."""
+
+    split: str = "train"
+    batch_size: int = Field(128, ge=1)
+    """Global number of Bradley-Terry pairs per optimizer step."""
+
+    micro_batch_size: int = Field(1, ge=1)
+    """Bradley-Terry pairs per device forward pass."""
+
+    seq_len: int = Field(2048, ge=1)
+    shuffle: bool = True
+    seed: int = 0
+
+    @model_validator(mode="after")
+    def validate_batch_size(self):
+        if self.batch_size % self.micro_batch_size != 0:
+            raise ValueError("batch_size must be divisible by micro_batch_size")
+        return self
+
+
+class RewardModelValConfig(BaseConfig):
+    interval: int = Field(50, ge=1)
+    eval_on_start: bool = False
+    data: BradleyTerryDataConfig
+    """Validation data. ``micro_batch_size`` controls memory; the full split is evaluated."""
+
+
+class RewardModelConfig(SFTConfig):
+    model: ModelConfig = ModelConfig(impl="hf", attn="flash_attention_2")
+    renderer: RendererConfig = AutoRendererConfig()
+    data: BradleyTerryDataConfig
+    val: RewardModelValConfig | None = None
+    optim: OptimizerConfig = AdamWConfig()
+    scheduler: SchedulerConfig = ConstantSchedulerConfig()
+    deployment: SingleNodeDeploymentConfig = SingleNodeDeploymentConfig()
+
+    @model_validator(mode="after")
+    def validate_reward_model(self):
+        if self.slurm is not None:
+            raise ValueError("Reward-model SLURM launch is not implemented; omit the slurm configuration.")
+        if self.model.impl != "hf":
+            raise ValueError("Reward-model training currently requires model.impl='hf'.")
+        if self.model.vlm is not None:
+            raise ValueError("Reward-model training currently supports text-only models.")
+        if self.model.cp != 1:
+            raise ValueError("Reward-model training currently requires model.cp=1.")
+        if self.model.ep not in (1, "auto"):
+            raise ValueError("Reward-model training currently requires model.ep=1 or 'auto'.")
+        if self.ckpt is not None and self.ckpt.resume_step is not None:
+            raise ValueError("Reward-model checkpoint resume is not supported yet.")
+        if self.model.lora is not None:
+            raise ValueError("Reward-model LoRA is not supported yet because the scalar head must remain trainable.")
+        return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
 [project.scripts]
 rl = "prime_rl.entrypoints.rl:main"
 sft = "prime_rl.entrypoints.sft:main"
+reward-model = "prime_rl.entrypoints.reward_model:main"
 inference = "prime_rl.entrypoints.inference:main"
 trainer = "prime_rl.entrypoints.trainer:main"
 orchestrator = "prime_rl.entrypoints.orchestrator:main"

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start-run
-description: How to launch prime-rl training runs — the `rl`, `sft`, and `inference` entrypoints, their config classes, and single-node/SLURM/dry-run modes. Use when starting a run or picking the right entrypoint.
+description: How to launch prime-rl training runs — the `rl`, `sft`, `reward-model`, and `inference` entrypoints, their config classes, and single-node/SLURM/dry-run modes. Use when starting a run or picking the right entrypoint.
 ---
 
 # Start a run
@@ -55,6 +55,20 @@ uv run sft @ examples/basic/reverse-text/sft.toml --dry-run
 - Entrypoint: `src/prime_rl/entrypoints/sft.py`
 - SLURM: single- and multi-node
 
+## `reward-model` — Bradley–Terry reward-model training
+
+Trains a text-only Hugging Face sequence-classification model with one scalar reward using `prompt`, `chosen`, and `rejected` preference rows.
+
+```bash
+uv run reward-model @ examples/reward_model/capitalization/reward_model.toml
+```
+
+- Config: `RewardModelConfig` (`packages/prime-rl-configs/src/prime_rl/configs/reward_model.py`)
+- Entrypoint: `src/prime_rl/entrypoints/reward_model.py`
+- Objective: `-log sigmoid(reward_chosen - reward_rejected)`
+- Current scope: text-only HF models, no CP or LoRA
+- Deployment: single-node only; SLURM is not implemented
+
 ## `inference` — vLLM server
 
 OpenAI-compatible API plus prime-rl custom endpoints (`/update_weights`, `/load_lora_adapter`, `/init_broadcaster`). Always use this entrypoint — never `vllm serve` directly. It starts a `vllm-router` on `server.port` (default 8000, the client-facing URL) fronting the engine on `backend_port` (default 8100); admin endpoints must target the engine port directly.
@@ -84,6 +98,7 @@ curl http://localhost:8000/v1/chat/completions \
 |---------|---------|-------------|
 | `rl` | Full RL pipeline | Production RL training |
 | `sft` | Supervised fine-tuning | SFT and hard-distill |
+| `reward-model` | Pairwise preference training | Bradley–Terry reward models |
 | `inference` | vLLM server | Standalone serving / debugging |
 
 ## Key paths

--- a/src/prime_rl/entrypoints/local_trainer.py
+++ b/src/prime_rl/entrypoints/local_trainer.py
@@ -1,0 +1,120 @@
+import os
+import sys
+import uuid
+from subprocess import Popen
+from threading import Event, Thread
+
+import tomli_w
+
+from prime_rl.configs.sft import SFTConfig
+from prime_rl.utils.config import to_toml_dict
+from prime_rl.utils.logger import setup_logger
+from prime_rl.utils.pathing import get_config_dir
+from prime_rl.utils.process import (
+    DEFAULT_COMMON_ENV_VARS,
+    DEFAULT_TRAINER_ENV_VARS,
+    cleanup_processes,
+    cleanup_threads,
+    monitor_process,
+)
+
+
+def launch_local_trainer(
+    config: SFTConfig,
+    *,
+    config_filename: str,
+    trainer_module: str,
+    display_name: str,
+) -> None:
+    assert config.deployment.type == "single_node"
+
+    logger = setup_logger(config.log.level or "info", json_logging=config.log.json_logging)
+    config_dir = get_config_dir(config.output_dir)
+    config_path = config_dir / config_filename
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with config_path.open("wb") as file:
+        tomli_w.dump(to_toml_dict(config), file)
+    logger.info(f"Wrote config to {config_path}")
+
+    if config.dry_run:
+        logger.success(f"Dry run complete. To start {display_name} locally, remove --dry-run from your command.")
+        return
+
+    log_dir = config.output_dir / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    from prime_rl.utils.utils import get_free_port
+
+    trainer_cmd = [
+        "torchrun",
+        "--role=trainer",
+        f"--rdzv-endpoint=localhost:{get_free_port()}",
+        f"--rdzv-id={uuid.uuid4().hex}",
+        f"--log-dir={log_dir / 'trainer' / 'torchrun'}",
+        f"--local-ranks-filter={','.join(map(str, config.log.ranks_filter))}",
+        "--redirect=3",
+        "--tee=3",
+        f"--nproc-per-node={config.deployment.num_gpus}",
+        "-m",
+        trainer_module,
+        "@",
+        config_path.as_posix(),
+    ]
+
+    logger.info(f"Starting {display_name} trainer with {config.deployment.num_gpus} GPU(s)")
+    logger.debug(f"Trainer command: {' '.join(trainer_cmd)}")
+
+    processes: list[Popen] = []
+    monitor_threads: list[Thread] = []
+    error_queue: list[Exception] = []
+    try:
+        with (log_dir / "trainer.log").open("w") as log_file:
+            trainer_process = Popen(
+                trainer_cmd,
+                env={
+                    **os.environ,
+                    **DEFAULT_COMMON_ENV_VARS,
+                    **DEFAULT_TRAINER_ENV_VARS,
+                    **config.env_vars,
+                },
+                stdout=log_file,
+                stderr=log_file,
+            )
+        processes.append(trainer_process)
+
+        stop_event = Event()
+        monitor_thread = Thread(
+            target=monitor_process,
+            args=(trainer_process, stop_event, error_queue, "trainer"),
+            daemon=True,
+        )
+        monitor_thread.start()
+        monitor_threads.append(monitor_thread)
+
+        logger.success("Startup complete. Showing trainer logs...")
+        tail_process = Popen(
+            f"tail -F '{log_dir / 'trainer.log'}' | sed -u 's/^\\[[a-zA-Z]*[0-9]*\\]://'",
+            shell=True,
+        )
+        processes.append(tail_process)
+        stop_event.wait()
+
+        if trainer_process.returncode != 0:
+            logger.error(f"Trainer failed with exit code {trainer_process.returncode}")
+            cleanup_threads(monitor_threads)
+            cleanup_processes(processes)
+            sys.exit(1)
+
+        logger.success(f"{display_name} training finished!")
+        cleanup_threads(monitor_threads)
+        cleanup_processes(processes)
+    except KeyboardInterrupt:
+        logger.warning("Received interrupt signal, terminating all processes...")
+        cleanup_threads(monitor_threads)
+        cleanup_processes(processes)
+        sys.exit(1)
+    except Exception as error:
+        logger.error(f"Error occurred: {error}")
+        cleanup_threads(monitor_threads)
+        cleanup_processes(processes)
+        raise

--- a/src/prime_rl/entrypoints/reward_model.py
+++ b/src/prime_rl/entrypoints/reward_model.py
@@ -1,0 +1,34 @@
+import os
+
+from prime_rl.configs.reward_model import RewardModelConfig
+from prime_rl.entrypoints.local_trainer import launch_local_trainer
+from prime_rl.utils.config import cli
+from prime_rl.utils.pathing import validate_output_dir
+from prime_rl.utils.process import set_proc_title
+
+
+def reward_model(config: RewardModelConfig) -> None:
+    clean = config.clean_output_dir and not os.environ.get("NEVER_CLEAN_OUTPUT_DIR")
+    validate_output_dir(config.output_dir, resuming=False, clean=clean)
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not config.dry_run:
+        from prime_rl.trainer.model import pre_download_model
+
+        pre_download_model(config.model.name)
+
+    launch_local_trainer(
+        config,
+        config_filename="reward_model.toml",
+        trainer_module="prime_rl.trainer.reward_model.train",
+        display_name="reward-model",
+    )
+
+
+def main() -> None:
+    set_proc_title("RewardModel")
+    reward_model(cli(RewardModelConfig))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -1,23 +1,18 @@
 import os
 import subprocess
 import sys
-import uuid
 from pathlib import Path
-from subprocess import Popen
-from threading import Event, Thread
 
 import tomli_w
 
 from prime_rl.configs.sft import SFTConfig
+from prime_rl.entrypoints.local_trainer import launch_local_trainer
 from prime_rl.utils.config import cli, to_toml_dict
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir, validate_output_dir
 from prime_rl.utils.process import (
     DEFAULT_COMMON_ENV_VARS,
     DEFAULT_TRAINER_ENV_VARS,
-    cleanup_processes,
-    cleanup_threads,
-    monitor_process,
     set_proc_title,
 )
 
@@ -109,100 +104,12 @@ def sft_slurm(config: SFTConfig):
 
 def sft_local(config: SFTConfig):
     """Run SFT training locally with process monitoring and cleanup."""
-    assert config.deployment.type == "single_node"
-
-    logger = setup_logger(config.log.level or "info", json_logging=config.log.json_logging)
-
-    config_dir = get_config_dir(config.output_dir)
-    config_path = config_dir / SFT_TOML
-    write_config(config, config_path)
-    logger.info(f"Wrote config to {config_path}")
-
-    if config.dry_run:
-        logger.success("Dry run complete. To start an SFT run locally, remove --dry-run from your command.")
-        return
-
-    log_dir = config.output_dir / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
-
-    from prime_rl.utils.utils import get_free_port
-
-    trainer_cmd = [
-        "torchrun",
-        "--role=trainer",
-        f"--rdzv-endpoint=localhost:{get_free_port()}",
-        f"--rdzv-id={uuid.uuid4().hex}",
-        f"--log-dir={config.output_dir / 'logs' / 'trainer' / 'torchrun'}",
-        f"--local-ranks-filter={','.join(map(str, config.log.ranks_filter))}",
-        "--redirect=3",
-        "--tee=3",
-        f"--nproc-per-node={config.deployment.num_gpus}",
-        "-m",
-        "prime_rl.trainer.sft.train",
-        "@",
-        (config_dir / SFT_TOML).as_posix(),
-    ]
-
-    logger.info(f"Starting SFT trainer with {config.deployment.num_gpus} GPU(s)")
-    logger.debug(f"Trainer command: {' '.join(trainer_cmd)}")
-
-    processes: list[Popen] = []
-    monitor_threads: list[Thread] = []
-    error_queue: list[Exception] = []
-
-    try:
-        with open(log_dir / "trainer.log", "w") as log_file:
-            trainer_process = Popen(
-                trainer_cmd,
-                env={
-                    **os.environ,
-                    **DEFAULT_COMMON_ENV_VARS,
-                    **DEFAULT_TRAINER_ENV_VARS,
-                    **config.env_vars,
-                },
-                stdout=log_file,
-                stderr=log_file,
-            )
-        processes.append(trainer_process)
-
-        stop_event = Event()
-        monitor_thread = Thread(
-            target=monitor_process,
-            args=(trainer_process, stop_event, error_queue, "trainer"),
-            daemon=True,
-        )
-        monitor_thread.start()
-        monitor_threads.append(monitor_thread)
-
-        logger.success("Startup complete. Showing trainer logs...")
-        tail_process = Popen(
-            f"tail -F '{log_dir / 'trainer.log'}' | sed -u 's/^\\[[a-zA-Z]*[0-9]*\\]://'",
-            shell=True,
-        )
-        processes.append(tail_process)
-
-        stop_event.wait()
-
-        if trainer_process.returncode != 0:
-            logger.error(f"Trainer failed with exit code {trainer_process.returncode}")
-            cleanup_threads(monitor_threads)
-            cleanup_processes(processes)
-            sys.exit(1)
-
-        logger.success("SFT training finished!")
-        cleanup_threads(monitor_threads)
-        cleanup_processes(processes)
-
-    except KeyboardInterrupt:
-        logger.warning("Received interrupt signal, terminating all processes...")
-        cleanup_threads(monitor_threads)
-        cleanup_processes(processes)
-        sys.exit(1)
-    except Exception as e:
-        logger.error(f"Error occurred: {e}")
-        cleanup_threads(monitor_threads)
-        cleanup_processes(processes)
-        raise
+    launch_local_trainer(
+        config,
+        config_filename=SFT_TOML,
+        trainer_module="prime_rl.trainer.sft.train",
+        display_name="SFT",
+    )
 
 
 def sft(config: SFTConfig):

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -396,7 +396,7 @@ class WeightCheckpointManager:
 
                 # Save model config, generation arguments and tokenizer
                 model.config.save_pretrained(path)
-                if model.generation_config:
+                if getattr(model, "generation_config", None):
                     # training sets use_cache=False which can conflict with
                     # cache_implementation — save with use_cache=True without
                     # mutating the model's config
@@ -450,7 +450,7 @@ class WeightCheckpointManager:
 
         # Remove tied weight keys to match original model format
         if getattr(model.config, "tie_word_embeddings", False):
-            for key in getattr(model, "_tied_weights_keys", []):
+            for key in getattr(model, "_tied_weights_keys", None) or []:
                 state_dict.pop(key, None)
 
         if has_lora_layers(model) and self.config.save_adapter_separately:

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -2,7 +2,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast
 
 # Disable transformers hub kernel interception by default. The `kernels` package, when installed,
 # causes transformers to auto-replace modules (e.g. mamba-ssm) with hub kernel versions that may
@@ -22,7 +22,14 @@ from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import CPUOffloadPolicy, FSDPModule, MixedPrecisionPolicy, OffloadPolicy, fully_shard
 from torch.distributed.tensor.parallel import parallelize_module
 from torchtitan.distributed.expert_parallel import ExpertParallel
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, GenerationConfig, PretrainedConfig
+from transformers import (
+    AutoConfig,
+    AutoModelForCausalLM,
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    GenerationConfig,
+    PretrainedConfig,
+)
 from transformers.tokenization_utils import PreTrainedTokenizer
 from transformers.utils.import_utils import is_flash_attn_3_available
 
@@ -528,8 +535,22 @@ def get_load_balance_stats(
     }
 
 
+ModelTask = Literal["causal_lm", "reward_model"]
+
+
+def get_output_head(model: nn.Module, task: ModelTask) -> nn.Module:
+    name = "score" if task == "reward_model" else "lm_head"
+    output_head = getattr(model, name, None)
+    if output_head is None:
+        raise ValueError(f"{type(model).__name__} does not expose the expected {name!r} output head for {task}.")
+    return output_head
+
+
 def get_model(
-    config: ModelConfig, device: torch.device = torch.device("cpu"), dtype: torch.dtype = torch.bfloat16
+    config: ModelConfig,
+    device: torch.device = torch.device("cpu"),
+    dtype: torch.dtype = torch.bfloat16,
+    task: ModelTask = "causal_lm",
 ) -> nn.Module:
     logger = get_logger()
     logger.info(
@@ -550,6 +571,9 @@ def get_model(
         ),
     )
     model_config.use_cache = False
+    if task == "reward_model":
+        model_config.num_labels = 1
+        model_config.problem_type = "regression"
     is_vlm_arch = is_vlm_architecture(model_config)
 
     if is_vlm_training:
@@ -673,6 +697,9 @@ def get_model(
     else:
         impl_to_use = config.impl
 
+    if task == "reward_model" and (impl_to_use != "hf" or is_vlm_arch):
+        raise ValueError('Reward models currently require a text-only model with model.impl="hf".')
+
     if config.attn in ("flash_attention_3", "flash_attention_4") and impl_to_use == "hf":
         raise ValueError(
             f"{config.attn} requires model.impl='custom' or 'auto' (resolved to 'custom'), "
@@ -698,6 +725,8 @@ def get_model(
             from transformers import AutoModelForImageTextToText
 
             model_cls = AutoModelForImageTextToText
+        elif task == "reward_model":
+            model_cls = AutoModelForSequenceClassification
         else:
             match impl_to_use:
                 case "hf":
@@ -722,8 +751,11 @@ def get_model(
             )
         logger.debug(f"Loaded model {config.name} in {time.perf_counter() - load_model_start_time:.2f} seconds")
 
-    assert model.lm_head.weight.dtype == dtype, (
-        f"LM head dtype wasnt loaded correctly {model.lm_head.weight.dtype} != {dtype}"
+    if task == "reward_model":
+        model.config.architectures = [type(model).__name__]
+    output_head = get_output_head(model, task)
+    assert output_head.weight.dtype == dtype, (
+        f"Output head dtype was not loaded correctly {output_head.weight.dtype} != {dtype}"
     )
     return model
 
@@ -762,7 +794,12 @@ def setup_processor(config: ModelConfig):
     return processor
 
 
-def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims):
+def setup_fsdp(
+    model: nn.Module,
+    config: ModelConfig,
+    parallel_dims: ParallelDims,
+    task: ModelTask = "causal_lm",
+):
     mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=DTYPE_MAP[config.reduce_dtype])
     offload_policy: OffloadPolicy = CPUOffloadPolicy(pin_memory=True) if config.fsdp_cpu_offload else OffloadPolicy()
 
@@ -819,9 +856,10 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
             **fsdp_config,
         )
 
-    shard_norm_and_lm_head = hasattr(model, "config") and not model.config.tie_word_embeddings
+    output_head = get_output_head(model, task)
+    shard_norm_and_output_head = task == "reward_model" or not model.config.tie_word_embeddings
 
-    if shard_norm_and_lm_head:
+    if shard_norm_and_output_head:
         # This optimization breaks weight tying
         embed_module = getattr(language_model, "embed_tokens", None) or getattr(language_model, "embeddings", None)
         fully_shard(
@@ -830,13 +868,31 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
             **fsdp_config,
         )
         norm_module = getattr(language_model, "norm", None) or language_model.norm_f
-        fully_shard(
-            [model.lm_head, norm_module],
-            mesh=hsdp_mesh,
-            mp_policy=mp_policy,
-            offload_policy=offload_policy,
-            reshard_after_forward=False,
-        )
+        if task == "reward_model":
+            # HF reward heads are newly initialized in FP32 while pretrained norms may be BF16.
+            # Separate FSDP units permit those original dtypes without changing causal-LM sharding.
+            fully_shard(
+                output_head,
+                mesh=hsdp_mesh,
+                mp_policy=mp_policy,
+                offload_policy=offload_policy,
+                reshard_after_forward=False,
+            )
+            fully_shard(
+                norm_module,
+                mesh=hsdp_mesh,
+                mp_policy=mp_policy,
+                offload_policy=offload_policy,
+                reshard_after_forward=False,
+            )
+        else:
+            fully_shard(
+                [output_head, norm_module],
+                mesh=hsdp_mesh,
+                mp_policy=mp_policy,
+                offload_policy=offload_policy,
+                reshard_after_forward=False,
+            )
     else:
         get_logger().warning("Model uses tied word embeddings, so skipping the last-layer no-reshard optimization.")
 
@@ -859,7 +915,7 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
 
     embed_module = getattr(language_model, "embed_tokens", None) or getattr(language_model, "embeddings", None)
     if embed_module is not None and len(language_model.layers) > 0:
-        if shard_norm_and_lm_head:
+        if shard_norm_and_output_head:
             embed_module.set_modules_to_forward_prefetch([transformer_blocks[0]])
 
     for transformer_block, next_transformer_block in zip(transformer_blocks, next_transformer_blocks):
@@ -873,17 +929,17 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
                 transformer_block.set_modules_to_forward_prefetch(prefetch_modules)
             else:
                 transformer_block.set_modules_to_forward_prefetch([next_transformer_block])
-        elif language_model.norm is not None and model.lm_head is not None:
-            if shard_norm_and_lm_head:
-                transformer_block.set_modules_to_forward_prefetch([language_model.norm, model.lm_head])
+        elif language_model.norm is not None and output_head is not None:
+            if shard_norm_and_output_head:
+                transformer_block.set_modules_to_forward_prefetch([language_model.norm, output_head])
 
     # backward
     reversed_transformer_blocks = list(reversed(language_model.layers))
     prev_transformer_blocks = reversed_transformer_blocks[1:] + [None]
 
-    if language_model.norm is not None and model.lm_head is not None and len(language_model.layers) > 0:
-        if shard_norm_and_lm_head:
-            model.lm_head.set_modules_to_backward_prefetch([reversed_transformer_blocks[0]])
+    if language_model.norm is not None and output_head is not None and len(language_model.layers) > 0:
+        if shard_norm_and_output_head:
+            output_head.set_modules_to_backward_prefetch([reversed_transformer_blocks[0]])
         else:
             model.set_modules_to_backward_prefetch([reversed_transformer_blocks[0]])
 
@@ -898,11 +954,16 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
             else:
                 transformer_block.set_modules_to_backward_prefetch([prev_transformer_block])
         elif embed_module is not None:
-            if shard_norm_and_lm_head:
+            if shard_norm_and_output_head:
                 transformer_block.set_modules_to_backward_prefetch([embed_module])
 
 
-def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims):
+def load_dcp_from_hf(
+    model: nn.Module,
+    config: ModelConfig,
+    parallel_dims: ParallelDims,
+    task: ModelTask = "causal_lm",
+):
     device = "cpu" if config.fsdp_cpu_offload else "cuda"
     model.to_empty(device=device)
     torch.distributed.barrier()
@@ -976,7 +1037,10 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
     state_dict = model.state_dict()
     state_dict = strip_lora_from_state_dict(state_dict)
     if model.config.tie_word_embeddings:
-        state_dict.pop("lm_head.weight")
+        state_dict.pop("lm_head.weight", None)
+    if task == "reward_model":
+        for name, _ in get_output_head(model, task).named_parameters():
+            state_dict.pop(f"score.{name}", None)
     dcp_load(
         state_dict,
         storage_reader=HuggingFaceStorageReader(path=snapshot_path.as_posix()),
@@ -985,6 +1049,11 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
     if not isinstance(model, PreTrainedModelPrimeRL) and model.config.tie_word_embeddings:
         model.tie_weights()
     _init_buffers_post_meta()
+
+    if task == "reward_model":
+        with torch.no_grad():
+            for parameter in get_output_head(model, task).parameters():
+                parameter.zero_()
 
     _move_buffers_to_cuda(model, config)
 
@@ -1259,6 +1328,7 @@ def setup_model(
     config: ModelConfig,
     parallel_dims: ParallelDims,
     loading_from_checkpoint_later: bool = False,
+    task: ModelTask = "causal_lm",
 ) -> nn.Module:
     resolve_auto_attn(config)
 
@@ -1273,7 +1343,7 @@ def setup_model(
     logger = get_logger()
 
     # 1. We load to meta device by default
-    model = get_model(config, device=torch.device("meta"), dtype=DTYPE_MAP[config.optimization_dtype])
+    model = get_model(config, device=torch.device("meta"), dtype=DTYPE_MAP[config.optimization_dtype], task=task)
     configure_moe_ep_backend(model, config)
 
     possible_to_load_to_meta = can_reinit_empty_buffers(model)
@@ -1286,14 +1356,15 @@ def setup_model(
     # 1a. We load to CPU if we cannot reinit empty buffers
     if not possible_to_load_to_meta:
         logger.warning("Cannot load model to meta device only, loading to CPU instead.")
-        model = get_model(config, device=torch.device("cpu"), dtype=DTYPE_MAP[config.optimization_dtype])
+        model = get_model(config, device=torch.device("cpu"), dtype=DTYPE_MAP[config.optimization_dtype], task=task)
         configure_moe_ep_backend(model, config)
 
     lm_head_chunk_size: int | None = None
     if isinstance(config.fused_lm_head_token_chunk_size, int):
         lm_head_chunk_size = config.fused_lm_head_token_chunk_size
 
-    inject_prime_lm_head(model, chunk_size=lm_head_chunk_size)
+    if task == "causal_lm":
+        inject_prime_lm_head(model, chunk_size=lm_head_chunk_size)
 
     apply_quantization(model, config)
 
@@ -1332,7 +1403,7 @@ def setup_model(
     if config.compile is not None:
         apply_compile(model, config.compile)
 
-    setup_fsdp(model, config, parallel_dims)
+    setup_fsdp(model, config, parallel_dims, task=task)
 
     if not possible_to_load_to_meta:
         _move_buffers_to_cuda(model, config)
@@ -1358,7 +1429,7 @@ def setup_model(
             _move_buffers_to_cuda(model, config)
         # - or load from HF with dcp
         else:
-            load_dcp_from_hf(model, config, parallel_dims)
+            load_dcp_from_hf(model, config, parallel_dims, task=task)
 
     _reset_runtime_moe_buffers(model)
     return model

--- a/src/prime_rl/trainer/reward_model/data.py
+++ b/src/prime_rl/trainer/reward_model/data.py
@@ -1,0 +1,165 @@
+from collections import defaultdict
+from pathlib import Path
+from typing import TypedDict, cast
+
+import torch
+from datasets import Dataset, load_dataset
+from renderers.base import Renderer, build_training_sample
+from torch import Tensor
+from torch.distributed.checkpoint.stateful import Stateful
+from torch.utils.data import IterableDataset, get_worker_info
+from torchdata.stateful_dataloader import StatefulDataLoader
+
+from prime_rl.configs.reward_model import BradleyTerryDataConfig
+from prime_rl.trainer.world import get_world
+from prime_rl.utils.chat_template import normalize_messages
+
+
+class BradleyTerryBatch(TypedDict):
+    input_ids: Tensor
+    attention_mask: Tensor
+    position_ids: Tensor
+    num_pairs: int
+    pair_weights: Tensor
+
+
+def load_bradley_terry_dataset(config: BradleyTerryDataConfig) -> Dataset:
+    path = Path(config.name)
+    if path.is_file():
+        return cast(Dataset, load_dataset("json", data_files=str(path), split="train"))
+    return cast(Dataset, load_dataset(config.name, split=config.split))
+
+
+def _messages(value, default_role: str) -> list[dict]:
+    return normalize_messages(value, default_role=default_role)
+
+
+def render_bradley_terry_pair(example: dict, renderer: Renderer, seq_len: int) -> tuple[list[int], list[int]]:
+    if example.get("prompt") is None or example.get("chosen") is None or example.get("rejected") is None:
+        raise ValueError("Bradley-Terry rows require non-null 'prompt', 'chosen', and 'rejected' fields.")
+
+    prompt = _messages(example["prompt"], "user")
+    chosen = prompt + _messages(example["chosen"], "assistant")
+    rejected = prompt + _messages(example["rejected"], "assistant")
+
+    chosen_ids = list(build_training_sample(renderer, chosen, ensure_final_stop=True).token_ids)
+    rejected_ids = list(build_training_sample(renderer, rejected, ensure_final_stop=True).token_ids)
+    if len(chosen_ids) > seq_len:
+        chosen_ids = chosen_ids[-seq_len:]
+    if len(rejected_ids) > seq_len:
+        rejected_ids = rejected_ids[-seq_len:]
+    if not chosen_ids or not rejected_ids:
+        raise ValueError("Rendered Bradley-Terry responses must contain at least one token.")
+    return chosen_ids, rejected_ids
+
+
+class BradleyTerryDataset(Stateful, IterableDataset):
+    def __init__(
+        self,
+        dataset: Dataset,
+        renderer: Renderer,
+        config: BradleyTerryDataConfig,
+        max_epochs: int | None = None,
+        pad_to_data_world_size: bool = False,
+    ):
+        self.dataset = dataset
+        self.renderer = renderer
+        self.config = config
+        self.max_epochs = max_epochs
+        self.pad_to_data_world_size = pad_to_data_world_size
+        self.step = 0
+        self.epoch = 0
+        self.num_samples = defaultdict(int)
+        self.num_tokens = defaultdict(int)
+        worker_info = get_worker_info()
+        worker_id, num_workers = (worker_info.id, worker_info.num_workers) if worker_info else (0, 1)
+        self.data_rank = get_world().rank * num_workers + worker_id
+        self.data_world_size = get_world().world_size * num_workers
+
+    def state_dict(self) -> dict:
+        return {"step": self.step, "epoch": self.epoch}
+
+    def load_state_dict(self, state_dict: dict):
+        self.step = state_dict["step"]
+        self.epoch = state_dict["epoch"]
+
+    def __iter__(self):
+        num_examples = len(self.dataset)
+        if num_examples == 0:
+            raise ValueError("Bradley-Terry datasets must contain at least one example.")
+        epoch_size = num_examples
+        if self.pad_to_data_world_size:
+            epoch_size = ((num_examples + self.data_world_size - 1) // self.data_world_size) * self.data_world_size
+        dataset = self.dataset.shuffle(seed=self.config.seed + self.epoch) if self.config.shuffle else self.dataset
+        while True:
+            epoch = self.step // epoch_size
+            if self.max_epochs is not None and epoch >= self.max_epochs:
+                break
+            if epoch > self.epoch:
+                self.epoch = epoch
+                dataset = self.dataset.shuffle(seed=self.config.seed + epoch) if self.config.shuffle else self.dataset
+            epoch_index = self.step % epoch_size
+            self.step += 1
+            if epoch_index % self.data_world_size != self.data_rank:
+                continue
+            sample_weight = epoch_index < num_examples
+            index = epoch_index % num_examples
+            chosen_ids, rejected_ids = render_bradley_terry_pair(
+                cast(dict, dataset[index]), self.renderer, self.config.seq_len
+            )
+            if sample_weight:
+                self.num_samples["bradley_terry"] += 1
+                self.num_tokens["bradley_terry"] += len(chosen_ids) + len(rejected_ids)
+            yield {
+                "chosen_ids": chosen_ids,
+                "rejected_ids": rejected_ids,
+                "sample_weight": sample_weight,
+            }
+
+
+def bradley_terry_collate(samples: list[dict], pad_token_id: int) -> BradleyTerryBatch:
+    sequences = [sample[side] for side in ("chosen_ids", "rejected_ids") for sample in samples]
+    max_len = max(map(len, sequences))
+    input_ids = torch.full((len(sequences), max_len), pad_token_id, dtype=torch.long)
+    attention_mask = torch.zeros((len(sequences), max_len), dtype=torch.long)
+    for row, sequence in enumerate(sequences):
+        input_ids[row, : len(sequence)] = torch.tensor(sequence, dtype=torch.long)
+        attention_mask[row, : len(sequence)] = 1
+    position_ids = attention_mask.cumsum(dim=-1) - 1
+    position_ids.masked_fill_(attention_mask == 0, 0)
+    return {
+        "input_ids": input_ids,
+        "attention_mask": attention_mask,
+        "position_ids": position_ids,
+        "num_pairs": len(samples),
+        "pair_weights": torch.tensor([sample.get("sample_weight", True) for sample in samples], dtype=torch.float32),
+    }
+
+
+def setup_dataset(
+    config: BradleyTerryDataConfig,
+    renderer: Renderer,
+    *,
+    raw_dataset: Dataset | None = None,
+    max_epochs: int | None = None,
+    pad_to_data_world_size: bool = False,
+) -> BradleyTerryDataset:
+    return BradleyTerryDataset(
+        raw_dataset if raw_dataset is not None else load_bradley_terry_dataset(config),
+        renderer,
+        config,
+        max_epochs=max_epochs,
+        pad_to_data_world_size=pad_to_data_world_size,
+    )
+
+
+def setup_dataloader(
+    dataset: BradleyTerryDataset,
+    config: BradleyTerryDataConfig,
+    pad_token_id: int,
+) -> StatefulDataLoader:
+    return StatefulDataLoader(
+        dataset,
+        batch_size=config.micro_batch_size,
+        collate_fn=lambda samples: bradley_terry_collate(samples, pad_token_id),
+    )

--- a/src/prime_rl/trainer/reward_model/train.py
+++ b/src/prime_rl/trainer/reward_model/train.py
@@ -1,0 +1,235 @@
+import time
+from contextlib import nullcontext
+from datetime import timedelta
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from renderers.base import create_renderer
+from torchtitan.distributed.utils import clip_grad_norm_
+
+import prime_rl._compat  # noqa: F401
+from prime_rl.configs.reward_model import RewardModelConfig
+from prime_rl.trainer.ckpt import setup_ckpt_managers
+from prime_rl.trainer.model import setup_model, setup_tokenizer
+from prime_rl.trainer.optim import setup_optimizer
+from prime_rl.trainer.parallel_dims import get_parallel_dims, resolve_ep
+from prime_rl.trainer.reward_model.data import (
+    load_bradley_terry_dataset,
+    setup_dataloader,
+    setup_dataset,
+)
+from prime_rl.trainer.runs import Progress
+from prime_rl.trainer.scheduler import setup_scheduler
+from prime_rl.trainer.utils import GarbageCollection, get_zero_gradient_ratio, setup_torch_distributed
+from prime_rl.trainer.world import get_world
+from prime_rl.utils.act_offloading import maybe_activation_offloading
+from prime_rl.utils.config import cli
+from prime_rl.utils.logger import format_time, setup_logger
+from prime_rl.utils.monitor import setup_monitor
+from prime_rl.utils.process import set_proc_title
+from prime_rl.utils.utils import clean_exit
+
+
+def bradley_terry_losses(chosen_rewards: torch.Tensor, rejected_rewards: torch.Tensor) -> torch.Tensor:
+    """Per-pair negative log-likelihood under the Bradley-Terry model."""
+    return -F.logsigmoid(chosen_rewards.float() - rejected_rewards.float())
+
+
+@clean_exit
+def train(config: RewardModelConfig):
+    world = get_world()
+    logger = setup_logger(config.log.level, json_logging=config.log.json_logging)
+    logger.info(f"Starting Bradley-Terry reward-model trainer in {world}")
+    monitor = setup_monitor(config.wandb, output_dir=config.output_dir, run_config=config)
+
+    setup_torch_distributed(timeout=timedelta(seconds=config.dist_timeout_seconds), enable_gloo=False)
+    torch.set_float32_matmul_precision(config.matmul_precision)
+    resolve_ep(config.model)
+    parallel_dims = get_parallel_dims(config.model, config.data.seq_len)
+    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(config.output_dir, config.ckpt)
+
+    total_pairs = config.data.batch_size
+    pairs_per_micro_step = world.world_size * config.data.micro_batch_size
+    if total_pairs % pairs_per_micro_step:
+        raise ValueError(
+            f"data.batch_size ({total_pairs}) must be divisible by world_size * data.micro_batch_size "
+            f"({pairs_per_micro_step})."
+        )
+    grad_accum_steps = total_pairs // pairs_per_micro_step
+
+    logger.info(f"Initializing scalar reward model ({config.model})")
+    model = setup_model(config.model, parallel_dims, task="reward_model")
+    tokenizer = setup_tokenizer(config.tokenizer)
+    renderer = create_renderer(tokenizer, config.renderer)
+
+    optimizer = setup_optimizer(
+        config.optim,
+        list(model.named_parameters()),
+        parallel_dims,
+        cpu_offload=config.model.optim_cpu_offload,
+    )
+    scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
+
+    dataset = setup_dataset(config.data, renderer)
+    dataloader = setup_dataloader(dataset, config.data, tokenizer.pad_token_id)
+    dataiter = iter(dataloader)
+    progress = Progress(step=0)
+
+    def save_checkpoint(step: int):
+        progress.step = step
+        progress.total_samples = dataset.step
+        progress.total_tokens = sum(dataset.num_tokens.values())
+        if ckpt_manager is not None and not config.ckpt.weights_only:
+            ckpt_manager.save(step, model, [optimizer], scheduler, progress, dataloader=dataloader)
+        if weight_ckpt_manager is not None:
+            weight_ckpt_manager.save(step, model, tokenizer)
+        if ckpt_manager is not None:
+            ckpt_manager.maybe_clean()
+        if weight_ckpt_manager is not None:
+            weight_ckpt_manager.maybe_clean()
+
+    val_raw_dataset = load_bradley_terry_dataset(config.val.data) if config.val is not None else None
+    dp_group = parallel_dims.get_mesh("dp").get_group()
+
+    def score_pairs(micro_batch: dict) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        input_ids = micro_batch["input_ids"].to("cuda")
+        attention_mask = micro_batch["attention_mask"].to("cuda")
+        position_ids = micro_batch["position_ids"].to("cuda")
+        num_pairs = micro_batch["num_pairs"]
+        pair_weights = micro_batch["pair_weights"].to("cuda")
+        with maybe_activation_offloading(config.model.ac_offloading):
+            output = model(input_ids=input_ids, attention_mask=attention_mask, position_ids=position_ids)
+            rewards = output.logits.squeeze(-1).float()
+            chosen_rewards = rewards[:num_pairs]
+            rejected_rewards = rewards[num_pairs:]
+            losses = bradley_terry_losses(chosen_rewards, rejected_rewards)
+        margin = chosen_rewards - rejected_rewards
+        if pair_weights.shape != losses.shape:
+            raise ValueError(
+                f"Pair weights and losses must have the same shape, got {tuple(pair_weights.shape)} and "
+                f"{tuple(losses.shape)}."
+            )
+        return (
+            (losses * pair_weights).sum(),
+            pair_weights.sum(),
+            ((margin > 0) * pair_weights).sum(),
+            (margin * pair_weights).sum(),
+        )
+
+    def run_validation(step: int):
+        assert config.val is not None and val_raw_dataset is not None
+        val_dataset = setup_dataset(
+            config.val.data,
+            renderer,
+            raw_dataset=val_raw_dataset,
+            max_epochs=1,
+            pad_to_data_world_size=True,
+        )
+        val_loader = setup_dataloader(val_dataset, config.val.data, tokenizer.pad_token_id)
+        totals = torch.zeros(4, dtype=torch.float64, device="cuda")
+        with torch.no_grad():
+            iterator = iter(val_loader)
+            while True:
+                batch = next(iterator, None)
+                has_data = torch.tensor(batch is not None, dtype=torch.int32, device="cuda")
+                dist.all_reduce(has_data, op=dist.ReduceOp.MIN)
+                if not has_data.item():
+                    break
+                loss_sum, pair_count, correct, margin_sum = score_pairs(batch)
+                totals += torch.stack([loss_sum, pair_count, correct, margin_sum]).double()
+        dist.all_reduce(totals, op=dist.ReduceOp.SUM, group=dp_group)
+        loss, count, correct, margin = totals.tolist()
+        metrics = {
+            "val/loss": loss / count,
+            "val/accuracy": correct / count,
+            "val/reward_margin": margin / count,
+            "step": step,
+        }
+        logger.success(
+            f"Validation | Step {step} | Loss {metrics['val/loss']:.4f} | "
+            f"Accuracy {metrics['val/accuracy']:.1%} | Margin {metrics['val/reward_margin']:.4f}"
+        )
+        monitor.log(metrics, step=step)
+
+    gc_handler = GarbageCollection(config.gc.interval) if config.gc else None
+    maybe_record_function = nullcontext
+    max_steps = config.max_steps
+    if max_steps is None:
+        raise ValueError("Reward-model training requires max_steps.")
+
+    if config.val is not None and config.val.eval_on_start:
+        run_validation(0)
+
+    logger.info(
+        f"Training for {max_steps} optimizer steps with {total_pairs} pairs/step "
+        f"({grad_accum_steps} accumulation steps)"
+    )
+    for step in range(1, max_steps + 1):
+        step_start = time.perf_counter()
+        if gc_handler is not None:
+            gc_handler.run(step)
+        optimizer.zero_grad()
+        local_totals = torch.zeros(4, dtype=torch.float64, device="cuda")
+
+        for _ in range(grad_accum_steps):
+            micro_batch = next(dataiter)
+            with maybe_record_function("forward"):
+                loss_sum, pair_count, correct, margin_sum = score_pairs(micro_batch)
+            (loss_sum / grad_accum_steps).backward()
+            local_totals += torch.stack([loss_sum.detach(), pair_count, correct, margin_sum.detach()]).double()
+
+        global_pair_count = local_totals[1].clone()
+        dist.all_reduce(global_pair_count, op=dist.ReduceOp.SUM, group=dp_group)
+        grad_scale = parallel_dims.fsdp_gradient_divide_factor * grad_accum_steps / global_pair_count.item()
+        for parameter in model.parameters():
+            if parameter.grad is not None:
+                parameter.grad.mul_(grad_scale)
+
+        grad_norm = None
+        if config.optim.max_norm is not None:
+            grad_norm = clip_grad_norm_(
+                model.parameters(), max_norm=config.optim.max_norm, ep_enabled=parallel_dims.ep_enabled
+            )
+        optimizer.step()
+        current_lr = optimizer.param_groups[0]["lr"]
+        scheduler.step()
+
+        dist.all_reduce(local_totals, op=dist.ReduceOp.SUM, group=dp_group)
+        loss, count, correct, margin = local_totals.tolist()
+        metrics = {
+            "loss/mean": loss / count,
+            "train/accuracy": correct / count,
+            "train/reward_margin": margin / count,
+            "optim/lr": current_lr,
+            "optim/zero_grad_ratio": get_zero_gradient_ratio(model.parameters(), parallel_dims.dp_replicate),
+            "perf/peak_memory": torch.cuda.max_memory_reserved() / 1024**3,
+            "step": step,
+        }
+        if grad_norm is not None:
+            metrics["optim/grad_norm"] = grad_norm.item()
+        monitor.log(metrics, step=step)
+        logger.success(
+            f"Step {step} | {format_time(time.perf_counter() - step_start):>7} | "
+            f"Loss {metrics['loss/mean']:.4f} | Accuracy {metrics['train/accuracy']:.1%} | "
+            f"Margin {metrics['train/reward_margin']:.4f} | LR {current_lr:.2e}"
+        )
+
+        if config.val is not None and step % config.val.interval == 0:
+            run_validation(step)
+        if config.ckpt is not None and config.ckpt.interval and step < max_steps and step % config.ckpt.interval == 0:
+            save_checkpoint(step)
+
+    if config.ckpt is not None:
+        logger.info("Writing final reward-model checkpoint")
+        save_checkpoint(max_steps)
+    logger.success("Reward-model training finished!")
+
+
+def main():
+    set_proc_title("RewardModelTrainer")
+    train(cli(RewardModelConfig))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -8,6 +8,7 @@ from pydantic_config import ConfigFileError
 
 from prime_rl.configs.inference import InferenceConfig
 from prime_rl.configs.orchestrator import OrchestratorConfig
+from prime_rl.configs.reward_model import RewardModelConfig
 from prime_rl.configs.rl import RLConfig
 from prime_rl.configs.sft import SFTConfig
 from prime_rl.configs.trainer import ModelConfig as TrainerModelConfig
@@ -19,6 +20,7 @@ CONFIG_CLASSES = [
     RLConfig,
     TrainerConfig,
     SFTConfig,
+    RewardModelConfig,
     OrchestratorConfig,
     InferenceConfig,
 ]

--- a/tests/unit/train/test_reward_model.py
+++ b/tests/unit/train/test_reward_model.py
@@ -1,0 +1,110 @@
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+from datasets import Dataset
+from renderers.base import RenderedTokens
+
+from prime_rl.configs.reward_model import BradleyTerryDataConfig, RewardModelConfig
+from prime_rl.trainer.reward_model import data as reward_model_data
+from prime_rl.trainer.reward_model.data import BradleyTerryDataset, bradley_terry_collate
+from prime_rl.trainer.reward_model.train import bradley_terry_losses
+
+
+def test_bradley_terry_loss_and_gradient_prefer_chosen():
+    chosen = torch.tensor([0.0], requires_grad=True)
+    rejected = torch.tensor([0.0], requires_grad=True)
+    loss = bradley_terry_losses(chosen, rejected).sum()
+    loss.backward()
+
+    assert math.isclose(loss.item(), math.log(2), rel_tol=1e-6)
+    assert chosen.grad.item() < 0
+    assert rejected.grad.item() > 0
+
+
+def test_bradley_terry_collate_orders_chosen_before_rejected():
+    batch = bradley_terry_collate(
+        [
+            {"chosen_ids": [10, 11], "rejected_ids": [20]},
+            {"chosen_ids": [12], "rejected_ids": [21, 22]},
+        ],
+        pad_token_id=0,
+    )
+
+    assert batch["input_ids"].tolist() == [[10, 11], [12, 0], [20, 0], [21, 22]]
+    assert batch["attention_mask"].tolist() == [[1, 1], [1, 0], [1, 0], [1, 1]]
+    assert batch["num_pairs"] == 2
+    assert batch["pair_weights"].tolist() == [1.0, 1.0]
+
+
+class _IndexedRenderer:
+    def render(self, messages, **kwargs):
+        token_id = int(messages[-1]["content"])
+        return RenderedTokens(
+            token_ids=[token_id],
+            message_indices=[len(messages) - 1],
+            sampled_mask=[True],
+        )
+
+    def get_stop_token_ids(self):
+        return [99]
+
+
+def test_validation_padding_preserves_distributed_tail(monkeypatch):
+    raw_dataset = Dataset.from_list(
+        [
+            {
+                "prompt": [{"role": "user", "content": "prompt"}],
+                "chosen": [{"role": "assistant", "content": str(10 + index)}],
+                "rejected": [{"role": "assistant", "content": str(20 + index)}],
+            }
+            for index in range(3)
+        ]
+    )
+    config = BradleyTerryDataConfig(name="unused", shuffle=False)
+    rank_samples = []
+    for rank in range(2):
+        monkeypatch.setattr(
+            reward_model_data,
+            "get_world",
+            lambda rank=rank: SimpleNamespace(rank=rank, world_size=2),
+        )
+        dataset = BradleyTerryDataset(
+            raw_dataset,
+            _IndexedRenderer(),
+            config,
+            max_epochs=1,
+            pad_to_data_world_size=True,
+        )
+        rank_samples.append(list(dataset))
+
+    assert [len(samples) for samples in rank_samples] == [2, 2]
+    assert sum(sample["sample_weight"] for samples in rank_samples for sample in samples) == 3
+    assert rank_samples[1][-1]["sample_weight"] is False
+
+
+def test_reward_model_config_keeps_sft_numerical_defaults():
+    config = RewardModelConfig.model_validate(
+        {
+            "model": {"name": "Qwen/Qwen3-0.6B", "impl": "hf", "attn": "flash_attention_2"},
+            "data": {"name": "preferences.jsonl"},
+            "max_steps": 1,
+        }
+    )
+
+    assert config.model.optimization_dtype == "float32"
+    assert config.model.reduce_dtype == "float32"
+    assert config.data.type == "bradley_terry"
+
+
+def test_reward_model_config_rejects_slurm():
+    with pytest.raises(ValueError, match="SLURM launch is not implemented"):
+        RewardModelConfig.model_validate(
+            {
+                "model": {"name": "Qwen/Qwen3-0.6B", "impl": "hf", "attn": "flash_attention_2"},
+                "data": {"name": "preferences.jsonl"},
+                "slurm": {},
+                "max_steps": 1,
+            }
+        )


### PR DESCRIPTION
## Summary

- add single-node Bradley–Terry reward-model training for `prompt`, `chosen`, and `rejected` datasets
- reuse the existing model, FSDP, launcher, and checkpoint infrastructure
- export standard Hugging Face sequence-classification checkpoints
- include a Qwen3-0.6B capitalization sanity check

## Validation

- focused reward-model, model, config, and checkpoint unit tests
- SFT and reward-model dry runs
- two-step Qwen3-0.6B run reached 100% validation pair accuracy
- exported checkpoint reloaded with `AutoModelForSequenceClassification`
