### PR TITLE
feat: nodes_per_replica for standalone multi-node inference

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -108,6 +108,21 @@ dp = 4
 
 This configuration will run 2 independent vLLM replicas, each with `tp=2` and `dp=4`. Routing is handled by a single global router running on the first inference node, fronting the per-rank endpoints of all replicas — either `vllm-router` (default) or the upstream `llm-d` EPP+Envoy, selected via the `[inference.router]` block. You can read more about the supported routing options in the [router](#router) section.
 
+For models too large to fit a single node, `nodes_per_replica` groups consecutive nodes into one replica: the replica's ranks form a single external-LB DP group with expert parallelism spanning the group, so expert weights shard across all of the replica's GPUs. Requires `enable_expert_parallel` and the `vllm-router` backend.
+
+```toml
+[inference.deployment]
+type = "multi_node"
+num_nodes = 4
+nodes_per_replica = 2  # 2 replicas, each spanning 2 nodes (dp=2, EP over 16 GPUs at tp=8)
+
+[inference]
+enable_expert_parallel = true
+
+[inference.parallel]
+tp = 8
+```
+
 ### Wide-EP
 
 For huge, 200B+ scale models, you might want to use multi-node expert parallelism to maximize the KV-cache space. This deployment shape is defined by setting `inference.deployment.type = "multi_node"` and `inference.enable_expert_parallel = true`.

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -253,12 +253,28 @@ class SingleNodeInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
     type: Literal["single_node"] = "single_node"
 
 
-# Multi-node inference: each node runs an independent vLLM replica.
+# Multi-node inference: each node runs an independent vLLM replica, unless
+# nodes_per_replica groups nodes into larger replicas.
 class MultiNodeInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
     type: Literal["multi_node"] = "multi_node"
 
     num_nodes: int = Field(2, ge=1)
     """Inference nodes."""
+
+    nodes_per_replica: int = Field(1, ge=1)
+    """Nodes each replica spans. 1 (default) runs an independent replica per node; >1 groups
+    consecutive nodes into one replica whose ranks form a single external-LB DP group with EP
+    spanning the group — for models too large for one node (e.g. BF16 550B on 8xH200 nodes).
+    Requires ``enable_expert_parallel`` and the ``vllm-router`` backend."""
+
+    @model_validator(mode="after")
+    def validate_nodes_per_replica(self):
+        if self.num_nodes % self.nodes_per_replica != 0:
+            raise ValueError(
+                f"deployment.num_nodes ({self.num_nodes}) must be a multiple of "
+                f"deployment.nodes_per_replica ({self.nodes_per_replica})."
+            )
+        return self
 
 
 # Disaggregated prefill/decode inference. Each replica is split into separate
@@ -427,6 +443,22 @@ class InferenceConfig(BaseConfig):
     def validate_multi_node_requires_slurm(self):
         if self.deployment.type in ("multi_node", "disaggregated") and self.slurm is None:
             raise ValueError("Must use SLURM for multi-node / disaggregated deployment.")
+        return self
+
+    @model_validator(mode="after")
+    def validate_nodes_per_replica_requires_ep(self):
+        if self.deployment.type != "multi_node" or self.deployment.nodes_per_replica == 1:
+            return self
+        if not self.enable_expert_parallel:
+            raise ValueError(
+                "deployment.nodes_per_replica > 1 requires enable_expert_parallel "
+                "(weights shard across the replica's node-spanning EP group)."
+            )
+        if self.router is not None and self.router.type == "llm-d":
+            raise ValueError(
+                "deployment.nodes_per_replica > 1 is only supported with the vllm-router backend "
+                "(llm-d endpoint discovery assumes one replica per node)."
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -113,6 +113,7 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
             data_parallel_rpc_port=config.data_parallel_rpc_port,
             enable_expert_parallel=config.enable_expert_parallel,
             infer_nodes_per_replica=config.deployment.num_nodes,
+            nodes_per_replica=config.deployment.nodes_per_replica,
         )
 
     script = template.render(**template_vars)

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -316,10 +316,11 @@ srun --kill-on-bad-exit=1 bash -c '
     fi
 
     # Replica geometry: each replica spans NODES_PER_REPLICA consecutive nodes (1 = the
-    # classic replica-per-node shape). For MoE the replica's ranks form one external-LB
+    # classic replica-per-node shape). For MoE the ranks of a replica form one external-LB
     # DP group (EP all2all spans them) rooted on the replica-head DP coordinator, matching
     # the RL and P/D launch paths: ranks on the head reach the coordinator via LOCAL_IP,
-    # ranks on other nodes via the head hostname.
+    # ranks on other nodes via the head hostname. NOTE: this whole block lives inside a
+    # single-quoted `srun bash -c` string — apostrophes in comments break the quoting.
     read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
     REPLICA_IDX=$((INFER_NODE_RANK / NODES_PER_REPLICA))
     RANK_IN_REPLICA=$((INFER_NODE_RANK % NODES_PER_REPLICA))

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -308,21 +308,34 @@ srun --kill-on-bad-exit=1 bash -c '
     DP_PER_NODE={{ dp_per_node }}
     TP=$((GPUS_PER_NODE / DP_PER_NODE))
     EP={{ "1" if enable_expert_parallel else "0" }}
+    NODES_PER_REPLICA={{ nodes_per_replica }}
 
     # Start the single global router on node 0 (balances across per-rank endpoints — no intra-node DP header)
     if [ "$INFER_NODE_RANK" -eq 0 ]; then
         launch_router regular "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$OUTPUT_DIR/logs/inference/router.log"
     fi
 
+    # Replica geometry: each replica spans NODES_PER_REPLICA consecutive nodes (1 = the
+    # classic replica-per-node shape). For MoE the replica's ranks form one external-LB
+    # DP group (EP all2all spans them) rooted on the replica-head DP coordinator, matching
+    # the RL and P/D launch paths: ranks on the head reach the coordinator via LOCAL_IP,
+    # ranks on other nodes via the head hostname.
+    read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
+    REPLICA_IDX=$((INFER_NODE_RANK / NODES_PER_REPLICA))
+    RANK_IN_REPLICA=$((INFER_NODE_RANK % NODES_PER_REPLICA))
+    REPLICA_HEAD_HOST="${HOSTNAMES[$((REPLICA_IDX * NODES_PER_REPLICA))]}"
+    GROUP_DP=$((NODES_PER_REPLICA * DP_PER_NODE))
+    if [ "$RANK_IN_REPLICA" -eq 0 ]; then DP_ADDR="$LOCAL_IP"; else DP_ADDR="$REPLICA_HEAD_HOST"; fi
+
     # External-LB: one vLLM API server per DP rank on this node (BACKEND_PORT + dp_local),
-    # each pinned to its TP slice of GPUs. Each node is an independent replica, so any MoE EP
-    # group is node-local (rendezvous on LOCAL_IP); dense models run independent engines.
+    # each pinned to its TP slice of GPUs; dense models run independent engines.
     for ((d=0; d<DP_PER_NODE; d++)); do
         RANK_GPUS=$(seq -s, $((d * TP)) $((d * TP + TP - 1)))
         RANK_LOG=$(rank_log "$INFER_NODE_RANK" "$d")
-        if [ "$EP" -eq 1 ] && [ "$DP_PER_NODE" -gt 1 ]; then
-            RANK_EXTRA="{\"data_parallel_rank\": $d, \"data_parallel_address\": \"$LOCAL_IP\"}"
-            launch_inference_rank "$((BACKEND_PORT + d))" "$RANK_GPUS" "$DP_PER_NODE" "$RPC_PORT" "$RANK_EXTRA" "" "$RANK_LOG"
+        if [ "$EP" -eq 1 ] && [ "$GROUP_DP" -gt 1 ]; then
+            GLOBAL_DP_RANK=$((RANK_IN_REPLICA * DP_PER_NODE + d))
+            RANK_EXTRA="{\"data_parallel_rank\": $GLOBAL_DP_RANK, \"data_parallel_address\": \"$DP_ADDR\"}"
+            launch_inference_rank "$((BACKEND_PORT + d))" "$RANK_GPUS" "$GROUP_DP" "$RPC_PORT" "$RANK_EXTRA" "" "$RANK_LOG"
         else
             # Dense or single-DP-rank EP (dp=1, e.g. EP within one tp=8 group):
             # independent single-engine servers. vLLM rejects the external-LB DP


### PR DESCRIPTION
Adds `deployment.nodes_per_replica` to the standalone multi-node inference launcher: groups consecutive nodes into one replica whose ranks form a single external-LB DP group with EP spanning the group (ports the RL template's replica-spanning geometry). Default 1 preserves the replica-per-node behavior — verified unchanged sbatch renders for existing single-node-replica configs.

Motivation: serving models too large for one node without P/D disaggregation (no NIXL/UCX build needed) — concretely Nemotron Ultra **BF16** (~1.1TB) as 2× 2-node replicas (tp=8, dp=2, EP over 16 GPUs) on 8xH200 nodes in PrimeIntellect-ai/research-prod#158.

Validators: requires `enable_expert_parallel` and the `vllm-router` backend; `num_nodes` must be divisible by `nodes_per_replica`. Docs updated (multi-node section).

Follow-up to #3184 (same deployment work); cherry-picked onto main post-merge, adapted to the router-field relocation and the removed mxfp8 validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-node MoE SLURM launch and DP/EP rendezvous geometry; misconfiguration could break distributed inference, though default 1 preserves prior behavior and validators gate the new path.
> 
> **Overview**
> Adds **`deployment.nodes_per_replica`** to standalone multi-node inference so consecutive nodes can form **one replica** instead of one replica per node. With expert parallel enabled, ranks in that group share a single external-LB **data-parallel** coordinator (`data_parallel_address` on the replica head, global `data_parallel_rank` across nodes), so **EP spans all GPUs in the replica**—aimed at models that do not fit on a single node without P/D disaggregation.
> 
> **Default `nodes_per_replica = 1`** keeps the existing replica-per-node launch path. The SLURM `inference.sbatch.j2` multi-node block now derives replica index, head hostname, and `GROUP_DP = nodes_per_replica × dp_per_node` when wiring vLLM rank extras.
> 
> **Validation:** `num_nodes` must divide `nodes_per_replica`; values **> 1** require **`enable_expert_parallel`** and the **`vllm-router`** backend (rejects **llm-d**). Docs in `docs/inference.md` include a 4-node / 2-nodes-per-replica example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de29e5b2e89f1afa4ea29e6423f69ce6f3ef4c41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->