### PR TITLE
feat: auto-resolve parsers for laguna, gpt-oss, and trinity

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/utils/parsers.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/parsers.py
@@ -2,12 +2,17 @@ import re
 
 # (regex, parser_name) — first match wins.
 TOOL_CALL_PARSER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Trinity-Large-Thinking uses the Qwen3-Coder tool format; the rest of the family is Hermes.
+    (re.compile(r"^arcee-ai/Trinity-Large-Thinking"), "qwen3_coder"),
+    (re.compile(r"^arcee-ai/Trinity-"), "hermes"),
     (re.compile(r"^deepseek-ai/DeepSeek-V3\.2"), "deepseek_v32"),
     (re.compile(r"^deepseek-ai/DeepSeek-V3\.1"), "deepseek_v31"),
     (re.compile(r"^zai-org/GLM-4\.5"), "glm45"),
     (re.compile(r"^zai-org/GLM-4\.7"), "glm47"),
     (re.compile(r"^zai-org/GLM-5"), "glm47"),
     (re.compile(r"^MiniMaxAI/MiniMax-M2"), "minimax_m2"),
+    (re.compile(r"^openai/gpt-oss"), "openai"),
+    (re.compile(r"^poolside/Laguna"), "poolside_v1"),
     (re.compile(r"^PrimeIntellect/INTELLECT-3"), "qwen3_coder"),
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3"), "qwen3_coder"),
     (re.compile(r"^stepfun-ai/Step-3\.5"), "step3p5"),
@@ -18,9 +23,13 @@ TOOL_CALL_PARSER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
 ]
 
 REASONING_PARSER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Trinity-Large-Preview doesn't reason; the Thinking/Mini/Nano variants do.
+    (re.compile(r"^arcee-ai/Trinity-(Large-Thinking|Mini|Nano)"), "deepseek_r1"),
     (re.compile(r"^deepseek-ai/DeepSeek-V3\.[12]"), "deepseek_r1"),
     (re.compile(r"^zai-org/GLM-"), "glm45"),
     (re.compile(r"^MiniMaxAI/MiniMax-M2"), "minimax_m2_append_think"),
+    # openai/gpt-oss has no entry here — vLLM's harmony serving path splits reasoning natively.
+    (re.compile(r"^poolside/Laguna"), "poolside_v1"),
     (re.compile(r"^PrimeIntellect/INTELLECT-3"), "deepseek_r1"),
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3-Super"), "nemotron_v3"),
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3-Nano"), "nano_v3"),

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -5,6 +5,11 @@ from prime_rl.utils.parsers import resolve_reasoning_parser, resolve_tool_call_p
 
 # (model_name, expected_tool_call_parser, expected_reasoning_parser)
 EXPECTED_PARSERS: list[tuple[str, str | None, str | None]] = [
+    # Arcee Trinity
+    ("arcee-ai/Trinity-Large-Thinking", "qwen3_coder", "deepseek_r1"),
+    ("arcee-ai/Trinity-Large-Preview", "hermes", None),
+    ("arcee-ai/Trinity-Mini", "hermes", "deepseek_r1"),
+    ("arcee-ai/Trinity-Nano-Preview", "hermes", "deepseek_r1"),
     # DeepSeek
     ("deepseek-ai/DeepSeek-V3.2", "deepseek_v32", "deepseek_r1"),
     ("deepseek-ai/DeepSeek-V3.2-Exp", "deepseek_v32", "deepseek_r1"),
@@ -33,6 +38,14 @@ EXPECTED_PARSERS: list[tuple[str, str | None, str | None]] = [
     ("MiniMaxAI/MiniMax-M2", "minimax_m2", "minimax_m2_append_think"),
     ("MiniMaxAI/MiniMax-M2.1", "minimax_m2", "minimax_m2_append_think"),
     ("MiniMaxAI/MiniMax-M2.5", "minimax_m2", "minimax_m2_append_think"),
+    # gpt-oss (reasoning handled natively by vLLM's harmony path)
+    ("openai/gpt-oss-20b", "openai", None),
+    ("openai/gpt-oss-120b", "openai", None),
+    # Poolside Laguna
+    ("poolside/Laguna-S-2.1", "poolside_v1", "poolside_v1"),
+    ("poolside/Laguna-S-2.1-FP8", "poolside_v1", "poolside_v1"),
+    ("poolside/Laguna-XS-2.1", "poolside_v1", "poolside_v1"),
+    ("poolside/Laguna-M.1", "poolside_v1", "poolside_v1"),
     # INTELLECT-3
     ("PrimeIntellect/INTELLECT-3", "qwen3_coder", "deepseek_r1"),
     ("PrimeIntellect/INTELLECT-3-FP8", "qwen3_coder", "deepseek_r1"),


### PR DESCRIPTION
## Summary

Adds parser auto-resolution for three model families we support in the trainer (`laguna`, `gpt_oss`, `afmoe` impls) but that were missing from the automap, so serving them previously required pinning `tool_call_parser` / `reasoning_parser` by hand:

- **poolside/Laguna** (`Laguna-S-2.1`, `Laguna-XS-2.1`, `Laguna-M.1`, …) → `poolside_v1` / `poolside_v1`, per the [vLLM recipes](https://docs.vllm.ai/projects/recipes/en/latest/poolside/Laguna-S-2.1.html) for all four Laguna models.
- **openai/gpt-oss** → tool `openai`, no reasoning parser — the [gpt-oss recipes](https://docs.vllm.ai/projects/recipes/en/latest/openai/gpt-oss-120b.html) set only the tool parser; vLLM's harmony serving path splits reasoning natively.
- **arcee-ai/Trinity** → heterogeneous per model cards: `Trinity-Large-Thinking` uses `qwen3_coder` + `deepseek_r1`; `Trinity-Mini` / `Trinity-Nano-*` use `hermes` + `deepseek_r1`; `Trinity-Large-Preview` uses `hermes` with no reasoning parser (non-thinking variant).

Extends the `EXPECTED_PARSERS` table in `tests/unit/test_parsers.py` accordingly (136 passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds regex entries and test cases for inference parser selection only; no changes to training logic, auth, or data handling.
> 
> **Overview**
> Extends the model-name → parser automap so **poolside/Laguna**, **openai/gpt-oss**, and **arcee-ai/Trinity** no longer need manual `tool_call_parser` / `reasoning_parser` overrides when serving.
> 
> **Laguna** models map to `poolside_v1` for both tool and reasoning parsing. **gpt-oss** uses the `openai` tool parser only; reasoning is intentionally omitted so vLLM’s harmony path can split it natively. **Trinity** is split by variant: `Trinity-Large-Thinking` gets `qwen3_coder` + `deepseek_r1`; other `Trinity-*` names default to `hermes` for tools, with `deepseek_r1` only for Thinking/Mini/Nano (Preview stays non-reasoning).
> 
> Unit expectations in `test_parsers.py` are updated for representative model IDs in each family.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9b3214162a6c393f0fc676068d9deada3c796a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->