### PR TITLE
refactor: make orchestration verifiers v1-native

### DIFF
--- a/configs/ci/integration/reverse-text-rl-opd/start.toml
+++ b/configs/ci/integration/reverse-text-rl-opd/start.toml
@@ -51,7 +51,7 @@ type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
-num_examples = 16
+num_tasks = 16
 
 [orchestrator.eval.sampling]
 max_completion_tokens = 128

--- a/configs/ci/integration/reverse-text-rl-sft/start.toml
+++ b/configs/ci/integration/reverse-text-rl-sft/start.toml
@@ -57,7 +57,7 @@ type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
-num_examples = 16
+num_tasks = 16
 
 [orchestrator.eval.sampling]
 max_completion_tokens = 128

--- a/configs/debug/algo/grpo.toml
+++ b/configs/debug/algo/grpo.toml
@@ -35,7 +35,7 @@ type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
-num_examples = 128
+num_tasks = 128
 
 [orchestrator.eval.sampling]
 max_completion_tokens = 128

--- a/configs/debug/algo/max_rl.toml
+++ b/configs/debug/algo/max_rl.toml
@@ -35,7 +35,7 @@ type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
-num_examples = 128
+num_tasks = 128
 
 [orchestrator.eval.sampling]
 max_completion_tokens = 128

--- a/configs/debug/algo/mixed_grpo_opd.toml
+++ b/configs/debug/algo/mixed_grpo_opd.toml
@@ -64,7 +64,7 @@ base_url = ["http://localhost:8001/v1"]
 
 [orchestrator.eval]
 interval = 5
-num_examples = 128
+num_tasks = 128
 
 [orchestrator.eval.sampling]
 max_completion_tokens = 128

--- a/configs/debug/algo/opd.toml
+++ b/configs/debug/algo/opd.toml
@@ -47,7 +47,7 @@ type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
-num_examples = 128
+num_tasks = 128
 
 [orchestrator.eval.sampling]
 max_completion_tokens = 128

--- a/configs/debug/algo/opd_lora.toml
+++ b/configs/debug/algo/opd_lora.toml
@@ -47,7 +47,7 @@ type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
-num_examples = 128
+num_tasks = 128
 
 [orchestrator.eval.sampling]
 max_completion_tokens = 128

--- a/configs/debug/algo/rae.toml
+++ b/configs/debug/algo/rae.toml
@@ -41,7 +41,7 @@ type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
-num_examples = 16
+num_tasks = 16
 
 [orchestrator.eval.sampling]
 max_completion_tokens = 512

--- a/configs/debug/algo/self_distill.toml
+++ b/configs/debug/algo/self_distill.toml
@@ -43,7 +43,7 @@ type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
-num_examples = 128
+num_tasks = 128
 
 [orchestrator.eval.sampling]
 max_completion_tokens = 128

--- a/configs/debug/algo/sft_distill.toml
+++ b/configs/debug/algo/sft_distill.toml
@@ -52,7 +52,7 @@ type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
-num_examples = 128
+num_tasks = 128
 
 [orchestrator.eval.sampling]
 max_completion_tokens = 128

--- a/configs/debug/algo/sft_distill_lora.toml
+++ b/configs/debug/algo/sft_distill_lora.toml
@@ -52,7 +52,7 @@ type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
-num_examples = 128
+num_tasks = 128
 
 [orchestrator.eval.sampling]
 max_completion_tokens = 128

--- a/configs/debug/multi-env/rl.toml
+++ b/configs/debug/multi-env/rl.toml
@@ -43,7 +43,7 @@ type = "subprocess"
 
 [orchestrator.eval]
 interval = 5
-num_examples = 64
+num_tasks = 64
 
 [orchestrator.eval.sampling]
 max_completion_tokens = 128

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -481,7 +481,7 @@ Filtered rollouts still appear in W&B distributions, just not in the trainer bat
 
 ## Multi-Turn Trajectories
 
