### PR TITLE
Revert "chore: single global router in front of engines for all deployments (#3105)"

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -30,9 +30,7 @@ We support 3 distinct deployment shapes:
 
 Most of the features are supported for all deployment shapes, with few exceptions. These exceptions are rejected on validation.
 
-Every deployment shape has the same client-facing layout: a single global router listens on `inference.server.port` and fronts all vLLM engines, which listen on `inference.backend_port` (+ rank offset). Clients always talk to one URL, regardless of how many engines run behind it.
-
-You can select the deployment shape with `InferenceDeploymentConfig` in your config file. This is a config-field that allows you to set the deployment shape and topology knobs such as `num_nodes` and `num_replicas`.
+You can select the deployment shape with `InferenceDeploymentConfig` in your config file. This is a config-field that allows you to set the deployment shape, deployment-specific knobs such as `num_nodes`, `num_replicas`, `backend_port`, and a `[...deployment.router]` block, etc.
 
 ```toml
 [inference.deployment]
@@ -57,8 +55,6 @@ The single-node deployment is the default deployment shape. It runs the inferenc
 [inference.deployment]
 type = "single_node"
 ```
-
-The launcher starts a `vllm-router` on `inference.server.port` (default `8000`) fronting the vLLM engine on `inference.backend_port` (default `8100`). Clients connect to the router URL; admin operations (weight updates, health checks) bypass the router and hit the engine port directly — the RL entrypoint wires `orchestrator.model.client.admin_base_url` accordingly.
 
 This deployment shape runs the inference server on a single node, if configured with NVLink enabled, it allows you more freedom in terms of parallelism configurations.
 
@@ -106,7 +102,7 @@ tp = 2
 dp = 4
 ```
 
-This configuration will run 2 independent vLLM replicas, each with `tp=2` and `dp=4`. Routing is handled by a single global router running on the first inference node, fronting the per-rank endpoints of all replicas — either `vllm-router` (default) or the upstream `llm-d` EPP+Envoy, selected via the `[inference.router]` block. You can read more about the supported routing options in the [router](#router) section.
+This configuration will run 2 independent vLLM replicas, each with `tp=2` and `dp=4`. Routing is handled by a router instance running on the same node as the 1st replica — either `vllm-router` (default) or the upstream `llm-d` EPP+Envoy, selected via the `[...deployment.router]` block. You can read more about the supported routing options in the [router](#router) section.
 
 ### Wide-EP
 
@@ -164,15 +160,15 @@ num_train_nodes = 4
 num_infer_replicas = 3
 ```
 
-This will run 3 inference islands, each running on 6 nodes. The total inference deployment will span 18 nodes, fronted by the single global router.
+This will run 3 inference islands, each running on 6 nodes. The total inference deployment will span 18 nodes and start 3 separate router instances.
 
 
 ## Router
 
-Every deployment fronts its vLLM engines with a single global router — it listens on `inference.server.port` and is the one URL clients connect to. The backend is configured via a discriminated `[inference.router]` block (`type = "vllm-router" | "llm-d"`):
+Multi-node and disaggregated deployments front their vLLM backends with a router, configured via a discriminated `[...deployment.router]` block (`type = "vllm-router" | "llm-d"`):
 
 ```toml
-[inference.router]              # or [router] for the standalone inference entrypoint
+[inference.deployment.router]   # or [deployment.router] for the standalone inference entrypoint
 type = "llm-d"                  # "vllm-router" (default) or "llm-d"
 non_cached_tokens = 16          # llm-d only: below this many non-cached prompt tokens, skip remote prefill (P/D)
 
@@ -187,8 +183,8 @@ non_cached_tokens = 16          # llm-d only: below this many non-cached prompt 
 "kv-cache-utilization-scorer" = 2.0
 ```
 
