### PR TITLE
feat: offload FP32 master weights behind persistent BF16 model

### DIFF
--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -159,7 +159,7 @@ grad_cpu_offload = true
 master_weight_cpu_offload = true
 ```
 
-This stores FP32 master weights in pinned CPU memory and refreshes the persistent BF16 GPU weights after each optimizer step. It currently supports AdamW and weights-only checkpoints; resumable optimizer checkpoints are rejected.
+This stores FP32 master weights and gradients in pinned CPU memory, updates them with fused CPU AdamW, and refreshes the persistent BF16 GPU weights after each optimizer step. Gradient accumulation requires two FP32 gradient-sized pinned buffers. It currently supports AdamW and weights-only checkpoints; resumable optimizer checkpoints are rejected.
 
 ### LM Head Chunking
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -87,6 +87,8 @@ FSDP2 is the default model sharding strategy. By default the trainer fully shard
 | `trainer.model.reshard_after_forward` | If `true` (default), parameters are resharded after the forward pass to free memory; the backward pass re-gathers. Set `false` to keep params resident — faster but more memory. |
 | `trainer.model.fsdp_cpu_offload` | Offload params + grads + optimizer state to CPU. Big memory win, large throughput hit. |
 | `trainer.model.optim_cpu_offload` | Offload only optimizer state. Mid-ground — small throughput cost, decent memory savings, especially at low GPU count. |
+| `trainer.model.grad_cpu_offload` | Additionally offload gradients during backward. Requires optimizer offload. |
+| `trainer.model.master_weight_cpu_offload` | Keep FP32 master weights on CPU and persistent BF16 compute weights on GPU. Experimental AdamW-only mode requiring optimizer and gradient offload. |
 
 ### Expert Parallelism
 
@@ -147,6 +149,17 @@ optim_cpu_offload = true   # already the default
 Mutually exclusive with `fsdp_cpu_offload`. Also incompatible with `trainer.max_concurrent_runs > 1` (multi-tenant training) — set `optim_cpu_offload = false` for multi-run. Muon doesn't support `fsdp_cpu_offload` but does support `optim_cpu_offload`.
 
 The optimizer step is performed per-transformer-layer with stream-overlapped H2D/D2H transfers: while layer *i* computes, layer *i+1* is prefetched and layer *i-1* is evicted. The prefetch waits for the eviction to complete, so at most two layers' optimizer states are on GPU at any time. This reduces peak GPU optimizer-state memory from the full model's states to about two layers' worth, preventing OOM when `weight + grad + all_opt_states > VRAM`.
+
+For the experimental persistent-BF16 path, enable all three offload options:
+
+```toml
+[trainer.model]
+optim_cpu_offload = true
+grad_cpu_offload = true
+master_weight_cpu_offload = true
+```
+
+This stores FP32 master weights in pinned CPU memory and refreshes the persistent BF16 GPU weights after each optimizer step. It currently supports AdamW and weights-only checkpoints; resumable optimizer checkpoints are rejected.
 
 ### LM Head Chunking
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -266,6 +266,12 @@ class SFTConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def validate_master_weight_offload_checkpointing(self):
+        if self.model.master_weight_cpu_offload and self.ckpt is not None and not self.ckpt.weights_only:
+            raise ValueError("Master-weight CPU offload requires weights-only checkpoints")
+        return self
+
+    @model_validator(mode="after")
     def validate_typed_renderer(self):
         """Require a typed renderer whenever SFT renders real samples."""
         if self.data.type == "fake" and self.val is None:

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -176,7 +176,7 @@ class ModelConfig(BaseModelConfig):
     """Offload sharded gradients to pinned CPU memory during backward and stream them back per optimizer chunk. This experimental path requires optim_cpu_offload."""
 
     master_weight_cpu_offload: bool = False
-    """Keep FP32 master weights and AdamW state on CPU with persistent BF16 compute weights on GPU. Updated BF16 weights are copied to the GPU once per optimizer step. This experimental path requires optimizer and gradient CPU offload and does not support resumable checkpoints."""
+    """Keep FP32 master weights and fused AdamW state on CPU with persistent BF16 compute weights on GPU. Gradients are offloaded directly into FP32 buffers, and updated BF16 weights are copied to the GPU once per optimizer step. This experimental path requires optimizer and gradient CPU offload and does not support resumable checkpoints."""
 
     reshard_after_forward: bool = True
     """Reshard the model after each forward pass."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -175,6 +175,9 @@ class ModelConfig(BaseModelConfig):
     grad_cpu_offload: bool = False
     """Offload sharded gradients to pinned CPU memory during backward and stream them back per optimizer chunk. This experimental path requires optim_cpu_offload."""
 
+    master_weight_cpu_offload: bool = False
+    """Keep FP32 master weights in pinned CPU memory and persistent BF16 compute weights on GPU. Master weights are streamed to the GPU once per optimizer step. This experimental AdamW path requires optimizer and gradient CPU offload and does not support resumable checkpoints."""
+
     reshard_after_forward: bool = True
     """Reshard the model after each forward pass."""
 
@@ -281,6 +284,8 @@ class ModelConfig(BaseModelConfig):
             raise ValueError("Cannot enable both fsdp_cpu_offload and optim_cpu_offload. Use one or the other.")
         if self.grad_cpu_offload and not self.optim_cpu_offload:
             raise ValueError("Gradient CPU offload requires optim_cpu_offload.")
+        if self.master_weight_cpu_offload and not self.grad_cpu_offload:
+            raise ValueError("Master-weight CPU offload requires grad_cpu_offload.")
         return self
 
     @model_validator(mode="after")
@@ -711,6 +716,12 @@ class TrainerConfig(BaseConfig):
     def validate_optim_cpu_offload_single_run(self):
         if self.model.optim_cpu_offload and self.max_concurrent_runs > 1:
             raise ValueError("Optimizer CPU offload is not supported with max_concurrent_runs > 1")
+        return self
+
+    @model_validator(mode="after")
+    def validate_master_weight_offload_checkpointing(self):
+        if self.model.master_weight_cpu_offload and self.ckpt is not None:
+            raise ValueError("Master-weight CPU offload does not support resumable checkpoints")
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -176,7 +176,7 @@ class ModelConfig(BaseModelConfig):
     """Offload sharded gradients to pinned CPU memory during backward and stream them back per optimizer chunk. This experimental path requires optim_cpu_offload."""
 
     master_weight_cpu_offload: bool = False
-    """Keep FP32 master weights in pinned CPU memory and persistent BF16 compute weights on GPU. Master weights are streamed to the GPU once per optimizer step. This experimental AdamW path requires optimizer and gradient CPU offload and does not support resumable checkpoints."""
+    """Keep FP32 master weights and AdamW state on CPU with persistent BF16 compute weights on GPU. Updated BF16 weights are copied to the GPU once per optimizer step. This experimental path requires optimizer and gradient CPU offload and does not support resumable checkpoints."""
 
     reshard_after_forward: bool = True
     """Reshard the model after each forward pass."""

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -23,6 +23,11 @@ All entrypoints run via `uv run <command>` and accept TOML configs via `@ path/t
 - Experimental gradient offload requires both `model.optim_cpu_offload = true` and
   `model.grad_cpu_offload = true`. Budget pinned CPU RAM for an accumulator plus
   a same-sized staging set when gradient accumulation is greater than one.
