### PR TITLE
feat(configs): launcher-owned env-server address overrides

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -537,6 +537,9 @@ class OrchestratorConfig(BaseConfig):
     env_server_base_port: int = Field(5000, ge=1, le=65535)
     """First port of the env-server port range: the source at position ``i`` (train, then eval) is served at ``tcp://127.0.0.1:<base + i>``. Give concurrent runs on one host distinct bases (e.g. one per multi-run orchestrator)."""
 
+    env_server_addresses: dict[str, str] = Field(default_factory=dict)
+    """Launcher-owned overrides of where each source's env server lives, keyed ``<split>/<resolved_name>`` (e.g. ``train/wordle``). A listed source is externally managed: the launchers neither write its env-server TOML nor spawn a server for it, and the orchestrator connects to the given address instead of the derived loopback one. Unlisted sources keep the derived ``tcp://127.0.0.1:<env_server_base_port + index>`` address (indices stay positional across ALL sources, so overriding one source never shifts another's port). Sources themselves stay deployment-agnostic — this block is the launcher recording where it chose to run each server, not user intent: launchers whose orchestrator and env servers cannot share a host (e.g. the k8s chart running env servers in separate pods) inject their addresses here."""
+
     batch_size: int | None = Field(None, ge=1)
     """Samples to train on per step (rollout-based batching). Set this OR ``token_batch_size``."""
 
@@ -746,11 +749,32 @@ class OrchestratorConfig(BaseConfig):
     @property
     def env_addresses(self) -> dict[tuple[str, str], str]:
         """Where each source's env server lives, keyed by ``(split, resolved_name)``:
+        an ``env_server_addresses`` override when the launcher set one, else
         ``tcp://127.0.0.1:<port>`` with ports from ``env_server_base_port`` in
         ``env_sources`` order. The launcher binds env servers at exactly these addresses
         and the orchestrator connects to them, so both sides agree from the config
         alone."""
         return {
-            (split, source.resolved_name): f"tcp://127.0.0.1:{self.env_server_base_port + index}"
+            (split, source.resolved_name): self.env_server_addresses.get(f"{split}/{source.resolved_name}")
+            or f"tcp://127.0.0.1:{self.env_server_base_port + index}"
             for index, (split, source) in enumerate(self.env_sources)
         }
+
+    @model_validator(mode="after")
+    def validate_env_server_addresses(self):
+        """Reject override keys that match no source — a typo would otherwise silently
+        fall back to the derived loopback address and the run would hang polling a
+        server nobody runs. Skipped when no sources are present: external render
+        paths (e.g. rl-k8s's validator) validate with the source sections stripped."""
+        if not self.env_server_addresses:
+            return self
+        known = {f"{split}/{source.resolved_name}" for split, source in self.env_sources}
+        if not known:
+            return self
+        unknown = sorted(set(self.env_server_addresses) - known)
+        if unknown:
+            raise ValueError(
+                f"env_server_addresses keys {unknown} match no train/eval source "
+                f"(known: {sorted(known)}); overrides are keyed '<split>/<resolved_name>'"
+            )
+        return self

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -49,11 +49,17 @@ ENVS_DIR = "envs"
 
 
 def env_servers(config: RLConfig) -> list[tuple[str, EnvConfig, str]]:
-    """``(split, source, address)`` for every train/eval source. The launcher runs one
-    env server per source at its deterministic address; the orchestrator connects there."""
+    """``(split, source, address)`` for every launcher-managed train/eval source. The
+    launcher runs one env server per source at its deterministic address; the
+    orchestrator connects there. Sources with an ``env_server_addresses`` override are
+    externally managed (another launcher runs their server at the given address) and
+    are skipped — no TOML is written and no server is spawned for them."""
     addresses = config.orchestrator.env_addresses
+    overridden = set(config.orchestrator.env_server_addresses)
     return [
-        (split, source, addresses[(split, source.resolved_name)]) for split, source in config.orchestrator.env_sources
+        (split, source, addresses[(split, source.resolved_name)])
+        for split, source in config.orchestrator.env_sources
+        if f"{split}/{source.resolved_name}" not in overridden
     ]
 
 
@@ -453,10 +459,12 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
         else {}
     )
 