-- **`vllm-router`** (default) — our fork of [vllm-router](https://github.com/PrimeIntellect-ai/router). Knob: `policy`. The only backend supported for single-node (local) deployments.
-- **`llm-d`** — the upstream [llm-d](https://llm-d.ai) Endpoint Picker (EPP) + Envoy proxy (multi-node / disaggregated SLURM deployments only). Routing combines **prefix-cache affinity** (grouped rollouts reuse a cached prefix and skip prefill) with the **`active-request-scorer`** — an in-flight load balancer that spreads requests across ranks immediately, unlike the metrics-scraped `queue-scorer` / `kv-cache-utilization-scorer` / `load-aware-scorer` (which lag and concentrate bursts of same-prefix requests). The scorer weights follow the upstream llm-d P/D guide; tune via `scorers` (base) + `prefill_scorer_overrides` / `decode_scorer_overrides` (per-profile, P/D). Does not support `enable_return_routed_experts` (router replay).
+- **`vllm-router`** (default) — our fork of [vllm-router](https://github.com/PrimeIntellect-ai/router). Knob: `policy`.
+- **`llm-d`** — the upstream [llm-d](https://llm-d.ai) Endpoint Picker (EPP) + Envoy proxy. Routing combines **prefix-cache affinity** (grouped rollouts reuse a cached prefix and skip prefill) with the **`active-request-scorer`** — an in-flight load balancer that spreads requests across ranks immediately, unlike the metrics-scraped `queue-scorer` / `kv-cache-utilization-scorer` / `load-aware-scorer` (which lag and concentrate bursts of same-prefix requests). The scorer weights follow the upstream llm-d P/D guide; tune via `scorers` (base) + `prefill_scorer_overrides` / `decode_scorer_overrides` (per-profile, P/D). Does not support `enable_return_routed_experts` (router replay).
 
 Both backends support the 2 most important things:
 - Request routing - KV cache re-use and balanced routing

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -231,7 +231,7 @@ Full multi-node configs ship under [`examples/advanced/`](https://github.com/Pri
 - [`nemotron-3-super/swe.toml`](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/examples/advanced/nemotron-3-super/swe.toml) — 4 trainer + 1 inference node RL on a 120B hybrid-Mamba MoE with NCCL weight broadcast.
 - [`glm-5.2/`](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples/advanced/glm-5.2) — large-scale and P/D-disaggregated inference across the GLM-5 family.
 
-For inference-only multi-node, set `[deployment] type = "multi_node"` on an inference TOML — each node runs an independent vLLM replica (TP and DP must fit within one node), fronted by a single global router on node 0. Point clients at the router URL the launcher prints.
+For inference-only multi-node, set `[deployment] type = "multi_node"` on an inference TOML — each node runs an independent vLLM replica (TP and DP must fit within one node), and the launcher prints one URL per node. Front the URLs with a router or point clients at any of them.
 
 ### Custom Templates
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -259,7 +259,7 @@ For LoRA runs, set `ckpt.weights.save_adapter_separately = true` to also write t
 
 ### Log Files
 
-The launcher tees every process's stdout/stderr into `<output_dir>/logs/`. The full layout (single-node runs skip the `node_*.log` and `router.log` files — there the router logs into `inference.log`):
+The launcher tees every process's stdout/stderr into `<output_dir>/logs/`. The full layout (single-node runs skip the `node_*.log` and `router_*.log` files):
 
 ```
 <output_dir>/logs/
@@ -271,7 +271,7 @@ The launcher tees every process's stdout/stderr into `<output_dir>/logs/`. The f
 │   └── torchrun/<rdzv>/attempt_0/<rank>/{stdout,stderr}.log   # per-rank
 ├── inference/
 │   ├── node_*.log               # per-node inference stdout (multi-node only)
-│   └── router.log               # the single global router (multi-node only)
+│   └── router_*.log             # vllm-router per replica (multi-node only)
 └── envs/{train,eval}/<env_name>.log # one env server process per source (broker + its workers)
 ```
 
@@ -282,7 +282,7 @@ Live tailing from a single point (works on the head node for multi-node runs ove
 ```bash
 tail -F <output_dir>/logs/{trainer,orchestrator,inference}.log
 tail -F <output_dir>/logs/trainer/node_*.log     # multi-node only
-tail -F <output_dir>/logs/inference/router.log   # multi-node only
+tail -F <output_dir>/logs/inference/router_*.log # multi-node only
 ```
 
 ### Console Output

--- a/examples/advanced/glm-5.2/infer/pd-llmd.toml
+++ b/examples/advanced/glm-5.2/infer/pd-llmd.toml
@@ -45,18 +45,18 @@ num_decode_replicas = 1
 "VLLM_DEEP_GEMM_WARMUP" = "skip"
 "UCX_RCACHE_MAX_UNRELEASED" = "1024"
 
-[router]
+[deployment.router]
 type = "llm-d"
 non_cached_tokens = 128
 
-[router.scorers]
+[deployment.router.scorers]
 "prefix-cache-scorer" = 3.0
 
-[router.prefill_scorer_overrides]
+[deployment.router.prefill_scorer_overrides]
 "queue-scorer" = 4.0
 "active-request-scorer" = 5.0
 
-[router.decode_scorer_overrides]
+[deployment.router.decode_scorer_overrides]
 "active-request-scorer" = 5.0
 "kv-cache-utilization-scorer" = 4.0
 "queue-scorer" = 3.0

--- a/examples/advanced/glm-5.2/swe-llmd.toml
+++ b/examples/advanced/glm-5.2/swe-llmd.toml
@@ -49,19 +49,19 @@ num_decode_replicas = 1
 "max_num_seqs" = 96
 
 
-[inference.router]
+[inference.deployment.router]
 type = "llm-d"
 
 non_cached_tokens = 128 # if <128 tokens, skip prefill go to decode immediately
 
-[inference.router.scorers] # need some prefix-cache routing, however due to shared mooncake pool do low prio
+[inference.deployment.router.scorers] # need some prefix-cache routing, however due to shared mooncake pool do low prio
 "prefix-cache-scorer" = 3.0
 
-[inference.router.prefill_scorer_overrides] # prefill creates queues quite heavily, queue scorer to 4.0, active request at 5.0 is needed due to burstiness of early pipeline RL fill
+[inference.deployment.router.prefill_scorer_overrides] # prefill creates queues quite heavily, queue scorer to 4.0, active request at 5.0 is needed due to burstiness of early pipeline RL fill
 "queue-scorer" = 4.0
 "active-request-scorer" = 5.0
 
-[inference.router.decode_scorer_overrides] # decode doesn't really create queue, it fills in KV cache fast, give 4.0
+[inference.deployment.router.decode_scorer_overrides] # decode doesn't really create queue, it fills in KV cache fast, give 4.0
 "active-request-scorer" = 5.0
 "kv-cache-utilization-scorer" = 4.0
 "queue-scorer" = 3.0

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -190,6 +190,9 @@ class VllmRouterConfig(BaseConfig):
 
     type: Literal["vllm-router"] = "vllm-router"
 
+    port: int = 8000
+    """Port the router listens on — becomes the client-facing router URL."""
+
     policy: str = "consistent_hash"
     """Routing policy, e.g. ``consistent_hash`` or ``round_robin``."""
 
@@ -198,6 +201,9 @@ class LlmdRouterConfig(BaseConfig):
     """llm-d router backend (EPP + Envoy)."""
 
     type: Literal["llm-d"] = "llm-d"
+
+    port: int = 8000
+    """Port the Envoy gateway listens on — becomes the client-facing router URL."""
 
     scorers: dict[str, float] = {
         "prefix-cache-scorer": 3.0,
@@ -247,6 +253,12 @@ RouterConfig: TypeAlias = Annotated[VllmRouterConfig | LlmdRouterConfig, Field(d
 class BaseInferenceDeploymentConfig(BaseConfig):
     gpus_per_node: int = 8
     """GPUs per node."""
+
+    backend_port: int = 8100
+    """Port for the per-rank vLLM backend instances."""
+
+    router: RouterConfig = VllmRouterConfig()
+    """Router fronting the per-rank endpoints."""
 
 
 class SingleNodeInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
@@ -318,12 +330,6 @@ InferenceDeploymentConfig: TypeAlias = Annotated[
 
 class InferenceConfig(BaseConfig):
     server: ServerConfig = ServerConfig()
-
-    router: RouterConfig | None = Field(default_factory=VllmRouterConfig)
-    """Router fronting the engine(s). Every deployment runs a single global router as the client-facing endpoint on ``server.port``, with the engines listening on ``backend_port``. Set to ``None`` to run a bare engine on ``server.port`` without a router (the SLURM launchers do this for per-rank engine processes; the sbatch script starts the router)."""
-
-    backend_port: int = 8100
-    """Port for the vLLM engine(s) behind the router. Defaults to ``server.port + 100``. Multi-node deployments start one engine per local DP rank at ``backend_port + rank``."""
 
     model: ModelConfig = Field(default_factory=ModelConfig)
 
@@ -432,27 +438,13 @@ class InferenceConfig(BaseConfig):
     @model_validator(mode="after")
     def validate_llmd_no_routed_experts(self):
         """Reject routed-expert return with the llm-d router (breaks P/D, unverified for multi-node)."""
-        if self.router is not None and self.router.type == "llm-d" and self.enable_return_routed_experts:
+        router = getattr(self.deployment, "router", None)
+        if router is not None and router.type == "llm-d" and self.enable_return_routed_experts:
             raise ValueError(
                 "The llm-d router backend does not support routed-expert return "
                 "(enable_return_routed_experts): it breaks P/D and is unverified for multi-node. "
                 "Use router type 'vllm-router' for routed-expert runs."
             )
-        return self
-
-    @model_validator(mode="after")
-    def validate_router_deployment(self):
-        """The llm-d router (EPP + Envoy) is launched by the SLURM templates only; multi-node deployments need a router to front the per-rank engines."""
-        if self.router is not None and self.router.type == "llm-d" and self.deployment.type == "single_node":
-            raise ValueError("The llm-d router backend requires a multi-node or disaggregated SLURM deployment.")
-        if self.router is None and self.deployment.type in ("multi_node", "disaggregated"):
-            raise ValueError("Multi-node / disaggregated deployments require a router fronting the per-rank engines.")
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_backend_port(self):
-        if self.router is not None and "backend_port" not in self.model_fields_set:
-            self.backend_port = self.server.port + 100
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -554,7 +554,7 @@ class RLConfig(BaseConfig):
         (after InferenceConfig's own validators, which therefore miss it).
         """
         if self.inference is not None and self.inference.enable_return_routed_experts:
-            router = self.inference.router
+            router = getattr(self.inference.deployment, "router", None)
             if router is not None and router.type == "llm-d":
                 raise ValueError(
                     "The llm-d router backend does not support routed-expert return "
@@ -562,12 +562,6 @@ class RLConfig(BaseConfig):
                     "breaks P/D and is unverified for multi-node. Use router type 'vllm-router' "
                     "for router-replay runs."
                 )
-        return self
-
-    @model_validator(mode="after")
-    def validate_multi_node_requires_router(self):
-        if self.deployment.type == "multi_node" and self.inference is not None and self.inference.router is None:
-            raise ValueError("Multi-node deployments require inference.router to front the per-rank engines.")
         return self
 
     @model_validator(mode="after")
@@ -738,27 +732,27 @@ class RLConfig(BaseConfig):
     def auto_setup_inference_client(self):
         """Auto-configure the orchestrator policy client from the inference server config.
 
-        When no train env samples from the policy (e.g. sft_distill), set
-        base_url. Policy-sourced algorithms rely on the ClientConfig default
-        (``["http://localhost:8000/v1"]``), which already matches the
-        auto-launched policy router at inference.server.port = 8000.
+        Direct single-node runs expose all local DP ranks behind one base URL,
+        so pin logical clients with ``X-data-parallel-rank``. Multi-node SLURM
+        runs expose a vllm-router URL instead; the router balances across
+        per-rank backend URLs and forwards request headers, so the orchestrator
+        must not inject a DP-rank header there. When no train env samples from
+        the policy (e.g. sft_distill), also set base_url — policy-sourced
+        algorithms rely on the ClientConfig default (``["http://localhost:8000/v1"]``)
+        which already matches the auto-launched policy vLLM at inference.server.port = 8000.
         """
         if self.inference is None:
             return self
         client = self.orchestrator.model.client
+        if "dp_rank_count" not in client.model_fields_set:
+            if self.deployment.type == "multi_node":
+                client.dp_rank_count = 1
+            else:
+                client.dp_rank_count = self.inference.data_parallel_size_local or self.inference.parallel.dp
         if not self.orchestrator.any_policy_sourced and "base_url" not in client.model_fields_set:
             host = self.inference.server.host or "localhost"
             port = self.inference.server.port
             client.base_url = [f"http://{host}:{port}/v1"]
-        if (
-            self.deployment.type == "single_node"
-            and self.inference.router is not None
-            and "admin_base_url" not in client.model_fields_set
-        ):
-            # Admin ops (pause/update_weights/resume) must bypass the router and hit
-            # the engine directly; multi-node runs get ADMIN_URLS from the sbatch.
-            host = self.inference.server.host or "localhost"
-            client.admin_base_url = [f"http://{host}:{self.inference.backend_port}/v1"]
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -141,6 +141,9 @@ class ClientConfig(BaseConfig):
     skip_model_check: bool = False
     """Skip checking that the model is available in the inference pool. Useful for external APIs or keys that do not expose ``/models``."""
 
+    dp_rank_count: int = Field(1, ge=1)
+    """Number of data-parallel ranks behind each base URL. When > 1, each URL is expanded into ``dp_rank_count`` logical clients pinned via the ``X-data-parallel-rank`` header, so every request within a rollout hits the same DP engine and reuses KV cache. Auto-set from the inference config when using the RL entrypoint."""
+
     admin_base_url: list[str] | None = None
     """Separate base URLs for admin operations (weight updates, health checks). When set, admin clients bypass routers and hit each server directly — used in disaggregated P/D deployments where the router must not handle admin traffic."""
 

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -57,7 +57,7 @@ Verify: `uv run python -c 'import deep_ep; print(deep_ep.__file__)'`.
 
 ### llm-d router backend
 
-Multi-node / disaggregated deployments can route through the upstream llm-d Endpoint Picker instead of `vllm-router` (set `[inference.router] type = "llm-d"`). It needs three native binaries — install once:
+Multi-node / disaggregated deployments can route through the upstream llm-d Endpoint Picker instead of `vllm-router` (set `[...deployment.router] type = "llm-d"`). It needs three native binaries — install once:
 
 ```bash
 bash scripts/install_llmd.sh   # builds epp + pd-sidecar from a pinned llm-d-router commit (vendored Go), fetches envoy

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -72,7 +72,7 @@ After a restart, verify all processes are back up and progress resumed before th
 │   └── torchrun/              # per-rank stdout/stderr
 ├── inference/
 │   ├── node_*.log             # per-node (multi-node only)
-│   └── router.log             # the single global router (multi-node only; single-node logs it in inference.log)
+│   └── router_0.log           # vllm-router per replica (multi-node only)
 └── envs/{train,eval}/{env_name}.log    # one log file per env
 ```
 
@@ -134,7 +134,7 @@ All metrics print to the console log (and W&B when configured).
 For live vLLM stats, query Prometheus directly:
 
 ```bash
-curl -s http://localhost:8100/metrics | grep -E "num_requests|gpu_cache_usage"  # engine port (8000 is the router)
+curl -s http://localhost:8000/metrics | grep -E "num_requests|gpu_cache_usage"
 # vllm:num_requests_running, vllm:num_requests_waiting, vllm:gpu_cache_usage_perc (→1.0 = KV cache saturated)
 ```
 

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -57,7 +57,7 @@ uv run sft @ examples/basic/reverse-text/sft.toml --dry-run
 
 ## `inference` — vLLM server
 
-OpenAI-compatible API plus prime-rl custom endpoints (`/update_weights`, `/load_lora_adapter`, `/init_broadcaster`). Always use this entrypoint — never `vllm serve` directly. It starts a `vllm-router` on `server.port` (default 8000, the client-facing URL) fronting the engine on `backend_port` (default 8100); admin endpoints must target the engine port directly.
+OpenAI-compatible API plus prime-rl custom endpoints (`/update_weights`, `/load_lora_adapter`, `/init_broadcaster`). Always use this entrypoint — never `vllm serve` directly.
 
 ```bash
 uv run inference --model.name Qwen/Qwen3-0.6B

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -1,10 +1,8 @@
 import json
 import os
-import signal
 import subprocess
 import sys
 from pathlib import Path
-from threading import Event, Thread
 from typing import Any
 
 import tomli_w
@@ -13,12 +11,7 @@ from prime_rl.configs.inference import InferenceConfig
 from prime_rl.utils.config import cli, to_toml_dict
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir
-from prime_rl.utils.process import (
-    DEFAULT_COMMON_ENV_VARS,
-    DEFAULT_INFERENCE_ENV_VARS,
-    cleanup_processes,
-    set_proc_title,
-)
+from prime_rl.utils.process import DEFAULT_COMMON_ENV_VARS, DEFAULT_INFERENCE_ENV_VARS, set_proc_title
 
 INFERENCE_TOML = "inference.toml"
 INFERENCE_SBATCH = "inference.sbatch"
@@ -35,21 +28,12 @@ def vllm_overrides_fragment(overrides: dict[str, Any]) -> str:
     return ", " + json.dumps(overrides)[1:-1].replace('"', '\\"')
 
 
-def write_config(
-    config: InferenceConfig, output_dir: Path, exclude: set[str] | None = None, engine_only: bool = False
-) -> Path:
-    """Write resolved config to disk.
-
-    With ``engine_only``, the router is nulled so per-rank processes run bare
-    engines — the sbatch script starts the single global router.
-    """
+def write_config(config: InferenceConfig, output_dir: Path, exclude: set[str] | None = None) -> Path:
+    """Write resolved config to disk."""
     output_dir.mkdir(parents=True, exist_ok=True)
     config_path = output_dir / INFERENCE_TOML
-    toml_dict = to_toml_dict(config, exclude=exclude)
-    if engine_only:
-        toml_dict["router"] = "None"
     with open(config_path, "wb") as f:
-        tomli_w.dump(toml_dict, f)
+        tomli_w.dump(to_toml_dict(config, exclude=exclude), f)
     return config_path
 
 
@@ -77,8 +61,6 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
         dp_per_node=dp_per_node,
         num_nodes=getattr(config.deployment, "num_nodes", 1),
         port=config.server.port,
-        router=config.router,
-        router_port=config.server.port,
         is_disaggregated=is_disaggregated,
         kv_offload=offload is not None,
         kv_offload_mooncake=is_mooncake,
@@ -100,6 +82,7 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
             num_decode_replicas=config.deployment.num_decode_replicas,
             prefill_port=config.deployment.prefill_port,
             decode_port=config.deployment.decode_port,
+            router=config.deployment.router,
             data_parallel_rpc_port=config.data_parallel_rpc_port,
             use_deep_gemm=config.use_deep_gemm,
             prefill_env_vars=config.deployment.prefill_env_vars,
@@ -109,7 +92,8 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
         )
     elif is_multi_node:
         template_vars.update(
-            backend_port=config.backend_port,
+            router=config.deployment.router,
+            backend_port=config.deployment.backend_port,
             data_parallel_rpc_port=config.data_parallel_rpc_port,
             enable_expert_parallel=config.enable_expert_parallel,
             infer_nodes_per_replica=config.deployment.num_nodes,
@@ -128,9 +112,12 @@ def inference_slurm(config: InferenceConfig):
     logger = setup_logger(config.log.level, json_logging=config.log.json_logging)
 
     config_dir = get_config_dir(config.output_dir)
-    is_multi_node = config.deployment.type in ("multi_node", "disaggregated")
-    exclude = {"deployment", "slurm", "dry_run"} if is_multi_node else {"slurm", "dry_run"}
-    config_path = write_config(config, config_dir, exclude=exclude, engine_only=is_multi_node)
+    exclude = (
+        {"deployment", "slurm", "dry_run"}
+        if config.deployment.type in ("multi_node", "disaggregated")
+        else {"slurm", "dry_run"}
+    )
+    config_path = write_config(config, config_dir, exclude=exclude)
     logger.info(f"Wrote config to {config_path}")
 
     script_path = config.output_dir / INFERENCE_SBATCH
@@ -154,35 +141,8 @@ def inference_slurm(config: InferenceConfig):
     logger.success(f"{result.stdout.strip()}\n\n{log_message}")
 
 
-def start_router(config: InferenceConfig) -> subprocess.Popen:
-    """Start the vllm-router on ``server.port``, fronting the local engine at ``backend_port``."""
-    assert config.router is not None and config.router.type == "vllm-router"
-    host = config.server.host
-    worker_host = "localhost" if host in (None, "0.0.0.0") else host
-    cmd = [
-        "vllm-router",
-        "--policy",
-        config.router.policy,
-        "--host",
-        host or "0.0.0.0",
-        "--port",
-        str(config.server.port),
-        "--worker-urls",
-        f"http://{worker_host}:{config.backend_port}",
-        "--intra-node-data-parallel-size",
-        str(config.data_parallel_size_local or config.parallel.dp),
-        "--request-id-headers",
-        "x-session-id",
-        "--worker-startup-timeout-secs",
-        "4200",
-        "--prometheus-port",
-        str(config.server.port + 21000),
-    ]
-    return subprocess.Popen(cmd)
-
-
 def inference_local(config: InferenceConfig):
-    """Run inference locally: a router on ``server.port`` fronting the engine on ``backend_port``."""
+    """Run inference locally."""
     from prime_rl.inference.server import setup_vllm_env
 
     logger = setup_logger(config.log.level, json_logging=config.log.json_logging)
@@ -193,6 +153,7 @@ def inference_local(config: InferenceConfig):
 
     host = config.server.host or "0.0.0.0"
     port = config.server.port
+    logger.info(f"Starting inference on http://{host}:{port}/v1\n")
 
     # Apply the inference env (defaults + [inference.env_vars]) in-process so a standalone
     # `uv run inference` gets the same environment the rl/SLURM launchers inject into the
@@ -201,32 +162,9 @@ def inference_local(config: InferenceConfig):
 
     setup_vllm_env(config)
 
-    router_process: subprocess.Popen | None = None
-    router_stopping = Event()
-    if config.router is not None:
-        logger.info(f"Starting router on http://{host}:{port}/v1 (engine on port {config.backend_port})\n")
-        router_process = start_router(config)
-        # The router owns the client-facing port; the engine moves behind it.
-        config.server.port = config.backend_port
-
-        def watch_router():
-            router_process.wait()
-            if not router_stopping.is_set():
-                logger.error(f"Router exited with code {router_process.returncode} - shutting down")
-                os.kill(os.getpid(), signal.SIGTERM)
-
-        Thread(target=watch_router, daemon=True).start()
-    else:
-        logger.info(f"Starting inference on http://{host}:{port}/v1\n")
-
     from prime_rl.inference.vllm.server import server  # pyright: ignore
 
-    try:
-        server(config, vllm_extra=config.vllm_extra)
-    finally:
-        if router_process is not None:
-            router_stopping.set()
-            cleanup_processes([router_process])
+    server(config, vllm_extra=config.vllm_extra)
 
 
 def inference(config: InferenceConfig):

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -86,12 +86,8 @@ def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
     if config.inference is not None:
         # Exclude launcher-only fields that are not needed by the vLLM server
         exclude_inference = {"deployment", "slurm", "output_dir", "dry_run"}
-        inference_dict = to_toml_dict(config.inference, exclude=exclude_inference)
-        if config.deployment.type == "multi_node":
-            # Per-rank processes run bare engines; the sbatch starts the single global router.
-            inference_dict["router"] = "None"
         with open(output_dir / INFERENCE_TOML, "wb") as f:
-            tomli_w.dump(inference_dict, f)
+            tomli_w.dump(to_toml_dict(config.inference, exclude=exclude_inference), f)
 
     # One EnvServerConfig TOML per source: `env-server @ <path>` binds at the source's
     # deterministic address, where the orchestrator connects. The source's env/serve/legacy
@@ -485,8 +481,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             num_prefill_replicas=infer_deploy.num_prefill_replicas,
             num_decode_replicas=infer_deploy.num_decode_replicas,
             gpus_per_node=config.deployment.gpus_per_node,
-            router=config.inference.router,
-            router_port=config.inference.server.port,
+            router=infer_deploy.router,
             prefill_port=infer_deploy.prefill_port,
             decode_port=infer_deploy.decode_port,
             inference_tp=config.inference.parallel.tp,
@@ -520,10 +515,9 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             nodes_per_infer_replica=config.deployment.infer_nodes_per_replica,
             num_infer_replicas=config.deployment.num_infer_replicas,
             gpus_per_node=config.deployment.gpus_per_node,
-            router=config.inference.router if config.inference else VllmRouterConfig(),
-            router_port=config.inference.server.port if config.inference else 8000,
+            router=config.inference.deployment.router if config.inference else VllmRouterConfig(),
             infer_nodes_per_replica=config.deployment.infer_nodes_per_replica,
-            backend_port=config.inference.backend_port if config.inference else 8100,
+            backend_port=config.inference.deployment.backend_port if config.inference else 8100,
             inference_tp=config.inference.parallel.tp if config.inference else 1,
             inference_enable_expert_parallel=config.inference.enable_expert_parallel if config.inference else False,
             inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port if config.inference else 29600,

--- a/src/prime_rl/templates/_launch_router.sh.j2
+++ b/src/prime_rl/templates/_launch_router.sh.j2
@@ -1,23 +1,21 @@
-{# Shared launch helper for the single global router, included once per template
-   and called by inference node 0. The router backend (vllm-router vs llm-d
-   EPP+Envoy) is chosen here via router.type, so the call sites stay
-   router-agnostic. llm-d endpoint discovery enumerates every inference node:
-   all nodes for regular mode; for disaggregated mode all prefill nodes across
-   replicas, then all decode nodes (matching the logical node order in
-   endpoints.yaml). #}
-# launch_router <mode:pd|regular> <worker_args> <port> <policy> <log>
+{# Shared router launch helper, included once per template and called by the
+   replica-head rank. The router backend (vllm-router vs llm-d EPP+Envoy) is
+   chosen here via router.type, so the call sites stay router-agnostic.
+   node_base/node_count locate this replica's nodes in HOSTNAMES for llm-d
+   endpoint discovery (disagg uses NUM_PREFILL_NODES/NUM_DECODE_NODES). #}
+# launch_router <mode:pd|regular> <worker_args> <port> <policy> <log> <replica_idx> <node_base> [node_count]
 launch_router() {
-    local mode="$1" worker_args="$2" port="$3" policy="$4" log="$5"
+    local mode="$1" worker_args="$2" port="$3" policy="$4" log="$5" replica="${6:-0}" node_base="${7:-0}" node_count="${8:-0}"
 {%- if router.type == "llm-d" %}
-    echo "Starting llm-d router (EPP+Envoy) on $LOCAL_IP:$port" | tee "$log"
+    echo "Starting llm-d router (EPP+Envoy) on $LOCAL_IP:$port for replica $replica" | tee "$log"
     export PATH="$PROJECT_DIR/third_party/llmd/bin:$PATH"
-    local LLMD_DIR="$OUTPUT_DIR/logs/inference/llmd"
+    local LLMD_DIR="$OUTPUT_DIR/logs/inference/llmd_${replica}"
     mkdir -p "$LLMD_DIR"
     read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
 {%- if is_disaggregated %}
 {%- set ep_disaggregated = true %}
-{%- set ep_num_prefill = num_prefill_nodes * (num_infer_replicas | default(1)) %}
-{%- set ep_num_decode = num_decode_nodes * (num_infer_replicas | default(1)) %}
+{%- set ep_num_prefill = num_prefill_nodes %}
+{%- set ep_num_decode = num_decode_nodes %}
 {%- set ep_dp = dp_per_node %}
 {%- set ep_prefill_port = prefill_port %}
 {%- set ep_sidecar_port = router.decode_sidecar_port %}
@@ -27,22 +25,12 @@ LLMD_EOF
     cat > "$LLMD_DIR/endpoints.yaml" <<LLMD_EOF
 {% include 'llmd/endpoints.yaml.j2' %}
 LLMD_EOF
-    local node=0 ip reps=${NUM_INFER_REPLICAS:-1} span=${NODES_PER_INFER_REPLICA:-$((NUM_PREFILL_NODES + NUM_DECODE_NODES))}
-    for ((rr=0; rr<reps; rr++)); do
-        for ((p=0; p<NUM_PREFILL_NODES; p++)); do
-            ip=$(getent hosts "${HOSTNAMES[$((rr * span + p))]}" | awk "{print \$1}")
-            sed -i "s|__LLMD_ADDR_${node}__|${ip}|g" "$LLMD_DIR/endpoints.yaml"; node=$((node + 1))
-        done
-    done
-    for ((rr=0; rr<reps; rr++)); do
-        for ((d=0; d<NUM_DECODE_NODES; d++)); do
-            ip=$(getent hosts "${HOSTNAMES[$((rr * span + NUM_PREFILL_NODES + d))]}" | awk "{print \$1}")
-            sed -i "s|__LLMD_ADDR_${node}__|${ip}|g" "$LLMD_DIR/endpoints.yaml"; node=$((node + 1))
-        done
-    done
+    local node=0 ip
+    for ((p=0; p<NUM_PREFILL_NODES; p++)); do ip=$(getent hosts "${HOSTNAMES[$((node_base + p))]}" | awk "{print \$1}"); sed -i "s|__LLMD_ADDR_${node}__|${ip}|g" "$LLMD_DIR/endpoints.yaml"; node=$((node + 1)); done
+    for ((d=0; d<NUM_DECODE_NODES; d++)); do ip=$(getent hosts "${HOSTNAMES[$((node_base + NUM_PREFILL_NODES + d))]}" | awk "{print \$1}"); sed -i "s|__LLMD_ADDR_${node}__|${ip}|g" "$LLMD_DIR/endpoints.yaml"; node=$((node + 1)); done
 {%- else %}
 {%- set ep_disaggregated = false %}
-{%- set ep_num_nodes = num_infer_nodes | default(num_nodes) %}
+{%- set ep_num_nodes = infer_nodes_per_replica %}
 {%- set ep_dp = dp_per_node %}
 {%- set ep_backend_port = backend_port %}
     cat > "$LLMD_DIR/epp.yaml" <<LLMD_EOF
@@ -52,16 +40,13 @@ LLMD_EOF
 {% include 'llmd/endpoints.yaml.j2' %}
 LLMD_EOF
     local ip
-    for ((n=0; n<{{ ep_num_nodes }}; n++)); do
-        ip=$(getent hosts "${HOSTNAMES[$n]}" | awk "{print \$1}")
-        sed -i "s|__LLMD_ADDR_${n}__|${ip}|g" "$LLMD_DIR/endpoints.yaml"
-    done
+    for ((n=0; n<node_count; n++)); do ip=$(getent hosts "${HOSTNAMES[$((node_base + n))]}" | awk "{print \$1}"); sed -i "s|__LLMD_ADDR_${n}__|${ip}|g" "$LLMD_DIR/endpoints.yaml"; done
 {%- endif %}
     cat > "$LLMD_DIR/envoy.yaml" <<LLMD_EOF
 {% include 'llmd/envoy.yaml.j2' %}
 LLMD_EOF
     # grpc-health-port avoids 9003: mooncake_master runs its metrics server on 9003 and
-    # shares node 0 with the EPP, so 9003 would fail to bind and kill the EPP.
+    # shares the replica-head node with the EPP, so 9003 would fail to bind and kill the EPP.
     epp --pool-name prime-rl --pool-namespace slurm \
         --config-file "$LLMD_DIR/epp.yaml" \
         --grpc-port 9002 --grpc-health-port 9013 --metrics-port 9090 \
@@ -70,10 +55,9 @@ LLMD_EOF
     envoy -c "$LLMD_DIR/envoy.yaml" >> "$log" 2>&1 &
 {%- else %}
     local tag="vllm-router"; [ "$mode" = pd ] && tag="vllm-router (PD)"
-    echo "Starting $tag on $LOCAL_IP:$port" | tee "$log"
+    echo "Starting $tag on $LOCAL_IP:$port${replica:+ for replica $replica}" | tee "$log"
     local -a cmd=(vllm-router --policy "$policy" --host 0.0.0.0 --port "$port"
         --request-id-headers x-session-id
-        --prometheus-port "$((port + 21000))"
         --worker-startup-timeout-secs 4200 --log-level debug)
     if [ "$mode" = pd ]; then
         cmd+=(--vllm-pd-disaggregation $worker_args)

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -38,13 +38,13 @@ export NODES_PER_PREFILL_REPLICA={{ prefill_nodes_per_replica }}
 export NODES_PER_DECODE_REPLICA={{ decode_nodes_per_replica }}
 export PREFILL_PORT={{ prefill_port }}
 export DECODE_PORT={{ decode_port }}
-export ROUTER_PORT={{ router_port }}
+export ROUTER_PORT={{ router.port }}
 export RPC_PORT={{ data_parallel_rpc_port }}
 {%- if router.type == "llm-d" %}
 export DECODE_SIDECAR_PORT={{ router.decode_sidecar_port }}
 {%- endif %}
 {%- elif num_nodes > 1 %}
-export ROUTER_PORT={{ router_port }}
+export ROUTER_PORT={{ router.port }}
 export BACKEND_PORT={{ backend_port }}
 export RPC_PORT={{ data_parallel_rpc_port }}
 {%- endif %}
@@ -77,24 +77,32 @@ uv sync --all-extras --all-packages
 export HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
 export HOSTNAMES_STR="${HOSTNAMES[*]}"
 {% if is_disaggregated -%}
-# Single global router on node 0 fronts every per-rank endpoint.
-INFER_URLS="http://${HOSTNAMES[0]}:${ROUTER_PORT}/v1"
-ROUTER_ARGS=""
-# External-LB: one --prefill/--decode endpoint per DP rank (PORT + k) on each node.
-for ((p=0; p<NUM_PREFILL_NODES; p++)); do
-    host="${HOSTNAMES[$p]}"
-    for ((k=0; k<{{ dp_per_node }}; k++)); do
-        ROUTER_ARGS="$ROUTER_ARGS --prefill http://${host}:$((PREFILL_PORT + k))"
+# Build per-replica router URLs
+INFER_URLS=""
+ALL_ROUTER_ARGS=""
+for ((r=0; r<NUM_NODES/NODES_PER_REPLICA; r++)); do
+    replica_base=$((r * NODES_PER_REPLICA))
+    router_host="${HOSTNAMES[$replica_base]}"
+    INFER_URLS="${INFER_URLS:+$INFER_URLS,}http://${router_host}:${ROUTER_PORT}/v1"
+
+    REPLICA_ROUTER_ARGS=""
+    # External-LB: one --prefill/--decode endpoint per DP rank (PORT + k) on each node.
+    for ((p=0; p<NUM_PREFILL_NODES; p++)); do
+        host="${HOSTNAMES[$((replica_base + p))]}"
+        for ((k=0; k<{{ dp_per_node }}; k++)); do
+            REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS --prefill http://${host}:$((PREFILL_PORT + k))"
+        done
     done
-done
-for ((d=0; d<NUM_DECODE_NODES; d++)); do
-    host="${HOSTNAMES[$((NUM_PREFILL_NODES + d))]}"
-    for ((k=0; k<{{ dp_per_node }}; k++)); do
-        ROUTER_ARGS="$ROUTER_ARGS --decode http://${host}:$((DECODE_PORT + k))"
+    for ((d=0; d<NUM_DECODE_NODES; d++)); do
+        host="${HOSTNAMES[$((replica_base + NUM_PREFILL_NODES + d))]}"
+        for ((k=0; k<{{ dp_per_node }}; k++)); do
+            REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS --decode http://${host}:$((DECODE_PORT + k))"
+        done
     done
+    ALL_ROUTER_ARGS="${ALL_ROUTER_ARGS:+$ALL_ROUTER_ARGS|}$REPLICA_ROUTER_ARGS"
 done
 export INFER_URLS
-export ROUTER_ARGS
+export ALL_ROUTER_ARGS
 {%- elif num_nodes > 1 %}
 # External LB: one router on node 0; one endpoint per DP rank (BACKEND_PORT + dp_local) on every node.
 INFER_URLS="http://${HOSTNAMES[0]}:${ROUTER_PORT}/v1"
@@ -265,9 +273,10 @@ srun --kill-on-bad-exit=1 bash -c '
     echo "NODE_RANK=$INFER_NODE_RANK ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK DP=$DP PORT=$PORT LOCAL_IP=$LOCAL_IP" \
         | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
 
-    # Start the single global router on node 0 (external LB across all per-rank endpoints)
-    if [ "$INFER_NODE_RANK" -eq 0 ]; then
-        launch_router pd "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$OUTPUT_DIR/logs/inference/router.log"
+    # Start the router on the first prefill node of each replica (external LB across per-rank endpoints)
+    if [ "$RANK_IN_REPLICA" -eq 0 ]; then
+        REPLICA_ROUTER_ARGS=$(echo "$ALL_ROUTER_ARGS" | cut -d"|" -f$((REPLICA_IDX + 1)))
+        launch_router pd "$REPLICA_ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$OUTPUT_DIR/logs/inference/router_${REPLICA_IDX}.log" "$REPLICA_IDX" "$REPLICA_BASE"
     fi
 {%- if router.type == "llm-d" %}
     # pd-sidecar on each decode node: EPP routes decode -> sidecar (DECODE_SIDECAR_PORT
@@ -309,9 +318,9 @@ srun --kill-on-bad-exit=1 bash -c '
     TP=$((GPUS_PER_NODE / DP_PER_NODE))
     EP={{ "1" if enable_expert_parallel else "0" }}
 
-    # Start the single global router on node 0 (balances across per-rank endpoints — no intra-node DP header)
+    # Start the router on node 0 (balances across per-rank endpoints — no intra-node DP header)
     if [ "$INFER_NODE_RANK" -eq 0 ]; then
-        launch_router regular "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$OUTPUT_DIR/logs/inference/router.log"
+        launch_router regular "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$OUTPUT_DIR/logs/inference/router.log" 0 0 "$NUM_NODES"
     fi
 
     # External-LB: one vLLM API server per DP rank on this node (BACKEND_PORT + dp_local),

--- a/src/prime_rl/templates/llmd/envoy.yaml.j2
+++ b/src/prime_rl/templates/llmd/envoy.yaml.j2
@@ -7,7 +7,7 @@ admin:
 static_resources:
   listeners:
     - name: prime_rl
-      address: { socket_address: { address: 0.0.0.0, port_value: {{ router_port }} } }
+      address: { socket_address: { address: 0.0.0.0, port_value: {{ router.port }} } }
       filter_chains:
         - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -32,7 +32,7 @@ export NODES_PER_INFER_REPLICA={{ nodes_per_infer_replica }}
 export NUM_INFER_REPLICAS={{ num_infer_replicas }}
 export GPUS_PER_NODE={{ gpus_per_node }}
 {% if num_infer_nodes > 0 -%}
-export ROUTER_PORT={{ router_port }}
+export ROUTER_PORT={{ router.port }}
 export INFERENCE_TP={{ inference_tp }}
 export INFERENCE_DP_LOCAL=$((GPUS_PER_NODE / INFERENCE_TP))
 export INFERENCE_DATA_PARALLEL_RPC_PORT={{ inference_data_parallel_rpc_port }}
@@ -75,43 +75,58 @@ export HOSTNAMES_STR="${HOSTNAMES[*]}"
 {% if num_infer_nodes > 0 -%}
 INFER_HOSTS=( ${HOSTNAMES[@]:0:$NUM_INFER_NODES} )
 
-# Single global router on inference node 0 fronts every per-rank endpoint;
-# admin URLs bypass it and hit each rank directly.
-INFER_URLS="http://${INFER_HOSTS[0]}:${ROUTER_PORT}/v1"
+# Build per-replica router URLs, admin URLs, and backend args for the router
+INFER_URLS=""
 ADMIN_URLS=""
-ROUTER_ARGS=""
+ALL_ROUTER_ARGS=""
 {% if is_disaggregated -%}
-# External-LB: one prefill/decode endpoint per DP rank (PORT + k) on each node.
 for ((r=0; r<NUM_INFER_REPLICAS; r++)); do
     replica_base=$((r * NODES_PER_INFER_REPLICA))
+    router_host="${INFER_HOSTS[$replica_base]}"
+    INFER_URLS="${INFER_URLS:+$INFER_URLS }http://${router_host}:${ROUTER_PORT}/v1"
+
+    REPLICA_ROUTER_ARGS=""
+    # External-LB: one prefill/decode endpoint per DP rank (PORT + k) on each node.
     for ((p=0; p<NUM_PREFILL_NODES; p++)); do
-        host="${INFER_HOSTS[$((replica_base + p))]}"
+        node_idx=$((replica_base + p))
+        host="${INFER_HOSTS[$node_idx]}"
         for ((k=0; k<INFERENCE_DP_LOCAL; k++)); do
             ADMIN_URLS="${ADMIN_URLS:+$ADMIN_URLS }http://${host}:$((PREFILL_PORT + k))/v1"
-            ROUTER_ARGS="$ROUTER_ARGS --prefill http://${host}:$((PREFILL_PORT + k))"
+            REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS --prefill http://${host}:$((PREFILL_PORT + k))"
         done
     done
     for ((d=0; d<NUM_DECODE_NODES; d++)); do
-        host="${INFER_HOSTS[$((replica_base + NUM_PREFILL_NODES + d))]}"
+        node_idx=$((replica_base + NUM_PREFILL_NODES + d))
+        host="${INFER_HOSTS[$node_idx]}"
         for ((k=0; k<INFERENCE_DP_LOCAL; k++)); do
             ADMIN_URLS="${ADMIN_URLS:+$ADMIN_URLS }http://${host}:$((DECODE_PORT + k))/v1"
-            ROUTER_ARGS="$ROUTER_ARGS --decode http://${host}:$((DECODE_PORT + k))"
+            REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS --decode http://${host}:$((DECODE_PORT + k))"
         done
     done
+    ALL_ROUTER_ARGS="${ALL_ROUTER_ARGS:+$ALL_ROUTER_ARGS|}$REPLICA_ROUTER_ARGS"
 done
 {%- else -%}
-# External-LB: one endpoint per DP rank (BACKEND_PORT + dp_local) on each node.
-for ((n=0; n<NUM_INFER_NODES; n++)); do
-    host="${INFER_HOSTS[$n]}"
-    for ((k=0; k<INFERENCE_DP_LOCAL; k++)); do
-        ADMIN_URLS="${ADMIN_URLS:+$ADMIN_URLS }http://${host}:$((BACKEND_PORT + k))/v1"
-        ROUTER_ARGS="$ROUTER_ARGS http://${host}:$((BACKEND_PORT + k))"
+for ((r=0; r<NUM_INFER_REPLICAS; r++)); do
+    head_idx=$((r * NODES_PER_INFER_REPLICA))
+    router_host="${INFER_HOSTS[$head_idx]}"
+    INFER_URLS="${INFER_URLS:+$INFER_URLS }http://${router_host}:${ROUTER_PORT}/v1"
+
+    REPLICA_ROUTER_ARGS=""
+    for ((n=0; n<NODES_PER_INFER_REPLICA; n++)); do
+        node_idx=$((head_idx + n))
+        host="${INFER_HOSTS[$node_idx]}"
+        # External-LB: one endpoint per DP rank (BACKEND_PORT + dp_local) on each node.
+        for ((k=0; k<INFERENCE_DP_LOCAL; k++)); do
+            ADMIN_URLS="${ADMIN_URLS:+$ADMIN_URLS }http://${host}:$((BACKEND_PORT + k))/v1"
+            REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS http://${host}:$((BACKEND_PORT + k))"
+        done
     done
+    ALL_ROUTER_ARGS="${ALL_ROUTER_ARGS:+$ALL_ROUTER_ARGS|}$REPLICA_ROUTER_ARGS"
 done
 {%- endif %}
 export INFER_URLS
 export ADMIN_URLS
-export ROUTER_ARGS
+export ALL_ROUTER_ARGS
 echo "INFER_HOSTS=${INFER_HOSTS[*]}"
 echo "INFER_URLS=${INFER_URLS}"
 echo "ADMIN_URLS=${ADMIN_URLS}"
@@ -295,9 +310,10 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     echo "ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK DP=$DP PORT=$PORT" \
         | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
 
-    # Start the single global router on inference node 0 (PD mode, external LB across all per-rank endpoints)
-    if [ "$INFER_NODE_RANK" -eq 0 ]; then
-        launch_router pd "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$OUTPUT_DIR/logs/inference/router.log"
+    # Start the router on the first node of each replica (PD mode, external LB across per-rank endpoints)
+    if [ "$RANK_IN_REPLICA" -eq 0 ]; then
+        REPLICA_ROUTER_ARGS=$(echo "$ALL_ROUTER_ARGS" | cut -d"|" -f$((REPLICA_IDX + 1)))
+        launch_router pd "$REPLICA_ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$OUTPUT_DIR/logs/inference/router_${REPLICA_IDX}.log" "$REPLICA_IDX" "$REPLICA_BASE"
     fi
 {%- if router.type == "llm-d" %}
     # pd-sidecar on each decode node: EPP routes decode -> sidecar (DECODE_SIDECAR_PORT
@@ -332,9 +348,10 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
         launch_inference_rank "$((PORT + k))" "$RANK_GPUS" "$DP" "$INFERENCE_DATA_PARALLEL_RPC_PORT" "$RANK_EXTRA" "$((5600 + k))" "$(rank_log "$INFER_NODE_RANK" "$k")"
     done
 {%- else -%}
-    # Start the single global router on inference node 0 (external LB across all per-rank endpoints)
-    if [ "$INFER_NODE_RANK" -eq 0 ]; then
-        launch_router regular "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$OUTPUT_DIR/logs/inference/router.log"
+    # Start the router on the first node of each replica
+    if [ "$RANK_IN_REPLICA" -eq 0 ]; then
+        REPLICA_ROUTER_ARGS=$(echo "$ALL_ROUTER_ARGS" | cut -d"|" -f$((REPLICA_IDX + 1)))
+        launch_router regular "$REPLICA_ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$OUTPUT_DIR/logs/inference/router_${REPLICA_IDX}.log" "$REPLICA_IDX" "$((REPLICA_IDX * NODES_PER_INFER_REPLICA))" "$NODES_PER_INFER_REPLICA"
     fi
 
     # External-LB: one vLLM API server per DP rank on this node (BACKEND_PORT + d),

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -10,7 +10,7 @@ from typing import Protocol, runtime_checkable
 import httpx
 import verifiers.v1 as vf
 from httpx import AsyncClient
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, NotFoundError
 from renderers import RendererConfig
 from tenacity import AsyncRetrying, retry, retry_if_exception, stop_after_attempt, stop_after_delay, wait_exponential
 from verifiers.v1.configs.client import EvalClientConfig, TrainClientConfig
@@ -18,12 +18,15 @@ from verifiers.v1.configs.client import EvalClientConfig, TrainClientConfig
 from prime_rl.configs.shared import ClientConfig
 from prime_rl.utils.logger import get_logger
 
-ClientIdentity = str
+# Identity tuple used by ``select_train_client`` to key load counts. ``base_url``
+# distinguishes servers; ``X-data-parallel-rank`` distinguishes DP shards within a
+# server, since the router uses that header to route to specific GPU ranks.
+ClientIdentity = tuple[str, str | None]
 
 
 def client_identity(client: vf.ClientConfig) -> ClientIdentity:
     """Stable identity for load balancing across inference clients."""
-    return client.base_url
+    return (client.base_url, client.headers.get("X-data-parallel-rank"))
 
 
 @runtime_checkable
@@ -132,13 +135,6 @@ class StaticInferencePool:
         )
         self._eval_clients = setup_clients(client_config, client_type=eval_client_type)
         self._admin_clients = setup_admin_clients(client_config)
-        # When admin URLs bypass a router, also health-check the client-facing
-        # (router) endpoint - it only starts serving once its workers are healthy.
-        self._router_clients = (
-            setup_admin_clients(client_config.model_copy(update={"admin_base_url": None}))
-            if client_config.admin_base_url
-            else []
-        )
         self._skip_model_check = client_config.skip_model_check
         self._wait_for_ready_timeout = client_config.wait_for_ready_timeout
         self._eval_cycle = cycle(self._eval_clients)
@@ -170,8 +166,7 @@ class StaticInferencePool:
 
     async def wait_for_ready(self, model_name: str, timeout: int | None = None) -> None:
         await check_health(
-            self._admin_clients + self._router_clients,
-            timeout=timeout if timeout is not None else self._wait_for_ready_timeout,
+            self._admin_clients, timeout=timeout if timeout is not None else self._wait_for_ready_timeout
         )
         await maybe_check_has_model(self._admin_clients, model_name, skip_model_check=self._skip_model_check)
 
@@ -221,7 +216,7 @@ def setup_clients(
     renderer_config: RendererConfig | None = None,
     renderer_model_name: str | None = None,
 ) -> list[vf.ClientConfig]:
-    """Build one v1 client config per base URL. ``client_type``
+    """Build v1 client configs (one per base_url × DP rank). ``client_type``
     ``renderer`` → token-in/out (``TrainClientConfig``, with the renderer the env
     server should use forwarded as a serialized config so it doesn't fall back to the
     default renderer); otherwise plain chat-completions (``EvalClientConfig``)."""
@@ -238,10 +233,13 @@ def setup_clients(
     }
     clients: list[vf.ClientConfig] = []
     for base_url in client_config.base_url:
-        headers = {**client_config.headers, **env_headers}
-        clients.append(
-            config_cls(base_url=base_url, api_key_var=client_config.api_key_var, headers=headers, **renderer_extra)
-        )
+        for dp_rank in range(client_config.dp_rank_count):
+            headers = {**client_config.headers, **env_headers}
+            if client_config.dp_rank_count > 1:
+                headers["X-data-parallel-rank"] = str(dp_rank)
+            clients.append(
+                config_cls(base_url=base_url, api_key_var=client_config.api_key_var, headers=headers, **renderer_extra)
+            )
     return clients
 
 
@@ -301,12 +299,11 @@ async def check_health(
         logger.debug("Starting pinging /health to check health")
         while wait_time < timeout:
             try:
-                response = await admin_client.get("/health")
-                if response.status_code == 404:
-                    logger.warning("The route /health does not exist. Skipping health check.")
-                    return
-                response.raise_for_status()
+                await admin_client.get("/health")
                 logger.debug(f"Inference pool is ready after {wait_time} seconds")
+                return
+            except NotFoundError:
+                logger.warning("The route /health does not exist. Skipping health check.")
                 return
             except Exception as e:
                 if wait_time % log_interval == 0 and wait_time > 0:

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -199,6 +199,7 @@ class ElasticInferencePool:
                 api_key_var=self.client_config.api_key_var,
                 headers=self.client_config.headers,
                 headers_from_env=self.client_config.headers_from_env,
+                dp_rank_count=self.client_config.dp_rank_count,
                 extra_headers_from_state=self.client_config.extra_headers_from_state,
             )
             self._train_clients = (

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -217,12 +217,12 @@ def test_trainer_enable_token_export_cli_flag():
     assert cli(TrainerConfig, args=["--enable-token-export"]).enable_token_export
 
 
-def test_single_node_auto_inference_ports_follow_server_port():
+def test_single_node_auto_inference_client_dp_rank_count_matches_local_dp():
     config = RLConfig.model_validate(
         {
             "trainer": {},
             "orchestrator": {},
-            "inference": {"server": {"port": 8001}, "parallel": {"tp": 1}},
+            "inference": {"parallel": {"tp": 1}},
             "deployment": {
                 "type": "single_node",
                 "gpus_per_node": 4,
@@ -234,11 +234,10 @@ def test_single_node_auto_inference_ports_follow_server_port():
 
     assert config.inference is not None
     assert config.inference.parallel.dp == 2
-    assert config.inference.backend_port == 8101
-    assert config.orchestrator.model.client.admin_base_url == ["http://localhost:8101/v1"]
+    assert config.orchestrator.model.client.dp_rank_count == 2
 
 
-def test_multi_node_auto_inference_parallelism():
+def test_multi_node_auto_inference_client_dp_rank_count_uses_router_url():
     config = RLConfig.model_validate(
         {
             "trainer": {},
@@ -257,6 +256,7 @@ def test_multi_node_auto_inference_parallelism():
     assert config.inference is not None
     assert config.inference.data_parallel_size_local == 2
     assert config.inference.parallel.dp == 2
+    assert config.orchestrator.model.client.dp_rank_count == 1
 
 
 def test_orchestrator_vlm_requires_renderer():

--- a/tests/unit/utils/test_client.py
+++ b/tests/unit/utils/test_client.py
@@ -1,12 +1,12 @@
 import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 from verifiers.v1.configs.client import EvalClientConfig
 
 from prime_rl.configs.shared import ClientConfig
-from prime_rl.utils.client import _is_retryable_lora_error, check_health, load_lora_adapter, setup_clients
+from prime_rl.utils.client import _is_retryable_lora_error, load_lora_adapter, setup_clients
 
 
 def test_is_retryable_lora_error_returns_true_for_404():
@@ -49,13 +49,14 @@ def test_load_lora_adapter_succeeds_on_first_attempt():
     )
 
 
-def test_setup_clients_creates_one_renderer_client_per_url():
+def test_setup_clients_assigns_renderer_and_dp_rank_headers():
     from renderers import Qwen3VLRendererConfig
 
     client_config = ClientConfig(
-        base_url=["http://worker-a:8000/v1", "http://worker-b:8000/v1"],
+        base_url=["http://worker-a:8000/v1"],
         api_key_var="PRIME_API_KEY",
         headers={"X-Test": "test"},
+        dp_rank_count=2,
         extra_headers_from_state={"X-Session-ID": "session_id"},
     )
 
@@ -69,25 +70,9 @@ def test_setup_clients_creates_one_renderer_client_per_url():
     assert [client.type for client in clients] == ["train", "train"]
     assert [client.renderer for client in clients] == [renderer_settings, renderer_settings]
     assert [client.renderer_model_name for client in clients] == [None, None]
-    assert [client.base_url for client in clients] == [
-        "http://worker-a:8000/v1",
-        "http://worker-b:8000/v1",
-    ]
-    assert all("X-data-parallel-rank" not in client.headers for client in clients)
+    assert [client.base_url for client in clients] == ["http://worker-a:8000/v1"] * 2
+    assert [client.headers["X-data-parallel-rank"] for client in clients] == ["0", "1"]
     assert clients[0].headers["X-Test"] == "test"
-
-
-def test_check_health_retries_non_success_status():
-    client = AsyncMock()
-    unavailable = httpx.Response(503, request=httpx.Request("GET", "http://worker/health"))
-    healthy = httpx.Response(200, request=httpx.Request("GET", "http://worker/health"))
-    client.get.side_effect = [unavailable, healthy]
-    client.base_url = httpx.URL("http://worker")
-
-    with patch("prime_rl.utils.client.asyncio.sleep", new=AsyncMock()):
-        asyncio.run(check_health([client], interval=1, timeout=2))
-
-    assert client.get.await_count == 2
 
 
 def test_setup_clients_assigns_renderer_model_name():

--- a/tests/unit/utils/test_elastic.py
+++ b/tests/unit/utils/test_elastic.py
@@ -415,6 +415,8 @@ def test_elastic_clients_preserve_renderer_model_name_when_model_name_updates():
         client_config.headers = {}
         client_config.headers_from_env = {}
         client_config.extra_headers_from_state = {}
+        client_config.dp_rank_count = 1
+
         from renderers import Qwen3VLRendererConfig
 
         renderer_settings = Qwen3VLRendererConfig()


### PR DESCRIPTION
Reverts #3105 (single global router in front of engines for all deployments).

## Why

Under full RL SWE load the single global router stalls, and the run makes no progress. Observed twice, back-to-back, on `chore/bump-vf-envs` (which includes current main) with GLM-4.5-Air, 768 inflight rollouts + 500 concurrent eval rollouts on 4 replicas:

| run | solver `ProviderError: Request timed out.` | trainer steps | duration |
|---|---|---|---|
| 1st | 8,283 | 0 | 1h13m |
| 2nd (clean reproduction) | 1,573 and climbing at kill | 0 | ~45m |

Signature, from the logs:

- Timeouts are the client's **600s read timeout** on `/inference/v1/generate`. Traced one end-to-end: the router mapped the session to a worker at `05:31:20`; the client gave up at `05:41:40`. Never on a rollout's first call (median: 3rd call) — short early calls return, long later ones die.
- The **engines were healthy and unsaturated throughout**: max queue depth 9, KV cache ~1%, zero preemptions, throughput flowing. The stall is between client and engine.
- The router logged hard errors sending to its workers (`Failed to send typed request worker_url=http://...:8100 route=/v1/chat/completions`), and starts with `request queue with size: 100, timeout: 60s` — all streaming traffic for ~1,270 concurrent rollouts funnels through this one process.
- Same config, same load, same models ran cleanly for 400+ steps on the pre-#3105 topology (per-replica routers, client pool balancing across them).

## Conflicts resolved

- `docs/training.md`: the log-tree section drifted after #3105 (env-server log layout changed separately) — restored the per-replica `router_*.log` line, kept the newer env log line.
- `examples/advanced/glm-5.2/{swe-llmd,infer/pd-llmd}.toml`: these gained `[inference.router.*]` scorer subsections after #3105; moved to `[inference.deployment.router.*]` to match the restored schema.

## Checks

`tests/unit/test_configs.py`, `tests/unit/utils/test_client.py`, `tests/unit/utils/test_elastic.py`: 140 passed.

A fix-forward that keeps the single-router topology but survives this load is presumably possible (queue sizing, per-worker connection pools, streaming backpressure) — but until then every multi-replica RL run on main is broken at scale, so reverting first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the production inference routing path for multi-replica RL and disaggregated SLURM runs; misconfigured URLs or client DP headers could break rollouts, though this restores a topology that previously survived large-scale SWE loads.
> 
> **Overview**
> Reverts the **single global router** topology (#3105) that funneled all multi-replica RL traffic through one `vllm-router` process and stalled under high concurrent load.
> 
> **Routing topology:** SLURM multi-node and P/D jobs again start a **router per inference replica** (logs under `inference/router_*.log`), with `launch_router` scoped to each replica’s nodes for llm-d endpoint discovery. Client-facing URLs become **one router URL per replica** (orchestrator can balance across them) instead of a single global URL on inference node 0.
> 
> **Config schema:** `router` and `backend_port` move from top-level `[inference]` into **`[inference.deployment]`** (and `[deployment.router]` for standalone inference). Router backends gain an explicit **`port`** field for the client-facing listener.
> 
> **Local inference:** `uv run inference` no longer spawns `vllm-router` in-process; it binds vLLM directly on **`inference.server.port`**.
> 
> **Orchestrator client wiring:** Adds **`dp_rank_count`** on `ClientConfig`—single-node RL auto-expands logical clients with **`X-data-parallel-rank`** for KV stickiness; multi-node SLURM sets **`dp_rank_count = 1`** because the router handles DP balancing. Removes auto **`admin_base_url`** bypass and separate health checks on the router URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d2fa3a0467c4fe2b6131e52d086a7229469c8d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->