### PR TITLE
fix(sft): drop rows with phantom media tokens; fail fast on fatal rank errors

### DIFF
--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -312,6 +312,29 @@ class SFTDataset(StatefulIterableDataset):
                 "Set [model.vlm] to train on multimodal samples."
             )
 
+        # Literal media-marker text (e.g. "<image>" inside a code comment or tool-call
+        # arguments) tokenizes to the model's image-placeholder id with no pixel data
+        # behind it. One phantom token in a packed batch fails the scatter-time
+        # token/feature check on whichever rank draws it — and that rank's teardown then
+        # wedges every other rank in a collective until the NCCL timeout, which blames a
+        # victim collective instead of the row. mm_token_type_ids marks only
+        # renderer-emitted placeholder runs, so any placeholder id at a type-0 position —
+        # or anywhere in a row that produced no multimodal data — is phantom text.
+        mm_map = getattr(self.renderer, "mm_token_type_id_map", None)
+        if mm_map:
+            placeholder_ids = set(mm_map)
+            if mm_token_type_ids is None:
+                phantom = sum(1 for t in input_ids if t in placeholder_ids)
+            else:
+                phantom = sum(1 for t, tt in zip(input_ids, mm_token_type_ids) if tt == 0 and t in placeholder_ids)
+            if phantom:
+                self.logger.warning(
+                    f"Dropping example {example.get('__index', '')} ({example.get('id', '?')}): "
+                    f"{phantom} media placeholder token(s) outside any renderer-emitted "
+                    f"placeholder run (literal marker text in content)"
+                )
+                return None
+
         # Causal shift: model predicts next token from current.
         target_ids = input_ids[1:]
         loss_mask = loss_mask[1:]

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -2,7 +2,6 @@ import asyncio
 import functools
 import importlib
 import os
-import sys
 from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
@@ -50,18 +49,21 @@ def clean_exit(func: Callable) -> Callable:
         async def async_wrapper(*args, **kwargs):
             try:
                 ret = await func(*args, **kwargs)
-                wandb.finish()
-                return ret
             except Exception:
                 get_logger().opt(exception=True).error(f"Fatal error in {func.__name__}")
                 wandb.finish(exit_code=1)
-                # sys.exit raises SystemExit so the finally block still runs.
-                # raise alone doesn't terminate the process in an async context —
-                # the event loop swallows it and the process hangs indefinitely.
-                sys.exit(1)
-            finally:
-                if dist.is_initialized():
-                    dist.destroy_process_group()
+                # Do NOT destroy the process group on the fatal path: peer ranks are
+                # typically still blocked in a collective this rank will never join, so
+                # a graceful shutdown hangs in ProcessGroup.shutdown() and the job only
+                # dies at the collective timeout — with the watchdog blaming a victim
+                # collective on a healthy rank. Hard-exit instead so the launcher's
+                # failure propagation (torchrun / srun --kill-on-bad-exit) tears the
+                # world down immediately.
+                os._exit(1)
+            wandb.finish()
+            if dist.is_initialized():
+                dist.destroy_process_group()
+            return ret
 
         return async_wrapper
     else:
@@ -70,16 +72,21 @@ def clean_exit(func: Callable) -> Callable:
         def sync_wrapper(*args, **kwargs):
             try:
                 ret = func(*args, **kwargs)
-                wandb.finish()
-                return ret
             except Exception:
                 get_logger().opt(exception=True).error(f"Fatal error in {func.__name__}")
                 wandb.finish(exit_code=1)
-                # sys.exit raises SystemExit so the finally block still runs.
-                sys.exit(1)
-            finally:
-                if dist.is_initialized():
-                    dist.destroy_process_group()
+                # Do NOT destroy the process group on the fatal path: peer ranks are
+                # typically still blocked in a collective this rank will never join, so
+                # a graceful shutdown hangs in ProcessGroup.shutdown() and the job only
+                # dies at the collective timeout — with the watchdog blaming a victim
+                # collective on a healthy rank. Hard-exit instead so the launcher's
+                # failure propagation (torchrun / srun --kill-on-bad-exit) tears the
+                # world down immediately.
+                os._exit(1)
+            wandb.finish()
+            if dist.is_initialized():
+                dist.destroy_process_group()
+            return ret
 
         return sync_wrapper
 


