### PR TITLE
fix: keep GLM-5.2 weight broadcast within GPU memory at 4-node scale

### DIFF
--- a/src/prime_rl/trainer/models/glm_moe_dsa/converting_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/converting_glm_moe_dsa.py
@@ -102,24 +102,46 @@ def convert_tt_layer_to_vllm_kernel(
         w2 = state_dict[w2_key]
         w3 = state_dict[w3_key]
         w13 = torch.cat([w1, w3], dim=1)
+        # The full routed-expert tensors dominate broadcast peak memory (tens of
+        # GiB per layer once gathered). Drop consumed inputs eagerly and write
+        # quantized experts into preallocated stacks instead of stack() copies.
+        del w1, w3
+        del state_dict[w1_key], state_dict[w3_key]
 
         if quantize_fp8:
-            w13_fp8: list[Tensor] = []
-            w13_scales: list[Tensor] = []
-            w2_fp8: list[Tensor] = []
-            w2_scales: list[Tensor] = []
-            for expert_idx in range(w1.shape[0]):
+            num_experts = w13.shape[0]
+            w13_fp8 = w13_scales = w2_fp8 = w2_scales = None
+            for expert_idx in range(num_experts):
                 expert_w13_fp8, expert_w13_scales = quantize_to_vllm_kernel_format(w13[expert_idx])
                 expert_w2_fp8, expert_w2_scales = quantize_to_vllm_kernel_format(w2[expert_idx])
-                w13_fp8.append(expert_w13_fp8)
-                w13_scales.append(expert_w13_scales)
-                w2_fp8.append(expert_w2_fp8)
-                w2_scales.append(expert_w2_scales)
+                if w13_fp8 is None:
+                    w13_fp8 = torch.empty(
+                        (num_experts, *expert_w13_fp8.shape), dtype=expert_w13_fp8.dtype, device=expert_w13_fp8.device
+                    )
+                    w13_scales = torch.empty(
+                        (num_experts, *expert_w13_scales.shape),
+                        dtype=expert_w13_scales.dtype,
+                        device=expert_w13_scales.device,
+                    )
+                    w2_fp8 = torch.empty(
+                        (num_experts, *expert_w2_fp8.shape), dtype=expert_w2_fp8.dtype, device=expert_w2_fp8.device
+                    )
+                    w2_scales = torch.empty(
+                        (num_experts, *expert_w2_scales.shape),
+                        dtype=expert_w2_scales.dtype,
+                        device=expert_w2_scales.device,
+                    )
+                w13_fp8[expert_idx] = expert_w13_fp8
+                w13_scales[expert_idx] = expert_w13_scales
+                w2_fp8[expert_idx] = expert_w2_fp8
+                w2_scales[expert_idx] = expert_w2_scales
+            del w13, w2
+            del state_dict[w2_key]
 
-            out[f"{prefix}.mlp.experts.w13_weight"] = torch.stack(w13_fp8)
-            out[f"{prefix}.mlp.experts.w13_weight_scale_inv"] = torch.stack(w13_scales)
-            out[f"{prefix}.mlp.experts.w2_weight"] = torch.stack(w2_fp8)
-            out[f"{prefix}.mlp.experts.w2_weight_scale_inv"] = torch.stack(w2_scales)
+            out[f"{prefix}.mlp.experts.w13_weight"] = w13_fp8
+            out[f"{prefix}.mlp.experts.w13_weight_scale_inv"] = w13_scales
+            out[f"{prefix}.mlp.experts.w2_weight"] = w2_fp8
+            out[f"{prefix}.mlp.experts.w2_weight_scale_inv"] = w2_scales
         else:
             out[f"{prefix}.mlp.experts.w13_weight"] = w13
             out[f"{prefix}.mlp.experts.w2_weight"] = w2

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -604,6 +604,10 @@ def train(config: TrainerConfig):
             )
             if not broadcast_unused:
                 broadcast_weights_start_time = time.perf_counter()
+                # The per-layer gather + fp8 conversion peaks ~50 GiB above the
+                # resident weights; release cached blocks (incl. offload-stream
+                # pools) so the broadcast gets the full headroom.
+                torch.cuda.empty_cache()
                 weight_broadcast.broadcast_weights(model, step=progress.step)
                 broadcast_weights_time = time.perf_counter() - broadcast_weights_start_time
                 # Clean up old broadcast directories (unless at ckpt interval if using filesystem weight broadcast)


### PR DESCRIPTION
## Summary

At 4 train nodes the resident FP32 master shards for GLM-5.2 are ~87 GiB/rank. The NCCL weight broadcast gathers each layer's full routed-expert tensors and fp8-quantizes them, transiently peaking ~49 GiB above that — the startup broadcast fit with ~4 GiB to spare, but the post-step broadcast OOMed because ~42 GiB of training transients sat in allocator caches (incl. per-stream pools) the broadcast's default stream could not reuse.

Two changes:

- `torch.cuda.empty_cache()` before each in-loop broadcast so cached training pools become reusable (measured: reserved drops 129.7 → 93.9 GiB entering the broadcast).
- Leaner GLM-5.2 layer conversion in `convert_tt_layer_to_vllm_kernel`: drop consumed expert tensors eagerly and quantize each expert into preallocated stacks instead of list + `torch.stack` copies. Per-layer transient peak drops from ~49 GiB to ~31 GiB (measured 135.4 → 117.8 GiB reserved during broadcast).

## Validation

GLM-5.2 wordle RL on 8 nodes (4 trainer + 2 prefill + 2 decode disaggregated NIXL), seq_len 8192, cp1/ep8, fp8 trainer quantization, optimizer+gradient CPU offload (#3196), sign_sgd: 20/20 steps with in-loop NCCL broadcasts every step, peak reserved stable at 129.8 GiB, no OOM. Layer-by-layer memory probes confirmed the numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)