+- Experimental master-weight offload additionally requires
+  `model.master_weight_cpu_offload = true`. It keeps a persistent BF16 compute
+  model on GPU, stores FP32 master weights in pinned CPU RAM, and refreshes the
+  BF16 weights once per optimizer step. It currently supports AdamW and
+  weights-only checkpoints; resumable optimizer checkpoints are rejected.
 
 ## `rl` — RL training
 

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -25,9 +25,11 @@ All entrypoints run via `uv run <command>` and accept TOML configs via `@ path/t
   a same-sized staging set when gradient accumulation is greater than one.
 - Experimental master-weight offload additionally requires
   `model.master_weight_cpu_offload = true`. It keeps a persistent BF16 compute
-  model on GPU, stores FP32 master weights in pinned CPU RAM, and refreshes the
-  BF16 weights once per optimizer step. It currently supports AdamW and
-  weights-only checkpoints; resumable optimizer checkpoints are rejected.
+  model on GPU, stores FP32 master weights and gradients in pinned CPU RAM, uses
+  fused CPU AdamW, and refreshes the BF16 weights once per optimizer step. With
+  gradient accumulation, budget two FP32 gradient-sized buffers. It currently
+  supports AdamW and weights-only checkpoints; resumable optimizer checkpoints
+  are rejected.
 
 ## `rl` — RL training
 

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -44,13 +44,20 @@ class _MasterWeight:
 class GradientOffloadManager:
     """Evicts finalized FSDP2 sharded gradients while backward is still running."""
 
-    def __init__(self, model: nn.Module, chunks: list[list[nn.Parameter]], dp_replicate: int):
+    def __init__(
+        self,
+        model: nn.Module,
+        chunks: list[list[nn.Parameter]],
+        dp_replicate: int,
+        cpu_dtype: torch.dtype | None = None,
+    ):
         if not torch.__version__.startswith("2.11."):
             raise RuntimeError(
                 "Gradient CPU offload hook ordering is verified only for the locked PyTorch 2.11 release"
             )
         self._chunks = chunks
         self._dp_replicate = dp_replicate
+        self._cpu_dtype = cpu_dtype
         self._optimizer_param_ids = {id(param) for chunk in chunks for param in chunk}
         self._buffers: dict[int, _CPUGradientBuffer] = {}
 
@@ -93,7 +100,12 @@ class GradientOffloadManager:
         param_id = id(param)
         if param_id not in self._buffers:
             local_grad = grad.to_local()
-            accumulator = torch.empty_like(local_grad, device="cpu", pin_memory=True)
+            accumulator = torch.empty_like(
+                local_grad,
+                dtype=self._cpu_dtype or local_grad.dtype,
+                device="cpu",
+                pin_memory=True,
+            )
             template = copy.copy(grad)
             template._local_tensor = accumulator
             self._buffers[param_id] = _CPUGradientBuffer(template, accumulator)
@@ -300,7 +312,14 @@ class CPUOffloadOptimizer:
         if master_weights is not None:
             gradient_chunks = [[master_weights[id(param)].model_param for param in chunk] for chunk in self._chunks]
         self._gradient_manager = (
-            GradientOffloadManager(model, gradient_chunks, dp_replicate) if grad_cpu_offload else None
+            GradientOffloadManager(
+                model,
+                gradient_chunks,
+                dp_replicate,
+                cpu_dtype=torch.float32 if master_weights is not None else None,
+            )
+            if grad_cpu_offload
+            else None
         )
 
     @staticmethod
@@ -517,7 +536,12 @@ def setup_optimizer(
             raise ValueError("Master-weight CPU offload requires the model")
         optimizer_named_params, master_weights = _create_cpu_master_weights(model, named_params)
 
-    optimizer = _create_optimizer(config, optimizer_named_params, parallel_dims)
+    optimizer = _create_optimizer(
+        config,
+        optimizer_named_params,
+        parallel_dims,
+        fused_adamw=master_weight_cpu_offload,
+    )
 
     if cpu_offload:
         offload_parts = ["optimizer state"]
@@ -583,6 +607,7 @@ def _create_optimizer(
     named_params: list[tuple[str, nn.Parameter]],
     parallel_dims: ParallelDims,
     lr: float | None = None,
+    fused_adamw: bool = False,
 ) -> Optimizer:
     """Create optimizer. If lr is None, uses config.lr."""
     if lr is None:
@@ -607,6 +632,7 @@ def _create_optimizer(
                 lr=lr,
                 weight_decay=config.weight_decay,
                 betas=(config.betas1, config.betas2),
+                fused=fused_adamw,
             )
         case "muon":
             return _create_muon_optimizer(config, named_params, parallel_dims, lr)

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -35,6 +35,12 @@ class _GradientCopyTask:
     buffers: list[tuple[_CPUGradientBuffer, bool]]
 
 
+@dataclass
+class _MasterWeight:
+    model_param: nn.Parameter
+    cpu_tensor: torch.Tensor
+
+
 class GradientOffloadManager:
     """Evicts finalized FSDP2 sharded gradients while backward is still running."""
 
@@ -196,23 +202,39 @@ class GradientOffloadManager:
         self._gradient_scale *= clip_coefficient
         return total_norm
 
-    def prefetch_chunk(self, chunk_idx: int, stream: torch.cuda.Stream) -> None:
+    def prefetch_chunk(
+        self,
+        chunk_idx: int,
+        stream: torch.cuda.Stream,
+        target_params: list[nn.Parameter] | None = None,
+    ) -> None:
+        source_params = self._chunks[chunk_idx]
+        if target_params is None:
+            target_params = source_params
+        if len(source_params) != len(target_params):
+            raise ValueError("Gradient source and target chunks must have the same size")
         with torch.cuda.stream(stream):
-            for param in self._chunks[chunk_idx]:
-                buffer = self._buffers.get(id(param))
+            for source_param, target_param in zip(source_params, target_params):
+                buffer = self._buffers.get(id(source_param))
                 if buffer is None or not buffer.initialized:
-                    param.grad = None
+                    target_param.grad = None
                     continue
                 local_grad = buffer.accumulator.to("cuda", non_blocking=True)
                 if self._gradient_scale != 1.0:
                     local_grad.mul_(self._gradient_scale)
-                grad = copy.copy(buffer.template)
-                grad._local_tensor = local_grad
-                param.grad = grad
+                if target_param is source_param:
+                    grad = copy.copy(buffer.template)
+                    grad._local_tensor = local_grad
+                    target_param.grad = grad
+                else:
+                    target_param.grad = local_grad.to(dtype=target_param.dtype)
 
-    def release_chunk(self, chunk_idx: int) -> None:
+    def release_chunk(self, chunk_idx: int, target_params: list[nn.Parameter] | None = None) -> None:
         for param in self._chunks[chunk_idx]:
             param.grad = None
+        if target_params is not None:
+            for param in target_params:
+                param.grad = None
 
     def zero_grad(self) -> None:
         self.wait()
@@ -240,6 +262,7 @@ class CPUOffloadOptimizer:
         named_params: list[tuple[str, nn.Parameter]],
         model: nn.Module | None = None,
         grad_cpu_offload: bool = False,
+        master_weights: dict[int, _MasterWeight] | None = None,
         dp_replicate: int = 1,
         pin_memory: bool = True,
     ):
@@ -252,9 +275,15 @@ class CPUOffloadOptimizer:
         # reserved memory every step and starving the default stream.
         self._h2d_stream = torch.cuda.Stream()
         self._d2h_stream = torch.cuda.Stream()
+        self._master_weights = master_weights
         if grad_cpu_offload and model is None:
             raise ValueError("Gradient CPU offload requires the model")
-        self._gradient_manager = GradientOffloadManager(model, self._chunks, dp_replicate) if grad_cpu_offload else None
+        gradient_chunks = self._chunks
+        if master_weights is not None:
+            gradient_chunks = [[master_weights[id(param)].model_param for param in chunk] for chunk in self._chunks]
+        self._gradient_manager = (
+            GradientOffloadManager(model, gradient_chunks, dp_replicate) if grad_cpu_offload else None
+        )
 
     @staticmethod
     def _extract_layer_idx(name: str) -> int | None:
@@ -323,6 +352,37 @@ class CPUOffloadOptimizer:
                             v.record_stream(stream)
                         state[k] = self._move_tensor(v, device)
 
+    @torch.no_grad()
+    def _prefetch_master_weights(self, chunk_idx: int, stream: torch.cuda.Stream) -> None:
+        if self._master_weights is None:
+            return
+        with torch.cuda.stream(stream):
+            for param in self._chunks[chunk_idx]:
+                master = self._master_weights[id(param)]
+                param.data = master.cpu_tensor.to("cuda", non_blocking=True)
+
+    @torch.no_grad()
+    def _update_compute_weights(self, chunk_idx: int) -> None:
+        if self._master_weights is None:
+            return
+        for param in self._chunks[chunk_idx]:
+            model_param = self._master_weights[id(param)].model_param
+            if not isinstance(model_param, DTensor):
+                raise TypeError(f"Expected FSDP2 DTensor parameter, got {type(model_param)}")
+            model_param.to_local().copy_(param.data)
+
+    @torch.no_grad()
+    def _offload_master_weights(self, chunk_idx: int, stream: torch.cuda.Stream) -> None:
+        if self._master_weights is None:
+            return
+        with torch.cuda.stream(stream):
+            for param in self._chunks[chunk_idx]:
+                master = self._master_weights[id(param)]
+                gpu_tensor = param.data
+                master.cpu_tensor.copy_(gpu_tensor, non_blocking=True)
+                gpu_tensor.record_stream(stream)
+                param.data = master.cpu_tensor
+
     def _step_chunk(self, chunk_idx: int, closure=None):
         """Run optimizer.step() for a single chunk by temporarily swapping param_groups."""
         chunk_ids = {id(p) for p in self._chunks[chunk_idx]}
@@ -359,22 +419,37 @@ class CPUOffloadOptimizer:
         compute_stream = torch.cuda.current_stream()
         n = len(self._chunks)
 
+        self._prefetch_master_weights(0, h2d_stream)
         self._move_chunk_states(0, "cuda", h2d_stream)
         if self._gradient_manager is not None:
-            self._gradient_manager.prefetch_chunk(0, h2d_stream)
+            self._gradient_manager.prefetch_chunk(
+                0,
+                h2d_stream,
+                self._chunks[0] if self._master_weights is not None else None,
+            )
         for i in range(n):
             compute_stream.wait_stream(h2d_stream)
             if i + 1 < n:
                 # Wait for previous D2H before reusing pinned CPU buffers.
                 h2d_stream.wait_stream(d2h_stream)
+                self._prefetch_master_weights(i + 1, h2d_stream)
                 self._move_chunk_states(i + 1, "cuda", h2d_stream)
                 if self._gradient_manager is not None:
-                    self._gradient_manager.prefetch_chunk(i + 1, h2d_stream)
+                    self._gradient_manager.prefetch_chunk(
+                        i + 1,
+                        h2d_stream,
+                        self._chunks[i + 1] if self._master_weights is not None else None,
+                    )
             self._step_chunk(i, closure if i == 0 else None)
             if self._gradient_manager is not None:
-                self._gradient_manager.release_chunk(i)
+                self._gradient_manager.release_chunk(
+                    i,
+                    self._chunks[i] if self._master_weights is not None else None,
+                )
+            self._update_compute_weights(i)
             d2h_stream.wait_stream(compute_stream)
             self._move_chunk_states(i, "cpu", d2h_stream)
+            self._offload_master_weights(i, d2h_stream)
         torch.cuda.synchronize()
 
         self._sync_step_counters(original_steps)
@@ -425,10 +500,15 @@ def setup_optimizer(
     lora: bool = False,
     cpu_offload: bool = False,
     grad_cpu_offload: bool = False,
+    master_weight_cpu_offload: bool = False,
     model: nn.Module | None = None,
 ) -> tuple[Optimizer | CPUOffloadOptimizer, GradientOffloadManager | None]:
     if grad_cpu_offload and not cpu_offload:
         raise ValueError("Gradient CPU offload requires optimizer CPU offload")
+    if master_weight_cpu_offload and not grad_cpu_offload:
+        raise ValueError("Master-weight CPU offload requires gradient CPU offload")
+    if master_weight_cpu_offload and config.type != "adamw":
+        raise ValueError("Master-weight CPU offload currently supports AdamW only")
     if lora:
         # Wait for run 0 to be created in the multi run manager
         # Otherwise, the creation will reset the parameters
@@ -436,21 +516,68 @@ def setup_optimizer(
         multi_run_manager.wait_for_run(0)
         named_params = multi_run_manager.get_named_parameters_for_run(0)
 
-    optimizer = _create_optimizer(config, named_params, parallel_dims)
+    master_weights = None
+    optimizer_named_params = named_params
+    if master_weight_cpu_offload:
+        if model is None:
+            raise ValueError("Master-weight CPU offload requires the model")
+        optimizer_named_params, master_weights = _create_cpu_master_weights(model, named_params)
+
+    optimizer = _create_optimizer(config, optimizer_named_params, parallel_dims)
 
     if cpu_offload:
-        offload_description = "optimizer state and gradient" if grad_cpu_offload else "optimizer state"
+        offload_parts = ["optimizer state"]
+        if grad_cpu_offload:
+            offload_parts.append("gradient")
+        if master_weight_cpu_offload:
+            offload_parts.append("FP32 master weight")
+        offload_description = ", ".join(offload_parts)
         get_logger().info(f"Wrapping optimizer for {offload_description} CPU offloading")
         optimizer = CPUOffloadOptimizer(
             optimizer,
-            named_params=named_params,
+            named_params=optimizer_named_params,
             model=model,
             grad_cpu_offload=grad_cpu_offload,
+            master_weights=master_weights,
             dp_replicate=parallel_dims.dp_replicate,
         )
         return optimizer, optimizer._gradient_manager
 
     return optimizer, None
+
+
+@torch.no_grad()
+def _create_cpu_master_weights(
+    model: nn.Module,
+    named_params: list[tuple[str, nn.Parameter]],
+) -> tuple[list[tuple[str, nn.Parameter]], dict[int, _MasterWeight]]:
+    master_named_params = []
+    master_weights = {}
+    for name, model_param in named_params:
+        if not model_param.requires_grad:
+            continue
+        if not isinstance(model_param, DTensor):
+            raise TypeError(f"Expected FSDP2 DTensor parameter, got {type(model_param)}")
+        local_param = model_param.to_local()
+        cpu_tensor = torch.empty_like(local_param, dtype=torch.float32, device="cpu", pin_memory=True)
+        cpu_tensor.copy_(local_param, non_blocking=True)
+        master_param = nn.Parameter(cpu_tensor, requires_grad=True)
+        master_named_params.append((name, master_param))
+        master_weights[id(master_param)] = _MasterWeight(model_param, cpu_tensor)
+    torch.cuda.synchronize()
+
+    original_buffers = {name: buffer.detach() for name, buffer in model.named_buffers() if buffer.is_floating_point()}
+    model.to(dtype=torch.bfloat16)
+    for name, buffer in model.named_buffers():
+        if name in original_buffers:
+            buffer.data = original_buffers[name]
+
+    allocation = sum(master.cpu_tensor.nbytes for master in master_weights.values())
+    get_logger().info(
+        f"Master-weight CPU offload allocated {allocation / 1024**3:.2f} GiB pinned RAM; "
+        "persistent GPU parameters use BF16"
+    )
+    return master_named_params, master_weights
 
 
 def _create_optimizer(

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -229,6 +229,21 @@ class GradientOffloadManager:
                 else:
                     target_param.grad = local_grad.to(dtype=target_param.dtype)
 
+    def load_cpu_chunk(self, chunk_idx: int, target_params: list[nn.Parameter]) -> None:
+        self.wait()
+        source_params = self._chunks[chunk_idx]
+        if len(source_params) != len(target_params):
+            raise ValueError("Gradient source and target chunks must have the same size")
+        for source_param, target_param in zip(source_params, target_params):
+            buffer = self._buffers.get(id(source_param))
+            if buffer is None or not buffer.initialized:
+                target_param.grad = None
+                continue
+            grad = buffer.accumulator.float()
+            if self._gradient_scale != 1.0:
+                grad.mul_(self._gradient_scale)
+            target_param.grad = grad
+
     def release_chunk(self, chunk_idx: int, target_params: list[nn.Parameter] | None = None) -> None:
         for param in self._chunks[chunk_idx]:
             param.grad = None
@@ -254,6 +269,9 @@ class CPUOffloadOptimizer:
     transfers: while layer *i* computes, layer *i+1* is prefetched and layer *i-1*
     is evicted. The prefetch waits for the eviction to complete, so at most two
     layers' optimizer states are on GPU at any time.
+
+    With master-weight offload, AdamW instead runs on CPU-resident FP32 masters
+    and only refreshed BF16 compute weights are copied to GPU.
     """
 
     def __init__(
@@ -353,35 +371,14 @@ class CPUOffloadOptimizer:
                         state[k] = self._move_tensor(v, device)
 
     @torch.no_grad()
-    def _prefetch_master_weights(self, chunk_idx: int, stream: torch.cuda.Stream) -> None:
-        if self._master_weights is None:
-            return
+    def _update_compute_weights(self, chunk_idx: int, stream: torch.cuda.Stream) -> None:
+        assert self._master_weights is not None
         with torch.cuda.stream(stream):
             for param in self._chunks[chunk_idx]:
                 master = self._master_weights[id(param)]
-                param.data = master.cpu_tensor.to("cuda", non_blocking=True)
-
-    @torch.no_grad()
-    def _update_compute_weights(self, chunk_idx: int) -> None:
-        if self._master_weights is None:
-            return
-        for param in self._chunks[chunk_idx]:
-            model_param = self._master_weights[id(param)].model_param
-            if not isinstance(model_param, DTensor):
-                raise TypeError(f"Expected FSDP2 DTensor parameter, got {type(model_param)}")
-            model_param.to_local().copy_(param.data)
-
-    @torch.no_grad()
-    def _offload_master_weights(self, chunk_idx: int, stream: torch.cuda.Stream) -> None:
-        if self._master_weights is None:
-            return
-        with torch.cuda.stream(stream):
-            for param in self._chunks[chunk_idx]:
-                master = self._master_weights[id(param)]
-                gpu_tensor = param.data
-                master.cpu_tensor.copy_(gpu_tensor, non_blocking=True)
-                gpu_tensor.record_stream(stream)
-                param.data = master.cpu_tensor
+                if not isinstance(master.model_param, DTensor):
+                    raise TypeError(f"Expected FSDP2 DTensor parameter, got {type(master.model_param)}")
+                master.model_param.to_local().copy_(master.cpu_tensor, non_blocking=True)
 
     def _step_chunk(self, chunk_idx: int, closure=None):
         """Run optimizer.step() for a single chunk by temporarily swapping param_groups."""
@@ -411,45 +408,42 @@ class CPUOffloadOptimizer:
             group["step"] = orig_step + 1
 
     def step(self, closure=None):
+        if self._master_weights is not None:
+            assert self._gradient_manager is not None
+            for i in range(len(self._chunks)):
+                self._gradient_manager.load_cpu_chunk(i, self._chunks[i])
+            self.optimizer.step(closure)
+            for i in range(len(self._chunks)):
+                self._gradient_manager.release_chunk(i, self._chunks[i])
+                self._update_compute_weights(i, self._h2d_stream)
+            torch.cuda.current_stream().wait_stream(self._h2d_stream)
+            torch.cuda.synchronize()
+            self._initialized = True
+            return
+
         self._original_param_groups = self.optimizer.param_groups
         original_steps = [g.get("step", 0) for g in self._original_param_groups]
-
         h2d_stream = self._h2d_stream
         d2h_stream = self._d2h_stream
         compute_stream = torch.cuda.current_stream()
         n = len(self._chunks)
 
-        self._prefetch_master_weights(0, h2d_stream)
         self._move_chunk_states(0, "cuda", h2d_stream)
         if self._gradient_manager is not None:
-            self._gradient_manager.prefetch_chunk(
-                0,
-                h2d_stream,
-                self._chunks[0] if self._master_weights is not None else None,
-            )
+            self._gradient_manager.prefetch_chunk(0, h2d_stream)
         for i in range(n):
             compute_stream.wait_stream(h2d_stream)
             if i + 1 < n:
                 # Wait for previous D2H before reusing pinned CPU buffers.
                 h2d_stream.wait_stream(d2h_stream)
-                self._prefetch_master_weights(i + 1, h2d_stream)
                 self._move_chunk_states(i + 1, "cuda", h2d_stream)
                 if self._gradient_manager is not None:
-                    self._gradient_manager.prefetch_chunk(
-                        i + 1,
-                        h2d_stream,
-                        self._chunks[i + 1] if self._master_weights is not None else None,
-                    )
+                    self._gradient_manager.prefetch_chunk(i + 1, h2d_stream)
             self._step_chunk(i, closure if i == 0 else None)
             if self._gradient_manager is not None:
-                self._gradient_manager.release_chunk(
-                    i,
-                    self._chunks[i] if self._master_weights is not None else None,
-                )
-            self._update_compute_weights(i)
+                self._gradient_manager.release_chunk(i)
             d2h_stream.wait_stream(compute_stream)
             self._move_chunk_states(i, "cpu", d2h_stream)
-            self._offload_master_weights(i, d2h_stream)
         torch.cuda.synchronize()
 
         self._sync_step_counters(original_steps)
@@ -564,6 +558,8 @@ def _create_cpu_master_weights(
         master_param = nn.Parameter(cpu_tensor, requires_grad=True)
         master_named_params.append((name, master_param))
         master_weights[id(master_param)] = _MasterWeight(model_param, cpu_tensor)
+    if not master_named_params:
+        raise ValueError("Master-weight CPU offload requires trainable parameters")
     torch.cuda.synchronize()
 
     original_buffers = {name: buffer.detach() for name, buffer in model.named_buffers() if buffer.is_floating_point()}
@@ -571,6 +567,8 @@ def _create_cpu_master_weights(
     for name, buffer in model.named_buffers():
         if name in original_buffers:
             buffer.data = original_buffers[name]
+    del local_param
+    torch.cuda.empty_cache()
 
     allocation = sum(master.cpu_tensor.nbytes for master in master_weights.values())
     get_logger().info(

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -174,6 +174,7 @@ def train(config: TrainerConfig):
             lora=config.model.lora is not None,
             cpu_offload=config.model.optim_cpu_offload,
             grad_cpu_offload=config.model.grad_cpu_offload,
+            master_weight_cpu_offload=config.model.master_weight_cpu_offload,
             model=model,
         )
         scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -186,6 +186,7 @@ def train(config: SFTConfig):
         parallel_dims,
         cpu_offload=config.model.optim_cpu_offload,
         grad_cpu_offload=config.model.grad_cpu_offload,
+        master_weight_cpu_offload=config.model.master_weight_cpu_offload,
         model=model,
     )
 


### PR DESCRIPTION
## Summary

Adds an experimental middle ground between gradient offload and full FSDP CPU offload:

- keep persistent BF16 compute weights on GPU
- keep FP32 master weights and fused AdamW state on CPU
- offload BF16 model gradients directly into FP32 pinned buffers
- copy refreshed BF16 weights to GPU once per optimizer step

The mode requires optimizer-state and gradient CPU offload, supports AdamW only, and rejects resumable optimizer checkpoints. SFT weights-only checkpoints remain supported.

This PR is stacked on #3200, which is stacked on #3196.

## Qwen3-4B result

One RTX PRO 6000, `Qwen/Qwen3-4B-Instruct-2507`, I3-SFT-10K `math`, sequence length 2048, batch size 2, micro-batch size 1, three steps:

| Metric | Optimizer + gradient offload | + CPU master-weight offload | Difference |
| --- | ---: | ---: | ---: |
| Mean step time, steps 2–3 | 5.769 s | 5.629 s | -2.4% |
| Mean forward/backward | 1.708 s | 1.566 s | -8.3% |
| Mean throughput | 691.5 tok/s | 723.4 tok/s | +4.6% |
| Peak GPU reserved memory | 35.379 GiB | 20.088 GiB | -15.291 GiB (-43.2%) |

The first implementation used default CPU AdamW and converted accumulated BF16 gradients after backward, resulting in a 22.3s step. Two changes remove that bottleneck: gradients now land directly in FP32 pinned buffers, and CPU AdamW uses PyTorch's fused implementation.

## Transfer and phase measurements

Pinned-memory microbenchmarks on this host measured 50–53 GiB/s across PCIe:

- 14.98 GiB FP32 master → BF16 GPU refresh: approximately 0.30s
- two accumulated BF16 GPU → FP32 CPU gradient copies: approximately 0.60s total

The real steady optimizer phases measured approximately 0.44s for gradient preparation, 2.18–2.91s for fused CPU AdamW, and 0.30s for BF16 refresh. This tracks the observed 5.63s total step after adding 1.57s forward/backward and clipping/other overhead.

The one-time FP32-to-BF16 conversion explicitly releases the old CUDA allocator cache. Without that, `max_memory_reserved()` counts stale blocks from the original 15 GiB FP32 model and badly overstates the treatment peak.

## Numerical check

The saved checkpoints contain 398 BF16 tensors and 4,022,468,096 elements. All tensors match at `rtol=1e-5, atol=1e-5`; mean absolute difference is `4.57e-9` and maximum absolute difference is `7.63e-6`.

## Validation

- `ruff check` and `ruff format --check` on changed Python files
- two consecutive optimizer steps on a small FSDP2 model, checking that masters and every AdamW state tensor remain on CPU, gradient buffers are FP32, and the BF16 shadow is refreshed
- config validation for the required offload combination and weights-only checkpoint restriction
- pinned H2D/D2H and CPU AdamW microbenchmarks
- matched three-step Qwen3-4B SFT benchmark and full saved-checkpoint comparison

`tests/unit/test_configs.py` was also attempted in the isolated worktree; it stops on the existing missing `alphabet-sort-v1` taskset dependency while loading `configs/debug/algo/echo.toml`.
