### PR TITLE
fix(slurm): export ORCH_PROCID so the orchestrator actually launches

### DIFF
--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -130,6 +130,7 @@ echo "MASTER_PORT=${MASTER_PORT}"
 # The ZMQ rollout transport binds in the orchestrator process, so both sides must
 # address the orchestrator's node.
 {% if num_infer_nodes > 0 and orchestrator_on_inference %}ORCH_PROCID=$((NUM_INFER_NODES - 1)){% else %}ORCH_PROCID=$NUM_INFER_NODES{% endif %}
+export ORCH_PROCID
 export ORCH_ADDR="${HOSTNAMES[$ORCH_PROCID]}"
 echo "ORCH_ADDR=${ORCH_ADDR}"
 


### PR DESCRIPTION
`#3189` hoisted `ORCH_PROCID` out of the srun body into the outer batch script so `ORCH_ADDR` could be derived from it. `ORCH_ADDR` was exported; `ORCH_PROCID` was not.

The srun body is a **quoted** heredoc, so `$ORCH_PROCID` in

```bash
if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
```

is expanded per task, and a plain (unexported) shell variable never reaches the task environment. The test becomes `[ "4" -eq "" ]`, which errors with `integer expression expected` and is false on every rank — so the block that starts **the orchestrator and both env servers** is skipped entirely.

## Verification

Rendered `multi_node_rl.sbatch.j2` and exercised the guard directly:

```
before:  block SKIPPED   (bash: [: : integer expression expected)
after:   ORCH_PROCID is EXPORTED (crosses into srun tasks)
         orchestrator block RUNS on PROCID 4
```

`bash -n` on the rendered script still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line export in the SLURM template; restores intended launch behavior with no auth or data-path changes.
> 
> **Overview**
> **Fixes multi-node RL jobs where the orchestrator (and env servers) never start** because `ORCH_PROCID` was set in the outer SLURM batch script but not exported into `srun` task environments.
> 
> The main launch body runs under a **quoted** heredoc (`<<'LAUNCH_SH'`), so the guard `if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]` reads `ORCH_PROCID` from each task’s environment. After `#3189` hoisted that variable out of the heredoc, only `ORCH_ADDR` was exported; tasks saw an empty `ORCH_PROCID`, the comparison failed on every rank, and the block that starts the orchestrator and env servers was skipped—often leaving inference/trainer up until NCCL timeouts with little obvious logging.
> 
> This change adds **`export ORCH_PROCID`** next to the existing `ORCH_ADDR` export so the correct node runs the orchestrator again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5edc12d0205a29408b2abd2edc10b9f5fcc4a06b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->