### PR TITLE
perf(nemotron-h): use fla causal_conv1d for packed Mamba conv

### DIFF
--- a/src/prime_rl/trainer/models/layers/cp_mamba.py
+++ b/src/prime_rl/trainer/models/layers/cp_mamba.py
@@ -16,45 +16,8 @@ from __future__ import annotations
 
 import torch
 import torch.distributed as dist
-
-
-def _build_seq_idx(boundaries: list[int], seq_len: int, device: torch.device) -> torch.Tensor:
-    """Return the packed-document id for each token in a full CP sequence."""
-    if boundaries[0] != 0 or boundaries[-1] != seq_len:
-        raise ValueError(f"cu_seqlens must span the full sequence length {seq_len}, got {boundaries}")
-
-    seq_idx = torch.empty(seq_len, dtype=torch.int32, device=device)
-    for sequence_id, (start, end) in enumerate(zip(boundaries[:-1], boundaries[1:])):
-        if end <= start:
-            raise ValueError(f"cu_seqlens must be strictly increasing, got {boundaries}")
-        seq_idx[start:end] = sequence_id
-    return seq_idx.unsqueeze(0)
-
-
-def _causal_conv1d_varlen(
-    hidden_states: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor | None,
-    boundaries: list[int],
-) -> torch.Tensor:
-    """Apply a depthwise causal convolution independently to packed documents."""
-    batch_size, _, channels = hidden_states.shape
-    if batch_size != 1:
-        raise ValueError(f"packed CP Mamba expects batch_size=1, got {batch_size}")
-
-    inputs = hidden_states.transpose(1, 2)
-    outputs = []
-    for start, end in zip(boundaries[:-1], boundaries[1:]):
-        convolved = torch.nn.functional.conv1d(
-            inputs[:, :, start:end],
-            weight,
-            bias,
-            groups=channels,
-            padding=weight.shape[2] - 1,
-        )
-        outputs.append(convolved[:, :, : end - start])
-
-    return torch.cat(outputs, dim=-1).transpose(1, 2)
+from fla.modules.conv import causal_conv1d as fla_causal_conv1d
+from fla.ops.utils import prepare_sequence_ids
 
 
 class _SeqToHeadParallel(torch.autograd.Function):
