### PR TITLE
fix(slurm): pin UCX_NET_DEVICES only when the UCX build has IB support

### DIFF
--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -211,8 +211,15 @@ srun --kill-on-bad-exit=1 bash -c '
             echo "$(basename "$dev"):$(basename "$port")"
         done | paste -sd,
     }
-    UCX_NET_DEVICES=$(rdma_ports InfiniBand)
-    [ -n "$UCX_NET_DEVICES" ] || UCX_NET_DEVICES=$(rdma_ports Ethernet)
+    # Pin RDMA devices only when the bundled UCX actually has the IB transport:
+    # a TCP-only build (no libuct_ib) pinned to mlx5 devices has no usable
+    # transport at all -> NIXL_ERR_BACKEND on every rank.
+    if [ -e "$PROJECT_DIR/third_party/ucx/lib/ucx/libuct_ib.so" ]; then
+        UCX_NET_DEVICES=$(rdma_ports InfiniBand)
+        [ -n "$UCX_NET_DEVICES" ] || UCX_NET_DEVICES=$(rdma_ports Ethernet)
+    else
+        UCX_NET_DEVICES=""
+    fi
     export UCX_NET_DEVICES=${UCX_NET_DEVICES:-all}
     export LD_LIBRARY_PATH="$PROJECT_DIR/third_party/ucx/lib:$PROJECT_DIR/third_party/ucx/lib/ucx:${LD_LIBRARY_PATH:-}"
 
@@ -247,7 +254,10 @@ srun --kill-on-bad-exit=1 bash -c '
         ROLE_EXTRA="\"all2all_backend\": \"deepep_high_throughput\"{{ prefill_vllm_extra_json }}"
     else
         # ── Decode node ──
-        export UCX_NET_DEVICES=mlx5_0:1
+        # Same guard as above: only pin when the UCX build has IB support.
+        if [ -e "$PROJECT_DIR/third_party/ucx/lib/ucx/libuct_ib.so" ]; then
+            export UCX_NET_DEVICES=mlx5_0:1
+        fi
         ROLE="decode"
         RANK_IN_DECODE=$((RANK_IN_REPLICA - NUM_PREFILL_NODES))
         SUB_REPLICA=$((RANK_IN_DECODE / NODES_PER_DECODE_REPLICA))

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -250,8 +250,15 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
             echo "$(basename "$dev"):$(basename "$port")"
         done | paste -sd,
     }
-    UCX_NET_DEVICES=$(rdma_ports InfiniBand)
-    [ -n "$UCX_NET_DEVICES" ] || UCX_NET_DEVICES=$(rdma_ports Ethernet)
+    # Pin RDMA devices only when the bundled UCX actually has the IB transport:
+    # a TCP-only build (no libuct_ib) pinned to mlx5 devices has no usable
+    # transport at all -> NIXL_ERR_BACKEND on every rank.
+    if [ -e "$PROJECT_DIR/third_party/ucx/lib/ucx/libuct_ib.so" ]; then
+        UCX_NET_DEVICES=$(rdma_ports InfiniBand)
+        [ -n "$UCX_NET_DEVICES" ] || UCX_NET_DEVICES=$(rdma_ports Ethernet)
+    else
+        UCX_NET_DEVICES=""
+    fi
     export UCX_NET_DEVICES=${UCX_NET_DEVICES:-all}
     export LD_LIBRARY_PATH="$PROJECT_DIR/third_party/ucx/lib:$PROJECT_DIR/third_party/ucx/lib/ucx:${LD_LIBRARY_PATH:-}"
     export VLLM_NIXL_SIDE_CHANNEL_HOST=$LOCAL_IP
@@ -277,7 +284,10 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
 {% endfor %}
         ROLE_EXTRA="\"all2all_backend\": \"deepep_high_throughput\"{{ prefill_vllm_extra_json }}"
     else
-        export UCX_NET_DEVICES=mlx5_0:1
+        # Same guard as above: only pin when the UCX build has IB support.
+        if [ -e "$PROJECT_DIR/third_party/ucx/lib/ucx/libuct_ib.so" ]; then
+            export UCX_NET_DEVICES=mlx5_0:1
+        fi
         ROLE="decode"
         RANK_IN_DECODE=$((RANK_IN_REPLICA - NUM_PREFILL_NODES))
         SUB_REPLICA=$((RANK_IN_DECODE / NODES_PER_DECODE_REPLICA))


### PR DESCRIPTION
## Summary

The sbatch templates enumerate ACTIVE IB/RoCE ports and pin `UCX_NET_DEVICES` to them (plus a hard `mlx5_0:1` pin on decode ranks). When `third_party/ucx` is a TCP-only build — which is exactly what `scripts/install_nixl_from_source.sh` produces on hosts without the rdma-core dev headers — that pin leaves UCX with **no usable transport at all**: NIXL backend creation fails on every rank (`nixl_agent.cpp createBackend ... NIXL_ERR_BACKEND`, preceded by `UCX WARN network devices 'mlx5_0:1',... are not available`), engines never come up, and the trainer hangs at weight-broadcast init until `dist_timeout` kills the job.

Guard both pin sites on `third_party/ucx/lib/ucx/libuct_ib.so` existing, falling back to `UCX_NET_DEVICES=all` (TCP) otherwise. IB-capable builds keep the exact current behavior.

Hit while bringing up a GLM-5.2 disaggregated (NIXL) run on a cluster with ACTIVE IB ports but a TCP-only UCX build; with this guard the run proceeds over TCP, and with an IB-enabled build the pinning works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)