### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prime-rl"
-version = "0.7.0"
+version = "0.8.0"
 description = "Async RL Training at Scale"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "annotated-types"
-version = "0.8.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "annotated-types"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
@@ -5153,7 +5153,7 @@ dev = [
 
 [[package]]
 name = "prime-rl"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Bumps `pyproject.toml` and `uv.lock` to version 0.8.0 for the v0.8.0 release.

The `uv.lock` change is limited to the `prime-rl` package version entry (0.7.0 → 0.8.0). Full `uv lock` re-resolution was not possible due to a pre-existing verifiers version constraint issue on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only; no runtime, security, or dependency resolution changes beyond the package version string.
> 
> **Overview**
> Bumps the **prime-rl** release version from **0.7.0** to **0.8.0** for the v0.8.0 release.
> 
> Updates `version` in `pyproject.toml` and the matching `[[package]]` entry for `prime-rl` in `uv.lock`. No dependency graph or application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ef170995b0d8068c5c47161c0fe89154cb3666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->