### PR TITLE
fix: accept seq_lens contract kwargs in GlmMoeDsaModel.forward

### DIFF
--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -207,10 +207,20 @@ class GlmMoeDsaModel(GlmMoeDsaPreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
+        # Document boundaries derive from position_ids (sparse MLA builds its
+        # varlen indices from them); seq_lens is accepted to satisfy the
+        # trainer's universal contract (the fused LM head wrapper forwards it).
+        *,
+        seq_lens: Optional[torch.LongTensor] = None,
+        seq_lens_are_pre_shard: bool = False,
     ) -> BaseModelOutputWithPast:
         """
         routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
+        seq_lens (`torch.LongTensor` of shape `(num_documents,)`, *optional*):
+            Per-document lengths of the packed row (PrimeRL packed-batch contract). Unused.
+        seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
+            Whether `seq_lens` holds pre-CP-shard (global) document boundaries. Unused.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -207,9 +207,6 @@ class GlmMoeDsaModel(GlmMoeDsaPreTrainedModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-        # Document boundaries derive from position_ids (sparse MLA builds its
-        # varlen indices from them); seq_lens is accepted to satisfy the
-        # trainer's universal contract (the fused LM head wrapper forwards it).
         *,
         seq_lens: Optional[torch.LongTensor] = None,
         seq_lens_are_pre_shard: bool = False,


### PR DESCRIPTION
## Summary

GLM-5.2 (`glm_moe_dsa`) crashes on any run with `fused_lm_head_token_chunk_size` set:

```
TypeError: GlmMoeDsaModel.forward() got an unexpected keyword argument 'seq_lens'
```

The fused LM head wrapper (`_patch_model_forward` in `models/layers/lm_head.py`) replaces the causal-LM forward and passes all remaining kwargs — including the trainer's universal `seq_lens` / `seq_lens_are_pre_shard` contract kwargs — straight to the inner `self.model`. Every other custom model accepts these on its inner `Model.forward` (e.g. `Glm4MoeModel`, `Qwen3Model`), but `glm_moe_dsa` only accepted them on `GlmMoeDsaForCausalLM`.

This adds the same accept-and-ignore keyword-only args to `GlmMoeDsaModel.forward` — document boundaries derive from `position_ids` (sparse MLA builds its varlen indices from them), matching the existing rationale on the CausalLM wrapper.

Hit on a 4-node GLM-5.2 fake-data trainer run (65k seq len, cp8, fused LM head) while testing #3196; the failure is independent of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Signature and documentation only; behavior unchanged because the new kwargs are ignored.
> 
> **Overview**
> Fixes a **`TypeError`** when training GLM-5.2 with **`fused_lm_head_token_chunk_size`**: the fused LM head forwards the trainer’s packed-batch kwargs (`seq_lens`, `seq_lens_are_pre_shard`) into the inner backbone, but **`GlmMoeDsaModel.forward`** did not accept them.
> 
> This PR adds the same **keyword-only, accept-and-ignore** parameters to **`GlmMoeDsaModel.forward`** (with docstrings noting they are unused), aligning with other PrimeRL models. Document boundaries for this architecture still come from **`position_ids`** for sparse MLA varlen indexing, as on the CausalLM wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97aff825c901f7cfa465e969675db452186f070d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->