### PR TITLE
fix: preserve CE-only zero-advantage rollouts

### DIFF
--- a/src/prime_rl/orchestrator/filters.py
+++ b/src/prime_rl/orchestrator/filters.py
@@ -99,15 +99,20 @@ class RepetitionFilter:
 @dataclass
 class ZeroAdvantageFilter:
     """Flags rollouts whose advantage stream is all zero (e.g. all rollouts in
-    a GRPO group earned the same reward, so the centered advantage collapses)."""
+    a GRPO group earned the same reward, so the centered advantage collapses),
+    unless another loss component still provides CE supervision."""
 
     name: str
     enforce: bool = True
 
     def check(self, rollout: Rollout) -> FilterResult:
-        if rollout.advantages is not None and all(a == 0.0 for a in rollout.advantages):
-            return FilterResult(detected=True)
-        return FilterResult(detected=False)
+        if rollout.advantages is None or any(a != 0.0 for a in rollout.advantages):
+            return FilterResult(detected=False)
+        has_ce_supervision = any(
+            sample.ce_weights is not None and any(weight != 0.0 for weight in sample.ce_weights)
+            for sample in rollout.samples
+        )
+        return FilterResult(detected=not has_ce_supervision)
 
 
 def setup_filter(config: FilterConfig, vocab_size: int) -> RolloutFilter:

--- a/tests/unit/orchestrator/test_algorithms.py
+++ b/tests/unit/orchestrator/test_algorithms.py
@@ -9,6 +9,7 @@ from verifiers.v1.types import AssistantMessage, ToolMessage, UserMessage
 
 from prime_rl.configs.algorithm import AlgoConfig, FrozenModelConfig
 from prime_rl.orchestrator.algo import EchoAlgorithm, stamp_advantages, stamp_loss_routing
+from prime_rl.orchestrator.filters import ZeroAdvantageFilter, apply_filters
 from prime_rl.orchestrator.trajectories import trace_to_samples
 from prime_rl.orchestrator.types import Rollout
 from prime_rl.transport.types import TrainingSample
@@ -244,7 +245,7 @@ def _node(message, *, parent, sampled, token_ids, logprobs=None, is_content=None
     )
 
 
-def _two_turn_rollout(observation_role: str = "tool") -> Rollout:
+def _two_turn_rollout(observation_role: str = "tool", reward: float = 1.0) -> Rollout:
     """A single linear branch: user prompt, an assistant response, an
     env-provided observation (tool output / user feedback), then a second
     assistant response. Tokens: prompt [1,2], action [3,4], observation
@@ -263,11 +264,36 @@ def _two_turn_rollout(observation_role: str = "tool") -> Rollout:
         task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt=None)),
         agent=vf.AgentInfo(config=vf.AgentConfig()),
         nodes=nodes,
-        rewards={"r": vf.Reward(score=1.0)},
+        rewards={"r": vf.Reward(score=reward)},
         env_name="test-env",
     )
     rollout.samples = trace_to_samples(rollout, env_name="test-env")
     return rollout
+
+
+@pytest.mark.parametrize(
+    ("rewards", "observation_role", "expected_samples"),
+    [
+        pytest.param([1.0, 1.0], "tool", 2, id="zero-advantage-with-ce"),
+        pytest.param([1.0, 1.0], "user", 0, id="zero-advantage-without-ce"),
+        pytest.param([0.0, 1.0], "tool", 2, id="nonzero-advantage-with-ce"),
+        pytest.param([0.0, 1.0], "user", 2, id="nonzero-advantage-without-ce"),
+    ],
+)
+def test_echo_zero_advantage_filter_preserves_ce_supervision(rewards, observation_role, expected_samples):
+    algo = _echo_algorithm()
+    group = [_two_turn_rollout(observation_role, reward) for reward in rewards]
+
+    async def finalize_group():
+        for rollout in group:
+            await algo.finalize_rollout(rollout)
+        await algo.finalize_group(group)
+
+    asyncio.run(finalize_group())
+    apply_filters([ZeroAdvantageFilter(name="zero_advantage")], group)
+
+    trainer_bound_samples = [sample for rollout in group if not rollout.is_filtered for sample in rollout.samples]
+    assert len(trainer_bound_samples) == expected_samples
 
 
 def test_echo_weights_observations_by_role():


### PR DESCRIPTION
Found a case where `ZeroAdvantageFilter` was dropping useful ECHO training signal.

When every rollout in a GRPO group gets the same reward, the centered advantages become zero. That normally makes sense to filter for GRPO, but ECHO still has valid CE supervision on its observation/tool-output tokens regardless of whether the group has reward variance.

The filter was only checking advantages, so rollouts with CE signal were getting dropped before reaching the trainer.

This changes the filter so zero-advantage rollouts are only removed when they also have no CE supervision.

Added regression coverage for zero/nonzero advantage with and without CE signal.