@@ -180,8 +143,7 @@ def mamba_cp_forward(
     hidden_states_B_C = torch.cat([x_part, B_part, C_part], dim=-1)
 
     full_seq_len = hidden_states_B_C.shape[1]  # S (full sequence)
-    boundaries = cu_seqlens.tolist()
-    seq_idx = _build_seq_idx(boundaries, full_seq_len, hidden_states.device)
+    seq_idx = prepare_sequence_ids(cu_seqlens).to(torch.int32).unsqueeze(0)
 
     # ── 3. Local head dimensions ──
     local_num_heads = mixer.num_heads // cp_size
@@ -216,9 +178,15 @@ def mamba_cp_forward(
     local_conv_weight = mixer.conv1d.weight[conv_indices]
     local_conv_bias = mixer.conv1d.bias[conv_indices] if mixer.conv1d.bias is not None else None
 
-    # ── 4. Conv1d on each packed document, local heads ──
-    hidden_states_B_C = torch.nn.functional.silu(
-        _causal_conv1d_varlen(hidden_states_B_C, local_conv_weight, local_conv_bias, boundaries)
+    # ── 4. Causal conv1d on the full sequence, local heads ──
+    # Must reset at sequence boundaries for packed batches, otherwise the
+    # kernel-1 left pad leaks state across sequences.
+    hidden_states_B_C, _ = fla_causal_conv1d(
+        x=hidden_states_B_C,
+        weight=local_conv_weight.squeeze(1),
+        bias=local_conv_bias,
+        activation=mixer.activation,
+        cu_seqlens=cu_seqlens,
     )
 
     local_groups_time_state_size = local_n_groups * mixer.ssm_state_size

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -10,6 +10,8 @@ from typing import Optional
 
 import torch
 import torch.distributed as dist
+from fla.modules.conv import causal_conv1d as fla_causal_conv1d
+from fla.ops.utils import prepare_sequence_ids
 from torch import Tensor, nn
 from transformers.generation import GenerationMixin
 from transformers.modeling_layers import GradientCheckpointingLayer
@@ -40,10 +42,8 @@ def _patch_mamba2_use_triton_ssd():
     Triton kernels and mamba_ssm use fp32. This causes ~0.4 KL divergence.
 
     This patch makes the mixer use mamba_chunk_scan_combined (Triton, fp32
-    softplus) for the SSD computation, with PyTorch nn.Conv1d for convolution.
-    Requires mamba_ssm installed; causal_conv1d should NOT be installed (it
-    needs arch-specific CUDA compilation). The HF cuda_kernels_forward
-    already falls back to PyTorch nn.Conv1d when causal_conv1d is absent.
+    softplus) for the SSD computation, with fla's Triton causal_conv1d for
+    convolution. Requires mamba_ssm installed.
     """
     global _patch_applied
     if _patch_applied:
@@ -68,7 +68,7 @@ def _patch_mamba2_use_triton_ssd():
     def _varlen_mamba_forward(self, hidden_states, cu_seqlens):
         """Varlen-aware mamba forward. `cu_seqlens` is required: shape [num_seq+1],
         e.g. [0, s1, s1+s2, ...]. Handles packed batches by:
-          - applying conv1d per-sequence (with kernel-1 leading zeros)
+          - passing cu_seqlens to causal_conv1d (conv state resets at boundaries)
           - passing seq_idx to mamba_chunk_scan_combined (SSM state resets at boundaries)
         """
         batch_size, seq_len, _ = hidden_states.shape
@@ -86,20 +86,15 @@ def _patch_mamba2_use_triton_ssd():
             dim=-1,
         )
 
-        # 2. Per-sequence causal conv1d. self.conv1d already has padding=kernel-1 so
-        # applying it to each segment independently gives the correct causal output
-        # without cross-sequence history.
-        hbc_t = hidden_states_B_C.transpose(1, 2)  # (1, C, L)
-        cu = cu_seqlens.tolist()
-        conv_outs = []
-        for i in range(len(cu) - 1):
-            s, e = cu[i], cu[i + 1]
-            if s == e:
-                continue
-            seg = hbc_t[:, :, s:e]
-            conv_out = self.conv1d(seg)[:, :, : e - s]
-            conv_outs.append(conv_out)
-        hidden_states_B_C = self.act(torch.cat(conv_outs, dim=-1).transpose(1, 2))
+        # 2. Causal conv1d — must reset at sequence boundaries for packed batches,
+        # otherwise the kernel-1 left pad leaks state across sequences.
+        hidden_states_B_C, _ = fla_causal_conv1d(
+            x=hidden_states_B_C,
+            weight=self.conv1d.weight.squeeze(1),
+            bias=self.conv1d.bias,
+            activation=self.activation,
+            cu_seqlens=cu_seqlens,
+        )
 
         hidden_states, B, C = torch.split(
             hidden_states_B_C,
@@ -108,12 +103,7 @@ def _patch_mamba2_use_triton_ssd():
         )
 
         # 3. SSM with seq_idx so state resets at sequence boundaries
-        seq_idx = torch.zeros(seq_len, dtype=torch.int32, device=hidden_states.device)
-        for i in range(len(cu) - 1):
-            s, e = cu[i], cu[i + 1]
-            if e > s:
-                seq_idx[s:e] = i
-        seq_idx = seq_idx.unsqueeze(0)  # (1, L)
+        seq_idx = prepare_sequence_ids(cu_seqlens).to(torch.int32).unsqueeze(0)
 
         scan_output = _mamba_chunk_scan_combined(
             hidden_states.view(batch_size, seq_len, -1, self.head_dim),

--- a/tests/unit/train/models/test_cp_mamba.py
+++ b/tests/unit/train/models/test_cp_mamba.py
@@ -6,6 +6,8 @@ import torch
 
 from prime_rl.trainer.models.layers import cp_mamba
 
+pytestmark = [pytest.mark.gpu]
+
 
 class _FakeMixer(torch.nn.Module):
     def __init__(self):
@@ -19,6 +21,7 @@ class _FakeMixer(torch.nn.Module):
         self.chunk_size = 1
         self.time_step_limit = None
         self.variance_epsilon = 1e-5
+        self.activation = "silu"
 
         self.in_proj = torch.nn.Linear(1, 5, bias=False)
         self.in_proj.weight.data.copy_(torch.tensor([[1.0], [1.0], [1.0], [1.0], [1.0]]))
@@ -27,7 +30,9 @@ class _FakeMixer(torch.nn.Module):
         self.dt_bias = torch.nn.Parameter(torch.zeros(1))
         self.conv1d = torch.nn.Conv1d(3, 3, kernel_size=2, groups=3, bias=False)
         self.conv1d.weight.data.fill_(1.0)
-        self.norm = types.SimpleNamespace(weight=torch.ones(1), variance_epsilon=self.variance_epsilon, group_size=1)
+        self.norm = types.SimpleNamespace(
+            weight=torch.ones(1, device="cuda"), variance_epsilon=self.variance_epsilon, group_size=1
+        )
         self.out_proj = torch.nn.Identity()
 
 
@@ -52,20 +57,29 @@ def test_mamba_cp_forward_resets_conv_and_scan_at_packed_boundaries(monkeypatch)
     monkeypatch.setattr(cp_mamba, "seq_to_head_parallel", lambda value, *_: value)
     monkeypatch.setattr(cp_mamba, "head_to_seq_parallel", lambda value, *_: value)
 
-    mixer = _FakeMixer()
-    cu_seqlens = torch.tensor([0, 2, 4], dtype=torch.int32)
-    first = torch.tensor([[[1.0], [2.0], [3.0], [4.0]]])
+    mixer = _FakeMixer().cuda()
+    cu_seqlens = torch.tensor([0, 2, 4], dtype=torch.int32, device="cuda")
+    first = torch.tensor([[[1.0], [2.0], [3.0], [4.0]]], device="cuda")
     second = first.clone()
     second[0, 1, 0] = 200.0
 
     first_out = cp_mamba.mamba_cp_forward(mixer, first, None, 0, 1, cu_seqlens)
     second_out = cp_mamba.mamba_cp_forward(mixer, second, None, 0, 1, cu_seqlens)
 
-    assert torch.equal(seen_seq_idx[0], torch.tensor([[0, 0, 1, 1]], dtype=torch.int32))
+    assert torch.equal(seen_seq_idx[0], torch.tensor([[0, 0, 1, 1]], dtype=torch.int32, device="cuda"))
     assert torch.equal(seen_seq_idx[1], seen_seq_idx[0])
     torch.testing.assert_close(first_out[:, 2:], second_out[:, 2:])
 
 
-def test_mamba_cp_forward_rejects_local_boundaries():
-    with pytest.raises(ValueError, match="full sequence length 4"):
-        cp_mamba._build_seq_idx([0, 2], 4, torch.device("cpu"))
+def test_mamba_cp_forward_builds_seq_idx_for_uneven_packs(monkeypatch):
+    seen_seq_idx: list[torch.Tensor] = []
+    _install_fake_scan(monkeypatch, seen_seq_idx)
+    monkeypatch.setattr(cp_mamba, "seq_to_head_parallel", lambda value, *_: value)
+    monkeypatch.setattr(cp_mamba, "head_to_seq_parallel", lambda value, *_: value)
+
+    cu_seqlens = torch.tensor([0, 1, 4, 6], dtype=torch.int32, device="cuda")
+    hidden_states = torch.arange(6, dtype=torch.float32, device="cuda").reshape(1, 6, 1)
+
+    cp_mamba.mamba_cp_forward(_FakeMixer().cuda(), hidden_states, None, 0, 1, cu_seqlens)
+
+    assert torch.equal(seen_seq_idx[0], torch.tensor([[0, 1, 1, 1, 2, 2]], dtype=torch.int32, device="cuda"))


### PR DESCRIPTION
## Problem

Both NemotronH Mamba paths derive their packed-document metadata inside the layer:

- `models/nemotron_h/modeling_nemotron_h.py:93` (`_varlen_mamba_forward`, non-CP) — `cu_seqlens.tolist()`, a per-document `nn.Conv1d` loop, a `torch.cat`, and a second Python loop to build `seq_idx`.
- `models/layers/cp_mamba.py:183` (`mamba_cp_forward`, Ulysses CP) — the same `.tolist()`, `_causal_conv1d_varlen`, and `_build_seq_idx`.

`.tolist()` on a CUDA tensor is a host-device sync. It runs once per Mamba layer, so on Nemotron-3-Super (40 `M` layers in `hybrid_override_pattern`) that is 40 stream drains per forward, 80 per micro-step with activation recompute. Each one blocks the Python thread until the stream drains, so the CPU cannot run ahead and enqueue the next layer's work, and per-step jitter on any rank propagates to all of them instead of being absorbed in queue depth.

The per-document conv loop compounds it: kernel launches scale with the document count (4–58 per rank on a 131k pack), which is also the most imbalanced work in the layer.

## Change

Use fla's Triton `causal_conv1d` and `prepare_sequence_ids` in both paths, matching the call shape already used for Qwen3.5 GDN in `trainer/model.py:203` and `qwen3_5_moe/modeling_qwen3_5_moe.py:168`:

```python
hidden_states_B_C, _ = fla_causal_conv1d(
    x=hidden_states_B_C,
    weight=self.conv1d.weight.squeeze(1),
    bias=self.conv1d.bias,
    activation=self.activation,
    cu_seqlens=cu_seqlens,
)
...
seq_idx = prepare_sequence_ids(cu_seqlens).to(torch.int32).unsqueeze(0)
```

Both fla helpers take `cu_seqlens` directly and are `@tensor_cache`d by argument identity, so the 40 layers of a forward share one build. `_build_seq_idx` and `_causal_conv1d_varlen` are deleted; the `[B, T, D]` layout fla expects is what the code already holds, so the transposes and the `torch.cat` go too, and `activation=` folds in the separate `silu`.

`flash-linear-attention` is already a required dependency (`pyproject.toml:40`) and its Triton backend needs no arch-specific CUDA compilation — that was the stated reason in `_patch_mamba2_use_triton_ssd`'s docstring for avoiding a fused conv here, so the docstring is updated too.

`cp_context` is deliberately left unset in `mamba_cp_forward`: after the seq-to-head all-to-all the conv is head-parallel and local over the full sequence, so fla's sequence-parallel CP conv is not the right primitive there.

## Measured effect

Nemotron-3-Super-120B-A12B, 8×H200 nodes (64 GPUs), seq_len 131072, cp=2 ulysses, full activation checkpointing. Four runs resumed from the same checkpoint over the **same 106 training steps with the same data order**, so the only variable is this patch:

| run | conv | mean step | MFU | slowest step |
|---|---|---|---|---|
| **this PR** | **fla** | **133.8 s** | **48.0%** | **150 s** |
| baseline a | stock | 143.7 s | 44.2% | 199 s |
| baseline b | stock | 145.7 s | 44.1% | 231 s |
| baseline c | stock | 144.9 s | 44.3% | 211 s |

**7.6% faster** (144.8 s → 133.8 s), **+3.8 MFU points**. The tail matters more than the mean: worst-case step drops from 199–231 s to 150 s, which is the run-ahead effect — without a per-layer sync, one slow rank no longer re-synchronizes the whole cluster at every layer.

## Correctness

Numerical equivalence against the per-document `nn.Conv1d` loop, forward and backward, relative L2:

| dtype | C | docs | T | fwd | dx | dw |
|---|---|---|---|---|---|---|
| fp32 | 128 | 4 | 2096 | 8.2e-08 | 7.8e-08 | 1.6e-07 |
| fp32 | 5120 | 2 | 4096 | 8.1e-08 | 7.7e-08 | 2.4e-07 |
| bf16 | 5120 | 4 | 4096 | 2.9e-03 | 2.7e-03 | 3.9e-03 |
| bf16 | 5120 | 1 | 4096 | 2.9e-03 | 2.7e-03 | 2.5e-03 |
| bf16 | 2048 | 3 | 4096 | 2.9e-03 | 2.7e-03 | 3.7e-03 |

fp32 agrees to fp32 rounding; bf16 to bf16 rounding (eps ≈ 7.8e-03), as expected from a different accumulation order. On the full 120B model this shows up as **1e-4**: resuming the same checkpoint into the same data, the first step logs loss 0.5301 / grad-norm 0.1257 with this patch versus 0.5300 / 0.1253–0.1255 across the three stock baselines. Not bit-identical, so it is best adopted at a phase boundary rather than mid-run.

## Tests

`tests/unit/train/models/test_cp_mamba.py` now needs a GPU (Triton), so it takes `pytestmark = [pytest.mark.gpu]` like the other model tests. `test_mamba_cp_forward_rejects_local_boundaries` covered a validation branch inside the deleted `_build_seq_idx`; it is replaced by `test_mamba_cp_forward_builds_seq_idx_for_uneven_packs`, which asserts the document ids fla produces for an uneven 3-document pack.

On one H200: `test_cp_mamba.py` 2 passed. `test_nemotron_h.py` + `test_nemotron_h_kl.py` 9 passed, 5 failed, 1 xfailed — the 5 failures (`AssertionError: varlen mamba expects batch_size=1 (packed)`) reproduce identically on unmodified `main` and are unrelated.

## What this does not do

This was written while chasing a deterministic multi-node hang in a Mamba CP all-to-all, on the theory that the per-layer sync was the mechanism. **It is not.** With this patch applied and the data order held fixed, the hang reproduces at exactly the same training step. The patch does change where ranks block — inside `all_to_all_single` rather than behind `cu_seqlens.tolist()` in a `cudaMemcpy` — which makes the stranded ranks visible to the NCCL flight recorder instead of hiding them. Useful, but the root cause is elsewhere and is not addressed here.
