### PR TITLE
fix: preserve non-RL signals in zero-advantage rollouts

### DIFF
--- a/src/prime_rl/orchestrator/filters.py
+++ b/src/prime_rl/orchestrator/filters.py
@@ -99,15 +99,16 @@ class RepetitionFilter:
 @dataclass
 class ZeroAdvantageFilter:
     """Flags rollouts whose advantage stream is all zero (e.g. all rollouts in
-    a GRPO group earned the same reward, so the centered advantage collapses)."""
+    a GRPO group earned the same reward, so the centered advantage collapses),
+    unless a non-RL loss component still provides supervision."""
 
     name: str
     enforce: bool = True
 
     def check(self, rollout: Rollout) -> FilterResult:
-        if rollout.advantages is not None and all(a == 0.0 for a in rollout.advantages):
-            return FilterResult(detected=True)
-        return FilterResult(detected=False)
+        if rollout.advantages is None or any(a != 0.0 for a in rollout.advantages):
+            return FilterResult(detected=False)
+        return FilterResult(detected=not rollout.has_non_rl_loss_signal)
 
 
 def setup_filter(config: FilterConfig, vocab_size: int) -> RolloutFilter:

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -134,6 +134,15 @@ class Rollout(vf.Trace[DataT], Generic[DataT]):
         return sum(nonzero) / len(nonzero) if nonzero else 0.0
 
     @property
+    def has_non_rl_loss_signal(self) -> bool:
+        """Whether any sample has nonzero weight in a non-RL loss component."""
+        return any(
+            weights is not None and any(weight != 0.0 for weight in weights)
+            for sample in self.samples
+            for weights in (sample.ce_weights, sample.ref_kl_weights)
+        )
+
+    @property
     def is_trainable(self) -> bool:
         """Whether the rollout carries a training signal — a nonzero advantage on some token. A
         uniform-reward GRPO group (all-zero advantages) or an unscored rollout has no gradient."""

--- a/tests/unit/orchestrator/test_algorithms.py
+++ b/tests/unit/orchestrator/test_algorithms.py
@@ -9,6 +9,7 @@ from verifiers.v1.types import AssistantMessage, ToolMessage, UserMessage
 
 from prime_rl.configs.algorithm import AlgoConfig, FrozenModelConfig
 from prime_rl.orchestrator.algo import EchoAlgorithm, stamp_advantages, stamp_loss_routing
+from prime_rl.orchestrator.filters import ZeroAdvantageFilter, apply_filters
 from prime_rl.orchestrator.trajectories import trace_to_samples
 from prime_rl.orchestrator.types import Rollout
 from prime_rl.transport.types import TrainingSample
@@ -244,7 +245,7 @@ def _node(message, *, parent, sampled, token_ids, logprobs=None, is_content=None
     )
 
 
-def _two_turn_rollout(observation_role: str = "tool") -> Rollout:
+def _two_turn_rollout(observation_role: str = "tool", reward: float = 1.0) -> Rollout:
     """A single linear branch: user prompt, an assistant response, an
     env-provided observation (tool output / user feedback), then a second
     assistant response. Tokens: prompt [1,2], action [3,4], observation
@@ -263,11 +264,46 @@ def _two_turn_rollout(observation_role: str = "tool") -> Rollout:
         task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt=None)),
         agent=vf.AgentInfo(config=vf.AgentConfig()),
         nodes=nodes,
-        rewards={"r": vf.Reward(score=1.0)},
+        rewards={"r": vf.Reward(score=reward)},
         env_name="test-env",
     )
     rollout.samples = trace_to_samples(rollout, env_name="test-env")
     return rollout
+
+
+@pytest.mark.parametrize(
+    ("rewards", "observation_role", "expected_samples"),
+    [
+        pytest.param([1.0, 1.0], "tool", 2, id="zero-advantage-with-ce"),
+        pytest.param([1.0, 1.0], "user", 0, id="zero-advantage-without-ce"),
+        pytest.param([0.0, 1.0], "tool", 2, id="nonzero-advantage-with-ce"),
+        pytest.param([0.0, 1.0], "user", 2, id="nonzero-advantage-without-ce"),
+    ],
+)
+def test_echo_zero_advantage_filter_preserves_ce_supervision(rewards, observation_role, expected_samples):
+    algo = _echo_algorithm()
+    group = [_two_turn_rollout(observation_role, reward) for reward in rewards]
+
+    async def finalize_group():
+        for rollout in group:
+            await algo.finalize_rollout(rollout)
+        await algo.finalize_group(group)
+
+    asyncio.run(finalize_group())
+    apply_filters([ZeroAdvantageFilter(name="zero_advantage")], group)
+
+    trainer_bound_samples = [sample for rollout in group if not rollout.is_filtered for sample in rollout.samples]
+    assert len(trainer_bound_samples) == expected_samples
+
+
+def test_zero_advantage_filter_preserves_ref_kl_supervision():
+    sample = _make_sample()
+    stamp_loss_routing(sample, "ref_kl")
+    rollout = _make_rollout([sample], advantages=[0.0] * len(sample.token_ids))
+
+    apply_filters([ZeroAdvantageFilter(name="zero_advantage")], [rollout])
+
+    assert rollout.is_filtered is False
 
 
 def test_echo_weights_observations_by_role():


### PR DESCRIPTION
## Problem

`ZeroAdvantageFilter` drops rollouts with all-zero GRPO advantages even when they still contain valid non-RL supervision.

For example, ECHO can still have CE signal on observation tokens when an equal-reward GRPO group produces zero advantages. The same applies to hybrid RL + ref-KL cases.

## Fix

Preserve zero-advantage rollouts whenever they contain nonzero non-RL loss signal through `ce_weights` or `ref_kl_weights`.

Zero-advantage rollouts with no other training signal are still filtered.

## Tests

Added regression coverage for:

* zero advantage + CE signal
* zero advantage + no CE signal
* nonzero advantage with and without CE
* zero advantage + ref-KL signal

53 tests pass, along with Ruff and `git diff --check`.