-Multi-turn rollouts (tool use, browser environments, long conversations) used to be stitched into a single fake "single-turn" sample, which silently corrupted the importance ratio when chat templates didn't roundtrip. Since [`verifiers` v0.1.8](https://github.com/PrimeIntellect-ai/verifiers/releases/tag/v0.1.8), `prime-rl` records each LLM request/response as an independent **trajectory step** and merges them at training time using best-effort interleaving — with [renderers](#renderers) as the mechanism that keeps the merge safe by construction.
+Multi-turn rollouts (tool use, browser environments, long conversations) record each LLM request/response as an independent **trajectory step** and merge them at training time using best-effort interleaving — with [renderers](#renderers) as the mechanism that keeps the merge safe by construction.
 
 ### Extension Property
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -57,9 +57,9 @@ A condensed view of the knobs you'll most often tune. For trainer-side paralleli
 
 | Knob | What it does |
 |---|---|
-| `orchestrator.batch_size` | Tasks per trainer step. |
-| `orchestrator.group_size` | Rollouts generated per task. |
-| `orchestrator.max_off_policy_steps` | How many distinct policies may have contributed to one rollout before it's discarded (default 8). The main off-policy dial on long agentic rollouts — bump for throughput, lower for tighter on-policyness. Watch `errored_rollouts` and `mismatch_kl/all/mean` when tuning. |
+| `orchestrator.batch_size` | Target selected traces per trainer step. Completed task groups stay atomic, so a batch may exceed the target. |
+| `orchestrator.group_size` | Episodes run per task. A v1 episode may contain multiple agent traces. |
+| `orchestrator.max_off_policy_steps` | How many policy updates an in-flight episode may cross before it's discarded (default 8). The main off-policy dial on long agentic runs — bump for throughput, lower for tighter on-policyness. Watch `train/agg/all/has_error/mean` and `mismatch_kl/all/mean` when tuning. |
 | `[orchestrator.algo]` | Training algorithm — its `type` names it (`grpo` default, `max_rl`, `rae`, `hierarchical_grpo`, `opd`, `opsd`, `sft`, `echo`). See [Algorithms](#algorithms). |
 | `[[orchestrator.train.source]]` | Training sources. List multiple tables for multi-env training; weight them via `ratio`. See [Configuration § Training sources](configuration.md#training-sources-orchestratortrainsource). |
 | `[[orchestrator.eval.source]]` + `orchestrator.eval.interval` | Eval environments and cadence (default every 100 steps). |
@@ -114,11 +114,11 @@ Pulled from the console logs and mirrored to W&B.
 
 **Progress** (orchestrator):
 
-- `reward/{all,env}/mean` — main signal. Should trend upward over hundreds of steps.
-- `seq_len/{all,env}/mean` and `is_truncated/{all,env}/mean` — rollout length and truncation rate.
-- `num_turns/{all,env}/mean` — for multi-turn envs.
-- `empty_rollouts/{all,env}`, `errored_rollouts/{all,env}` — non-zero is fine in small numbers; sustained > 5% is a smell.
-- `eval/{env}/{avg@k,pass@k}` — eval scores when `[orchestrator.eval]` is set.
+- `train/agg/effective/<agent>/reward/mean` — main signal. Should trend upward over hundreds of steps.
+- `train/agg/effective/<agent>/is_truncated/mean` — trace truncation rate.
+- `train/agg/effective/num_turns/mean` — turns per episode, summed across its agents.
+- `train/agg/all/has_error/mean` — failed-episode rate, including zero-trace failures; sustained > 5% is a smell.
+- `eval/<env>/effective/<agent>/{avg@k,pass@k}` — per-agent eval scores when eval is configured.
 
 **Stability** (trainer):
 

--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -166,7 +166,7 @@ interval = 20
 
 [[orchestrator.eval.source]]
 name = "browsecomp"
-num_examples = 500 # full set is 1266; cap eval at 500
+num_tasks = 500 # full set is 1266; cap eval at 500
 
 [orchestrator.eval.source.env.agent.harness]
 id = "rlm"

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -151,9 +151,6 @@ class EnvConfig(BaseConfig):
     name: str | None = None
     """Display name for this environment in logs, metrics, and buffer keys. Defaults to the taskset id. Must be unique across all envs in the same group."""
 
-    ratio: float = Field(1.0, gt=0)
-    """Sampling weight for this environment in the buffer. Relative weights are normalized to probabilities across envs (e.g. [1, 1] and [0.5, 0.5] are equivalent). Defaults to 1, i.e. equal weight per env."""
-
     @model_validator(mode="before")
     @classmethod
     def _resolve_env(cls, data):
@@ -181,11 +178,14 @@ class EnvConfig(BaseConfig):
 
 
 class TrainSourceConfig(EnvConfig):
+    ratio: float = Field(1.0, gt=0)
+    """Relative sampling weight across training environments."""
+
     sampling: TrainSamplingConfig = TrainSamplingConfig()
     """Per-env sampling overrides. Unset fields inherit from the group-level train sampling config."""
 
     group_size: int = Field(1, ge=1)
-    """Rollouts generated per example for GRPO group-relative advantages.
+    """Episodes run per task for GRPO group-relative advantages.
     Inherits from ``orchestrator.group_size`` when unset."""
 
     algo: AlgoConfig | None = None
@@ -198,11 +198,11 @@ class EvalSourceConfig(EnvConfig):
     sampling: EvalSamplingConfig = EvalSamplingConfig()
     """Per-env sampling overrides. Unset fields inherit from the group-level eval sampling config."""
 
-    num_examples: int = -1
-    """Eval examples to sample from the dataset. ``-1`` uses all available examples."""
+    num_tasks: Literal[-1] | Annotated[int, Field(ge=1)] = -1
+    """Tasks to evaluate from the taskset. ``-1`` uses every available task."""
 
     group_size: int = Field(1, ge=1)
-    """Rollouts generated per example. Used for pass@k estimation (e.g. ``group_size=8`` enables pass@1 through pass@8)."""
+    """Episodes run per task. An episode may contain multiple agent traces."""
 
     interval: int = Field(100, ge=1)
     """Per-env eval interval. If unset, inherits from the group-level eval interval."""
@@ -246,11 +246,11 @@ class EvalConfig(BaseConfig):
     sampling: EvalSamplingConfig = Field(default_factory=EvalSamplingConfig)
     """Shared eval sampling configuration; can differ from training sampling."""
 
-    num_examples: int = -1
-    """Default eval examples per environment. ``-1`` uses all. Can be overridden per env."""
+    num_tasks: Literal[-1] | Annotated[int, Field(ge=1)] = -1
+    """Default eval tasks per environment. ``-1`` uses all. Can be overridden per env."""
 
     group_size: int = Field(1, ge=1)
-    """Default rollouts per example. Can be overridden per env."""
+    """Default episodes per eval task. Can be overridden per env."""
 
     interval: int = Field(100, ge=1)
     """Step interval at which to evaluate the model."""
@@ -266,7 +266,7 @@ class EvalConfig(BaseConfig):
 
     @model_validator(mode="after")
     def resolve_env_defaults(self):
-        """Resolve per-env overrides: inherit group-level sampling, num_examples,
+        """Resolve per-env overrides: inherit group-level sampling, num_tasks,
         group_size, and interval (the worker ``pool`` is configured per env, default elastic)."""
         group_sampling = self.sampling.model_dump()
         for source in self.source:
@@ -275,8 +275,8 @@ class EvalConfig(BaseConfig):
             else:
                 merged = group_sampling | source.sampling.model_dump(exclude_unset=True)
                 source.sampling = EvalSamplingConfig(**merged)
-            if "num_examples" not in source.model_fields_set:
-                source.num_examples = self.num_examples
+            if "num_tasks" not in source.model_fields_set:
+                source.num_tasks = self.num_tasks
             if "group_size" not in source.model_fields_set:
                 source.group_size = self.group_size
             if "interval" not in source.model_fields_set:
@@ -496,7 +496,8 @@ class OrchestratorConfig(BaseConfig):
     """First port of the env-server port range: the source at position ``i`` (train, then eval) is served at ``tcp://127.0.0.1:<base + i>``. Give concurrent runs on one host distinct bases (e.g. one per multi-run orchestrator)."""
 
     batch_size: int | None = Field(None, ge=1)
-    """Samples to train on per step (rollout-based batching). Set this OR ``token_batch_size``."""
+    """Target selected traces per training step. Complete task groups remain atomic,
+    so the shipped batch may exceed this target. Set this OR ``token_batch_size``."""
 
     token_batch_size: int | None = Field(None, ge=1)
     """Tokens to train on per step (token-based batching). Set this OR ``batch_size``."""
@@ -505,10 +506,13 @@ class OrchestratorConfig(BaseConfig):
     """Rollout-mode batching only. Multiplier used to derive ``max_inflight_episodes`` from ``batch_size`` when ``max_inflight_episodes`` is unset. Values below 1.0 intentionally cap in-flight episode capacity below ``batch_size``."""
 
     max_inflight_episodes: int | None = Field(None, ge=1)
-    """Maximum number of episodes kept in-flight — one episode is one agent run at a time, whatever the env's agents are. Required for token-based batching. With ``batch_size`` set, defaults to ``batch_size * oversampling_factor`` (or ``batch_size`` when ``oversampling_factor`` is unset)."""
+    """Maximum number of env runs kept in flight. Each run returns one v1 episode,
+    which may contain zero, one, or many agent traces. Required for token-based
+    batching. With ``batch_size`` set, defaults to ``batch_size *
+    oversampling_factor`` (or ``batch_size`` when unset)."""
 
     group_size: int = Field(1, ge=1)
-    """Output sequences returned per example during training."""
+    """Episodes run per task during training."""
 
     seq_len: int = 2048
     """Training sequence length. Shorter samples are padded; longer samples are truncated."""
@@ -521,7 +525,9 @@ class OrchestratorConfig(BaseConfig):
     """Maximum training steps. If None, runs indefinitely."""
 
     max_off_policy_steps: int = Field(8, ge=0)
-    """Maximum policies allowed to generate a single rollout. Rollouts generated more than ``max_off_policy_steps`` ahead of training are discarded. Higher values yield better throughput at the cost of off-policy noise."""
+    """Maximum policy updates an in-flight episode may cross before its task group
+    is discarded. Higher values yield better throughput at the cost of off-policy
+    noise."""
 
     bench: bool = False
     """Benchmark mode. Sets ``max_steps`` to 5 and disables W&B."""
@@ -637,22 +643,14 @@ class OrchestratorConfig(BaseConfig):
                 raise ValueError("max_inflight_episodes must be set when token_batch_size is set")
         else:
             assert self.batch_size is not None
-            if self.batch_size % self.group_size != 0:
-                raise ValueError("Batch size must be divisible by the number of samples per problem")
             oversampling_factor = self.oversampling_factor if self.oversampling_factor is not None else 1.0
-            resolved_max_inflight_episodes = max(
-                self.group_size,
-                int(self.batch_size * oversampling_factor),
-            )
+            resolved_max_inflight_episodes = max(1, int(self.batch_size * oversampling_factor))
             if self.max_inflight_episodes is not None and self.oversampling_factor is not None:
                 expected_max_inflight_episodes = resolved_max_inflight_episodes
                 if self.max_inflight_episodes != expected_max_inflight_episodes:
                     raise ValueError("max_inflight_episodes conflicts with oversampling_factor * batch_size")
             if self.max_inflight_episodes is None:
                 self.max_inflight_episodes = resolved_max_inflight_episodes
-
-        if self.max_inflight_episodes is not None and self.max_inflight_episodes < self.group_size:
-            raise ValueError("max_inflight_episodes must be at least the number of rollouts per example")
 
         # Propagate the top-level ``group_size`` into each train env that didn't set its own.
         for env_cfg in self.train.source:

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -94,7 +94,7 @@ All metrics print to the console log (and W&B when configured).
 - `{scope}/{subset}/<metric>/<stat>` — episode-level facts only: the token/turn/branch counts, summed over an episode's traces.
 - `{scope}/{subset}/<agent>/<metric>/<stat>` — every trace-level metric (reward, truncation, errors, timing, env metrics, filter verdicts, eval scores), keyed by agent name so seats never mix. Flat over that agent's traces: one sample is one trace, so an in-episode fan-out like n solvers contributes n samples.
 
-`scope` is `train/agg` (all train envs) or `train/<env>` (`eval/<env>` for eval); `subset` is `all` (every rollout) or `effective` (post-filter). Single-agent envs have one agent — usually `agent` — and one trace per episode, so both levels agree; multi-agent envs name each seat (`proposer`, `solver`, `judge`, …).
+`scope` is `train/agg` (all train envs) or `train/<env>` (`eval/<env>` for eval); `subset` is `all` (every episode and its traces) or `effective` (post-filter traces). Single-agent envs have one agent — usually `agent` — and one trace per episode, so both levels agree; multi-agent envs name each seat (`proposer`, `solver`, `judge`, …).
 
 | Metric | Description |
 |--------|-------------|
@@ -103,7 +103,8 @@ All metrics print to the console log (and W&B when configured).
 | `train/agg/effective/num_turns/mean` | avg turns per episode, summed over its agents |
 | `train/<env>/effective/<agent>/num_turns/mean` | avg turns for that agent alone (also token counts, `num_branches`) |
 | `train/agg/effective/<agent>/is_truncated/mean` | fraction of that agent's rollouts truncated |
-| `train/agg/all/<agent>/has_error/mean` | fraction of that agent's rollouts errored (per-type under `train/agg/all/<agent>/error/<type>`; also `dispatcher/errored/{train,eval}`) |
+| `train/agg/all/has_error/mean` | fraction of episodes that failed, including zero-trace failures (also `dispatcher/errored/{train,eval}`) |
+| `train/agg/all/<agent>/has_error/mean` | fraction of that agent's traces errored (per-type under `train/agg/all/<agent>/error/<type>`) |
 | `train/agg/all/<agent>/is_trainable/mean` | fraction carrying a training signal — 0.0 for a frozen seat like a judge (also `is_filtered`, `filters/<name>`) |
 | `train/<env>/effective/<agent>/metrics/<name>/mean` | env-specific metrics for that agent (e.g. pass rate) |
 | `train/<env>/effective/<agent>/timing/agent/model/mean` | model vs harness share of that agent's phase |
@@ -141,25 +142,28 @@ curl -s http://localhost:8100/metrics | grep -E "num_requests|gpu_cache_usage"  
 ### Traces
 
 ```
-{output_dir}/rollouts/step_N/{train,eval}/all/traces.jsonl        # appended per rollout as it completes
+{output_dir}/rollouts/step_N/{train,eval}/all/traces.jsonl        # one v1 Episode per line, appended as it completes
 {output_dir}/rollouts/step_N/{train,eval}/effective/traces.jsonl  # written per finalized batch / eval epoch
 ```
 
-JSONL files of `vf.Trace` records (training tensors excluded), one line per trace — a
-multi-agent env's episode contributes several lines sharing one `info.episode_id`. `all`
-gets every completed rollout the moment it arrives — errored, filtered, and never-batched
-ones included — so it's crash-durable; `effective` gets the clean trainable subset that went
+The `all` stream contains canonical v1 `Episode` records, one line per episode, with each
+episode's traces nested under `.traces`. This preserves zero-trace failures and keeps a
+multi-agent episode atomic. The episode-level `prime_rl` object carries `env_name`, `group_id`,
+the originating `task`, `policy_version`, and the run kind. `all` gets every completed episode the moment it arrives —
+errored, filtered, and never-batched ones included — so it's crash-durable. `effective` remains
+a derived stream of `vf.Trace` records (training tensors excluded), one line per clean trace that went
 into the step's train batch (eval: the non-errored trainable epoch cohort; multiple eval envs
 share the step file) — untrainable traces (a frozen judge's) appear only in `all`. Each record carries `run` (`{type, id, step}`; for eval, `step` is the trigger step),
 `verifiers` (producing build), `agent` (model, sampling, harness, `name`, `trainable`), `ok`
 (the success sentinel — `errors` alone keeps retry history even after a recovery), and
-`runtime` (config + provisioned resource id, e.g. the sandbox id), plus `env_name`,
-`group_id`, `episode_id`, and `policy_version` under `info`.
+`runtime` (config + provisioned resource id, e.g. the sandbox id). Effective trace records keep
+`env_name`, `group_id`, `episode_id`, and `policy_version` under `info.prime_rl`.
 
 ```bash
 wc -l {output_dir}/rollouts/step_42/train/{all,effective}/traces.jsonl
 jq '.rewards' {output_dir}/rollouts/step_42/train/effective/traces.jsonl
-jq 'select(.ok | not) | {id, env: .info.env_name, runtime}' {output_dir}/rollouts/step_*/train/all/traces.jsonl
+jq 'select(.ok | not) | {id, env: .prime_rl.env_name, error: .errors[-1]}' {output_dir}/rollouts/step_*/train/all/traces.jsonl
+jq '.traces[] | select(.ok | not)' {output_dir}/rollouts/step_*/train/all/traces.jsonl
 ```
 
 The batches consumed by the trainer are shipped over ZMQ by default, so nothing binary is written. With `rollout_transport.type = "filesystem"` they land at `{output_dir}/rollouts/step_N/train_rollouts.bin`, next to the trace subtrees.

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -1,25 +1,24 @@
-"""RolloutDispatcher: schedules rollouts under a shared permit counter.
+"""EpisodeDispatcher: schedules v1 episodes under a shared capacity bound.
 
 - Capacity (``max_inflight_episodes``) is shared across train + eval. One permit is
   one episode and one env-server ``run`` request.
 - Optional rate limiting via ``AsyncLimiter(tasks_per_minute, 60)``.
 - Emit-everything invariant: every dispatched episode eventually reaches
-  ``out_q`` exactly once, as a ``list[Rollout]``. Failures
-  (env error, empty trajectory, task exception, off-policy cancel) carry
-  ``trace.last_error`` set; sinks decide drop / partial-train policy.
+  ``out_q`` exactly once as an ``EpisodeResult``. Zero-trace failures and
+  cancellations retain their v1 episode shell and episode-level error.
 - ``DispatcherMode.PREFER_TRAIN`` / ``PREFER_EVAL`` controls which kind to
   schedule next. Transitions are level-triggered (driven by the eval
-  source's emptiness), so in-flight rollouts of the opposite kind drain
+  source's emptiness), so in-flight episodes of the opposite kind drain
   naturally on either side of an eval boundary.
 - ``on_version_pending`` (called by the watcher before the engines pause for
-  the weight update) bumps ``off_policy_steps`` on in-flight train rollouts and
+  the weight update) bumps ``off_policy_steps`` on in-flight train episodes and
   drops groups past ``max_off_policy_steps``.
-  Eval rollouts are measurements for the policy version they started with,
-  so they are allowed to finish even if training advances. Train rollouts
+  Eval episodes are measurements for the policy version they started with,
+  so they are allowed to finish even if training advances. Train episodes
   sampled from a frozen model never age — their sampler doesn't change
   with policy updates.
-  Cancellations surface as synthetic ``Cancelled`` markers so the sink's
-  count-to-``group_size`` finalization still fires.
+  Cancellations surface as empty failed episodes so the sink's
+  count-to-``group_size`` finalization still fires without fake traces.
 """
 
 from __future__ import annotations
@@ -33,15 +32,17 @@ from typing import Literal
 
 import verifiers.v1 as vf
 from aiolimiter import AsyncLimiter
+from verifiers.v1.episode import EnvInfo
 
 from prime_rl.orchestrator.envs import EvalEnvs, TrainEnvs
 from prime_rl.orchestrator.eval_source import EvalSource
 from prime_rl.orchestrator.train_source import TrainSource
 from prime_rl.orchestrator.types import (
+    ROLLOUT_TYPE,
+    EpisodeResult,
     GroupState,
-    InflightRollout,
+    InflightEpisode,
     Policy,
-    Rollout,
     RolloutKind,
 )
 from prime_rl.utils.async_utils import safe_cancel, safe_cancel_all
@@ -60,7 +61,7 @@ class DispatcherMode(Enum):
 class DispatcherMetrics:
     """Per-tick drain counters for the orchestrator's periodic log.
     ``drained()`` returns the current values and clears them; point-in-time
-    gauges live on ``RolloutDispatcher.gauges`` instead."""
+    gauges live on ``EpisodeDispatcher.gauges`` instead."""
 
     cancelled_by_kind_env: dict[tuple[Literal["train", "eval"], str], int] = field(
         default_factory=lambda: defaultdict(int)
@@ -113,10 +114,10 @@ class DispatcherMetrics:
         return keys
 
 
-class RolloutDispatcher:
+class EpisodeDispatcher:
     """``await dispatcher.start()`` runs the dispatch loop until ``stop()``.
-    Pulls examples from ``TrainSource`` / ``EvalSource``, schedules
-    rollouts under shared capacity, and emits ``Rollout``\\ s to
+    Pulls tasks from ``TrainSource`` / ``EvalSource``, schedules
+    episodes under shared capacity, and emits ``EpisodeResult`` objects to
     ``out_q``. The watcher drives ``on_version_pending`` for off-policy
     cancellation; the orchestrator triggers eval epochs."""
 
@@ -136,7 +137,7 @@ class RolloutDispatcher:
         self.policy = policy
         self.train_envs = train_envs
         self.eval_envs = eval_envs
-        # Train rollouts go to the env sampler's pool; eval always
+        # Train episodes go to the env sampler's pool; eval always
         # evaluates the policy.
         self.policy_pool = policy_pool
         self.train_source = train_source
@@ -144,21 +145,20 @@ class RolloutDispatcher:
         self.max_off_policy_steps = max_off_policy_steps
 
         self.max_inflight = max_inflight_episodes
-        self.inflight_permits = 0
         self.rate_limiter: AsyncLimiter | None = (
             AsyncLimiter(tasks_per_minute, time_period=60) if tasks_per_minute else None
         )
 
-        self.inflight: dict[asyncio.Task, InflightRollout] = {}
+        self.inflight: dict[asyncio.Task, InflightEpisode] = {}
         self.groups: dict[uuid.UUID, GroupState] = {}
 
         # Bounded so the dispatcher backpressures on a slow sink. One entry per
         # episode — the sinks count episodes, never loose traces.
-        self.out_q: asyncio.Queue[list[Rollout]] = asyncio.Queue(maxsize=max(8, self.max_inflight))
+        self.out_q: asyncio.Queue[EpisodeResult] = asyncio.Queue(maxsize=max(8, self.max_inflight))
 
         self.mode: DispatcherMode = DispatcherMode.PREFER_TRAIN
         # Set by the orchestrator after the final train step; pipeline then
-        # winds down without scheduling new train rollouts
+        # winds down without scheduling new train episodes
         self.train_scheduling_disabled: bool = False
         self.metrics = DispatcherMetrics()
 
@@ -172,7 +172,7 @@ class RolloutDispatcher:
         self.task: asyncio.Task | None = None
 
     def _train_pool_for(self, env_name: str) -> tuple[InferencePool, str, bool]:
-        """``(pool, model_name, is_live)`` for *train* rollouts of this env —
+        """``(pool, model_name, is_live)`` for *train* episodes of this env —
         the env sampler's pool. (Eval always uses the policy.)"""
         sampler = self.train_envs.get(env_name).sampler
         if sampler.samples_from_live_policy:
@@ -189,7 +189,7 @@ class RolloutDispatcher:
 
     @property
     def available_permits(self) -> int:
-        return self.max_inflight - self.inflight_permits
+        return self.max_inflight - len(self.inflight)
 
     @property
     def inflight_by_env(self) -> dict[tuple[RolloutKind, str], int]:
@@ -199,17 +199,17 @@ class RolloutDispatcher:
         return dict(counts)
 
     @property
-    def queued_eval_examples(self) -> int:
+    def queued_eval_tasks(self) -> int:
         return len(self.eval_source) if self.eval_source is not None else 0
 
     @property
     def eval_has_work(self) -> bool:
         """Eval has work while its source queue is non-empty OR any opened eval group still has
-        rollouts to schedule. An example leaves ``eval_source`` when its group opens
-        (``next_fresh_group``), but its ``group_size`` rollouts dispatch one at a time across
+        episodes to schedule. A task leaves ``eval_source`` when its group opens
+        (``next_fresh_group``), but its ``group_size`` episodes dispatch one at a time across
         ``fill_inflight`` passes — so the queue can be empty while a group is still mid-schedule."""
         return bool(self.eval_source) or any(
-            g.kind == "eval" and g.rollouts_to_schedule > 0 for g in self.groups.values()
+            g.kind == "eval" and g.episodes_to_schedule > 0 for g in self.groups.values()
         )
 
     @property
@@ -219,7 +219,7 @@ class RolloutDispatcher:
         return not self.inflight and not self.eval_has_work and self.out_q.empty()
 
     def disable_train_scheduling(self) -> None:
-        """Stop scheduling new train rollouts; in-flight train + any
+        """Stop scheduling new train episodes; in-flight train + any
         triggered eval drain naturally."""
         self.train_scheduling_disabled = True
 
@@ -256,13 +256,13 @@ class RolloutDispatcher:
                     timeout=0.5,  # wake periodically to re-check fill (mode flips)
                 )
                 for task in done:
-                    await self.handle_completed_rollout(task)
+                    await self.handle_completed_episode(task)
         except asyncio.CancelledError:
             return
 
     async def stop(self) -> None:
         self.stopped.set()
-        await self.cancel_inflight_rollouts()
+        await self.cancel_inflight_episodes()
         if self.task is not None:
             await safe_cancel(self.task)
             self.task = None
@@ -270,7 +270,7 @@ class RolloutDispatcher:
     async def on_version_pending(self, step: int) -> None:
         """Bump off-policy counters and drop groups past
         ``max_off_policy_steps`` (drop_group emits ``Cancelled`` markers so
-        the sink still finalizes the partial group). Eval rollouts are not
+        the sink still finalizes the partial group). Eval episodes are not
         aged because they are tied to their start-time policy version.
 
         Runs *before* the inference engines are paused for the weight update so
@@ -282,7 +282,7 @@ class RolloutDispatcher:
         for meta in self.inflight.values():
             if meta.kind != "train":
                 continue
-            # Frozen-sourced rollouts never go stale — their sampler doesn't
+            # Frozen-sourced episodes never go stale — their sampler doesn't
             # change with policy updates.
             if not self.train_envs.get(meta.env_name).sampler.samples_from_live_policy:
                 continue
@@ -296,7 +296,7 @@ class RolloutDispatcher:
 
         if cancelled:
             get_logger().warning(
-                f"Cancelled {cancelled} train rollouts past max_off_policy_steps={self.max_off_policy_steps}. "
+                f"Cancelled {cancelled} train episodes past max_off_policy_steps={self.max_off_policy_steps}. "
                 "Consider increasing it to avoid this."
             )
 
@@ -304,7 +304,7 @@ class RolloutDispatcher:
         """No-op: the dispatcher drains in ``on_version_pending`` (pre-pause)."""
 
     async def fill_inflight(self) -> None:
-        """Schedule new rollouts up to ``max_inflight``, honoring
+        """Schedule new episodes up to ``max_inflight``, honoring
         ``self.mode``. Eval scheduling ignores the orchestrator's dispatch
         gate (evals are version-pinned measurements); only train scheduling
         respects it. When ``PREFER_EVAL``'s source exhausts we flip back to
@@ -337,11 +337,11 @@ class RolloutDispatcher:
         if new_mode == self.mode:
             return
         prefer = "eval" if new_mode == DispatcherMode.PREFER_EVAL else "train"
-        get_logger().info(f"Switching dispatcher mode to prefer {prefer} rollouts because {reason}")
+        get_logger().info(f"Switching dispatcher mode to prefer {prefer} episodes because {reason}")
         self.mode = new_mode
 
     async def try_schedule(self, kind: RolloutKind) -> bool:
-        """Schedule one rollout of ``kind``: prefer continuing an existing
+        """Schedule one episode of ``kind``: prefer continuing an existing
         group (keeps prefix-cache hits); otherwise open a fresh group from
         the corresponding source. Returns False if nothing could be
         scheduled."""
@@ -352,54 +352,50 @@ class RolloutDispatcher:
             return False
 
         for gid, group in list(self.groups.items()):
-            if group.kind != kind or group.rollouts_to_schedule <= 0:
+            if group.kind != kind or group.episodes_to_schedule <= 0:
                 continue
             if self.available_permits >= 1:
-                return await self.schedule_group_rollout(gid, group)
+                return await self.schedule_group_episode(gid, group)
 
         fresh = self.next_fresh_group(kind, envs)
         if fresh is None:
             return False
         gid = uuid.uuid4()
         self.groups[gid] = fresh
-        return await self.schedule_group_rollout(gid, fresh)
+        return await self.schedule_group_episode(gid, fresh)
 
     def next_fresh_group(self, kind: RolloutKind, envs) -> GroupState | None:
-        """Pop the next example from the corresponding source and wrap it in
-        a ``GroupState``. Returns ``None`` if the source is empty or the
-        picked env's permit cost doesn't fit."""
+        """Pop the next task from the corresponding source and wrap it in
+        a ``GroupState``. Returns ``None`` if the source is empty."""
         if kind == "train":
             source = self.train_source
         else:
             assert self.eval_source is not None
             source = self.eval_source
-        example = source.next_example(self.available_permits)
-        if example is None:
+        item = source.next_task()
+        if item is None:
             return None
 
-        env_name = example["env_name"]
-        group_size = envs.get(env_name).config.group_size
-        eval_step: int | None = example.get("eval_step") if kind == "eval" else None
+        group_size = envs.get(item.env_name).config.group_size
 
         return GroupState(
             kind=kind,
-            env_name=env_name,
-            task_idx=example["task_idx"],
-            task=example["task"],
-            rollouts_to_schedule=group_size,
-            target_rollouts=group_size,
-            eval_step=eval_step,
+            env_name=item.env_name,
+            task_data=item.data,
+            episodes_to_schedule=group_size,
+            target_episodes=group_size,
+            eval_step=item.eval_step,
             policy_version_at_start=self.policy.version,
         )
 
-    async def schedule_group_rollout(self, group_id: uuid.UUID, group: GroupState) -> bool:
+    async def schedule_group_episode(self, group_id: uuid.UUID, group: GroupState) -> bool:
         """Dispatch one run for this group.
 
-        Returns False only if we couldn't even schedule one rollout (no clients
+        Returns False only if we couldn't even schedule one episode (no clients
         ready, no permits). Returns True after issuing one task — the caller
         loops to keep scheduling.
         """
-        # Train rollouts use the env sampler's pool via the
+        # Train episodes use the env sampler's pool via the
         # renderer/token train client. Eval always evaluates the policy and
         # goes through the eval client (chat-completions).
         if group.kind == "eval":
@@ -427,7 +423,7 @@ class RolloutDispatcher:
         if env_collection is None:
             return False
         env = env_collection.get(group.env_name)
-        # Frozen-sourced train rollouts hit a frozen pool; salting per policy
+        # Frozen-sourced train episodes hit a frozen pool; salting per policy
         # version would invalidate its prefix cache every weight update for
         # no reason.
         if live_sourced:
@@ -435,87 +431,65 @@ class RolloutDispatcher:
         else:
             cache_salt = None
 
-        group.rollouts_to_schedule -= 1
-        await self.acquire(1)
+        if self.rate_limiter is not None:
+            await self.rate_limiter.acquire()
+        if group_id not in self.groups:
+            return False
+        group.episodes_to_schedule -= 1
         task = asyncio.create_task(
             env.run(
                 client=client,
                 model_name=model_name,
                 cache_salt=cache_salt,
-                task_data=group.task.data.model_dump(mode="json"),
+                task_data=group.task_data,
             )
         )
 
-        self.inflight[task] = InflightRollout(
+        self.inflight[task] = InflightEpisode(
             kind=group.kind,
             env_name=group.env_name,
             group_id=group_id,
+            task_data=group.task_data,
             policy_version=group.policy_version_at_start,
             client_config=client,
             eval_step=group.eval_step,
         )
         return True
 
-    async def acquire(self, n: int) -> None:
-        """Reserve ``n`` permits + rate-limit each one. Caller must precheck
-        ``available_permits >= n``; this is not a blocking acquire."""
-        for _ in range(n):
-            if self.rate_limiter is not None:
-                await self.rate_limiter.acquire()
-            self.inflight_permits += 1
-
-    def release(self, n: int) -> None:
-        self.inflight_permits -= n
-
-    async def handle_completed_rollout(self, task: asyncio.Task) -> None:
-        """Emit every dispatched episode exactly once to ``out_q``. Task exceptions
-        synthesize an error-marker episode so the sink's count-to-``group_size``
-        finalization still triggers. Cancelled tasks (popped by ``drop_group``) raise
-        ``CancelledError`` and are discarded — ``drop_group`` already emitted their
-        markers."""
+    async def handle_completed_episode(self, task: asyncio.Task) -> None:
+        """Emit every dispatched episode exactly once to ``out_q``."""
         meta = self.inflight.pop(task, None)
         if meta is None:
-            return  # already handled by drop_group / cancel_inflight_rollouts
-        self.release(1)
+            return  # already handled by drop_group / cancel_inflight_episodes
         group = self.groups.get(meta.group_id)
 
-        is_synth_exception = False
         try:
-            result = task.result()
-            rollouts: list[Rollout] = result if isinstance(result, list) else [result]
-            if not rollouts:
-                raise RuntimeError("env run returned an empty episode (no traces)")
+            episode = task.result()
         except asyncio.CancelledError:
             return
         except Exception as exc:
-            get_logger().warning(f"Rollout task failed in group {meta.group_id} ({meta.env_name}): {exc!r}")
-            task_idx = group.task_idx if group is not None else -1
-            rollouts = [
-                Rollout(
-                    task=vf.TraceTask(type="Task", data=vf.TaskData(idx=task_idx, prompt=None)),
-                    agent=vf.AgentInfo(config=vf.AgentConfig()),
+            get_logger().warning(f"Episode task failed in group {meta.group_id} ({meta.env_name}): {exc!r}")
+            episode = self.failed_episode(meta.env_name, type(exc).__name__, str(exc))
+
+        episode.traces = [ROLLOUT_TYPE.model_construct(**dict(trace)) for trace in episode.traces]
+        if not episode.ok:
+            self.metrics.record_error(kind=meta.kind, env_name=meta.env_name)
+            if episode.last_error is not None:
+                get_logger().warning(
+                    f"Episode failed in group {meta.group_id} ({meta.env_name}) — "
+                    f"{episode.last_error.type}: {episode.last_error.message}"
                 )
-            ]
-            for r in rollouts:
-                r.record_error(exc)
-            is_synth_exception = True
+        await self.emit_episode(meta, group, episode)
 
-        for r in rollouts:
-            if not r.has_error and r.num_turns == 0:
-                # Empty trajectory: promote to an explicit error so the sink
-                # treats it like any other failure (``has_error`` reads ``ok``)
-                r.errors.append(vf.Error(type="EmptyTrajectory", message="Rollout returned with no trajectory steps"))
-                r.ok = False
-                get_logger().warning(f"Empty trajectory in group {meta.group_id} ({meta.env_name})")
-            if r.has_error:
-                self.metrics.record_error(kind=meta.kind, env_name=meta.env_name)
-                if not is_synth_exception and r.last_error is not None:
-                    get_logger().warning(
-                        f"Rollout failed in group {meta.group_id} ({meta.env_name}) — {r.last_error.type}: {r.last_error.message}"
-                    )
-        await self.emit_episode(meta, group, rollouts)
+    @staticmethod
+    def failed_episode(env_name: str, error_type: str, message: str) -> vf.WireEpisode:
+        return vf.WireEpisode(
+            env=EnvInfo(id=env_name),
+            ok=False,
+            errors=[vf.Error(type=error_type, message=message)],
+        )
 
-    async def emit_episode(self, meta: InflightRollout, group: GroupState | None, rollouts: list[Rollout]) -> None:
+    async def emit_episode(self, meta: InflightEpisode, group: GroupState | None, episode: vf.WireEpisode) -> None:
         """Stamp prime-rl metadata onto one completed episode and put it on
         ``out_q``. Pops the group from ``self.groups`` once every owed episode
         has been emitted."""
@@ -525,89 +499,95 @@ class RolloutDispatcher:
             eval_step = group.eval_step
             policy_version = group.policy_version_at_start
             group.emitted += 1
-            if group.emitted >= group.target_rollouts:
+            if group.emitted >= group.target_episodes:
                 self.groups.pop(meta.group_id, None)
 
-        for rollout in rollouts:
+        for rollout in episode.traces:
             rollout.kind = meta.kind
             rollout.env_name = meta.env_name
             rollout.group_id = meta.group_id
+            rollout.episode_id = episode.id
+            rollout.episode_ok = episode.ok
             rollout.policy_version = policy_version
             rollout.off_policy_steps = meta.off_policy_steps
             if meta.kind == "eval":
                 assert eval_step is not None, "eval rollout missing eval_step"
                 rollout.eval_step = eval_step
-        await self.out_q.put(rollouts)
+        await self.out_q.put(
+            EpisodeResult(
+                episode=episode,
+                kind=meta.kind,
+                env_name=meta.env_name,
+                group_id=meta.group_id,
+                task_data=meta.task_data,
+                policy_version=policy_version,
+                off_policy_steps=meta.off_policy_steps,
+                eval_step=eval_step,
+            )
+        )
 
     async def drop_group(self, group_id: uuid.UUID) -> int:
         """Cancel remaining in-flight tasks for this group and emit a
-        ``Cancelled`` marker for every rollout it still owes the sink
+        failed ``Cancelled`` episode for every episode it still owes the sink
         (both in-flight and not-yet-scheduled). Returns the count for
         off-policy metrics."""
         group = self.groups.pop(group_id, None)
-        task_idx = group.task_idx if group is not None else -1
 
-        # Sync claim phase: pop matching tasks from ``self.inflight`` and
-        # release their permits in one non-yielding sweep. After this loop
+        # Sync claim phase: pop matching tasks from ``self.inflight`` in one
+        # non-yielding sweep. After this loop
         # the dropped tasks are no longer reachable from ``self.inflight``,
-        # so ``handle_completed_rollout``'s existing None-guard makes the
+        # so ``handle_completed_episode``'s existing None-guard makes the
         # subsequent async emit phase race-free.
-        claimed: list[tuple[asyncio.Task, InflightRollout]] = []
+        claimed: list[tuple[asyncio.Task, InflightEpisode]] = []
         for task, meta in list(self.inflight.items()):
             if meta.group_id != group_id:
                 continue
             del self.inflight[task]
-            self.release(1)
             claimed.append((task, meta))
 
         tasks_to_cancel = [task for task, _ in claimed]
         inflight_cancelled = len(claimed)
-        last_meta: InflightRollout | None = claimed[-1][1] if claimed else None
+        last_meta: InflightEpisode | None = claimed[-1][1] if claimed else None
         for _, meta in claimed:
-            trace = Rollout(
-                task=vf.TraceTask(type="Task", data=vf.TaskData(idx=task_idx, prompt=None)),
-                agent=vf.AgentInfo(config=vf.AgentConfig()),
-                ok=False,
-                errors=[vf.Error(type="Cancelled", message="Off-policy cancel")],
-                stop_condition="error",
+            await self.emit_episode(
+                meta,
+                group,
+                self.failed_episode(meta.env_name, "Cancelled", "Off-policy cancel"),
             )
-            await self.emit_episode(meta, group, [trace])
 
-        # The group may have rollouts that were never dispatched
-        # (``rollouts_to_schedule > 0``). Emit markers for those too so the
-        # sink hits ``target_rollouts``.
+        # The group may have episodes that were never dispatched. Emit failed
+        # episodes for those too so the sink reaches ``target_episodes``.
         #
         # ``last_meta`` can be ``None`` if the only inflight task for this
         # group completed naturally between ``on_version_pending``'s snapshot
         # and us reaching it — synthesize a stand-in from the group state
         unscheduled_cancelled = 0
-        if group is not None and group.rollouts_to_schedule > 0:
-            fallback_meta = last_meta or InflightRollout(
+        if group is not None and group.episodes_to_schedule > 0:
+            fallback_meta = last_meta or InflightEpisode(
                 kind=group.kind,
                 env_name=group.env_name,
                 group_id=group_id,
+                task_data=group.task_data,
                 policy_version=group.policy_version_at_start,
                 eval_step=group.eval_step,
             )
-            unscheduled_cancelled = group.rollouts_to_schedule
+            unscheduled_cancelled = group.episodes_to_schedule
             for _ in range(unscheduled_cancelled):
-                trace = Rollout(
-                    task=vf.TraceTask(type="Task", data=vf.TaskData(idx=task_idx, prompt=None)),
-                    agent=vf.AgentInfo(config=vf.AgentConfig()),
-                    ok=False,
-                    errors=[vf.Error(type="Cancelled", message="Off-policy cancel")],
-                    stop_condition="error",
+                await self.emit_episode(
+                    fallback_meta,
+                    group,
+                    self.failed_episode(group.env_name, "Cancelled", "Off-policy cancel"),
                 )
-                await self.emit_episode(fallback_meta, group, [trace])
 
         cancelled = inflight_cancelled + unscheduled_cancelled
         if cancelled > 0:
             meta_for_log = last_meta or (
-                InflightRollout(
+                InflightEpisode(
                     kind=group.kind,
                     env_name=group.env_name,
                     group_id=group_id,
-                    policy_version=group.policy_version_at_start if group else 0,
+                    task_data=group.task_data,
+                    policy_version=group.policy_version_at_start,
                     eval_step=group.eval_step,
                 )
                 if group is not None
@@ -624,20 +604,19 @@ class RolloutDispatcher:
             await safe_cancel_all(tasks_to_cancel)
         return cancelled
 
-    async def cancel_inflight_rollouts(self) -> None:
-        """Cancel all in-flight rollouts. Used on shutdown — doesn't emit
+    async def cancel_inflight_episodes(self) -> None:
+        """Cancel all in-flight episodes. Used on shutdown — doesn't emit
         markers since the sinks are being torn down anyway."""
         for meta in self.inflight.values():
             self.metrics.record_cancellation(kind=meta.kind, env_name=meta.env_name)
-            self.release(1)
         tasks = list(self.inflight.keys())
         self.inflight.clear()
         self.groups.clear()
         if tasks:
             await safe_cancel_all(tasks)
 
-    async def cancel_inflight_train_rollouts(self) -> int:
-        """Cancel in-flight train rollouts, leaving eval alone. Used by the
+    async def cancel_inflight_train_episodes(self) -> int:
+        """Cancel in-flight train episodes, leaving eval alone. Used by the
         orchestrator at ``max_steps`` so triggered eval can still complete
         through the pipeline while wasted train inference is short-circuited."""
         train_tasks: list[asyncio.Task] = []
@@ -647,7 +626,6 @@ class RolloutDispatcher:
             if meta.kind != "train":
                 continue
             self.inflight.pop(task, None)
-            self.release(1)
             self.metrics.record_cancellation(kind="train", env_name=meta.env_name)
             cancelled += 1
             train_tasks.append(task)
@@ -665,7 +643,7 @@ class RolloutDispatcher:
         return {
             "dispatcher/inflight_train": float(self.inflight_train_count),
             "dispatcher/inflight_eval": float(self.inflight_eval_count),
-            "dispatcher/queued/eval": float(self.queued_eval_examples),
+            "dispatcher/queued/eval": float(self.queued_eval_tasks),
             "dispatcher/mode": float(self.mode == DispatcherMode.PREFER_EVAL),
             "dispatcher/groups_in_flight": float(len(self.groups)),
             "dispatcher/off_policy_level_max": float(self.max_off_policy_level),

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -4,7 +4,7 @@
   one episode and one env-server ``run`` request.
 - Optional rate limiting via ``AsyncLimiter(tasks_per_minute, 60)``.
 - Emit-everything invariant: every dispatched episode eventually reaches
-  ``out_q`` exactly once as an ``EpisodeResult``. Zero-trace failures and
+  ``out_q`` exactly once as a typed v1 ``Episode``. Zero-trace failures and
   cancellations retain their v1 episode shell and episode-level error.
 - ``DispatcherMode.PREFER_TRAIN`` / ``PREFER_EVAL`` controls which kind to
   schedule next. Transitions are level-triggered (driven by the eval
@@ -39,7 +39,7 @@ from prime_rl.orchestrator.eval_source import EvalSource
 from prime_rl.orchestrator.train_source import TrainSource
 from prime_rl.orchestrator.types import (
     ROLLOUT_TYPE,
-    EpisodeResult,
+    Episode,
     GroupState,
     InflightEpisode,
     Policy,
@@ -117,7 +117,7 @@ class DispatcherMetrics:
 class EpisodeDispatcher:
     """``await dispatcher.start()`` runs the dispatch loop until ``stop()``.
     Pulls tasks from ``TrainSource`` / ``EvalSource``, schedules
-    episodes under shared capacity, and emits ``EpisodeResult`` objects to
+    episodes under shared capacity, and emits typed v1 ``Episode`` objects to
     ``out_q``. The watcher drives ``on_version_pending`` for off-policy
     cancellation; the orchestrator triggers eval epochs."""
 
@@ -154,7 +154,7 @@ class EpisodeDispatcher:
 
         # Bounded so the dispatcher backpressures on a slow sink. One entry per
         # episode — the sinks count episodes, never loose traces.
-        self.out_q: asyncio.Queue[EpisodeResult] = asyncio.Queue(maxsize=max(8, self.max_inflight))
+        self.out_q: asyncio.Queue[Episode] = asyncio.Queue(maxsize=max(8, self.max_inflight))
 
         self.mode: DispatcherMode = DispatcherMode.PREFER_TRAIN
         # Set by the orchestrator after the final train step; pipeline then
@@ -471,7 +471,6 @@ class EpisodeDispatcher:
             get_logger().warning(f"Episode task failed in group {meta.group_id} ({meta.env_name}): {exc!r}")
             episode = self.failed_episode(meta.env_name, type(exc).__name__, str(exc))
 
-        episode.traces = [ROLLOUT_TYPE.model_construct(**dict(trace)) for trace in episode.traces]
         if not episode.ok:
             self.metrics.record_error(kind=meta.kind, env_name=meta.env_name)
             if episode.last_error is not None:
@@ -502,20 +501,24 @@ class EpisodeDispatcher:
             if group.emitted >= group.target_episodes:
                 self.groups.pop(meta.group_id, None)
 
-        for rollout in episode.traces:
-            rollout.kind = meta.kind
-            rollout.env_name = meta.env_name
-            rollout.group_id = meta.group_id
-            rollout.episode_id = episode.id
-            rollout.episode_ok = episode.ok
-            rollout.policy_version = policy_version
-            rollout.off_policy_steps = meta.off_policy_steps
+        traces = [ROLLOUT_TYPE.model_construct(**dict(trace)) for trace in episode.traces]
+        for trace in traces:
+            trace.kind = meta.kind
+            trace.env_name = meta.env_name
+            trace.group_id = meta.group_id
+            trace.episode_id = episode.id
+            trace.policy_version = policy_version
+            trace.off_policy_steps = meta.off_policy_steps
             if meta.kind == "eval":
                 assert eval_step is not None, "eval rollout missing eval_step"
-                rollout.eval_step = eval_step
+                trace.eval_step = eval_step
         await self.out_q.put(
-            EpisodeResult(
-                episode=episode,
+            Episode.model_construct(
+                id=episode.id,
+                env=episode.env,
+                ok=episode.ok,
+                errors=episode.errors,
+                traces=traces,
                 kind=meta.kind,
                 env_name=meta.env_name,
                 group_id=meta.group_id,

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -12,7 +12,7 @@ once, and each dispatched episode ships its task's data on the request
 pool) stateless about data — no per-worker dataset loads, no idx-addressed task
 cache — and gives the orchestrator real tasks to cycle, shuffle, and filter.
 
-The server answers one ``Episode`` per run request, whose traces we validate into
+The server answers one ``Episode`` per run request; the dispatcher validates its traces into
 ``Trace[WireTaskData]`` — real ``vf.Trace``\\ s (never loose dicts) whose task
 keeps the env's task-specific fields as extras (``WireTaskData`` allows them).
 """
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterator, Sequence
-from itertools import islice
 from typing import Generic, TypeVar
 
 import verifiers.v1 as vf
@@ -30,13 +29,7 @@ from verifiers.v1.serve import EnvClient
 from prime_rl.configs.orchestrator import EnvConfig, EvalSourceConfig, TrainSourceConfig
 from prime_rl.orchestrator.algo import Algorithm, build_algorithm
 from prime_rl.orchestrator.sampler import Sampler
-from prime_rl.orchestrator.types import Rollout
 from prime_rl.utils.logger import get_logger
-
-# Every wire trace validates into this type. WireTaskData (extra="allow") keeps the env's task
-# fields without importing the env package — the orchestrator never reads them typed (only
-# task.idx + task.model_dump).
-ROLLOUT_TYPE = Rollout[vf.WireTaskData]
 
 # Max wait for the env server to answer health. The launcher spawns servers
 # concurrently with the orchestrator.
@@ -53,8 +46,8 @@ class Env:
         self.sampling_args: dict = {}
         self.num_tasks: int | None = 0
         """Task count; ``None`` means the taskset is infinite."""
-        self.tasks: Iterator[vf.Task] = iter(())
-        """The env's tasks, client-side. A finite taskset is materialized at ``start()``
+        self.tasks: Iterator[vf.TaskData] = iter(())
+        """The env's task data, client-side. A finite taskset is materialized at ``start()``
         (``num_tasks`` is its count) and iterated from there; an infinite one streams
         off its generator. Consumed once — by ``TrainSource`` (train) or
         ``EvalEnv.start`` (eval)."""
@@ -77,17 +70,25 @@ class Env:
         # The server may still be coming up (the launcher spawns it concurrently with
         # the orchestrator), so poll until it answers.
         await self.env_client.wait_for_server_startup(timeout=ENV_SERVER_STARTUP_TIMEOUT)
-        taskset = vf.load_taskset(self.config.env.taskset)
-        if type(taskset).INFINITE:
-            self.tasks = iter(taskset.load())
+        taskset = self.load_taskset()
+        if taskset.INFINITE:
+            self.tasks = (task.data for task in taskset)
             self.num_tasks = None
         else:
-            # Materialize off the event loop — load() may pull a dataset.
-            materialized = await asyncio.to_thread(lambda: list(taskset.load()))
-            self.tasks = iter(materialized)
-            self.num_tasks = len(materialized)
+            # Materialize off the event loop — taskset iteration may pull a dataset.
+            tasks = await asyncio.to_thread(lambda: list(taskset))
+            self.tasks = iter(task.data for task in tasks)
+            self.num_tasks = len(tasks)
         num_tasks = self.num_tasks if self.num_tasks is not None else "infinite"
         get_logger().info(f"Env {self.name} ready: num_tasks={num_tasks}")
+
+    def load_taskset(self) -> vf.Taskset:
+        return vf.load_taskset(self.config.env.taskset)
+
+    async def close(self) -> None:
+        if self._env_client is not None:
+            await self._env_client.close()
+            self._env_client = None
 
     def _sampling(self, cache_salt: str | None) -> vf.SamplingConfig:
         sampling = {**self.sampling_args}
@@ -100,31 +101,15 @@ class Env:
         client: vf.ClientConfig,
         model_name: str,
         cache_salt: str | None,
-        task_data: dict,
-    ) -> list[Rollout]:
-        """Run one episode and return its typed traces. A zero-trace episode raises
-        (the dispatcher synthesizes the error marker); a not-``ok`` episode marks its
-        clean traces failed so partial episodes never train."""
-        episode = await self.env_client.run(
-            task_data=task_data,
+        task_data: vf.TaskData,
+    ) -> vf.WireEpisode:
+        """Run one v1 episode and preserve its episode-level standing."""
+        return await self.env_client.run(
+            task_data=task_data.model_dump(mode="json"),
             client=client,
             model=model_name,
             sampling=self._sampling(cache_salt),
         )
-        if not episode.traces:
-            error = episode.last_error
-            detail = f"{error.type}: {error.message}" if error is not None else "no traces and no error recorded"
-            raise RuntimeError(f"episode failed before any trace was produced — {detail}")
-        rollouts = [ROLLOUT_TYPE.model_construct(**dict(wire)) for wire in episode.traces]
-        for rollout in rollouts:
-            rollout.episode_id = episode.id
-            if not episode.ok and rollout.ok:
-                error = episode.last_error or vf.Error(
-                    type="EpisodeFailed", message="A sibling trace in this episode failed"
-                )
-                rollout.errors = [*rollout.errors, error]
-                rollout.ok = False
-        return rollouts
 
 
 class TrainEnv(Env):
@@ -143,16 +128,23 @@ class EvalEnv(Env):
     def __init__(self, config: EvalSourceConfig, address: str):
         super().__init__(config, address)
         self.sampling_args = config.sampling.to_sampling_args()
-        self.examples: list[dict] = []
+        self.eval_tasks: list[vf.TaskData] = []
+
+    def load_taskset(self) -> vf.Taskset:
+        taskset = super().load_taskset()
+        n = self.config.num_tasks
+        if n < 0:
+            if taskset.INFINITE:
+                raise ValueError(f"Eval env {self.name} has an infinite taskset — set num_tasks to bound it")
+            return taskset
+        return taskset.head(n)
 
     async def start(self) -> None:
         await super().start()
-        n = self.config.num_examples
-        if self.num_tasks is None and n < 0:
-            raise ValueError(f"Eval env {self.name} has an infinite taskset — set num_examples to bound it")
-        # A fixed eval set, pulled off the tasks once and reused every epoch.
-        tasks = list(self.tasks) if n < 0 else list(islice(self.tasks, n))
-        self.examples = [{"task_idx": task.data.idx, "task": task} for task in tasks]
+        # A fixed eval set, pulled off the bounded taskset view and reused every epoch.
+        self.eval_tasks = list(self.tasks)
+        if not self.eval_tasks:
+            raise ValueError(f"Eval env {self.name} has no tasks to evaluate")
 
 
 EnvT = TypeVar("EnvT", bound=Env)
@@ -184,6 +176,9 @@ class Envs(Generic[EnvT]):
         """Connect to all env servers in parallel — every address is known up front,
         so there's nothing to serialize on."""
         await asyncio.gather(*(env.start() for env in self))
+
+    async def stop(self) -> None:
+        await asyncio.gather(*(env.close() for env in self))
 
 
 class TrainEnvs(Envs[TrainEnv]):

--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -8,7 +8,7 @@ Same shape as ``TrainSink``, but no tokenization / advantages / filters:
 3. ``process_batch`` — at ``num_tasks × group_size`` episodes, return an
    ``EvalBatch`` with the full returned cohort (metrics are computed downstream).
 
-``add()`` takes one ``EpisodeResult`` and returns ``EvalBatch | None``;
+``add()`` takes one v1 ``Episode`` and returns ``EvalBatch | None``;
 all accounting counts episodes, never loose traces.
 """
 
@@ -18,8 +18,8 @@ import uuid
 from collections import defaultdict
 
 from prime_rl.orchestrator.envs import EvalEnvs
-from prime_rl.orchestrator.metrics import EvalRollouts
-from prime_rl.orchestrator.types import EpisodeResult, EvalBatch, Rollout
+from prime_rl.orchestrator.metrics import EvalEpisodes
+from prime_rl.orchestrator.types import Episode, EvalBatch, Rollout
 from prime_rl.utils.logger import get_logger
 
 
@@ -28,19 +28,19 @@ class EvalSink:
 
     def __init__(self, *, eval_envs: EvalEnvs) -> None:
         self.eval_envs = eval_envs
-        self.pending_groups: dict[uuid.UUID, list[EpisodeResult]] = defaultdict(list)
-        self.pending_batches: dict[tuple[str, int], list[EpisodeResult]] = defaultdict(list)
+        self.pending_groups: dict[uuid.UUID, list[Episode]] = defaultdict(list)
+        self.pending_batches: dict[tuple[str, int], list[Episode]] = defaultdict(list)
 
-    def add(self, result: EpisodeResult) -> EvalBatch | None:
+    def add(self, episode: Episode) -> EvalBatch | None:
         """Process one episode arrival; finalize the group on the ``group_size``-th
         episode and the per-env epoch on the ``num_tasks × group_size``-th."""
-        env_name = result.env_name
-        group_id = result.group_id
-        for rollout in result.rollouts:
-            self.process_rollout(rollout)
-        assert result.eval_step is not None, "eval episode missing eval_step"
-        bkey = (env_name, result.eval_step)
-        self.pending_groups[group_id].append(result)
+        env_name = episode.env_name
+        group_id = episode.group_id
+        for trace in episode.traces:
+            self.process_rollout(trace)
+        assert episode.eval_step is not None, "eval episode missing eval_step"
+        bkey = (env_name, episode.eval_step)
+        self.pending_groups[group_id].append(episode)
         if len(self.pending_groups[group_id]) >= self.group_size_for(env_name):
             self.process_group(group_id)
         if len(self.pending_batches[bkey]) >= self.batch_size_for(env_name):
@@ -96,7 +96,7 @@ class EvalSink:
         episodes = self.pending_groups.pop(group_id, [])
         if not episodes:
             return
-        group = [rollout for result in episodes for rollout in result.rollouts]
+        group = [trace for episode in episodes for trace in episode.traces]
         env_name = episodes[0].env_name
         task_idx = episodes[0].task_data.idx
         eval_step = episodes[0].eval_step
@@ -104,8 +104,8 @@ class EvalSink:
         bucket = self.pending_batches[(env_name, eval_step)]
         bucket.extend(episodes)
 
-        survivors = [r for r in group if r.episode_ok and not r.has_error]
-        num_failed_episodes = sum(not result.episode.ok for result in episodes)
+        survivors = [trace for episode in episodes if episode.ok for trace in episode.traces if not trace.has_error]
+        num_failed_episodes = sum(not episode.ok for episode in episodes)
         num_errored_traces = sum(r.has_error for r in group)
         rewards = [r.reward for r in survivors]
         avg_reward = sum(rewards) / len(rewards) if rewards else 0.0
@@ -117,15 +117,12 @@ class EvalSink:
 
     def process_batch(self, key: tuple[str, int]) -> EvalBatch:
         """Pop the finished ``(env, eval_step)`` epoch and return the ``EvalBatch`` with its full
-        returned cohort (errored rollouts included — the ``all`` set). Metrics are computed
-        downstream via ``EvalBatch.rollouts.metrics`` over the all/effective subsets, so the sink
-        does no aggregation."""
+        returned cohort (failed episodes and errored traces included). Metrics are derived
+        downstream from ``EvalBatch.episodes``, so the sink does no aggregation."""
         env_name, step = key
         episodes = self.pending_batches.pop(key, [])
-        rollouts = [rollout for result in episodes for rollout in result.rollouts]
         return EvalBatch(
             env_name=env_name,
             step=step,
-            episodes=episodes,
-            rollouts=EvalRollouts(rollouts, episode_results=episodes),
+            episodes=EvalEpisodes(episodes),
         )

--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -3,12 +3,12 @@
 Same shape as ``TrainSink``, but no tokenization / advantages / filters:
 
 1. ``process_rollout`` — no-op.
-2. ``process_group`` — at ``group_size`` episodes, move the rollouts
+2. ``process_group`` — at ``group_size`` episodes, move the episode results
    (errored ones included) into the ``(env, eval_step)`` bucket.
-3. ``process_batch`` — at ``num_examples × group_size`` episodes, return an
+3. ``process_batch`` — at ``num_tasks × group_size`` episodes, return an
    ``EvalBatch`` with the full returned cohort (metrics are computed downstream).
 
-``add()`` takes one episode (``list[Rollout]``) and returns ``EvalBatch | None``;
+``add()`` takes one ``EpisodeResult`` and returns ``EvalBatch | None``;
 all accounting counts episodes, never loose traces.
 """
 
@@ -19,7 +19,7 @@ from collections import defaultdict
 
 from prime_rl.orchestrator.envs import EvalEnvs
 from prime_rl.orchestrator.metrics import EvalRollouts
-from prime_rl.orchestrator.types import EvalBatch, Rollout
+from prime_rl.orchestrator.types import EpisodeResult, EvalBatch, Rollout
 from prime_rl.utils.logger import get_logger
 
 
@@ -28,25 +28,22 @@ class EvalSink:
 
     def __init__(self, *, eval_envs: EvalEnvs) -> None:
         self.eval_envs = eval_envs
-        self.pending_groups: dict[uuid.UUID, list[Rollout]] = defaultdict(list)
-        # Episodes arrived per group / per batch bucket — the finalization counts.
-        self.pending_group_episodes: dict[uuid.UUID, int] = defaultdict(int)
-        self.pending_batches: dict[tuple[str, int], list[Rollout]] = defaultdict(list)
-        self.pending_batch_episodes: dict[tuple[str, int], int] = defaultdict(int)
+        self.pending_groups: dict[uuid.UUID, list[EpisodeResult]] = defaultdict(list)
+        self.pending_batches: dict[tuple[str, int], list[EpisodeResult]] = defaultdict(list)
 
-    def add(self, episode: list[Rollout]) -> EvalBatch | None:
+    def add(self, result: EpisodeResult) -> EvalBatch | None:
         """Process one episode arrival; finalize the group on the ``group_size``-th
-        episode and the per-env epoch on the ``num_examples × group_size``-th."""
-        env_name = episode[0].env_name
-        group_id = episode[0].group_id
-        for rollout in episode:
+        episode and the per-env epoch on the ``num_tasks × group_size``-th."""
+        env_name = result.env_name
+        group_id = result.group_id
+        for rollout in result.rollouts:
             self.process_rollout(rollout)
-        bkey = (env_name, episode[0].eval_step)
-        self.pending_groups[group_id].extend(episode)
-        self.pending_group_episodes[group_id] += 1
-        if self.pending_group_episodes[group_id] >= self.group_size_for(env_name):
+        assert result.eval_step is not None, "eval episode missing eval_step"
+        bkey = (env_name, result.eval_step)
+        self.pending_groups[group_id].append(result)
+        if len(self.pending_groups[group_id]) >= self.group_size_for(env_name):
             self.process_group(group_id)
-        if self.pending_batch_episodes[bkey] >= self.batch_size_for(env_name):
+        if len(self.pending_batches[bkey]) >= self.batch_size_for(env_name):
             return self.process_batch(bkey)
         return None
 
@@ -54,24 +51,25 @@ class EvalSink:
         return self.eval_envs.get(env_name).config.group_size
 
     def batch_size_for(self, env_name: str) -> int:
-        """``num_examples × group_size`` — total episodes expected for one
+        """``num_tasks × group_size`` — total episodes expected for one
         epoch of ``env_name``."""
         env = self.eval_envs.get(env_name)
-        return len(env.examples) * env.config.group_size
+        return len(env.eval_tasks) * env.config.group_size
 
     def batch_progress(self) -> list[tuple[str, int, int, int, int]]:
         """One entry per accumulating ``(env, eval_step)`` batch:
         ``(env_name, eval_step, batch_count, expected, buffered)``.
         ``batch_count`` is finalized-group episodes in ``pending_batches``;
         ``buffered`` is partial-group episode arrivals."""
-        batch_counts: dict[tuple[str, int], int] = dict(self.pending_batch_episodes)
+        batch_counts = {key: len(episodes) for key, episodes in self.pending_batches.items()}
         buffered: dict[tuple[str, int], int] = {}
-        for group_id, rollouts in self.pending_groups.items():
-            if not rollouts:
+        for episodes in self.pending_groups.values():
+            if not episodes:
                 continue
-            env_name = rollouts[0].env_name
-            bkey = (env_name, rollouts[0].eval_step)
-            buffered[bkey] = buffered.get(bkey, 0) + self.pending_group_episodes.get(group_id, 0)
+            first = episodes[0]
+            assert first.eval_step is not None
+            bkey = (first.env_name, first.eval_step)
+            buffered[bkey] = buffered.get(bkey, 0) + len(episodes)
         return [
             (
                 env_name,
@@ -95,24 +93,26 @@ class EvalSink:
     # ── level 2: per-group (move into batch bucket) ───────────────────────
 
     def process_group(self, group_id: uuid.UUID) -> None:
-        group = self.pending_groups.pop(group_id, [])
-        episodes = self.pending_group_episodes.pop(group_id, 0)
-        if not group:
+        episodes = self.pending_groups.pop(group_id, [])
+        if not episodes:
             return
-        env_name = group[0].env_name
-        task_idx = group[0].task.data.idx
-        eval_step = group[0].eval_step
+        group = [rollout for result in episodes for rollout in result.rollouts]
+        env_name = episodes[0].env_name
+        task_idx = episodes[0].task_data.idx
+        eval_step = episodes[0].eval_step
+        assert eval_step is not None
         bucket = self.pending_batches[(env_name, eval_step)]
-        bucket.extend(group)
-        self.pending_batch_episodes[(env_name, eval_step)] += episodes
+        bucket.extend(episodes)
 
-        survivors = [r for r in group if not r.has_error]
-        num_errored = len(group) - len(survivors)
+        survivors = [r for r in group if r.episode_ok and not r.has_error]
+        num_failed_episodes = sum(not result.episode.ok for result in episodes)
+        num_errored_traces = sum(r.has_error for r in group)
         rewards = [r.reward for r in survivors]
         avg_reward = sum(rewards) / len(rewards) if rewards else 0.0
         get_logger().debug(
             f"Finished group | env={env_name} task_idx={task_idx} eval_step={eval_step} | "
-            f"rollouts={len(group)} (errored={num_errored}) | reward={avg_reward:.4f}"
+            f"episodes={len(episodes)} (failed={num_failed_episodes}) | "
+            f"traces={len(group)} (errored={num_errored_traces}) | reward={avg_reward:.4f}"
         )
 
     def process_batch(self, key: tuple[str, int]) -> EvalBatch:
@@ -121,6 +121,11 @@ class EvalSink:
         downstream via ``EvalBatch.rollouts.metrics`` over the all/effective subsets, so the sink
         does no aggregation."""
         env_name, step = key
-        rollouts = self.pending_batches.pop(key, [])
-        self.pending_batch_episodes.pop(key, None)
-        return EvalBatch(env_name=env_name, step=step, rollouts=EvalRollouts(rollouts))
+        episodes = self.pending_batches.pop(key, [])
+        rollouts = [rollout for result in episodes for rollout in result.rollouts]
+        return EvalBatch(
+            env_name=env_name,
+            step=step,
+            episodes=episodes,
+            rollouts=EvalRollouts(rollouts, episode_results=episodes),
+        )

--- a/src/prime_rl/orchestrator/eval_source.py
+++ b/src/prime_rl/orchestrator/eval_source.py
@@ -1,7 +1,7 @@
-"""EvalSource: trigger-driven, finite-per-epoch pull of eval examples.
+"""EvalSource: trigger-driven, finite-per-epoch pull of eval tasks.
 
 The orchestrator pokes ``trigger(step)`` after each ship + once at
-startup; the dispatcher pulls via ``next_example(available_permits)``
+startup; the dispatcher pulls via ``next_task()``
 until ``bool(source) == False``. Constructed only when eval is
 configured."""
 
@@ -12,10 +12,11 @@ from itertools import zip_longest
 
 from prime_rl.configs.orchestrator import EvalConfig
 from prime_rl.orchestrator.envs import EvalEnvs
+from prime_rl.orchestrator.types import TaskItem
 
 
 class EvalSource:
-    """Finite-per-epoch source of eval examples."""
+    """Finite-per-epoch source of eval tasks."""
 
     def __init__(
         self,
@@ -26,18 +27,14 @@ class EvalSource:
     ) -> None:
         self.eval_config = eval_config
 
-        self.examples_by_env: dict[str, list[dict]] = {}
+        self.tasks_by_env: dict[str, list[TaskItem]] = {}
         self.intervals: dict[str, int] = {}
         for env in eval_envs:
-            rows: list[dict] = []
-            for ex in env.examples:
-                row = dict(ex)
-                row["env_name"] = env.name
-                rows.append(row)
-            self.examples_by_env[env.name] = rows
+            rows = [TaskItem(env_name=env.name, data=data) for data in env.eval_tasks]
+            self.tasks_by_env[env.name] = rows
             self.intervals[env.name] = env.config.interval
 
-        self.queue: deque[dict] = deque()
+        self.queue: deque[TaskItem] = deque()
 
         # On resume we skip the startup eval; on fresh start the first
         # trigger fires every env (subject to ``skip_first_step``)
@@ -54,22 +51,20 @@ class EvalSource:
             if is_first or step % interval == 0:
                 fired.append(name)
         # Round-robin across fired envs (A₁, B₁, A₂, B₂, …) so the
-        # dispatcher rotates at example granularity. ``try_schedule``'s
-        # continue-group branch still keeps each example's group_size
-        # rollouts back-to-back, so per-example prefix-cache locality holds
-        iters = [iter(self.examples_by_env[name]) for name in fired]
-        for round_examples in zip_longest(*iters):
-            for example in round_examples:
-                if example is None:
+        # dispatcher rotates at task granularity. ``try_schedule``'s
+        # continue-group branch still keeps each task's group_size
+        # episodes back-to-back, so per-task prefix-cache locality holds.
+        iters = [iter(self.tasks_by_env[name]) for name in fired]
+        for round_tasks in zip_longest(*iters):
+            for task in round_tasks:
+                if task is None:
                     continue
-                row = dict(example)
-                row["eval_step"] = step
-                self.queue.append(row)
+                self.queue.append(TaskItem(env_name=task.env_name, data=task.data, eval_step=step))
         return fired
 
-    def next_example(self, available_permits: int) -> dict | None:
-        """Pop the next eval example when a rollout permit is available."""
-        if not self.queue or available_permits < 1:
+    def next_task(self) -> TaskItem | None:
+        """Pop the next eval task, if any."""
+        if not self.queue:
             return None
         return self.queue.popleft()
 

--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -1,9 +1,7 @@
-"""Train and eval rollout metrics.
+"""Train and eval episode metrics.
 
-A rollout container (``TrainRollouts`` / ``EvalRollouts``) owns the rollout list and exposes
-``.effective`` (the clean subset, as the same container type) and ``.metrics`` (``TrainMetrics`` /
-``EvalMetrics``). The metrics object exposes each distributional / rate metric as a ``Stat`` — so
-``rollouts.metrics.num_input_tokens.mean()`` works — and assembles the full
+An episode collection owns the v1 episodes and derives trace views for training and metrics.
+The metrics object exposes each distributional / rate metric as a ``Stat`` and assembles the full
 ``{prefix}/{subset}/<metric>/<stat>`` wandb dict via ``.to_wandb(...)``.
 
 The wandb layout mirrors the episode/trace hierarchy, one aggregation per level:
@@ -21,12 +19,10 @@ No I/O, no pandas — plain Python over the ``vf.Trace`` properties each rollout
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal
+from typing import Any, Callable, Iterator, Literal, Self
 
+from prime_rl.orchestrator.types import Episode, Rollout
 from prime_rl.orchestrator.utils import compute_pass_metrics
-
-if TYPE_CHECKING:
-    from prime_rl.orchestrator.types import EpisodeResult, Rollout
 
 Subset = Literal["all", "effective"]
 
@@ -258,27 +254,49 @@ class TraceMetrics(StatGroup):
         return out
 
 
+TraceFilter = Callable[[Episode, Rollout], bool]
+
+
+class EpisodeCollection:
+    """An episode-owned cohort with an optional derived trace filter."""
+
+    def __init__(self, episodes: list[Episode] | None = None, *, trace_filter: TraceFilter | None = None) -> None:
+        self.items = episodes if episodes is not None else []
+        self._trace_filter = trace_filter
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def __iter__(self) -> Iterator[Episode]:
+        return iter(self.items)
+
+    @property
+    def traces_by_episode(self) -> list[list[Rollout]]:
+        if self._trace_filter is None:
+            return [episode.traces for episode in self.items]
+        return [[trace for trace in episode.traces if self._trace_filter(episode, trace)] for episode in self.items]
+
+    @property
+    def traces(self) -> list[Rollout]:
+        return [trace for traces in self.traces_by_episode for trace in traces]
+
+    def _copy(self, episodes: list[Episode]) -> Self:
+        return type(self)(episodes, trace_filter=self._trace_filter)
+
+    def by_env(self) -> dict[str, Self]:
+        grouped: dict[str, list[Episode]] = {}
+        for episode in self.items:
+            grouped.setdefault(episode.env_name, []).append(episode)
+        return {env_name: self._copy(episodes) for env_name, episodes in grouped.items()}
+
+
 class EpisodeMetrics:
-    """Metrics shared by train and eval over a rollout list. The count metrics (tokens/turns/
-    branches) are episode-level — one value per episode, summing its traces — alongside the
-    episode failure rate; every trace-level metric is emitted per
-    agent via ``by_agent()``. The boolean ``Stat`` properties (0/1 distributions, ``.mean()`` is
-    the rate) serve the console log lines. ``TrainMetrics`` / ``EvalMetrics`` extend ``to_wandb``
-    with the train pipeline rates and the eval scores."""
+    """Episode-level counts and failure rate plus per-agent trace metrics."""
 
-    def __init__(self, rollouts: list[Rollout], episode_results: list[EpisodeResult] | None = None) -> None:
-        self.rollouts = rollouts
-        self.episode_results = episode_results
-
-    def episodes(self) -> list[list[Rollout]]:
-        """The subset's rollouts grouped into their episodes. A rollout without an
-        ``episode_id`` (a synthesized error marker) is its own episode."""
-        grouped: dict[str, list[Rollout]] = {}
-        for r in self.rollouts:
-            grouped.setdefault(r.episode_id or r.id, []).append(r)
-        if self.episode_results:
-            return [grouped.get(result.episode.id, []) for result in self.episode_results]
-        return list(grouped.values())
+    def __init__(self, episodes: EpisodeCollection) -> None:
+        self.episodes = episodes
+        self.episode_traces = episodes.traces_by_episode
+        self.rollouts = [trace for traces in self.episode_traces for trace in traces]
 
     def by_agent(self) -> dict[str, TraceMetrics]:
         """Per-agent metric views (``vf.Episode.by_agent`` over the subset's rollouts)."""
@@ -291,23 +309,23 @@ class EpisodeMetrics:
     # aggregation as ``vf.Episode.num_turns`` / ``num_*_tokens``.
     @property
     def num_total_tokens(self) -> Stat:
-        return Stat([float(sum(r.num_total_tokens for r in episode)) for episode in self.episodes()])
+        return Stat([float(sum(r.num_total_tokens for r in traces)) for traces in self.episode_traces])
 
     @property
     def num_input_tokens(self) -> Stat:
-        return Stat([float(sum(r.num_input_tokens for r in episode)) for episode in self.episodes()])
+        return Stat([float(sum(r.num_input_tokens for r in traces)) for traces in self.episode_traces])
 
     @property
     def num_output_tokens(self) -> Stat:
-        return Stat([float(sum(r.num_output_tokens for r in episode)) for episode in self.episodes()])
+        return Stat([float(sum(r.num_output_tokens for r in traces)) for traces in self.episode_traces])
 
     @property
     def num_turns(self) -> Stat:
-        return Stat([float(sum(r.num_turns for r in episode)) for episode in self.episodes()])
+        return Stat([float(sum(r.num_turns for r in traces)) for traces in self.episode_traces])
 
     @property
     def num_branches(self) -> Stat:
-        return Stat([float(sum(r.num_branches for r in episode)) for episode in self.episodes()])
+        return Stat([float(sum(r.num_branches for r in traces)) for traces in self.episode_traces])
 
     # Boolean rate metrics for the console log lines (0/1 distributions — ``.mean()`` is the
     # rate); to_wandb emits their per-agent counterparts instead.
@@ -317,13 +335,11 @@ class EpisodeMetrics:
 
     @property
     def has_error(self) -> Stat:
-        if self.episode_results:
-            return Stat([float(not result.episode.ok) for result in self.episode_results])
-        return Stat([float(r.has_error) for r in self.rollouts])
+        return Stat([float(not episode.ok) for episode in self.episodes])
 
     def to_wandb(self, *, prefix: str, subset: Subset) -> dict[str, float]:
         """The common metric dict for one ``{prefix}/{subset}`` slice. Empty input → ``{}``."""
-        if not self.rollouts and not self.episode_results:
+        if not self.episode_traces:
             return {}
         p = f"{prefix}/{subset}"
         out: dict[str, float] = {}
@@ -384,14 +400,9 @@ class EvalMetrics(EpisodeMetrics):
     that agent's traces per example in the full epoch, so multi-agent episodes cannot inflate one
     another's score key."""
 
-    def __init__(
-        self,
-        rollouts: list[Rollout],
-        group_sizes_by_agent: dict[str, int],
-        episode_results: list[EpisodeResult] | None = None,
-    ) -> None:
-        super().__init__(rollouts, episode_results)
-        self.group_sizes_by_agent = group_sizes_by_agent
+    def __init__(self, episodes: EvalEpisodes) -> None:
+        super().__init__(episodes)
+        self.group_sizes_by_agent = episodes.group_sizes_by_agent
 
     @property
     def reward(self) -> Stat:
@@ -408,97 +419,68 @@ class EvalMetrics(EpisodeMetrics):
         return out
 
 
-class TrainRollouts:
-    """A list of train rollouts (everything that came back, errored + filtered + untrainable
-    included). ``effective`` is the clean trainable subset (a view of the same traces);
-    ``metrics`` builds ``TrainMetrics`` over them."""
-
-    def __init__(
-        self,
-        rollouts: list[Rollout] | None = None,
-        episode_results: list[EpisodeResult] | None = None,
-    ) -> None:
-        self.rollouts = rollouts if rollouts is not None else []
-        self.episode_results = episode_results if episode_results is not None else []
-
-    def append(self, rollout: Rollout) -> None:
-        self.rollouts.append(rollout)
-
-    def append_episode(self, result: EpisodeResult) -> None:
-        self.episode_results.append(result)
-        self.rollouts.extend(result.rollouts)
-
-    def __len__(self) -> int:
-        return len(self.rollouts)
-
-    def __iter__(self) -> Iterator[Rollout]:
-        return iter(self.rollouts)
+class TrainEpisodes(EpisodeCollection):
+    """Training episodes and their clean, trainable trace view."""
 
     @property
-    def effective(self) -> TrainRollouts:
-        rollouts = [
-            r for r in self.rollouts if r.episode_ok and not r.has_error and not r.is_filtered and r.agent.trainable
-        ]
-        episode_ids = {r.episode_id for r in rollouts}
-        episodes = [result for result in self.episode_results if result.episode.id in episode_ids]
-        return TrainRollouts(rollouts, episodes)
+    def effective(self) -> TrainEpisodes:
+        def trace_filter(episode: Episode, trace: Rollout) -> bool:
+            return episode.ok and not trace.has_error and not trace.is_filtered and trace.agent.trainable
 
-    def by_env(self) -> dict[str, TrainRollouts]:
-        grouped: dict[str, list[Rollout]] = {}
-        for r in self.rollouts:
-            grouped.setdefault(r.env_name, []).append(r)
-        for result in self.episode_results:
-            grouped.setdefault(result.env_name, [])
-        return {
-            env: TrainRollouts(rs, [result for result in self.episode_results if result.env_name == env])
-            for env, rs in grouped.items()
-        }
+        episodes = [episode for episode in self.items if any(trace_filter(episode, trace) for trace in episode.traces)]
+        return TrainEpisodes(episodes, trace_filter=trace_filter)
 
     @property
     def metrics(self) -> TrainMetrics:
-        return TrainMetrics(self.rollouts, self.episode_results)
+        return TrainMetrics(self)
 
 
-class EvalRollouts:
-    """A list of eval rollouts (errored + untrainable included). ``effective`` is the
-    non-errored trainable subset (a view).
+class EvalEpisodes(EpisodeCollection):
+    """Evaluation episodes and their non-errored, trainable trace view.
+
     Per-agent group sizes are derived from the full epoch and carried onto ``effective`` so each
     agent's ``avg@k`` key stays stable across subsets."""
 
     def __init__(
         self,
-        rollouts: list[Rollout] | None = None,
+        episodes: list[Episode] | None = None,
+        *,
+        trace_filter: TraceFilter | None = None,
         group_sizes_by_agent: dict[str, int] | None = None,
-        episode_results: list[EpisodeResult] | None = None,
     ) -> None:
-        self.rollouts = rollouts if rollouts is not None else []
-        self.episode_results = episode_results if episode_results is not None else []
+        super().__init__(episodes, trace_filter=trace_filter)
         self._group_sizes_by_agent = group_sizes_by_agent
 
-    def __len__(self) -> int:
-        return len(self.rollouts)
-
-    def __iter__(self) -> Iterator[Rollout]:
-        return iter(self.rollouts)
+    def _copy(self, episodes: list[Episode]) -> Self:
+        return type(self)(
+            episodes,
+            trace_filter=self._trace_filter,
+            group_sizes_by_agent=self.group_sizes_by_agent,
+        )
 
     @property
     def group_sizes_by_agent(self) -> dict[str, int]:
         if self._group_sizes_by_agent is not None:
             return self._group_sizes_by_agent
         counts: dict[str, dict] = {}
-        for r in self.rollouts:
+        for r in self.traces:
             if r.agent.trainable:
                 by_group = counts.setdefault(r.agent.name, {})
                 by_group[r.group_id] = by_group.get(r.group_id, 0) + 1
         return {agent: max(by_group.values(), default=0) for agent, by_group in counts.items()}
 
     @property
-    def effective(self) -> EvalRollouts:
-        rollouts = [r for r in self.rollouts if r.episode_ok and not r.has_error and r.agent.trainable]
-        episode_ids = {r.episode_id for r in rollouts}
-        episodes = [result for result in self.episode_results if result.episode.id in episode_ids]
-        return EvalRollouts(rollouts, self.group_sizes_by_agent, episodes)
+    def effective(self) -> EvalEpisodes:
+        def trace_filter(episode: Episode, trace: Rollout) -> bool:
+            return episode.ok and not trace.has_error and trace.agent.trainable
+
+        episodes = [episode for episode in self.items if any(trace_filter(episode, trace) for trace in episode.traces)]
+        return EvalEpisodes(
+            episodes,
+            trace_filter=trace_filter,
+            group_sizes_by_agent=self.group_sizes_by_agent,
+        )
 
     @property
     def metrics(self) -> EvalMetrics:
-        return EvalMetrics(self.rollouts, self.group_sizes_by_agent, self.episode_results)
+        return EvalMetrics(self)

--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -9,7 +9,7 @@ A rollout container (``TrainRollouts`` / ``EvalRollouts``) owns the rollout list
 The wandb layout mirrors the episode/trace hierarchy, one aggregation per level:
 
 - ``{prefix}/{subset}/<metric>/<stat>`` — episode level, one value per episode summing its traces
-  (matching ``vf.Episode``'s aggregates). Only the count metrics live here.
+  (matching ``vf.Episode``'s aggregates), plus the episode ``has_error`` rate on ``all``.
 - ``{prefix}/{subset}/<agent>/<metric>/<stat>`` — agent level, one value per trace, grouped by agent
   name (``vf.Episode.by_agent``) so agents never mix into one distribution. Everything trace-scoped
   lives here: reward, rates, timing, custom metrics, the pipeline verdicts, the eval scores.
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal
 from prime_rl.orchestrator.utils import compute_pass_metrics
 
 if TYPE_CHECKING:
-    from prime_rl.orchestrator.types import Rollout
+    from prime_rl.orchestrator.types import EpisodeResult, Rollout
 
 Subset = Literal["all", "effective"]
 
@@ -260,14 +260,15 @@ class TraceMetrics(StatGroup):
 
 class EpisodeMetrics:
     """Metrics shared by train and eval over a rollout list. The count metrics (tokens/turns/
-    branches) are episode-level — one value per episode, summing its traces — and are the only
-    per-metric keys ``to_wandb`` emits at the env level; every trace-level metric is emitted per
+    branches) are episode-level — one value per episode, summing its traces — alongside the
+    episode failure rate; every trace-level metric is emitted per
     agent via ``by_agent()``. The boolean ``Stat`` properties (0/1 distributions, ``.mean()`` is
     the rate) serve the console log lines. ``TrainMetrics`` / ``EvalMetrics`` extend ``to_wandb``
     with the train pipeline rates and the eval scores."""
 
-    def __init__(self, rollouts: list[Rollout]) -> None:
+    def __init__(self, rollouts: list[Rollout], episode_results: list[EpisodeResult] | None = None) -> None:
         self.rollouts = rollouts
+        self.episode_results = episode_results
 
     def episodes(self) -> list[list[Rollout]]:
         """The subset's rollouts grouped into their episodes. A rollout without an
@@ -275,6 +276,8 @@ class EpisodeMetrics:
         grouped: dict[str, list[Rollout]] = {}
         for r in self.rollouts:
             grouped.setdefault(r.episode_id or r.id, []).append(r)
+        if self.episode_results:
+            return [grouped.get(result.episode.id, []) for result in self.episode_results]
         return list(grouped.values())
 
     def by_agent(self) -> dict[str, TraceMetrics]:
@@ -314,11 +317,13 @@ class EpisodeMetrics:
 
     @property
     def has_error(self) -> Stat:
+        if self.episode_results:
+            return Stat([float(not result.episode.ok) for result in self.episode_results])
         return Stat([float(r.has_error) for r in self.rollouts])
 
     def to_wandb(self, *, prefix: str, subset: Subset) -> dict[str, float]:
         """The common metric dict for one ``{prefix}/{subset}`` slice. Empty input → ``{}``."""
-        if not self.rollouts:
+        if not self.rollouts and not self.episode_results:
             return {}
         p = f"{prefix}/{subset}"
         out: dict[str, float] = {}
@@ -327,6 +332,8 @@ class EpisodeMetrics:
         out |= self.num_output_tokens.to_dict(f"{p}/num_output_tokens")
         out |= self.num_turns.to_dict(f"{p}/num_turns")
         out |= self.num_branches.to_dict(f"{p}/num_branches")
+        if subset == "all":
+            out[f"{p}/has_error/mean"] = self.has_error.mean()
         for agent, agent_metrics in self.by_agent().items():
             out |= agent_metrics.to_dict(f"{p}/{agent}", subset=subset)
         return out
@@ -373,13 +380,18 @@ def pass_at_k(rollouts: list[Rollout]) -> dict[str, float]:
 class EvalMetrics(EpisodeMetrics):
     """Common metrics plus the per-agent ``avg@<group_size>`` score and (on the effective subset,
     for binary-reward tasks) pass@k / pass^k. Both score an agent's own traces, so they live in its
-    subtree like every other trace-level metric. ``group_size`` (the ``avg@k`` k, the run's rollouts
-    per example) is supplied by the container so the ``all`` and ``effective`` subsets — and every
-    agent — share one stable key."""
+    subtree like every other trace-level metric. Each agent gets its own stable ``k`` derived from
+    that agent's traces per example in the full epoch, so multi-agent episodes cannot inflate one
+    another's score key."""
 
-    def __init__(self, rollouts: list[Rollout], group_size: int) -> None:
-        super().__init__(rollouts)
-        self.group_size = group_size
+    def __init__(
+        self,
+        rollouts: list[Rollout],
+        group_sizes_by_agent: dict[str, int],
+        episode_results: list[EpisodeResult] | None = None,
+    ) -> None:
+        super().__init__(rollouts, episode_results)
+        self.group_sizes_by_agent = group_sizes_by_agent
 
     @property
     def reward(self) -> Stat:
@@ -389,7 +401,8 @@ class EvalMetrics(EpisodeMetrics):
         out = super().to_wandb(prefix=prefix, subset=subset)
         for agent, traces in self.by_agent().items():
             p = f"{prefix}/{subset}/{agent}"
-            out[f"{p}/avg@{self.group_size}"] = traces.stats()["reward"].mean()
+            k = self.group_sizes_by_agent.get(agent, 0)
+            out[f"{p}/avg@{k}"] = traces.stats()["reward"].mean()
             if subset == "effective":
                 out |= {f"{p}/{k}": v for k, v in pass_at_k(traces.rollouts).items()}
         return out
@@ -400,11 +413,20 @@ class TrainRollouts:
     included). ``effective`` is the clean trainable subset (a view of the same traces);
     ``metrics`` builds ``TrainMetrics`` over them."""
 
-    def __init__(self, rollouts: list[Rollout] | None = None) -> None:
+    def __init__(
+        self,
+        rollouts: list[Rollout] | None = None,
+        episode_results: list[EpisodeResult] | None = None,
+    ) -> None:
         self.rollouts = rollouts if rollouts is not None else []
+        self.episode_results = episode_results if episode_results is not None else []
 
     def append(self, rollout: Rollout) -> None:
         self.rollouts.append(rollout)
+
+    def append_episode(self, result: EpisodeResult) -> None:
+        self.episode_results.append(result)
+        self.rollouts.extend(result.rollouts)
 
     def __len__(self) -> int:
         return len(self.rollouts)
@@ -414,28 +436,44 @@ class TrainRollouts:
 
     @property
     def effective(self) -> TrainRollouts:
-        return TrainRollouts([r for r in self.rollouts if not r.has_error and not r.is_filtered and r.agent.trainable])
+        rollouts = [
+            r for r in self.rollouts if r.episode_ok and not r.has_error and not r.is_filtered and r.agent.trainable
+        ]
+        episode_ids = {r.episode_id for r in rollouts}
+        episodes = [result for result in self.episode_results if result.episode.id in episode_ids]
+        return TrainRollouts(rollouts, episodes)
 
     def by_env(self) -> dict[str, TrainRollouts]:
         grouped: dict[str, list[Rollout]] = {}
         for r in self.rollouts:
             grouped.setdefault(r.env_name, []).append(r)
-        return {env: TrainRollouts(rs) for env, rs in grouped.items()}
+        for result in self.episode_results:
+            grouped.setdefault(result.env_name, [])
+        return {
+            env: TrainRollouts(rs, [result for result in self.episode_results if result.env_name == env])
+            for env, rs in grouped.items()
+        }
 
     @property
     def metrics(self) -> TrainMetrics:
-        return TrainMetrics(self.rollouts)
+        return TrainMetrics(self.rollouts, self.episode_results)
 
 
 class EvalRollouts:
     """A list of eval rollouts (errored + untrainable included). ``effective`` is the
     non-errored trainable subset (a view).
-    ``group_size`` (rollouts per example, the ``avg@k`` k) is derived from the full epoch and carried
-    onto ``effective`` so both subsets share one stable key; ``metrics`` builds ``EvalMetrics``."""
+    Per-agent group sizes are derived from the full epoch and carried onto ``effective`` so each
+    agent's ``avg@k`` key stays stable across subsets."""
 
-    def __init__(self, rollouts: list[Rollout] | None = None, group_size: int | None = None) -> None:
+    def __init__(
+        self,
+        rollouts: list[Rollout] | None = None,
+        group_sizes_by_agent: dict[str, int] | None = None,
+        episode_results: list[EpisodeResult] | None = None,
+    ) -> None:
         self.rollouts = rollouts if rollouts is not None else []
-        self._group_size = group_size
+        self.episode_results = episode_results if episode_results is not None else []
+        self._group_sizes_by_agent = group_sizes_by_agent
 
     def __len__(self) -> int:
         return len(self.rollouts)
@@ -444,25 +482,23 @@ class EvalRollouts:
         return iter(self.rollouts)
 
     @property
-    def group_size(self) -> int:
-        """The largest group in trainable (policy) traces — equals the configured group size
-        whenever one example kept all its rollouts; untrainable traces don't count, so a
-        multi-agent episode doesn't inflate ``k``. A subview carries its parent's value so
-        ``avg@k`` doesn't drift across subsets."""
-        if self._group_size is not None:
-            return self._group_size
-        counts: dict = {}
+    def group_sizes_by_agent(self) -> dict[str, int]:
+        if self._group_sizes_by_agent is not None:
+            return self._group_sizes_by_agent
+        counts: dict[str, dict] = {}
         for r in self.rollouts:
             if r.agent.trainable:
-                counts[r.group_id] = counts.get(r.group_id, 0) + 1
-        return max(counts.values(), default=0)
+                by_group = counts.setdefault(r.agent.name, {})
+                by_group[r.group_id] = by_group.get(r.group_id, 0) + 1
+        return {agent: max(by_group.values(), default=0) for agent, by_group in counts.items()}
 
     @property
     def effective(self) -> EvalRollouts:
-        return EvalRollouts(
-            [r for r in self.rollouts if not r.has_error and r.agent.trainable], group_size=self.group_size
-        )
+        rollouts = [r for r in self.rollouts if r.episode_ok and not r.has_error and r.agent.trainable]
+        episode_ids = {r.episode_id for r in rollouts}
+        episodes = [result for result in self.episode_results if result.episode.id in episode_ids]
+        return EvalRollouts(rollouts, self.group_sizes_by_agent, episodes)
 
     @property
     def metrics(self) -> EvalMetrics:
-        return EvalMetrics(self.rollouts, self.group_size)
+        return EvalMetrics(self.rollouts, self.group_sizes_by_agent, self.episode_results)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -4,12 +4,11 @@
 and drives the pipeline. Components are single-purpose:
 
 - ``EpisodeDispatcher`` schedules and emits complete v1 episodes.
-- ``TrainSink`` ingests train rollouts (tokenize → advantages → filters)
+- ``TrainSink`` ingests train episodes (tokenize → advantages → filters)
   and returns a ``TrainBatch`` when the threshold is met.
-- ``EvalSink`` ingests eval rollouts and returns an ``EvalBatch`` (the full
+- ``EvalSink`` ingests eval episodes and returns an ``EvalBatch`` (the full
   returned cohort) on epoch completion.
-- ``TrainRollouts`` / ``EvalRollouts`` carry the rollouts and build the per-step W&B metrics
-  (``batch.rollouts.metrics`` / ``.effective.metrics``).
+- ``TrainEpisodes`` / ``EvalEpisodes`` own episodes and derive trace and metric views.
 - ``WeightWatcher`` advances ``Policy`` and notifies observers.
 - ``PeriodicLogger`` polls the components on a shared interval for the
   ``_timestamp``-axis pipeline log.
@@ -56,7 +55,7 @@ from prime_rl.orchestrator.periodic_logger import PeriodicLogger
 from prime_rl.orchestrator.train_sink import TrainSink
 from prime_rl.orchestrator.train_source import TrainSource
 from prime_rl.orchestrator.types import (
-    EpisodeResult,
+    Episode,
     EvalBatch,
     Policy,
     Progress,
@@ -508,7 +507,7 @@ class Orchestrator:
             trim_process_memory()
 
     async def main_loop(self) -> None:
-        """Consume ``EpisodeResult`` objects from the dispatcher and route them
+        """Consume v1 ``Episode`` objects from the dispatcher and route them
         to the train / eval sink. Both sinks return a finalized batch (or
         ``None``) from ``add()``; we just dispatch on the result."""
         while not self.stopped.is_set():
@@ -518,7 +517,7 @@ class Orchestrator:
                 break
 
             try:
-                result: EpisodeResult = await asyncio.wait_for(self.dispatcher.out_q.get(), timeout=0.5)
+                episode: Episode = await asyncio.wait_for(self.dispatcher.out_q.get(), timeout=0.5)
             except asyncio.TimeoutError:
                 continue
 
@@ -526,38 +525,38 @@ class Orchestrator:
             # ``all`` stream the moment it arrives, so zero-trace failures survive crashes
             # and drains. Train episodes belong to the batch window currently collecting
             # (``progress.step``); eval episodes use their trigger step.
-            kind = result.kind
-            step = result.eval_step if kind == "eval" else self.progress.step
+            kind = episode.kind
+            step = episode.eval_step if kind == "eval" else self.progress.step
             assert step is not None
             run: vf.RunInfo = (
                 vf.EvalRunInfo(id=self.run_id, step=step)
                 if kind == "eval"
                 else vf.TrainRunInfo(id=self.run_id, step=step)
             )
-            for rollout in result.rollouts:
-                rollout.record_run(
+            for trace in episode.traces:
+                trace.record_run(
                     run,
                     prime_rl={
-                        "env_name": rollout.env_name,
-                        "group_id": str(rollout.group_id),
-                        "episode_id": rollout.episode_id,
-                        "policy_version": rollout.policy_version,
+                        "env_name": trace.env_name,
+                        "group_id": str(trace.group_id),
+                        "episode_id": trace.episode_id,
+                        "policy_version": trace.policy_version,
                     },
                 )
             await asyncio.to_thread(
                 save_rollouts,
-                [result.to_record()],
+                [episode.to_record()],
                 get_trace_path(self.config.output_dir, step, kind, "all"),
             )
 
             if kind == "eval":
-                assert self.eval_sink is not None  # eval rollouts only emitted when eval is configured
-                eval_batch = self.eval_sink.add(result)
+                assert self.eval_sink is not None  # eval episodes only emit when eval is configured
+                eval_batch = self.eval_sink.add(episode)
                 if eval_batch is not None:
                     await self.finalize_eval_batch(eval_batch)
                 continue
 
-            train_batch = await self.train_sink.add(result)
+            train_batch = await self.train_sink.add(episode)
             # In drain mode any late-arriving train batch is dropped — we
             # don't want to ship past ``max_steps``
             if train_batch is not None and not self.draining and not self.stopped.is_set():
@@ -570,6 +569,8 @@ class Orchestrator:
         done all data-transformation work."""
         config = self.config
         step = self.progress.step
+        episodes = batch.episodes
+        traces = episodes.traces
 
         # Sink-to-sink cycle time — the actual time between batches, not
         # including the orchestrator's ship I/O (overlapped with the
@@ -591,7 +592,7 @@ class Orchestrator:
         if not batch.samples:
             self.consecutive_empty_batches += 1
             get_logger().warning(
-                f"Step {step}: empty train batch (0 of {len(batch.rollouts)} generated rollouts shipped — "
+                f"Step {step}: empty train batch (0 of {len(traces)} generated traces shipped — "
                 f"all errored or filtered out) "
                 f"(consecutive empty batches: {self.consecutive_empty_batches}/{MAX_CONSECUTIVE_EMPTY_BATCHES})"
             )
@@ -602,12 +603,13 @@ class Orchestrator:
                 )
             return
         self.consecutive_empty_batches = 0
-        effective = batch.rollouts.effective
-        n_trainable = sum(1 for r in effective if r.is_trainable)
-        if effective and n_trainable / len(effective) <= 0.1:
+        effective = episodes.effective
+        effective_traces = effective.traces
+        n_trainable = sum(1 for trace in effective_traces if trace.is_trainable)
+        if effective_traces and n_trainable / len(effective_traces) <= 0.1:
             get_logger().warning(
-                f"Only {n_trainable}/{len(effective)} effective rollouts are trainable "
-                f"({n_trainable / len(effective):.1%}) — consider reviewing task difficulty / filter config"
+                f"Only {n_trainable}/{len(effective_traces)} effective traces are trainable "
+                f"({n_trainable / len(effective_traces):.1%}) — consider reviewing task difficulty / filter config"
             )
 
         # Ship batch ``step`` only once the trainer has published v{step-1-TARGET_LAG}.
@@ -635,15 +637,15 @@ class Orchestrator:
         # off-policy — queue time included, unlike the dispatcher's in-flight
         # counter, which only sees weight updates during generation. Frozen-
         # sourced rollouts stay 0 (their sampler doesn't follow the policy).
-        for r in batch.rollouts:
-            if self.train_envs.get(r.env_name).sampler.samples_from_live_policy:
-                r.off_policy_steps = (step - 1) - r.policy_version
+        for trace in traces:
+            if self.train_envs.get(trace.env_name).sampler.samples_from_live_policy:
+                trace.off_policy_steps = (step - 1) - trace.policy_version
 
         # The effective (clean, trained-on) subset lands in the per-step ``effective`` trace file
         # at ship time; the full arrival window already streamed into ``all`` on arrival.
         # to_record drops the per-node training tensors — they're for training, not the rollout
         # record, and can't round-trip json (raw numpy bytes).
-        records = [r.to_record() for r in effective]
+        records = [trace.to_record() for trace in effective_traces]
         await asyncio.to_thread(save_rollouts, records, get_trace_path(config.output_dir, step, "train", "effective"))
 
         await self.sender.send(TrainingBatch(examples=batch.samples, step=step))
@@ -653,10 +655,9 @@ class Orchestrator:
         save_ckpt_time = await self.maybe_save_ckpt(step)
         trim_process_memory()
 
-        # Rollout metrics over the {agg,<env>} × {all,effective} matrix. ``batch.rollouts`` is the
-        # full arrival window (errored + filtered included); ``.effective`` is the clean subset.
+        # Episode metrics over the {agg,<env>} × {all,effective} matrix.
         metrics: dict[str, float] = {}
-        for subset, pool in (("all", batch.rollouts), ("effective", effective)):
+        for subset, pool in (("all", episodes), ("effective", effective)):
             metrics |= pool.metrics.to_wandb(prefix="train/agg", subset=subset)
             for env_name, env_pool in pool.by_env().items():
                 metrics |= env_pool.metrics.to_wandb(prefix=f"train/{env_name}", subset=subset)
@@ -665,18 +666,18 @@ class Orchestrator:
         # objects). ``num_tokens`` is over the full arrival window; the input/output breakdown is over
         # the effective (shipped) subset, summing the same ``vf.Trace`` token properties the metric
         # matrix reports.
-        num_tokens = sum(r.num_total_tokens for r in batch.rollouts)
-        num_input = sum(r.num_input_tokens for r in effective)
-        num_output = sum(r.num_output_tokens for r in effective)
-        num_rollouts = len(batch.rollouts)
-        num_episodes = len(batch.episodes)
-        num_failed_episodes = sum(not episode.episode.ok for episode in batch.episodes)
-        num_unique_examples = len({episode.group_id for episode in batch.episodes})
+        num_tokens = sum(trace.num_total_tokens for trace in traces)
+        num_input = sum(trace.num_input_tokens for trace in effective_traces)
+        num_output = sum(trace.num_output_tokens for trace in effective_traces)
+        num_traces = len(traces)
+        num_episodes = len(episodes)
+        num_failed_episodes = sum(not episode.ok for episode in episodes)
+        num_unique_examples = len({episode.group_id for episode in episodes})
         metrics |= {
             "progress/tokens": num_tokens,
             "progress/input_tokens": num_input,
             "progress/output_tokens": num_output,
-            "progress/traces": num_rollouts,
+            "progress/traces": num_traces,
             "progress/episodes": num_episodes,
             "progress/failed_episodes": num_failed_episodes,
             "progress/tasks": num_unique_examples,
@@ -688,8 +689,8 @@ class Orchestrator:
             "time/wait_for_policy": self.wait_for_policy_time,
             "step": step,
         }
-        for env_name, env_pool in batch.rollouts.by_env().items():
-            metrics[f"batch/{env_name}"] = len(env_pool) / len(batch.rollouts)
+        for env_name, env_pool in episodes.by_env().items():
+            metrics[f"batch/{env_name}"] = len(env_pool.traces) / len(traces)
         if self.train_sink.pre_filter_seen > 0:
             metrics["pre_filters/all/dropped_rate"] = (
                 self.train_sink.pre_filter_dropped / self.train_sink.pre_filter_seen
@@ -698,11 +699,13 @@ class Orchestrator:
                 metrics[f"pre_filters/all/{name}/rate"] = count / self.train_sink.pre_filter_seen
         self.monitor.log(metrics, step=step)
         self.wait_for_policy_time = 0.0
-        self.monitor.log_samples(effective.rollouts, step=step)
+        self.monitor.log_samples(effective_traces, step=step)
         self.monitor.log_distributions(
             distributions={
-                "rewards": [r.reward for r in effective],
-                "advantages": [a for r in effective if (a := r.scalar_advantage()) is not None],
+                "rewards": [trace.reward for trace in effective_traces],
+                "advantages": [
+                    advantage for trace in effective_traces if (advantage := trace.scalar_advantage()) is not None
+                ],
             },
             step=step,
         )
@@ -719,7 +722,7 @@ class Orchestrator:
             self.heart.beat()
 
         self.progress.total_tokens += num_tokens
-        self.progress.total_samples += num_rollouts
+        self.progress.total_samples += num_traces
         self.progress.total_problems += num_unique_examples
 
         self.log_train_batch(batch, step=step, step_time=step_time)
@@ -815,38 +818,40 @@ class Orchestrator:
         """Per-step ``Step …`` success line. Multi-env runs append an indented ``╰─`` line per env.
         ``Error`` is the failed-episode rate over the full window;
         the quality metrics are over the effective (clean, trained-on) subset, as is ``Trainable``."""
-        rollouts = batch.rollouts
-        effective = rollouts.effective
+        episodes = batch.episodes
+        traces = episodes.traces
+        effective = episodes.effective
+        effective_traces = effective.traces
         eff = effective.metrics
-        n_generated = len(rollouts)
-        n_effective = len(effective)
-        n_trainable = sum(1 for r in effective if r.is_trainable)
+        n_generated = len(traces)
+        n_effective = len(effective_traces)
+        n_trainable = sum(1 for trace in effective_traces if trace.is_trainable)
         trainable_rate = (n_trainable / n_effective) if n_effective else 0.0
-        max_off_policy = max((r.off_policy_steps for r in effective), default=0)
+        max_off_policy = max((trace.off_policy_steps for trace in effective_traces), default=0)
 
         head = (
             f"Step {step} | {format_time(step_time):>7} | Reward {eff.reward.mean():.4f} | "
             f"Trainable {n_trainable}/{n_effective} ({trainable_rate:.1%}) | "
             f"Turns {eff.num_turns.mean():.1f} | Branches {eff.num_branches.mean():.1f} | "
             f"Max Off-Policy {max_off_policy} | "
-            f"Error {rollouts.metrics.has_error.mean():.1%} | Truncation {eff.is_truncated.mean():.1%}"
+            f"Error {episodes.metrics.has_error.mean():.1%} | Truncation {eff.is_truncated.mean():.1%}"
         )
         if len(self.train_envs) <= 1:
             get_logger().success(head)
             return
 
-        by_env = rollouts.by_env()
+        by_env = episodes.by_env()
         name_width = max((len(n) for n in by_env), default=0)
         lines = [head]
         for env_name in sorted(by_env):
             pool = by_env[env_name]
             env_eff_pool = pool.effective
             env_eff = env_eff_pool.metrics
-            ratio = (len(pool) / n_generated) if n_generated else 0.0
+            ratio = (len(pool.traces) / n_generated) if n_generated else 0.0
             lines.append(
                 f"╰─ {env_name:<{name_width}} | Ratio {ratio:.1%} | Reward {env_eff.reward.mean():.4f} | "
                 f"Turns {env_eff.num_turns.mean():.1f} | Branches {env_eff.num_branches.mean():.1f} | "
-                f"Max Off-Policy {max((r.off_policy_steps for r in env_eff_pool), default=0)} | "
+                f"Max Off-Policy {max((r.off_policy_steps for r in env_eff_pool.traces), default=0)} | "
                 f"Error {pool.metrics.has_error.mean():.1%} | Truncation {env_eff.is_truncated.mean():.1%}"
             )
         get_logger().success("\n\t\t ".join(lines))
@@ -858,23 +863,23 @@ class Orchestrator:
         # completion (multiple eval envs share the step file — each epoch appends its cohort
         # once, and every record carries ``env_name``); the full returned cohort already
         # streamed into ``all`` on arrival.
-        records = [r.to_record() for r in batch.rollouts.effective]
+        episodes = batch.episodes
+        effective = episodes.effective
+        records = [trace.to_record() for trace in effective.traces]
         await asyncio.to_thread(
             save_rollouts, records, get_trace_path(self.config.output_dir, batch.step, "eval", "effective")
         )
-        self.monitor.log_eval_samples(batch.rollouts, env_name=batch.env_name, step=batch.step)
-        policy_versions = {episode.policy_version for episode in batch.episodes}
+        self.monitor.log_eval_samples(episodes.traces, env_name=batch.env_name, step=batch.step)
+        policy_versions = {episode.policy_version for episode in episodes}
         policy_version = min(policy_versions)
         if len(policy_versions) > 1:
             get_logger().warning(
                 f"Eval {batch.env_name} step {batch.step} had mixed policy versions: {sorted(policy_versions)}"
             )
-        # Rollout metrics over {all,effective} (eval batches are per-env, so no `agg` axis).
+        # Episode metrics over {all,effective} (eval batches are per-env, so no `agg` axis).
         # ``effective`` = non-errored; pass@k / pass^k only over the effective set.
-        rollouts = batch.rollouts
-        effective = rollouts.effective
         metrics: dict[str, float] = {}
-        for subset, pool in (("all", rollouts), ("effective", effective)):
+        for subset, pool in (("all", episodes), ("effective", effective)):
             metrics |= pool.metrics.to_wandb(prefix=f"eval/{batch.env_name}", subset=subset)
         metrics[f"eval/{batch.env_name}/policy_version"] = float(policy_version)
         metrics["step"] = float(batch.step)
@@ -882,7 +887,7 @@ class Orchestrator:
 
         # Success line — quality metrics over the effective traces, failed-episode rate over the
         # full cohort. ``Stat.mean()`` is 0.0 for an empty set.
-        eff, full = effective.metrics, rollouts.metrics
+        eff, full = effective.metrics, episodes.metrics
         triggered_at = self.eval_triggered_at.pop((batch.env_name, batch.step), None)
         elapsed = (time.perf_counter() - triggered_at) if triggered_at is not None else 0.0
         get_logger().success(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -3,8 +3,7 @@
 ``Orchestrator`` owns the shared state (policy, progress, ckpt, monitor)
 and drives the pipeline. Components are single-purpose:
 
-- ``RolloutDispatcher`` schedules rollouts; emits ``Rollout`` (train/eval
-  discriminated by ``kind``) on its queue.
+- ``EpisodeDispatcher`` schedules and emits complete v1 episodes.
 - ``TrainSink`` ingests train rollouts (tokenize → advantages → filters)
   and returns a ``TrainBatch`` when the threshold is met.
 - ``EvalSink`` ingests eval rollouts and returns an ``EvalBatch`` (the full
@@ -43,7 +42,7 @@ if TYPE_CHECKING:
 import prime_rl._compat  # noqa: F401 — patch ring_flash_attn compat before transitive imports
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.ckpt import setup_ckpt_manager
-from prime_rl.orchestrator.dispatcher import DispatcherMetrics, DispatcherMode, RolloutDispatcher
+from prime_rl.orchestrator.dispatcher import DispatcherMetrics, DispatcherMode, EpisodeDispatcher
 from prime_rl.orchestrator.envs import EvalEnvs, TrainEnvs
 from prime_rl.orchestrator.eval_sink import EvalSink
 from prime_rl.orchestrator.eval_source import EvalSource
@@ -57,10 +56,10 @@ from prime_rl.orchestrator.periodic_logger import PeriodicLogger
 from prime_rl.orchestrator.train_sink import TrainSink
 from prime_rl.orchestrator.train_source import TrainSource
 from prime_rl.orchestrator.types import (
+    EpisodeResult,
     EvalBatch,
     Policy,
     Progress,
-    Rollout,
     TrainBatch,
 )
 from prime_rl.orchestrator.utils import (
@@ -133,7 +132,7 @@ class Orchestrator:
     train_envs: TrainEnvs
     train_source: TrainSource
     train_sink: TrainSink
-    dispatcher: RolloutDispatcher
+    dispatcher: EpisodeDispatcher
     watcher: WeightWatcher
     lag_monitor: EventLoopLagMonitor
     periodic_logger: PeriodicLogger
@@ -394,7 +393,7 @@ class Orchestrator:
         assert config.max_inflight_episodes is not None, "max_inflight_episodes must be resolved before dispatcher init"
         log_interval = config.log.interval
         wandb_enabled = config.wandb is not None
-        self.dispatcher = RolloutDispatcher(
+        self.dispatcher = EpisodeDispatcher(
             train_envs=self.train_envs,
             eval_envs=self.eval_envs,
             train_source=self.train_source,
@@ -509,7 +508,7 @@ class Orchestrator:
             trim_process_memory()
 
     async def main_loop(self) -> None:
-        """Consume episodes (``list[Rollout]``) from the dispatcher and route them
+        """Consume ``EpisodeResult`` objects from the dispatcher and route them
         to the train / eval sink. Both sinks return a finalized batch (or
         ``None``) from ``add()``; we just dispatch on the result."""
         while not self.stopped.is_set():
@@ -519,44 +518,46 @@ class Orchestrator:
                 break
 
             try:
-                episode: list[Rollout] = await asyncio.wait_for(self.dispatcher.out_q.get(), timeout=0.5)
+                result: EpisodeResult = await asyncio.wait_for(self.dispatcher.out_q.get(), timeout=0.5)
             except asyncio.TimeoutError:
                 continue
 
-            # Every completed rollout — errored, filtered, or never batched — lands in the
-            # ``all`` trace file the moment it arrives, so it survives crashes and drains.
-            # Train rollouts belong to the batch window currently collecting (``progress.step``),
-            # eval rollouts to the step whose eval triggered them.
-            kind = episode[0].kind
-            step = episode[0].eval_step if kind == "eval" else self.progress.step
+            # Every completed episode — failed, filtered, or never batched — lands in the
+            # ``all`` stream the moment it arrives, so zero-trace failures survive crashes
+            # and drains. Train episodes belong to the batch window currently collecting
+            # (``progress.step``); eval episodes use their trigger step.
+            kind = result.kind
+            step = result.eval_step if kind == "eval" else self.progress.step
             assert step is not None
             run: vf.RunInfo = (
                 vf.EvalRunInfo(id=self.run_id, step=step)
                 if kind == "eval"
                 else vf.TrainRunInfo(id=self.run_id, step=step)
             )
-            for rollout in episode:
+            for rollout in result.rollouts:
                 rollout.record_run(
                     run,
-                    env_name=rollout.env_name,
-                    group_id=str(rollout.group_id),
-                    episode_id=rollout.episode_id,
-                    policy_version=rollout.policy_version,
+                    prime_rl={
+                        "env_name": rollout.env_name,
+                        "group_id": str(rollout.group_id),
+                        "episode_id": rollout.episode_id,
+                        "policy_version": rollout.policy_version,
+                    },
                 )
             await asyncio.to_thread(
                 save_rollouts,
-                [rollout.to_record() for rollout in episode],
+                [result.to_record()],
                 get_trace_path(self.config.output_dir, step, kind, "all"),
             )
 
             if kind == "eval":
                 assert self.eval_sink is not None  # eval rollouts only emitted when eval is configured
-                eval_batch = self.eval_sink.add(episode)
+                eval_batch = self.eval_sink.add(result)
                 if eval_batch is not None:
                     await self.finalize_eval_batch(eval_batch)
                 continue
 
-            train_batch = await self.train_sink.add(episode)
+            train_batch = await self.train_sink.add(result)
             # In drain mode any late-arriving train batch is dropped — we
             # don't want to ship past ``max_steps``
             if train_batch is not None and not self.draining and not self.stopped.is_set():
@@ -580,9 +581,9 @@ class Orchestrator:
         if config.max_steps is not None and step > config.max_steps:
             self.draining = True
             self.dispatcher.disable_train_scheduling()
-            n_cancelled = await self.dispatcher.cancel_inflight_train_rollouts()
+            n_cancelled = await self.dispatcher.cancel_inflight_train_episodes()
             get_logger().info(
-                f"Draining pipeline (cancelled {n_cancelled} in-flight train rollout(s); "
+                f"Draining pipeline (cancelled {n_cancelled} in-flight train episode(s); "
                 f"any in-flight evals will complete)"
             )
             return
@@ -668,15 +669,19 @@ class Orchestrator:
         num_input = sum(r.num_input_tokens for r in effective)
         num_output = sum(r.num_output_tokens for r in effective)
         num_rollouts = len(batch.rollouts)
-        num_unique_examples = len({r.group_id for r in batch.rollouts})
+        num_episodes = len(batch.episodes)
+        num_failed_episodes = sum(not episode.episode.ok for episode in batch.episodes)
+        num_unique_examples = len({episode.group_id for episode in batch.episodes})
         metrics |= {
             "progress/tokens": num_tokens,
             "progress/input_tokens": num_input,
             "progress/output_tokens": num_output,
-            "progress/rollouts": num_rollouts,
+            "progress/traces": num_rollouts,
+            "progress/episodes": num_episodes,
+            "progress/failed_episodes": num_failed_episodes,
             "progress/tasks": num_unique_examples,
             "progress/total_tokens": self.progress.total_tokens,
-            "progress/total_rollouts": self.progress.total_samples,
+            "progress/total_traces": self.progress.total_samples,
             "progress/total_tasks": self.progress.total_problems,
             "time/step": step_time,
             "time/save_ckpt": save_ckpt_time,
@@ -737,11 +742,11 @@ class Orchestrator:
         for env_name in fired:
             self.eval_triggered_at[(env_name, step)] = now
         assert self.eval_envs is not None
-        total_rollouts = sum(
-            self.eval_envs.get(env_name).config.group_size * len(self.eval_envs.get(env_name).examples)
+        total_episodes = sum(
+            self.eval_envs.get(env_name).config.group_size * len(self.eval_envs.get(env_name).eval_tasks)
             for env_name in fired
         )
-        get_logger().info(f"Starting evals in {', '.join(fired)} ({total_rollouts} total rollouts)")
+        get_logger().info(f"Starting evals in {', '.join(fired)} ({total_episodes} total episodes)")
 
     def collect_pipeline_view(self) -> tuple[str, dict[str, float]]:
         """Pipeline view for the orchestrator's ``PeriodicLogger``. Returns
@@ -784,7 +789,7 @@ class Orchestrator:
         # Unified inflight tail: total, then train/eval split, then per-env
         # (only when more than one env of a kind makes the split ambiguous)
         inflight_part = (
-            f"{inflight_train + inflight_eval} inflight rollouts (train={inflight_train}, eval={inflight_eval}"
+            f"{inflight_train + inflight_eval} inflight episodes (train={inflight_train}, eval={inflight_eval}"
         )
         if multi_train or multi_eval:
             env_pairs = [(e.name, inflight_by_env.get(("train", e.name), 0)) for e in self.train_envs]
@@ -808,7 +813,7 @@ class Orchestrator:
 
     def log_train_batch(self, batch: TrainBatch, *, step: int, step_time: float) -> None:
         """Per-step ``Step …`` success line. Multi-env runs append an indented ``╰─`` line per env.
-        ``Error`` is the sink-level rate (errored arrivals / total arrivals, over the full window);
+        ``Error`` is the failed-episode rate over the full window;
         the quality metrics are over the effective (clean, trained-on) subset, as is ``Trainable``."""
         rollouts = batch.rollouts
         effective = rollouts.effective
@@ -849,10 +854,6 @@ class Orchestrator:
     async def finalize_eval_batch(self, batch: EvalBatch) -> None:
         """Persist + log one completed eval epoch (save_rollouts,
         monitor.log_eval_samples, monitor.log)."""
-        if not batch.rollouts:
-            get_logger().warning(f"Eval @ step={batch.step} env={batch.env_name}: no rollouts returned, skipping log")
-            return
-
         # The non-errored subset lands in the per-step ``effective`` trace file on epoch
         # completion (multiple eval envs share the step file — each epoch appends its cohort
         # once, and every record carries ``env_name``); the full returned cohort already
@@ -862,7 +863,7 @@ class Orchestrator:
             save_rollouts, records, get_trace_path(self.config.output_dir, batch.step, "eval", "effective")
         )
         self.monitor.log_eval_samples(batch.rollouts, env_name=batch.env_name, step=batch.step)
-        policy_versions = {r.policy_version for r in batch.rollouts}
+        policy_versions = {episode.policy_version for episode in batch.episodes}
         policy_version = min(policy_versions)
         if len(policy_versions) > 1:
             get_logger().warning(
@@ -879,8 +880,8 @@ class Orchestrator:
         metrics["step"] = float(batch.step)
         self.monitor.log(metrics, step=batch.step)
 
-        # Success line — quality metrics over the effective set, error rate over the full returned
-        # cohort. ``Stat.mean()`` is 0.0 for an empty set.
+        # Success line — quality metrics over the effective traces, failed-episode rate over the
+        # full cohort. ``Stat.mean()`` is 0.0 for an empty set.
         eff, full = effective.metrics, rollouts.metrics
         triggered_at = self.eval_triggered_at.pop((batch.env_name, batch.step), None)
         elapsed = (time.perf_counter() - triggered_at) if triggered_at is not None else 0.0
@@ -983,6 +984,9 @@ class Orchestrator:
                 for env in self.train_envs:
                     for pool in (*env.sampler.connected_pools, *env.algorithm.connected_pools):
                         await pool.stop()
+                await self.train_envs.stop()
+            if self.eval_envs is not None:
+                await self.eval_envs.stop()
             if self.usage_reporter is not None:
                 self.usage_reporter.close()
 

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -10,7 +10,7 @@
 3. ``process_batch`` — applies post-batch filter annotations and assembles
    the trainer-bound ``TrainingSample`` list. Returns a ``TrainBatch``.
 
-``add()`` takes one ``EpisodeResult`` and returns
+``add()`` takes one v1 ``Episode`` and returns
 ``TrainBatch | None``; group accounting counts episodes, never loose traces.
 I/O concerns (ship to trainer, save_rollouts, monitor.log) live on the
 orchestrator.
@@ -21,14 +21,13 @@ from __future__ import annotations
 import asyncio
 import uuid
 from collections import defaultdict
-from dataclasses import dataclass
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.envs import TrainEnvs
 from prime_rl.orchestrator.filters import RolloutFilter, apply_filters
-from prime_rl.orchestrator.metrics import TrainRollouts
+from prime_rl.orchestrator.metrics import TrainEpisodes
 from prime_rl.orchestrator.trajectories import trace_to_samples
-from prime_rl.orchestrator.types import EpisodeResult, Rollout, TrainBatch
+from prime_rl.orchestrator.types import Episode, Rollout, TrainBatch
 from prime_rl.transport import TrainingSample
 from prime_rl.utils.logger import get_logger
 
@@ -46,16 +45,8 @@ def payload_tokens(rollout: Rollout) -> int:
     return sum(len(sample.token_ids) for sample in rollout.samples) or rollout.num_total_tokens
 
 
-@dataclass
-class CompletedTrainGroup:
-    """A finalized group kept whole until it enters a trainer batch."""
-
-    episodes: list[EpisodeResult]
-    selected: list[Rollout]
-
-
 class TrainSink:
-    """Three-level train sink. Constructed once, fed via ``add(rollout)``."""
+    """Three-level train sink. Constructed once, fed via ``add(episode)``."""
 
     def __init__(
         self,
@@ -81,16 +72,14 @@ class TrainSink:
         self.pre_filters = pre_filters
         self.post_filters = post_filters
 
-        # Observation window for the next shipped batch: rollouts of groups
-        # finalized since the last ship (errored + filtered + survivors).
-        # In-progress groups stay out until they finalize.
-        self.pending_rollouts: TrainRollouts = TrainRollouts()
         # Keyed by the dispatcher's group UUID. ``(env_name, task_idx)``
         # isn't unique — the same task can be re-sampled while an
         # earlier group is still in flight
-        self.pending_groups: dict[uuid.UUID, list[EpisodeResult]] = defaultdict(list)
-        self.ready_groups: list[CompletedTrainGroup] = []
-        self.pending_episodes: list[EpisodeResult] = []
+        self.pending_groups: dict[uuid.UUID, list[Episode]] = defaultdict(list)
+        self.ready_groups: list[list[Rollout]] = []
+        # Observation window for the next successful ship. In-progress groups
+        # stay out until they finalize.
+        self.pending_episodes: list[Episode] = []
         self.pending_selected: int = 0
         # Running payload-token total of ready groups for token-batched runs.
         self.pending_tokens: int = 0
@@ -122,20 +111,21 @@ class TrainSink:
         values sum to the aggregate."""
         counts: dict[str, int] = defaultdict(int)
         for group in self.ready_groups:
-            for rollout in group.selected:
+            for rollout in group:
                 counts[rollout.env_name] += 1
         return dict(counts)
 
-    async def add(self, result: EpisodeResult) -> TrainBatch | None:
+    async def add(self, episode: Episode) -> TrainBatch | None:
         """Process one episode arrival; finalize the group on the
         ``group_size``-th episode; return a ``TrainBatch`` if the finalization
         pushed (or left) the batch over its threshold. Arrivals into
         still-incomplete groups never ship a batch."""
-        group_id = result.group_id
-        env_name = result.env_name
-        for rollout in result.rollouts:
-            await self.process_rollout(rollout)
-        self.pending_groups[group_id].append(result)
+        group_id = episode.group_id
+        env_name = episode.env_name
+        if episode.ok:
+            for trace in episode.traces:
+                await self.process_rollout(trace)
+        self.pending_groups[group_id].append(episode)
         if len(self.pending_groups[group_id]) < self.group_size_for(env_name):
             return None
         await self.process_group(group_id)
@@ -156,7 +146,7 @@ class TrainSink:
         message graph. Training is renderer-only across all modes (RL/OPD student, SFT teacher),
         so every node already carries its tokens. Errored rollouts are dropped at the group
         level, so skip them here; untrainable traces never become training data."""
-        if not rollout.episode_ok or rollout.has_error or not rollout.agent.trainable:
+        if rollout.has_error or not rollout.agent.trainable:
             return
         samples = await asyncio.to_thread(
             trace_to_samples,
@@ -176,18 +166,16 @@ class TrainSink:
         episodes = self.pending_groups.pop(group_id, [])
         if not episodes:
             return
-        group = [rollout for result in episodes for rollout in result.rollouts]
+        group = [trace for episode in episodes for trace in episode.traces]
         # Window membership follows group finalization, not arrival: a rollout
         # only becomes observable (metrics / persistence) once its whole group
         # is finalized, so a batch's window never claims rollouts of a group
         # that ships later. Dropped groups still land here — they were observed.
-        for result in episodes:
-            self.pending_rollouts.append_episode(result)
         self.pending_episodes.extend(episodes)
         env_name = episodes[0].env_name
         task_idx = episodes[0].task_data.idx
-        survivors = [r for r in group if r.episode_ok and not r.has_error]
-        num_failed_episodes = sum(not result.episode.ok for result in episodes)
+        survivors = [trace for episode in episodes if episode.ok for trace in episode.traces if not trace.has_error]
+        num_failed_episodes = sum(not episode.ok for episode in episodes)
         num_errored_traces = sum(r.has_error for r in group)
 
         env = self.train_envs.get(env_name)
@@ -199,7 +187,7 @@ class TrainSink:
                 f"episodes={len(episodes)} (failed={num_failed_episodes}) | "
                 f"traces={len(group)} (errored={num_errored_traces}) | dropped: no trainable survivors"
             )
-            self.ready_groups.append(CompletedTrainGroup(episodes=episodes, selected=[]))
+            self.ready_groups.append([])
             return
 
         # Advantages + per-sample wire stamping (advantage stream, loss
@@ -236,7 +224,7 @@ class TrainSink:
                 self.pending_tokens += payload_tokens(r)
 
         selected = [r for r in survivors if not r.is_filtered]
-        self.ready_groups.append(CompletedTrainGroup(episodes=episodes, selected=selected))
+        self.ready_groups.append(selected)
 
         # Per-group summary. One line per finalized group; per-filter
         # detection breakdown lives at debug level in ``apply_filters``
@@ -253,7 +241,7 @@ class TrainSink:
     def process_batch(self) -> TrainBatch:
         """Pop all ready groups as one cohort, preserving group atomicity."""
         groups, self.ready_groups = self.ready_groups, []
-        cohort = [rollout for group in groups for rollout in group.selected]
+        cohort = [rollout for group in groups for rollout in group]
         self.pending_selected = 0
         self.pending_tokens = 0
 
@@ -264,18 +252,11 @@ class TrainSink:
         # advantage stream and loss routing on each sample. Filtered rollouts don't ship.
         samples: list[TrainingSample] = [sample for r in cohort if not r.is_filtered for sample in r.samples]
 
-        # ``rollouts`` is the observation window — every rollout of every group finalized since the
-        # last ship (errored + filtered + survivors) — while ``samples`` is the shipped cohort's
-        # trainable payload. ``rollouts.effective`` / ``rollouts.metrics`` derive the clean subset +
-        # metric views on demand. Reset the window only when the batch actually ships (non-empty
-        # samples) — an empty batch is dropped unlogged by the orchestrator, so keep accumulating its
-        # finalized groups (and any overflow) into the next shipped batch's window.
-        rollouts = self.pending_rollouts
-        episodes = self.pending_episodes
+        # Episodes are the observation window; trace and metric views are derived from them.
+        episodes = TrainEpisodes(self.pending_episodes)
         if samples:
-            self.pending_rollouts = TrainRollouts()
             self.pending_episodes = []
-        return TrainBatch(episodes=episodes, rollouts=rollouts, samples=samples)
+        return TrainBatch(episodes=episodes, samples=samples)
 
     def reset_pre_filter_stats(self) -> None:
         self.pre_filter_seen = 0

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -10,7 +10,7 @@
 3. ``process_batch`` — applies post-batch filter annotations and assembles
    the trainer-bound ``TrainingSample`` list. Returns a ``TrainBatch``.
 
-``add()`` takes one episode (``list[Rollout]``) and returns
+``add()`` takes one ``EpisodeResult`` and returns
 ``TrainBatch | None``; group accounting counts episodes, never loose traces.
 I/O concerns (ship to trainer, save_rollouts, monitor.log) live on the
 orchestrator.
@@ -21,13 +21,14 @@ from __future__ import annotations
 import asyncio
 import uuid
 from collections import defaultdict
+from dataclasses import dataclass
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.envs import TrainEnvs
 from prime_rl.orchestrator.filters import RolloutFilter, apply_filters
 from prime_rl.orchestrator.metrics import TrainRollouts
 from prime_rl.orchestrator.trajectories import trace_to_samples
-from prime_rl.orchestrator.types import Rollout, TrainBatch
+from prime_rl.orchestrator.types import EpisodeResult, Rollout, TrainBatch
 from prime_rl.transport import TrainingSample
 from prime_rl.utils.logger import get_logger
 
@@ -43,6 +44,14 @@ def payload_tokens(rollout: Rollout) -> int:
     stream then ships empty batches and trips the orchestrator's
     consecutive-empty-batch abort instead of stalling the readiness check."""
     return sum(len(sample.token_ids) for sample in rollout.samples) or rollout.num_total_tokens
+
+
+@dataclass
+class CompletedTrainGroup:
+    """A finalized group kept whole until it enters a trainer batch."""
+
+    episodes: list[EpisodeResult]
+    selected: list[Rollout]
 
 
 class TrainSink:
@@ -79,14 +88,11 @@ class TrainSink:
         # Keyed by the dispatcher's group UUID. ``(env_name, task_idx)``
         # isn't unique — the same task can be re-sampled while an
         # earlier group is still in flight
-        self.pending_groups: dict[uuid.UUID, list[Rollout]] = defaultdict(list)
-        # Episodes arrived per group — the finalization count (an episode may
-        # add several traces to ``pending_groups`` but counts once here).
-        self.pending_group_episodes: dict[uuid.UUID, int] = defaultdict(int)
-        self.pending_batch: list[Rollout] = []
-        # Running payload-token total of ``pending_batch`` (token-batched
-        # runs), kept in sync on append/pop so the readiness check never
-        # re-sums per arrival.
+        self.pending_groups: dict[uuid.UUID, list[EpisodeResult]] = defaultdict(list)
+        self.ready_groups: list[CompletedTrainGroup] = []
+        self.pending_episodes: list[EpisodeResult] = []
+        self.pending_selected: int = 0
+        # Running payload-token total of ready groups for token-batched runs.
         self.pending_tokens: int = 0
 
         # Reset by the orchestrator after each ship via ``reset_pre_filter_stats``
@@ -99,45 +105,45 @@ class TrainSink:
 
     def batch_progress(self) -> tuple[int, int, str]:
         """``(current, target, unit)`` for the train batch — counts only
-        ``pending_batch`` (survivors of finalized groups, queued for the
-        trainer), so it's an honest 0→target fill. Partial-group arrivals are
+        survivors of finalized groups queued for the trainer, so it's an
+        honest 0→target fill. Partial-group arrivals are
         reported separately by ``buffered_count()``."""
         if self.batch_size is not None:
-            return len(self.pending_batch), self.batch_size, "rollouts"
+            return self.pending_selected, self.batch_size, "rollouts"
         assert self.token_batch_size is not None
         return self.pending_tokens, self.token_batch_size, "tokens"
 
     def buffered_count(self) -> int:
         """Episodes buffered in not-yet-complete groups ahead of the batch."""
-        return sum(self.pending_group_episodes.values())
+        return sum(len(episodes) for episodes in self.pending_groups.values())
 
     def pending_batch_by_env(self) -> dict[str, int]:
-        """Per-env breakdown of ``batch_progress()`` (``pending_batch`` only);
+        """Per-env breakdown of ``batch_progress()`` (selected rollouts only);
         values sum to the aggregate."""
         counts: dict[str, int] = defaultdict(int)
-        for r in self.pending_batch:
-            counts[r.env_name] += 1
+        for group in self.ready_groups:
+            for rollout in group.selected:
+                counts[rollout.env_name] += 1
         return dict(counts)
 
-    async def add(self, episode: list[Rollout]) -> TrainBatch | None:
+    async def add(self, result: EpisodeResult) -> TrainBatch | None:
         """Process one episode arrival; finalize the group on the
         ``group_size``-th episode; return a ``TrainBatch`` if the finalization
         pushed (or left) the batch over its threshold. Arrivals into
         still-incomplete groups never ship a batch."""
-        group_id = episode[0].group_id
-        env_name = episode[0].env_name
-        for rollout in episode:
+        group_id = result.group_id
+        env_name = result.env_name
+        for rollout in result.rollouts:
             await self.process_rollout(rollout)
-        self.pending_groups[group_id].extend(episode)
-        self.pending_group_episodes[group_id] += 1
-        if self.pending_group_episodes[group_id] < self.group_size_for(env_name):
+        self.pending_groups[group_id].append(result)
+        if len(self.pending_groups[group_id]) < self.group_size_for(env_name):
             return None
         await self.process_group(group_id)
-        # ``pending_batch`` only grows on group finalization, so readiness is
+        # The ready cohort only grows on group finalization, so readiness is
         # only re-checked here — the window of a shipped batch then always
         # contains at least the group that finalized it.
         ready = (
-            len(self.pending_batch) >= self.batch_size
+            self.pending_selected >= self.batch_size
             if self.batch_size is not None
             else self.pending_tokens >= (self.token_batch_size or 0)
         )
@@ -150,7 +156,7 @@ class TrainSink:
         message graph. Training is renderer-only across all modes (RL/OPD student, SFT teacher),
         so every node already carries its tokens. Errored rollouts are dropped at the group
         level, so skip them here; untrainable traces never become training data."""
-        if rollout.has_error or not rollout.agent.trainable:
+        if not rollout.episode_ok or rollout.has_error or not rollout.agent.trainable:
             return
         samples = await asyncio.to_thread(
             trace_to_samples,
@@ -166,21 +172,23 @@ class TrainSink:
 
     async def process_group(self, group_id: uuid.UUID) -> None:
         """Finalize one GRPO group: drop errored rollouts, assign advantages, run
-        pre-batch filters, and append survivors to ``pending_batch``."""
-        group = self.pending_groups.pop(group_id, [])
-        self.pending_group_episodes.pop(group_id, None)
-        if not group:
+        pre-batch filters, and append the completed group to the ready cohort."""
+        episodes = self.pending_groups.pop(group_id, [])
+        if not episodes:
             return
+        group = [rollout for result in episodes for rollout in result.rollouts]
         # Window membership follows group finalization, not arrival: a rollout
         # only becomes observable (metrics / persistence) once its whole group
         # is finalized, so a batch's window never claims rollouts of a group
         # that ships later. Dropped groups still land here — they were observed.
-        for r in group:
-            self.pending_rollouts.append(r)
-        env_name = group[0].env_name
-        task_idx = group[0].task.data.idx
-        survivors = [r for r in group if not r.has_error]
-        num_errored = len(group) - len(survivors)
+        for result in episodes:
+            self.pending_rollouts.append_episode(result)
+        self.pending_episodes.extend(episodes)
+        env_name = episodes[0].env_name
+        task_idx = episodes[0].task_data.idx
+        survivors = [r for r in group if r.episode_ok and not r.has_error]
+        num_failed_episodes = sum(not result.episode.ok for result in episodes)
+        num_errored_traces = sum(r.has_error for r in group)
 
         env = self.train_envs.get(env_name)
         # Untrainable traces carry no samples and must not skew the group baseline.
@@ -188,8 +196,10 @@ class TrainSink:
         if not survivors:
             get_logger().debug(
                 f"Finished group | env={env_name} task_idx={task_idx} | "
-                f"rollouts={len(group)} (errored={num_errored}) | dropped: no trainable survivors"
+                f"episodes={len(episodes)} (failed={num_failed_episodes}) | "
+                f"traces={len(group)} (errored={num_errored_traces}) | dropped: no trainable survivors"
             )
+            self.ready_groups.append(CompletedTrainGroup(episodes=episodes, selected=[]))
             return
 
         # Advantages + per-sample wire stamping (advantage stream, loss
@@ -221,9 +231,12 @@ class TrainSink:
             # Reset annotations so the post-batch filter pass starts clean
             r.filter_results = {}
             r.is_filtered = False
-            self.pending_batch.append(r)
+            self.pending_selected += 1
             if self.token_batch_size is not None:
                 self.pending_tokens += payload_tokens(r)
+
+        selected = [r for r in survivors if not r.is_filtered]
+        self.ready_groups.append(CompletedTrainGroup(episodes=episodes, selected=selected))
 
         # Per-group summary. One line per finalized group; per-filter
         # detection breakdown lives at debug level in ``apply_filters``
@@ -232,31 +245,17 @@ class TrainSink:
         filter_str = ", ".join(f"{n}={c}" for n, c in filtered_by_name.items()) if filtered_by_name else "—"
         get_logger().debug(
             f"Finished group | env={env_name} task_idx={task_idx} | "
-            f"rollouts={len(group)} (errored={num_errored}, filtered={num_filtered}) | "
+            f"episodes={len(episodes)} (failed={num_failed_episodes}) | "
+            f"traces={len(group)} (errored={num_errored_traces}, filtered={num_filtered}) | "
             f"reward={avg_reward:.4f} | filters: {filter_str}"
         )
 
     def process_batch(self) -> TrainBatch:
-        """Pop a cohort off ``pending_batch`` (by rollout count when
-        ``batch_size`` is set, by token count when ``token_batch_size`` is
-        set), apply post-batch filter annotations, and assemble the
-        trainer-bound ``TrainingSample`` list. Overflow stays for the next
-        batch."""
-        if self.batch_size is not None:
-            cohort = self.pending_batch[: self.batch_size]
-            self.pending_batch = self.pending_batch[self.batch_size :]
-        else:
-            assert self.token_batch_size is not None
-            cut = 0
-            running = 0
-            for i, r in enumerate(self.pending_batch):
-                running += payload_tokens(r)
-                cut = i + 1
-                if running >= self.token_batch_size:
-                    break
-            cohort = self.pending_batch[:cut]
-            self.pending_batch = self.pending_batch[cut:]
-            self.pending_tokens -= running
+        """Pop all ready groups as one cohort, preserving group atomicity."""
+        groups, self.ready_groups = self.ready_groups, []
+        cohort = [rollout for group in groups for rollout in group.selected]
+        self.pending_selected = 0
+        self.pending_tokens = 0
 
         if self.post_filters:
             apply_filters(self.post_filters, cohort)
@@ -272,9 +271,11 @@ class TrainSink:
         # samples) — an empty batch is dropped unlogged by the orchestrator, so keep accumulating its
         # finalized groups (and any overflow) into the next shipped batch's window.
         rollouts = self.pending_rollouts
+        episodes = self.pending_episodes
         if samples:
             self.pending_rollouts = TrainRollouts()
-        return TrainBatch(rollouts=rollouts, samples=samples)
+            self.pending_episodes = []
+        return TrainBatch(episodes=episodes, rollouts=rollouts, samples=samples)
 
     def reset_pre_filter_stats(self) -> None:
         self.pre_filter_seen = 0

--- a/src/prime_rl/orchestrator/train_source.py
+++ b/src/prime_rl/orchestrator/train_source.py
@@ -14,12 +14,11 @@ from collections.abc import Iterator
 import verifiers.v1 as vf
 
 from prime_rl.orchestrator.envs import TrainEnvs
+from prime_rl.orchestrator.types import TaskItem
 
 
 class TrainSource:
-    """``next_example(available_permits)`` picks a weighted-RR env and returns its
-    next example. Returned dicts carry ``env_name``, ``task_idx``, and ``task``;
-    the task data is shipped to the env server at dispatch.
+    """``next_task()`` picks a weighted-RR env and returns its next v1 task item.
 
     The data position round-trips through a checkpoint via ``state_dict()``
     / ``load_state_dict()``: per-env ``{epoch, cursor}`` plus the env-choice
@@ -37,30 +36,32 @@ class TrainSource:
         if not self.envs:
             raise ValueError("TrainSource needs at least one train env")
 
-        # A finite env's example table in canonical order (each epoch's shuffle
+        # A finite env's task table in canonical order (each epoch's shuffle
         # starts from this); ``None`` for an infinite env, whose generator
-        # (``self.iters``) is pulled per example.
-        self.base_rows: dict[str, list[dict] | None] = {}
-        self.examples: dict[str, list[dict] | None] = {}
-        self.iters: dict[str, Iterator[vf.Task]] = {}
+        # (``self.iters``) is pulled per task.
+        self.base_rows: dict[str, list[TaskItem] | None] = {}
+        self.task_rows: dict[str, list[TaskItem] | None] = {}
+        self.iters: dict[str, Iterator[vf.TaskData]] = {}
         self.epochs: dict[str, int] = {}
         self.cursors: dict[str, int] = {}
         for env in self.envs:
-            if env.num_tasks is None:  # infinite: pull the generator per example
+            if env.num_tasks is None:  # infinite: pull the generator per task
                 rows = None
                 self.iters[env.name] = env.tasks
             else:
-                rows = [{"task_idx": task.data.idx, "task": task, "env_name": env.name} for task in env.tasks]
+                rows = [TaskItem(env_name=env.name, data=data) for data in env.tasks]
+                if not rows:
+                    raise ValueError(f"Train env {env.name} has no tasks")
             self.base_rows[env.name] = rows
             self.epochs[env.name] = 1
             self.cursors[env.name] = 0
-            self.examples[env.name] = self._shuffle(env.name)
+            self.task_rows[env.name] = self._shuffle(env.name)
 
         self.env_names = [e.name for e in self.envs]
         self.weights: list[float] = [float(e.config.ratio) for e in self.envs]
 
-    def _shuffle(self, env_name: str) -> list[dict] | None:
-        """The env's example table shuffled for its current epoch — a pure
+    def _shuffle(self, env_name: str) -> list[TaskItem] | None:
+        """The env's task table shuffled for its current epoch — a pure
         function of (canonical order, epoch), so a restored position replays
         the exact epoch permutation."""
         rows = self.base_rows[env_name]
@@ -88,23 +89,21 @@ class TrainSource:
                 for _ in range(position["cursor"]):
                     next(self.iters[name])
             else:
-                self.examples[name] = self._shuffle(name)
+                self.task_rows[name] = self._shuffle(name)
 
-    def next_example(self, available_permits: int) -> dict | None:
-        if available_permits < 1:
-            return None
+    def next_task(self) -> TaskItem:
         env_name = self.rng.choices(self.env_names, weights=self.weights, k=1)[0]
-        rows = self.examples[env_name]
+        rows = self.task_rows[env_name]
         cursor = self.cursors[env_name]
         if rows is None:  # infinite env: pull the next generated task
-            task = next(self.iters[env_name])
+            data = next(self.iters[env_name])
             self.cursors[env_name] = cursor + 1
-            return {"task_idx": task.data.idx, "task": task, "env_name": env_name}
+            return TaskItem(env_name=env_name, data=data)
         if cursor >= len(rows):
             self.epochs[env_name] += 1
             rows = self._shuffle(env_name)
-            self.examples[env_name] = rows
+            self.task_rows[env_name] = rows
             cursor = 0
-        example = rows[cursor]
+        task = rows[cursor]
         self.cursors[env_name] = cursor + 1
-        return example
+        return task

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, Literal, Protocol, cast
+from typing import TYPE_CHECKING, Generic, Literal, Protocol
 
 import verifiers.v1 as vf
 from pydantic import ConfigDict, Field
@@ -13,7 +13,7 @@ from verifiers.v1.task import DataT
 from prime_rl.transport import TrainingSample
 
 if TYPE_CHECKING:
-    from prime_rl.orchestrator.metrics import EvalRollouts, TrainRollouts
+    from prime_rl.orchestrator.metrics import EvalEpisodes, TrainEpisodes
 
 
 @dataclass
@@ -91,7 +91,6 @@ class Rollout(vf.Trace[DataT], Generic[DataT]):
     # Links the traces of one episode; stamped into ``info`` on arrival so
     # saved records keep their grouping.
     episode_id: str = Field(default="", exclude=True)
-    episode_ok: bool = Field(default=True, exclude=True)
     policy_version: int = Field(default=0, exclude=True)
     off_policy_steps: int = Field(default=0, exclude=True)
     samples: list[TrainingSample] = Field(default_factory=list, exclude=True)
@@ -152,27 +151,21 @@ class TaskItem:
     eval_step: int | None = None
 
 
-@dataclass
-class EpisodeResult:
-    """A complete v1 episode with the metadata needed by prime-rl's pipeline."""
+class Episode(vf.WireEpisode):
+    """A v1 episode carrying prime-rl's orchestration metadata."""
 
-    episode: vf.WireEpisode
-    kind: RolloutKind
-    env_name: str
-    group_id: uuid.UUID
-    task_data: vf.TaskData
-    policy_version: int
-    off_policy_steps: int = 0
-    eval_step: int | None = None
-
-    @property
-    def rollouts(self) -> list[Rollout]:
-        """The episode's traces after dispatcher validation and stamping."""
-        return cast(list[Rollout], self.episode.traces)
+    traces: list[ROLLOUT_TYPE] = Field(default_factory=list)
+    kind: RolloutKind = Field(exclude=True)
+    env_name: str = Field(exclude=True)
+    group_id: uuid.UUID = Field(exclude=True)
+    task_data: vf.TaskData = Field(exclude=True)
+    policy_version: int = Field(exclude=True)
+    off_policy_steps: int = Field(default=0, exclude=True)
+    eval_step: int | None = Field(default=None, exclude=True)
 
     def to_record(self) -> dict:
         """Serialize the canonical episode shell with prime-rl trace records."""
-        record = self.episode.model_dump(mode="json", exclude={"traces"}, exclude_none=True)
+        record = self.model_dump(mode="json", exclude={"traces"}, exclude_none=True)
         record["prime_rl"] = {
             "kind": self.kind,
             "env_name": self.env_name,
@@ -181,34 +174,25 @@ class EpisodeResult:
             "policy_version": self.policy_version,
             "eval_step": self.eval_step,
         }
-        record["traces"] = [rollout.to_record() for rollout in self.rollouts]
+        record["traces"] = [trace.to_record() for trace in self.traces]
         return record
 
 
 @dataclass
 class TrainBatch:
-    """``episodes`` is the v1 observation window since the last successful ship;
-    ``rollouts`` is its flattened trace view — every trace of every group
-    finalized in that span (errored + filtered included; rollouts of still-incomplete groups wait
-    for a later window). Its ``.effective`` / ``.metrics`` views drive logging. ``samples`` is the
-    trainer-bound payload (the shipped cohort's post-filter survivors) — an empty list means nothing
-    ships, which would stall the trainer. Trainable counts derive from ``rollouts.effective``
-    (``r.is_trainable``) and token totals from ``samples``, so neither is carried as a field."""
+    """The episode observation window and its trainer-bound sample payload."""
 
-    episodes: list[EpisodeResult]
-    rollouts: TrainRollouts
+    episodes: TrainEpisodes
     samples: list[TrainingSample]
 
 
 @dataclass
 class EvalBatch:
-    """One env's eval epoch. ``episodes`` is the canonical returned cohort and
-    ``rollouts`` its flattened trace view; ``.effective`` / ``.metrics`` drive logging."""
+    """One environment's episode-native eval epoch."""
 
     env_name: str
     step: int
-    episodes: list[EpisodeResult]
-    rollouts: EvalRollouts
+    episodes: EvalEpisodes
 
 
 class VersionObserver(Protocol):

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, Literal, Protocol
+from typing import TYPE_CHECKING, Generic, Literal, Protocol, cast
 
 import verifiers.v1 as vf
 from pydantic import ConfigDict, Field
@@ -39,12 +39,13 @@ RolloutKind = Literal["train", "eval"]
 
 
 @dataclass
-class InflightRollout:
-    """Per-task scheduling state in the dispatcher; one entry per in-flight run."""
+class InflightEpisode:
+    """Scheduling metadata for one in-flight v1 episode."""
 
     kind: RolloutKind
     env_name: str
     group_id: uuid.UUID
+    task_data: vf.TaskData
     policy_version: int
     client_config: vf.ClientConfig | None = None
     off_policy_steps: int = 0
@@ -58,11 +59,10 @@ class GroupState:
 
     kind: RolloutKind
     env_name: str
-    task_idx: int
-    task: vf.Task
-    """The group's task; its data is shipped on every dispatch."""
-    rollouts_to_schedule: int
-    target_rollouts: int
+    task_data: vf.TaskData
+    """The v1 wire half of the group's task, shipped on every dispatch."""
+    episodes_to_schedule: int
+    target_episodes: int
     emitted: int = 0
     eval_step: int | None = None
     pinned_client: vf.ClientConfig | None = None
@@ -75,8 +75,8 @@ class Rollout(vf.Trace[DataT], Generic[DataT]):
     returns), so there's no wrapper. Train vs eval is the ``kind`` discriminator. All metadata
     fields are ``exclude=True``, so dumping a Rollout yields a plain trace on the wire; the
     orchestrator mirrors them onto the trace's own fields via ``vf.Trace.record_run`` (``kind`` as
-    ``run.type``, the run id, the step, and ``env_name``/``group_id``/``policy_version`` into
-    ``info``) when a rollout arrives, so the on-disk records stay fully placeable.
+    ``run.type``, the run id, the step, and prime-rl routing metadata under ``info.prime_rl``)
+    when a rollout arrives, so the on-disk records stay fully placeable.
 
     It is also the single currency the scoring hooks receive: a hook reads the trace
     directly (``rollout.reward``, ``rollout.nodes``, ``rollout.num_turns``) and writes
@@ -91,6 +91,7 @@ class Rollout(vf.Trace[DataT], Generic[DataT]):
     # Links the traces of one episode; stamped into ``info`` on arrival so
     # saved records keep their grouping.
     episode_id: str = Field(default="", exclude=True)
+    episode_ok: bool = Field(default=True, exclude=True)
     policy_version: int = Field(default=0, exclude=True)
     off_policy_steps: int = Field(default=0, exclude=True)
     samples: list[TrainingSample] = Field(default_factory=list, exclude=True)
@@ -137,26 +138,76 @@ class Rollout(vf.Trace[DataT], Generic[DataT]):
         return bool(self.advantages) and any(a != 0.0 for a in self.advantages)
 
 
+# Every wire trace validates into this type. WireTaskData preserves task-specific fields without
+# importing the environment package into the orchestrator.
+ROLLOUT_TYPE = Rollout[vf.WireTaskData]
+
+
+@dataclass(frozen=True)
+class TaskItem:
+    """A source item: v1 task data plus prime-rl routing metadata."""
+
+    env_name: str
+    data: vf.TaskData
+    eval_step: int | None = None
+
+
+@dataclass
+class EpisodeResult:
+    """A complete v1 episode with the metadata needed by prime-rl's pipeline."""
+
+    episode: vf.WireEpisode
+    kind: RolloutKind
+    env_name: str
+    group_id: uuid.UUID
+    task_data: vf.TaskData
+    policy_version: int
+    off_policy_steps: int = 0
+    eval_step: int | None = None
+
+    @property
+    def rollouts(self) -> list[Rollout]:
+        """The episode's traces after dispatcher validation and stamping."""
+        return cast(list[Rollout], self.episode.traces)
+
+    def to_record(self) -> dict:
+        """Serialize the canonical episode shell with prime-rl trace records."""
+        record = self.episode.model_dump(mode="json", exclude={"traces"}, exclude_none=True)
+        record["prime_rl"] = {
+            "kind": self.kind,
+            "env_name": self.env_name,
+            "group_id": str(self.group_id),
+            "task": self.task_data.model_dump(mode="json"),
+            "policy_version": self.policy_version,
+            "eval_step": self.eval_step,
+        }
+        record["traces"] = [rollout.to_record() for rollout in self.rollouts]
+        return record
+
+
 @dataclass
 class TrainBatch:
-    """``rollouts`` is the observation window since the last ship — every rollout of every group
+    """``episodes`` is the v1 observation window since the last successful ship;
+    ``rollouts`` is its flattened trace view — every trace of every group
     finalized in that span (errored + filtered included; rollouts of still-incomplete groups wait
     for a later window). Its ``.effective`` / ``.metrics`` views drive logging. ``samples`` is the
     trainer-bound payload (the shipped cohort's post-filter survivors) — an empty list means nothing
     ships, which would stall the trainer. Trainable counts derive from ``rollouts.effective``
     (``r.is_trainable``) and token totals from ``samples``, so neither is carried as a field."""
 
+    episodes: list[EpisodeResult]
     rollouts: TrainRollouts
     samples: list[TrainingSample]
 
 
 @dataclass
 class EvalBatch:
-    """One env's eval epoch. ``rollouts`` is the full returned cohort (errored included); its
-    ``.effective`` / ``.metrics`` views drive logging."""
+    """One env's eval epoch. ``episodes`` is the canonical returned cohort and
+    ``rollouts`` its flattened trace view; ``.effective`` / ``.metrics`` drive logging."""
 
     env_name: str
     step: int
+    episodes: list[EpisodeResult]
     rollouts: EvalRollouts
 
 

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -49,15 +49,17 @@ async def setup_policy_inference_pool(*, config: OrchestratorConfig, tokenizer):
     return renderer, inference_pool
 
 
-def save_rollouts(rollouts: list[dict], path: Path) -> None:
-    """Append rollouts (Trace record dicts, already JSON-serializable) to a JSONL file.
-    The trace streams are append-only: ``all`` grows one rollout at a time as they
-    complete, ``effective`` one batch at a time on finalize."""
+def save_rollouts(records: list[dict], path: Path) -> None:
+    """Append JSON-serializable records to a trace JSONL stream.
+
+    The ``all`` stream stores one v1 episode per line; ``effective`` stores the
+    selected trace projection when a train or eval batch finalizes.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     opts = orjson.OPT_APPEND_NEWLINE | orjson.OPT_SERIALIZE_NUMPY
     with open(path, "ab") as f:
-        for rollout in rollouts:
-            f.write(orjson.dumps(rollout, default=str, option=opts))
+        for record in records:
+            f.write(orjson.dumps(record, default=str, option=opts))
 
 
 def intercept_vf_logging(logger: str = "verifiers", level: str = "DEBUG", prefix: str | None = None):

--- a/tests/unit/orchestrator/test_metrics.py
+++ b/tests/unit/orchestrator/test_metrics.py
@@ -7,8 +7,8 @@ import pytest
 import verifiers.v1 as vf
 
 from prime_rl.orchestrator.eval_sink import EvalSink
-from prime_rl.orchestrator.metrics import EvalRollouts, Stat, TrainRollouts
-from prime_rl.orchestrator.types import EpisodeResult
+from prime_rl.orchestrator.metrics import EvalEpisodes, Stat, TrainEpisodes
+from prime_rl.orchestrator.types import Episode
 from prime_rl.orchestrator.utils import compute_pass_metrics
 
 _ids = count()
@@ -27,7 +27,6 @@ def mk(
     is_truncated: bool = False,
     is_completed: bool = True,
     has_error: bool = False,
-    episode_ok: bool = True,
     error_type: str = "error",
     stop_condition: str | None = None,
     metrics: dict | None = None,
@@ -61,7 +60,6 @@ def mk(
         is_truncated=is_truncated,
         is_completed=is_completed,
         has_error=has_error,
-        episode_ok=episode_ok,
         last_error=SimpleNamespace(type=error_type) if has_error else None,
         stop_condition=stop_condition,
         metrics=metrics or {},
@@ -85,7 +83,32 @@ def mk(
 
 
 def train_wandb(rollouts, subset: str = "all") -> dict:
-    return TrainRollouts(rollouts).metrics.to_wandb(prefix="train/agg", subset=subset)
+    return train_episodes(rollouts).metrics.to_wandb(prefix="train/agg", subset=subset)
+
+
+def episode_collection(collection_type, traces):
+    grouped = {}
+    for trace in traces:
+        grouped.setdefault(trace.episode_id or trace.id, []).append(trace)
+    episodes = [
+        SimpleNamespace(
+            id=episode_id,
+            ok=not any(trace.has_error for trace in episode_traces),
+            traces=episode_traces,
+            env_name=episode_traces[0].env_name,
+            group_id=episode_traces[0].group_id,
+        )
+        for episode_id, episode_traces in grouped.items()
+    ]
+    return collection_type(episodes)
+
+
+def train_episodes(traces):
+    return episode_collection(TrainEpisodes, traces)
+
+
+def eval_episodes(traces):
+    return episode_collection(EvalEpisodes, traces)
 
 
 def test_stat():
@@ -96,22 +119,20 @@ def test_stat():
     assert Stat([]).p90() == 0.0 and Stat([]).to_dict("p") == {}
 
 
-def test_container_effective_by_env_and_listlike():
-    rc = TrainRollouts(
+def test_episode_collection_effective_and_by_env():
+    rc = train_episodes(
         [mk(env_name="a"), mk(env_name="a", has_error=True), mk(env_name="b", is_filtered=True), mk(env_name="b")]
     )
-    assert len(rc) == 4 and [r.env_name for r in rc] == ["a", "a", "b", "b"]  # sized + iterable
+    assert len(rc) == 4 and [episode.env_name for episode in rc] == ["a", "a", "b", "b"]
     eff = rc.effective
-    assert isinstance(eff, TrainRollouts) and len(eff) == 2  # same type, errored + filtered dropped
-    assert all(not r.has_error and not r.is_filtered and r in rc.rollouts for r in eff)  # view of references
+    assert isinstance(eff, TrainEpisodes) and len(eff) == 2
+    assert all(not trace.has_error and not trace.is_filtered and trace in rc.traces for trace in eff.traces)
     by_env = rc.by_env()
-    assert set(by_env) == {"a", "b"} and len(by_env["a"]) == 2 and isinstance(by_env["a"], TrainRollouts)
-    rc.append(mk())
-    assert len(rc) == 5
+    assert set(by_env) == {"a", "b"} and len(by_env["a"]) == 2 and isinstance(by_env["a"], TrainEpisodes)
 
 
 def test_to_wandb_distributions():
-    m = TrainRollouts(
+    m = train_episodes(
         [
             mk(reward=1.0, num_total_tokens=10, num_input_tokens=4),
             mk(reward=0.0, num_total_tokens=20, num_input_tokens=6),
@@ -137,7 +158,7 @@ def test_episode_and_agent_levels():
         mk(reward=1.0, num_turns=6, agent_name="solver", episode_id="e2"),
         mk(reward=0.0, num_turns=8, agent_name="solver", episode_id="e2"),
     ]
-    m = TrainRollouts(rollouts).metrics
+    m = train_episodes(rollouts).metrics
     assert m.num_turns.mean() == 12.0  # episode-level sums: 1+2+4 and 3+6+8
     assert m.num_total_tokens.values == [30.0, 30.0]  # summed across the episode's traces
     out = m.to_wandb(prefix="train/agg", subset="all")
@@ -159,7 +180,7 @@ def test_agent_metrics_are_flat_over_traces():
         mk(agent_name="solver", episode_id="e1", is_truncated=True, reward=1.0),
         *[mk(agent_name="solver", episode_id="e2", is_truncated=False, reward=0.0) for _ in range(3)],
     ]
-    out = TrainRollouts(rollouts).metrics.to_wandb(prefix="train/agg", subset="all")
+    out = train_episodes(rollouts).metrics.to_wandb(prefix="train/agg", subset="all")
     assert out["train/agg/all/solver/is_truncated/mean"] == 0.25  # 1 of 4 traces, not (1.0 + 0.0) / 2
     assert out["train/agg/all/solver/is_completed/mean"] == 1.0
     assert out["train/agg/all/solver/is_trainable/mean"] == 1.0  # sibling rates agree
@@ -167,7 +188,7 @@ def test_agent_metrics_are_flat_over_traces():
 
 
 def test_boolean_rates_and_error_breakdown_all_only():
-    rc = TrainRollouts([mk(is_truncated=True), mk(has_error=True, error_type="ProviderError"), mk(is_filtered=True)])
+    rc = train_episodes([mk(is_truncated=True), mk(has_error=True, error_type="ProviderError"), mk(is_filtered=True)])
     out = rc.metrics.to_wandb(prefix="train/agg", subset="all")
     assert out["train/agg/all/agent/is_truncated/mean"] == 1 / 3
     assert out["train/agg/all/agent/is_completed/mean"] == 1.0
@@ -178,8 +199,8 @@ def test_boolean_rates_and_error_breakdown_all_only():
     eff = rc.effective.metrics.to_wandb(prefix="train/agg", subset="effective")
     assert not any(k.endswith("/has_error/mean") or "/error/" in k for k in eff)
 
-    failed_episode = SimpleNamespace(episode=SimpleNamespace(id="failed", ok=False), env_name="env")
-    zero_trace = TrainRollouts([], [failed_episode]).metrics.to_wandb(prefix="train/agg", subset="all")
+    failed_episode = SimpleNamespace(id="failed", ok=False, traces=[], env_name="env")
+    zero_trace = TrainEpisodes([failed_episode]).metrics.to_wandb(prefix="train/agg", subset="all")
     assert zero_trace["train/agg/all/has_error/mean"] == 1.0
     assert zero_trace["train/agg/all/num_total_tokens/mean"] == 0.0
 
@@ -210,7 +231,7 @@ def test_nested_metrics_and_rewards():
         # scoring failed after seeding: unscored (None) entries count as 0.0 on `all`
         mk(has_error=True, metrics={"acc": None}, rewards={"correct": None, "format": None}),
     ]
-    rc = TrainRollouts(rollouts)
+    rc = train_episodes(rollouts)
     m = rc.metrics
     agent = m.by_agent()["agent"]
     assert agent.metrics["acc"].mean() == pytest.approx(4 / 3)  # nested group access
@@ -225,13 +246,15 @@ def test_nested_metrics_and_rewards():
     assert eff["train/agg/effective/agent/rewards/format/mean"] == 0.5
     # cross-env agg: another env's unscored trace carries different keys, so it can't dilute these
     other = mk(env_name="other", has_error=True, rewards={"solved": None})
-    agg = TrainRollouts(rollouts + [other]).metrics.to_wandb(prefix="train/agg", subset="all")
+    agg = train_episodes(rollouts + [other]).metrics.to_wandb(prefix="train/agg", subset="all")
     assert agg["train/agg/all/agent/rewards/format/mean"] == pytest.approx(1 / 3)
     assert agg["train/agg/all/agent/rewards/solved/mean"] == 0.0
 
 
 def test_nested_timing():
-    m = TrainRollouts([mk(setup=1.0, agent=2.0, agent_model=1.5, agent_harness=0.5, finalize=0.5, scoring=0.5)]).metrics
+    m = train_episodes(
+        [mk(setup=1.0, agent=2.0, agent_model=1.5, agent_harness=0.5, finalize=0.5, scoring=0.5)]
+    ).metrics
     timing = m.by_agent()["agent"].timing
     assert timing.setup.mean() == 1.0 and timing.total.mean() == 4.0  # total sums all four phases
     assert timing.agent_model.mean() == 1.5 and timing.agent_harness.mean() == 0.5
@@ -252,12 +275,12 @@ def test_train_only_metrics_absent_from_eval():
     assert out["train/agg/all/agent/is_filtered/mean"] == 0.5
     assert out["train/agg/all/agent/filters/gibberish/mean"] == 0.5
     assert "train/agg/all/is_trainable/mean" not in out  # pipeline verdicts are per-trace
-    eval_out = EvalRollouts(rollouts).metrics.to_wandb(prefix="eval/x", subset="all")
+    eval_out = eval_episodes(rollouts).metrics.to_wandb(prefix="eval/x", subset="all")
     assert not any("is_trainable" in k or "is_filtered" in k or "/filters/" in k for k in eval_out)
 
 
 def test_eval_avg_at_k_and_pass_k():
-    binary = EvalRollouts([mk(reward=1.0, group_id="g0"), mk(reward=0.0, group_id="g0")])
+    binary = eval_episodes([mk(reward=1.0, group_id="g0"), mk(reward=0.0, group_id="g0")])
     eff = binary.effective.metrics.to_wandb(prefix="eval/x", subset="effective")
     assert eff["eval/x/effective/agent/avg@2"] == 0.5  # mean reward under avg@<k> (k from the groups)
     assert "eval/x/effective/avg@2" not in eff  # scores are per-agent, never pooled
@@ -265,10 +288,10 @@ def test_eval_avg_at_k_and_pass_k():
     all_out = binary.metrics.to_wandb(prefix="eval/x", subset="all")
     assert all_out["eval/x/all/agent/avg@2"] == 0.5
     assert not any("pass@" in k or "pass^" in k for k in all_out)  # pass@k effective-only
-    non_binary = EvalRollouts([mk(reward=0.5, group_id="g0"), mk(reward=1.0, group_id="g0")])
+    non_binary = eval_episodes([mk(reward=0.5, group_id="g0"), mk(reward=1.0, group_id="g0")])
     assert not any("pass@" in k for k in non_binary.effective.metrics.to_wandb(prefix="eval/x", subset="effective"))
 
-    multi_agent = EvalRollouts(
+    multi_agent = eval_episodes(
         [
             mk(agent_name="proposer", group_id="g0"),
             mk(agent_name="solver", group_id="g0"),
@@ -294,12 +317,10 @@ def test_zero_trace_episode_survives_eval_sink_and_persistence():
     task_data = vf.TaskData(idx=3, prompt="prompt")
     env = SimpleNamespace(config=SimpleNamespace(group_size=1), eval_tasks=[task_data])
     sink = EvalSink(eval_envs=SimpleNamespace(get=lambda _name: env))
-    result = EpisodeResult(
-        episode=vf.WireEpisode(
-            env={"id": "test-v1"},
-            ok=False,
-            errors=[vf.Error(type="TaskError", message="failed before tracing")],
-        ),
+    episode = Episode(
+        env={"id": "test-v1"},
+        ok=False,
+        errors=[vf.Error(type="TaskError", message="failed before tracing")],
         kind="eval",
         env_name="test",
         group_id=uuid.uuid4(),
@@ -308,11 +329,11 @@ def test_zero_trace_episode_survives_eval_sink_and_persistence():
         eval_step=7,
     )
 
-    batch = sink.add(result)
+    batch = sink.add(episode)
     assert batch is not None
-    assert batch.episodes == [result]
-    assert len(batch.rollouts) == 0
-    assert batch.rollouts.metrics.has_error.mean() == 1.0
-    assert result.to_record()["traces"] == []
-    assert result.to_record()["prime_rl"]["group_id"] == str(result.group_id)
-    assert result.to_record()["prime_rl"]["task"] == task_data.model_dump(mode="json")
+    assert list(batch.episodes) == [episode]
+    assert batch.episodes.traces == []
+    assert batch.episodes.metrics.has_error.mean() == 1.0
+    assert episode.to_record()["traces"] == []
+    assert episode.to_record()["prime_rl"]["group_id"] == str(episode.group_id)
+    assert episode.to_record()["prime_rl"]["task"] == task_data.model_dump(mode="json")

--- a/tests/unit/orchestrator/test_metrics.py
+++ b/tests/unit/orchestrator/test_metrics.py
@@ -1,11 +1,14 @@
 import math
+import uuid
 from itertools import count
 from types import SimpleNamespace
 
 import pytest
 import verifiers.v1 as vf
 
+from prime_rl.orchestrator.eval_sink import EvalSink
 from prime_rl.orchestrator.metrics import EvalRollouts, Stat, TrainRollouts
+from prime_rl.orchestrator.types import EpisodeResult
 from prime_rl.orchestrator.utils import compute_pass_metrics
 
 _ids = count()
@@ -24,6 +27,7 @@ def mk(
     is_truncated: bool = False,
     is_completed: bool = True,
     has_error: bool = False,
+    episode_ok: bool = True,
     error_type: str = "error",
     stop_condition: str | None = None,
     metrics: dict | None = None,
@@ -57,6 +61,7 @@ def mk(
         is_truncated=is_truncated,
         is_completed=is_completed,
         has_error=has_error,
+        episode_ok=episode_ok,
         last_error=SimpleNamespace(type=error_type) if has_error else None,
         stop_condition=stop_condition,
         metrics=metrics or {},
@@ -173,6 +178,11 @@ def test_boolean_rates_and_error_breakdown_all_only():
     eff = rc.effective.metrics.to_wandb(prefix="train/agg", subset="effective")
     assert not any(k.endswith("/has_error/mean") or "/error/" in k for k in eff)
 
+    failed_episode = SimpleNamespace(episode=SimpleNamespace(id="failed", ok=False), env_name="env")
+    zero_trace = TrainRollouts([], [failed_episode]).metrics.to_wandb(prefix="train/agg", subset="all")
+    assert zero_trace["train/agg/all/has_error/mean"] == 1.0
+    assert zero_trace["train/agg/all/num_total_tokens/mean"] == 0.0
+
 
 def test_solve_rates():
     groups = {"A": [1.0, 1.0], "B": [0.0, 0.0], "C": [1.0, 0.0], "D": [1.0, 0.0]}  # all / none / some / some
@@ -258,6 +268,19 @@ def test_eval_avg_at_k_and_pass_k():
     non_binary = EvalRollouts([mk(reward=0.5, group_id="g0"), mk(reward=1.0, group_id="g0")])
     assert not any("pass@" in k for k in non_binary.effective.metrics.to_wandb(prefix="eval/x", subset="effective"))
 
+    multi_agent = EvalRollouts(
+        [
+            mk(agent_name="proposer", group_id="g0"),
+            mk(agent_name="solver", group_id="g0"),
+            mk(agent_name="solver", group_id="g0"),
+            mk(agent_name="proposer", group_id="g0"),
+            mk(agent_name="solver", group_id="g0"),
+            mk(agent_name="solver", group_id="g0"),
+        ]
+    ).metrics.to_wandb(prefix="eval/x", subset="all")
+    assert "eval/x/all/proposer/avg@2" in multi_agent
+    assert "eval/x/all/solver/avg@4" in multi_agent
+
 
 def test_compute_pass_metrics_matches_closed_form():
     out = compute_pass_metrics([1.0, 1.0, 0.0, 0.0])  # n=4, c=2
@@ -265,3 +288,31 @@ def test_compute_pass_metrics_matches_closed_form():
     assert out["pass@2"] == 1.0 - math.comb(2, 2) / math.comb(4, 2)
     assert out["pass^2"] == math.comb(2, 2) / math.comb(4, 2)
     assert set(out) == {"pass@1", "pass@2", "pass@4", "pass^1", "pass^2", "pass^4"}
+
+
+def test_zero_trace_episode_survives_eval_sink_and_persistence():
+    task_data = vf.TaskData(idx=3, prompt="prompt")
+    env = SimpleNamespace(config=SimpleNamespace(group_size=1), eval_tasks=[task_data])
+    sink = EvalSink(eval_envs=SimpleNamespace(get=lambda _name: env))
+    result = EpisodeResult(
+        episode=vf.WireEpisode(
+            env={"id": "test-v1"},
+            ok=False,
+            errors=[vf.Error(type="TaskError", message="failed before tracing")],
+        ),
+        kind="eval",
+        env_name="test",
+        group_id=uuid.uuid4(),
+        task_data=task_data,
+        policy_version=2,
+        eval_step=7,
+    )
+
+    batch = sink.add(result)
+    assert batch is not None
+    assert batch.episodes == [result]
+    assert len(batch.rollouts) == 0
+    assert batch.rollouts.metrics.has_error.mean() == 1.0
+    assert result.to_record()["traces"] == []
+    assert result.to_record()["prime_rl"]["group_id"] == str(result.group_id)
+    assert result.to_record()["prime_rl"]["task"] == task_data.model_dump(mode="json")

--- a/tests/unit/orchestrator/test_qwen3_vl_e2e.py
+++ b/tests/unit/orchestrator/test_qwen3_vl_e2e.py
@@ -1,7 +1,7 @@
 """End-to-end integration test for the Qwen3-VL renderer path.
 
-Walks a multimodal request through the full client stack — RendererClient
-→ renderers.client.generate → /inference/v1/generate features payload —
+Walks a multimodal request through the renderer transport used by the v1
+train client — renderers.client.generate → /inference/v1/generate —
 with the HTTP layer mocked, and verifies that vLLM can deserialize the
 features back into engine inputs identical to what its own server-side
 processor would have produced for the same messages.
@@ -14,13 +14,15 @@ sampling tokens, and returning them) is exercised in real rollouts.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
+from io import BytesIO
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
 
 import httpx
 import pytest
+import verifiers.v1 as vf
 
 _HF_CACHE = Path("~/.cache/huggingface/hub").expanduser()
 _MODEL = "Qwen/Qwen3-VL-4B-Instruct"
@@ -43,7 +45,7 @@ pytestmark = pytest.mark.skipif(
 class _FakeOpenAI:
     """Minimal AsyncOpenAI stand-in that captures POST bodies.
 
-    The renderer client calls ``client.post(absolute_url, body=...)``;
+    The renderer transport calls ``client.post(absolute_url, body=...)``;
     we capture the body for assertions and return a canned generate
     response so the parse-side of the flow runs.
     """
@@ -64,9 +66,9 @@ class _FakeOpenAI:
                     "token_ids": [50, 60, 151645],
                     "logprobs": {
                         "content": [
-                            {"token": "t1", "logprob": -0.1},
-                            {"token": "t2", "logprob": -0.2},
-                            {"token": "t3", "logprob": -0.3},
+                            {"token": "token_id:50", "logprob": -0.1},
+                            {"token": "token_id:60", "logprob": -0.2},
+                            {"token": "token_id:151645", "logprob": -0.3},
                         ]
                     },
                     "finish_reason": "stop",
@@ -76,8 +78,8 @@ class _FakeOpenAI:
         return httpx.Response(200, content=json.dumps(payload).encode())
 
 
-def test_renderer_client_qwen3_vl_e2e_features_payload_roundtrips_through_vllm():
-    """Walk a Qwen3-VL multimodal turn through the renderer client and
+def test_v1_train_client_qwen3_vl_features_payload_roundtrips_through_vllm(monkeypatch):
+    """Walk a Qwen3-VL multimodal turn through the v1 renderer transport and
     verify the resulting ``/inference/v1/generate`` body has a valid
     ``features`` payload that:
 
@@ -91,11 +93,8 @@ def test_renderer_client_qwen3_vl_e2e_features_payload_roundtrips_through_vllm()
     from renderers.base import load_tokenizer
     from renderers.qwen3_vl import Qwen3VLRenderer
     from transformers import AutoProcessor
-    from verifiers.clients.renderer_client import RendererClient
-    from verifiers.types import (
-        ClientConfig,
-        UserMessage,
-    )
+    from verifiers.v1.clients.train import ElasticRendererPool, RendererSlot, TrainClient
+    from verifiers.v1.dialects import ChatDialect
     from vllm.entrypoints.scale_out.token_in_token_out.mm_serde import decode_mm_kwargs_item
     from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateRequest
 
@@ -106,47 +105,51 @@ def test_renderer_client_qwen3_vl_e2e_features_payload_roundtrips_through_vllm()
 
     image_pad_id = tokenizer.convert_tokens_to_ids("<|image_pad|>")
 
-    # ── Manually wire a RendererClient bypassing the pool factory. ──────
-    client_cfg = ClientConfig(client_type="renderer", base_url="http://fake-host:8000/v1")
-    rc = object.__new__(RendererClient)
-    rc._config = client_cfg
-    rc._renderer = renderer
-    rc._pool_size = 1
-    rc._client = _FakeOpenAI()
-    rc.logger = MagicMock()
+    # ── Seed the v1 train client's shared renderer pool. ────────────────
+    monkeypatch.setattr(ElasticRendererPool, "_renderers", {})
+    pool = ElasticRendererPool(_MODEL, None, multiplex=1)
+    pool.renderers.append(RendererSlot(renderer))
 
-    # ── Build a verifiers-shaped user message with an image. ────────────
-    img = Image.new("RGB", (224, 224), color=(64, 128, 255))
-    # The renderer accepts the OpenAI ``image_url`` content-part shape —
-    # the same shape verifiers' UserMessage carries through.
-    user = UserMessage(
-        content=[
-            {"type": "text", "text": "What's in this picture?"},
-            # Embed the PIL image directly. The verifiers→renderer message
-            # converter forwards content unchanged for our purposes.
-            {"type": "image", "image": img},
-        ]
+    config = vf.TrainClientConfig(
+        base_url="http://fake-host:8000/v1",
+        renderer_model_name=_MODEL,
+        multiplex=1,
     )
+    client = object.__new__(TrainClient)
+    client.config = config
+    fake = _FakeOpenAI()
+    client.client = fake
 
-    # to_native_prompt converts to renderer-shaped messages.
-    prompt, _ = asyncio.run(rc.to_native_prompt([user]))
-    sampling = {"max_tokens": 16}
+    # ── Build the OpenAI request body parsed by the v1 ChatDialect. ─────
+    img = Image.new("RGB", (224, 224), color=(64, 128, 255))
+    image_bytes = BytesIO()
+    img.save(image_bytes, format="PNG")
+    image_url = f"data:image/png;base64,{base64.b64encode(image_bytes.getvalue()).decode()}"
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What's in this picture?"},
+                    {"type": "image_url", "image_url": {"url": image_url}},
+                ],
+            }
+        ]
+    }
 
     response = asyncio.run(
-        rc.get_native_response(
-            prompt=prompt,
+        client.get_response(
+            dialect=ChatDialect(),
+            body=body,
             model=_MODEL,
-            sampling_args=sampling,
-            tools=None,
+            sampling_args=vf.SamplingConfig(max_tokens=16),
         )
     )
 
     # ── The HTTP body should carry a features payload. ──────────────────
-    fake = rc.client
-    assert isinstance(fake, _FakeOpenAI)
     assert len(fake.calls) == 1
     body = fake.calls[0]["body"]
-    assert "features" in body, "RendererClient should ship features for image content"
+    assert "features" in body, "TrainClient should ship features for image content"
     features = body["features"]
 
     # ── Pydantic-roundtrip through vLLM's GenerateRequest model. ────────
@@ -184,7 +187,8 @@ def test_renderer_client_qwen3_vl_e2e_features_payload_roundtrips_through_vllm()
     assert item["image_grid_thw"].data.tolist() == expected_grid
 
     # ── Response parsed through renderer's parse_response. ──────────────
-    assert response["completion_ids"] == [50, 60, 151645]
-    # multi_modal_data surfaces on the result so the caller can persist it.
-    assert response["multi_modal_data"] is not None
-    assert len(response["multi_modal_data"].mm_items["image"]) == 1
+    assert response.tokens is not None
+    assert response.tokens.completion_ids == [50, 60, 151645]
+    # multi_modal_data surfaces on the result so the v1 client can persist it.
+    assert response.tokens.multi_modal_data is not None
+    assert len(response.tokens.multi_modal_data.mm_items["image"]) == 1

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -590,9 +590,23 @@ def test_orchestrator_renderer_auto_rejects_unmapped_model():
 
 def test_orchestrator_renderer_auto_accepts_mapped_model():
     """The default Qwen model is in MODEL_RENDERER_MAP and should validate cleanly."""
-    config = OrchestratorConfig.model_validate({"model": {"name": "Qwen/Qwen3-0.6B"}})
+    config = OrchestratorConfig.model_validate(
+        {
+            "model": {"name": "Qwen/Qwen3-0.6B"},
+            "batch_size": 5,
+            "group_size": 4,
+            "max_inflight_episodes": 1,
+            "eval": {
+                "num_tasks": 2,
+                "source": [{"env": {"taskset": {"id": "reverse-text-v1"}}}],
+            },
+        }
+    )
     assert config.renderer is not None
     assert config.renderer.name == "auto"
+    assert config.max_inflight_episodes == 1
+    assert config.eval is not None
+    assert config.eval.source[0].num_tasks == 2
 
 
 def test_sft_renderer_auto_accepts_prime_qwen_model():


### PR DESCRIPTION
Stacked on #3219; merge that PR first.

Targets prime-rl 0.8.0 and the checked-out verifiers v0.3.0 tag.

## Summary

- make the typed v1 `Episode` the sole orchestration currency from dispatch through sinks, batches, metrics, and persistence; remove `EpisodeResult`, copied `episode_ok` state, and parallel episode/rollout buffers
- derive flattened trace, effective-subset, and per-environment views from their parent episodes while preserving zero-trace failures and multi-agent episodes
- make scheduling and batching episode-native: derive capacity from in-flight work, allow groups larger than capacity, preserve complete task groups at trainer-batch boundaries, and separate episode failures from trace errors
- tighten v1-only lifecycle and configuration around canonical taskset iteration/`head()`, `num_tasks`, train-only source ratios, client shutdown, and the v1 renderer client
- update configs, docs, metrics guidance, and the monitoring skill for the episode JSONL schema and per-agent eval semantics

## Validation

- `ruff check` passed on the changed Python surface
- `ruff format --check` passed on the changed Python surface
- focused orchestrator unit suite — 72 passed
- focused config validation — 2 passed
- dispatcher/train-sink/eval-sink import smoke passed
- successful v1 episode conversion and record round-trip smoke passed

The optional Qwen3-VL/vLLM integration test was migrated to the v1 `TrainClient` path and linted, but was not executed in this local macOS environment.