-    # Env servers launch next to the orchestrator, one per train/eval source.
-    sources = config.orchestrator.env_sources
-    train_env_names = [source.resolved_name for split, source in sources if split == "train"]
-    eval_env_names = [source.resolved_name for split, source in sources if split == "eval"]
+    # Env servers launch next to the orchestrator, one per launcher-managed
+    # train/eval source (externally-managed sources — env_server_addresses
+    # overrides — are skipped, same as env_servers()).
+    launcher_sources = [(split, source) for split, source, _ in env_servers(config)]
+    train_env_names = [source.resolved_name for split, source in launcher_sources if split == "train"]
+    eval_env_names = [source.resolved_name for split, source in launcher_sources if split == "eval"]
 
     if config.deployment.type == "single_node":
         script = template.render(

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -177,6 +177,41 @@ def test_to_toml_dict_roundtrips_explicit_none(tmp_path):
     assert "max_steps" not in to_toml_dict(cli(TrainerConfig, args=[]))
 
 
+def test_env_server_address_overrides():
+    base = {
+        "train": {"source": [{"legacy": {"id": "a"}}, {"legacy": {"id": "b"}}]},
+        "eval": {"source": [{"legacy": {"id": "c"}}]},
+    }
+
+    # Default: derived loopback addresses, positional ports, train then eval.
+    config = OrchestratorConfig.model_validate(base)
+    assert config.env_addresses == {
+        ("train", "a"): "tcp://127.0.0.1:5000",
+        ("train", "b"): "tcp://127.0.0.1:5001",
+        ("eval", "c"): "tcp://127.0.0.1:5002",
+    }
+
+    # Overriding one source relocates only it; the others keep their positional
+    # ports (indices count ALL sources, so no port shifting).
+    config = OrchestratorConfig.model_validate(
+        {**base, "env_server_addresses": {"train/b": "tcp://env-b.ns.svc.cluster.local:5000"}}
+    )
+    assert config.env_addresses == {
+        ("train", "a"): "tcp://127.0.0.1:5000",
+        ("train", "b"): "tcp://env-b.ns.svc.cluster.local:5000",
+        ("eval", "c"): "tcp://127.0.0.1:5002",
+    }
+
+    # A key matching no source is a typo that would otherwise silently fall back
+    # to loopback and hang the run polling a server nobody runs.
+    with pytest.raises(ValidationError, match="env_server_addresses"):
+        OrchestratorConfig.model_validate({**base, "env_server_addresses": {"train/nope": "tcp://x:1"}})
+
+    # External render paths validate with the source sections stripped; overrides
+    # alone must not trip the unknown-key check.
+    OrchestratorConfig.model_validate({"env_server_addresses": {"train/a": "tcp://x:1"}})
+
+
 def test_env_algo_overrides_top_level():
     config = OrchestratorConfig.model_validate(
         {

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -177,41 +177,6 @@ def test_to_toml_dict_roundtrips_explicit_none(tmp_path):
     assert "max_steps" not in to_toml_dict(cli(TrainerConfig, args=[]))
 
 
-def test_env_server_address_overrides():
-    base = {
-        "train": {"source": [{"legacy": {"id": "a"}}, {"legacy": {"id": "b"}}]},
-        "eval": {"source": [{"legacy": {"id": "c"}}]},
-    }
-
-    # Default: derived loopback addresses, positional ports, train then eval.
-    config = OrchestratorConfig.model_validate(base)
-    assert config.env_addresses == {
-        ("train", "a"): "tcp://127.0.0.1:5000",
-        ("train", "b"): "tcp://127.0.0.1:5001",
-        ("eval", "c"): "tcp://127.0.0.1:5002",
-    }
-
-    # Overriding one source relocates only it; the others keep their positional
-    # ports (indices count ALL sources, so no port shifting).
-    config = OrchestratorConfig.model_validate(
-        {**base, "env_server_addresses": {"train/b": "tcp://env-b.ns.svc.cluster.local:5000"}}
-    )
-    assert config.env_addresses == {
-        ("train", "a"): "tcp://127.0.0.1:5000",
-        ("train", "b"): "tcp://env-b.ns.svc.cluster.local:5000",
-        ("eval", "c"): "tcp://127.0.0.1:5002",
-    }
-
-    # A key matching no source is a typo that would otherwise silently fall back
-    # to loopback and hang the run polling a server nobody runs.
-    with pytest.raises(ValidationError, match="env_server_addresses"):
-        OrchestratorConfig.model_validate({**base, "env_server_addresses": {"train/nope": "tcp://x:1"}})
-
-    # External render paths validate with the source sections stripped; overrides
-    # alone must not trip the unknown-key check.
-    OrchestratorConfig.model_validate({"env_server_addresses": {"train/a": "tcp://x:1"}})
-
-
 def test_env_algo_overrides_top_level():
     config = OrchestratorConfig.model_validate(
         {


### PR DESCRIPTION
#3162 made env-server addresses fully derived (tcp://127.0.0.1:<base + index>) on the grounds that addresses are wiring, not intent - correct, but it bakes in the assumption that the launcher and the orchestrator always share a host. Kubernetes launchers wire across pods: the prime-rl-fft chart currently has no choice but to spawn every env server inside the orchestrator pod, because the orchestrator will only ever dial loopback. That forecloses per-source pods (isolated resources, per-env log streams, independent restarts) entirely.

Add OrchestratorConfig.env_server_addresses: a launcher-owned map keyed '<split>/<resolved_name>'. A listed source is externally managed - the local/sbatch launchers neither write its env-server TOML nor spawn a server for it, and the orchestrator connects to the given address; the env-server side binds wherever that launcher told it to. Unlisted sources keep the derived loopback address, with indices still counted across ALL sources so overriding one source never shifts another's port. Sources themselves stay deployment-agnostic: this is the launcher recording where it chose to run each server, not user intent - the same framing #3162 established, extended to launchers that cannot use loopback.

Default-empty means zero behavior change for every existing deployment: rl.py and the sbatch templates render identically when the field is unset.

A model validator rejects override keys matching no source (a typo would otherwise silently fall back to loopback and the run would hang polling a server nobody runs), skipped when no sources are present so external render paths that validate with source sections stripped (e.g. the k8s validator service) still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestrator connectivity and launcher env-server lifecycle; mis-keyed overrides are now rejected, but wrong addresses could still cause connection failures at runtime.
> 
> **Overview**
> Adds **`OrchestratorConfig.env_server_addresses`**, a launcher-owned map keyed by `<split>/<resolved_name>` so the orchestrator can connect to env servers that are not on loopback (e.g. separate Kubernetes pods). **`env_addresses`** now prefers an override when present; port indices still follow the full train-then-eval source list so overriding one source does not change others’ derived ports.
> 
> The **RL launcher** (`env_servers()` and SLURM template wiring) **skips** overridden sources: it does not write env-server TOML or spawn a local server for them. Unset overrides keep today’s loopback behavior.
> 
> A **validator** rejects override keys that do not match any train/eval source (avoids silent typos and hangs); validation is skipped when there are no sources so stripped configs (e.g. k8s validator) still load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fab3add85b3964d2554b72938fb8fd4ae67328af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->