### PR TITLE
chore: revert release v0.8.0 version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prime-rl"
-version = "0.8.0"
+version = "0.7.0"
 description = "Async RL Training at Scale"
 readme = "README.md"
 requires-python = "~=3.12.0"


### PR DESCRIPTION
Reverts the version bump from #3207 to keep  at 0.7.0 while the v0.8.0 draft release is being finalized.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version field change with no runtime, dependency, or behavioral impact.
> 
> **Overview**
> Reverts the **`prime-rl` package version** in `pyproject.toml` from **0.8.0** back to **0.7.0**, undoing the bump introduced in #3207.
> 
> This keeps the published/metadata version aligned with the current release line while the **v0.8.0 draft release** is still being finalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d065033d37819cc77ffbd14cd616a5a09c96493e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->