### PR TITLE
fix: disable dynamo on Ulysses all-to-all to prevent FSDP×compile NCCL deadlock

### DIFF
--- a/src/prime_rl/trainer/models/layers/ulysses_attn.py
+++ b/src/prime_rl/trainer/models/layers/ulysses_attn.py
@@ -68,11 +68,18 @@ def _replicate_kv_heads(t: torch.Tensor, cp_size: int) -> torch.Tensor:
     return t.repeat_interleave(cp_size // h, dim=1)
 
 
+@torch._dynamo.disable
 def _all_to_all_seq_to_head(t: torch.Tensor, cp_size: int, cp_group: dist.ProcessGroup) -> torch.Tensor:
     """Redistribute [S_local, H, D] -> [S_global, H_local, D].
 
     Splits the head dim into cp_size groups and exchanges them so each rank
     ends up with the full sequence but only H/cp_size heads. Differentiable.
+
+    Disabled for dynamo: the collective must execute eagerly so it is scheduled
+    by the autograd engine in a consistent order across ranks, not reordered by
+    the compiled backward graph. Otherwise FSDP's post_backward reduce-scatter
+    and the all-to-all backward can interleave differently per rank, deadlocking
+    NCCL (see PR #3186 job 1578).
     """
     s_local, h, d = t.shape
     assert h % cp_size == 0, (
@@ -90,6 +97,7 @@ def _all_to_all_seq_to_head(t: torch.Tensor, cp_size: int, cp_group: dist.Proces
     return out.reshape(cp_size * s_local, h_local, d)
 
 
+@torch._dynamo.disable
 def _all_to_all_head_to_seq(t: torch.Tensor, cp_size: int, cp_group: dist.ProcessGroup) -> torch.Tensor:
     """Inverse of `_all_to_all_seq_to_head`: [S_global, H_local, D] -> [S_local, H, D]."""
     s_global, h_local, d = t.shape


### PR DESCRIPTION
## Summary

Fixes the NCCL collective ordering deadlock that occurs when `torch.compile` is used together with Ulysses context parallelism and FSDP (reported in PR #3186, Slurm job 1578).

### Root cause

At NCCL sequence number 3750, rank 0 was stuck on FSDP's `reduce_scatter_tensor` (from `post_backward`) while rank 1 was stuck on Ulysses' `all_to_all_single` (from `dist_nn.functional` backward). Both ranks had completed all collectives up to 3749, then diverged — a classic collective ordering mismatch that deadlocks NCCL after the 1-hour watchdog timeout.

The issue is that `torch.compile` traces the Ulysses all-to-all collectives into the compiled backward graph for each decoder layer, while FSDP's `post_backward` reduce-scatter hooks fire eagerly via the autograd engine *outside* the compiled graph. The compiler may reorder the all-to-all backward differently across ranks (especially for MoE models with data-dependent expert routing or variable-length sequences), causing the two collective systems to interleave in inconsistent orders across ranks.

### Fix

Wrap `_all_to_all_seq_to_head` and `_all_to_all_head_to_seq` with `@torch._dynamo.disable`. This forces a graph break around the collectives so they execute eagerly in the autograd engine — the same scheduling path as FSDP hooks — restoring a single consistent backward ordering between the two collective systems. This mirrors the existing `torch._dynamo.disable` on the FA4 flash kernel itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed training collectives under compile+FSDP; the change is small and aligns scheduling with existing FA4 dynamo-disable behavior, but incorrect ordering could still deadlock or regress multi-GPU training.
> 
> **Overview**
> Fixes an NCCL collective-ordering deadlock when **`torch.compile`**, **Ulysses context parallelism**, and **FSDP** run together (PR #3186 / job 1578).
> 
> **`_all_to_all_seq_to_head`** and **`_all_to_all_head_to_seq`** in `ulysses_attn.py` are now wrapped with **`@torch._dynamo.disable`**, with docstrings noting that Ulysses **`all_to_all_single`** must run eagerly in the autograd engine so its backward ordering matches FSDP **`post_backward`** reduce-scatter hooks instead of being reordered inside compiled backward graphs (which can differ across ranks).
> 
> This follows the same pattern already used for the FA4 flash kernel in that module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8e305fe9e28b3f504fdfba6841d80fb2d677e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->