### PR DESCRIPTION
## The failure this fixes

Five consecutive 64-GPU SFT runs (Nemotron-VL graft, 8×H200, cp=2 ulysses, seq 131k) wedged at the **same training step** under a fixed data seed: 62 ranks spinning at 100% GPU inside NCCL, two ranks at 0% in `futex_wait`, no error in the job log, and after `dist_timeout` a watchdog report blaming an FSDP all-gather on a healthy rank. It looked like fabric. It wasn't.

The two silent ranks (one CP pair) had hit, inside `model.forward`:

```
ValueError: Nemotron-VL image token/feature mismatch before scatter:
  img_context_token_id=18, image_tokens=8936, image_features=8935, ...
```

Their pack contained a **text-only SWE trace** in which an assistant tool-call writes a file whose docs contain the literal string `<image>` (`{type<image>|bold}`, a template-language example). The tokenizer maps that substring to the image-placeholder id — one phantom placeholder with no pixel features behind it, so the packed batch counts N+1 image tokens against N features.

`clean_exit` then caught the exception and, in its `finally`, called `dist.destroy_process_group()` — while the 62 peers were still blocked in a collective the dying pair would never join. The graceful shutdown hangs in `ProcessGroup.shutdown()`, the peers spin to the collective timeout, and the flight-recorder dump describes only victims (the two culprit ranks never reach a collective, so they write no trace). With `--local-ranks-filter=0` the actual traceback existed only in the per-rank torchrun log of local ranks 2–3.

## Fix 1 — drop rows with phantom media tokens (`sft/data.py`)

`mm_token_type_ids` is built from renderer-emitted `PlaceholderRange`s only, so a placeholder id at a type-0 position — or anywhere in a row that produced no multimodal data at all — is phantom text, never legitimate. `SFTDataset._process` now counts those and drops the row with a warning naming the example:

```
WARNING Dropping example 9690 (swe_code_agent-train-9776): 1 media placeholder
token(s) outside any renderer-emitted placeholder run (literal marker text in content)
```

The check is renderer-agnostic (uses the `mm_token_type_id_map` protocol attribute, inert for text-only renderers) and O(seq_len) per row against a 1–2 element set.

## Fix 2 — fail fast on fatal rank errors (`utils.py`)

On the fatal path, `clean_exit` no longer attempts a graceful `destroy_process_group()`; it logs, flushes wandb, and `os._exit(1)`. The launcher's failure propagation (torchrun / `srun --kill-on-bad-exit`) then tears the world down in seconds instead of `dist_timeout` minutes, and the surviving logs point at the rank that actually raised rather than at a victim collective. The clean path is unchanged: `wandb.finish()` then graceful destroy.

This applies to both the sync and async wrappers (the async comment about `sys.exit` being swallowed by the event loop applied to `raise`, and `os._exit` is immune to both).

## Verification

- Guard tested against the actual offending corpus row: dropped with the warning above; healthy text-only, single-image, and multi-image (3-tile) rows all render unchanged.
- Before the guard, the row reproducibly wedged an 8-node run at the same step under seed 0 (four resumed runs + one from-scratch run); a seed bump moved the row and the run passed the step — confirming the row, not the step, as the trigger.
- `ruff check` / `ruff format --check` clean on both files.

## Corpus census

A full sweep of the 46-subset corpus (13.1M rows) for literal media markers in **any** message field found 24 flagged rows, all in `tool_calls` arguments — the field the previous content-only sanitizer never walked. Rendering all 24 through the guard: **7 are real phantoms** (2–11 phantom tokens each, all in the SWE-agent family; the guard drops every one) and 17 are benign (the marker never survives into the token stream on that render path). Every other subset is clean. So the guard costs 7 rows out of 13.1M while removing the entire crash class.
