### PR TITLE
feat!: drop v0 env compat

### DIFF
--- a/configs/basic/alphabet-sort/rl.toml
+++ b/configs/basic/alphabet-sort/rl.toml
@@ -36,7 +36,7 @@ max_completion_tokens = 768
 name = "alphabet-sort"
 
 [orchestrator.train.source.env.taskset]
-id = "alphabet-sort-v1"
+id = "alphabet-sort"
 min_turns = 3
 max_turns = 5
 

--- a/configs/basic/hendrycks-sanity/rl.toml
+++ b/configs/basic/hendrycks-sanity/rl.toml
@@ -23,7 +23,7 @@ seq_len = 8192
 name = "hendrycks-math"
 
 [orchestrator.train.source.env.taskset]
-id = "math-env-v1"
+id = "math-env"
 dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B"
 dataset_subset = "default"
 

--- a/configs/basic/reverse-text/rl.toml
+++ b/configs/basic/reverse-text/rl.toml
@@ -26,7 +26,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"

--- a/configs/basic/wiki-search/rl.toml
+++ b/configs/basic/wiki-search/rl.toml
@@ -44,7 +44,7 @@ max_completion_tokens = 512
 name = "wiki-search"
 
 [orchestrator.train.source.env.taskset]
-id = "wiki-search-v1"
+id = "wiki-search"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"

--- a/configs/basic/wordle/rl.toml
+++ b/configs/basic/wordle/rl.toml
@@ -25,7 +25,7 @@ group_size = 8
 name = "wordle"
 
 [orchestrator.train.source.env.taskset]
-id = "wordle-v1"
+id = "wordle"
 
 [orchestrator.train.source.env.player.harness]
 id = "null"

--- a/configs/ci/integration/alphabet_sort.toml
+++ b/configs/ci/integration/alphabet_sort.toml
@@ -26,7 +26,7 @@ max_completion_tokens = 384
 name = "alphabet-sort"
 
 [orchestrator.train.source.env.taskset]
-id = "alphabet-sort-v1"
+id = "alphabet-sort"
 min_turns = 2
 max_turns = 2
 min_names_per_turn = 1

--- a/configs/ci/integration/reverse-text-lora/resume.toml
+++ b/configs/ci/integration/reverse-text-lora/resume.toml
@@ -30,7 +30,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"

--- a/configs/ci/integration/reverse-text-lora/start.toml
+++ b/configs/ci/integration/reverse-text-lora/start.toml
@@ -29,7 +29,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"

--- a/configs/ci/integration/reverse-text-moe/start.toml
+++ b/configs/ci/integration/reverse-text-moe/start.toml
@@ -29,7 +29,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"

--- a/configs/ci/integration/reverse-text-rl-opd/start.toml
+++ b/configs/ci/integration/reverse-text-rl-opd/start.toml
@@ -41,7 +41,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -60,7 +60,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.eval.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/configs/ci/integration/reverse-text-rl-sft/start.toml
+++ b/configs/ci/integration/reverse-text-rl-sft/start.toml
@@ -47,7 +47,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -66,7 +66,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.eval.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/configs/ci/integration/reverse-text/resume.toml
+++ b/configs/ci/integration/reverse-text/resume.toml
@@ -27,7 +27,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"

--- a/configs/ci/integration/reverse-text/start.toml
+++ b/configs/ci/integration/reverse-text/start.toml
@@ -26,7 +26,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"

--- a/configs/ci/nightly-fft/alphabet-sort.toml
+++ b/configs/ci/nightly-fft/alphabet-sort.toml
@@ -22,7 +22,7 @@ group_size = 16
 name = "alphabet-sort"
 
 [orchestrator.train.source.env.taskset]
-id = "alphabet-sort-v1"
+id = "alphabet-sort"
 min_turns = 3
 max_turns = 5
 

--- a/configs/ci/nightly-fft/hendrycks-sanity.toml
+++ b/configs/ci/nightly-fft/hendrycks-sanity.toml
@@ -22,7 +22,7 @@ seq_len = 8192
 name = "hendrycks-math"
 
 [orchestrator.train.source.env.taskset]
-id = "math-env-v1"
+id = "math-env"
 dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B"
 dataset_subset = "default"
 
@@ -40,7 +40,7 @@ name = "aime2024"
 group_size = 32
 
 [orchestrator.eval.source.env.taskset]
-id = "aime24-v1"
+id = "aime24"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/configs/ci/nightly-fft/reverse-text.toml
+++ b/configs/ci/nightly-fft/reverse-text.toml
@@ -22,7 +22,7 @@ group_size = 16
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"

--- a/configs/ci/nightly-fft/wiki-search.toml
+++ b/configs/ci/nightly-fft/wiki-search.toml
@@ -27,7 +27,7 @@ enforce = true
 name = "wiki-search"
 
 [orchestrator.train.source.env.taskset]
-id = "wiki-search-v1"
+id = "wiki-search"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"

--- a/configs/ci/nightly-fft/wordle.toml
+++ b/configs/ci/nightly-fft/wordle.toml
@@ -22,7 +22,7 @@ group_size = 16
 name = "wordle"
 
 [orchestrator.train.source.env.taskset]
-id = "wordle-v1"
+id = "wordle"
 
 [orchestrator.train.source.env.player.harness]
 id = "null"

--- a/configs/ci/nightly/multimodal_color_codeword.toml
+++ b/configs/ci/nightly/multimodal_color_codeword.toml
@@ -24,7 +24,7 @@ max_completion_tokens = 64
 name = "color-codeword"
 
 [orchestrator.train.source.env.taskset]
-id = "color-codeword-v1"
+id = "color-codeword"
 images_per_turn = 1
 
 [orchestrator.train.source.env.agent.harness]

--- a/configs/debug/algo/echo.toml
+++ b/configs/debug/algo/echo.toml
@@ -28,7 +28,7 @@ alpha = 0.1
 name = "alphabet-sort"
 
 [orchestrator.train.source.env.taskset]
-id = "alphabet-sort-v1"
+id = "alphabet-sort"
 min_turns = 3
 max_turns = 5
 

--- a/configs/debug/algo/grpo.toml
+++ b/configs/debug/algo/grpo.toml
@@ -25,7 +25,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -44,7 +44,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.eval.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/configs/debug/algo/max_rl.toml
+++ b/configs/debug/algo/max_rl.toml
@@ -25,7 +25,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -44,7 +44,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.eval.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/configs/debug/algo/mixed_grpo_opd.toml
+++ b/configs/debug/algo/mixed_grpo_opd.toml
@@ -35,7 +35,7 @@ max_completion_tokens = 128
 name = "reverse-text-grpo"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -47,7 +47,7 @@ type = "subprocess"
 name = "reverse-text-opd"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -73,7 +73,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.eval.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/configs/debug/algo/opd.toml
+++ b/configs/debug/algo/opd.toml
@@ -37,7 +37,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -56,7 +56,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.eval.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/configs/debug/algo/opd_lora.toml
+++ b/configs/debug/algo/opd_lora.toml
@@ -37,7 +37,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -56,7 +56,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.eval.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/configs/debug/algo/rae.toml
+++ b/configs/debug/algo/rae.toml
@@ -25,7 +25,7 @@ max_completion_tokens = 512
 name = "kuhn-poker"
 
 [orchestrator.train.source.env.taskset]
-id = "kuhn-poker-v1"
+id = "kuhn-poker"
 
 [orchestrator.train.source.env.player0.harness]
 id = "null"
@@ -50,7 +50,7 @@ max_completion_tokens = 512
 name = "kuhn-poker"
 
 [orchestrator.eval.source.env.taskset]
-id = "kuhn-poker-v1"
+id = "kuhn-poker"
 
 [orchestrator.eval.source.env.player0.harness]
 id = "null"

--- a/configs/debug/algo/self_distill.toml
+++ b/configs/debug/algo/self_distill.toml
@@ -33,7 +33,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -52,7 +52,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.eval.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/configs/debug/algo/sft_distill.toml
+++ b/configs/debug/algo/sft_distill.toml
@@ -42,7 +42,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -61,7 +61,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.eval.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/configs/debug/algo/sft_distill_lora.toml
+++ b/configs/debug/algo/sft_distill_lora.toml
@@ -42,7 +42,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -61,7 +61,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.eval.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/configs/debug/multi-env/rl.toml
+++ b/configs/debug/multi-env/rl.toml
@@ -21,7 +21,7 @@ max_completion_tokens = 128
 name = "reverse-text-a"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -33,7 +33,7 @@ type = "subprocess"
 name = "reverse-text-b"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -52,7 +52,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.eval.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -126,7 +126,7 @@ type = "grpo"
 name = "math"  # inherits the top-level grpo
 
 [orchestrator.train.source.env.taskset]
-id = "math-v1"
+id = "math"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -138,7 +138,7 @@ type = "subprocess"
 name = "terminal"
 
 [orchestrator.train.source.env.taskset]
-id = "terminal-v1"
+id = "terminal"
 
 [orchestrator.train.source.env.agent.harness]
 id = "bash"
@@ -354,7 +354,7 @@ The solver attempts for A should not be compared with the solver attempts for B:
 
 For example, if three solvers receive rewards `[1, 1, 0]` on one proposed problem, their average is `2/3` and their advantages are `[1/3, 1/3, -2/3]`. Solver rewards from other proposed problems do not affect those values. The proposers are scored separately according to how useful their problems were for the solvers, then compared with the other proposers in the group.
 
-Configure which roles are compared within a single proposed problem with `episode_agents`. For `proposer-solver-v1`, that role is `solver`:
+Configure which roles are compared within a single proposed problem with `episode_agents`. For `proposer-solver`, that role is `solver`:
 
 ```toml
 [orchestrator.algo]
@@ -367,7 +367,7 @@ group_size = 4  # proposed problems per source task
 env.n = 4  # solver attempts per proposed problem
 
 [orchestrator.train.source.env.taskset]
-id = "proposer-solver-v1"
+id = "proposer-solver"
 
 [orchestrator.train.source.env.proposer.harness]
 id = "null"
@@ -401,7 +401,7 @@ decay = 0.95
 name = "kuhn-poker"
 
 [orchestrator.train.source.env.taskset]
-id = "kuhn-poker-v1"
+id = "kuhn-poker"
 
 [orchestrator.train.source.env.player0.harness]
 id = "null"
@@ -416,7 +416,7 @@ id = "null"
 type = "subprocess"
 ```
 
-Both of `kuhn-poker-v1`'s agents late-bind to the run's own model — shared-policy self-play against a continuously improving opponent. Pin one agent to a frozen endpoint (`env.player1.model = ...`) for asymmetric play; its traces are marked untrainable by the env and never reach the advantage computation. A single-agent env under `rae` degrades to REINFORCE with an EMA baseline.
+Both of `kuhn-poker`'s agents late-bind to the run's own model — shared-policy self-play against a continuously improving opponent. Pin one agent to a frozen endpoint (`env.player1.model = ...`) for asymmetric play; its traces are marked untrainable by the env and never reach the advantage computation. A single-agent env under `rae` degrades to REINFORCE with an EMA baseline.
 
 ### Authoring an Algorithm
 
@@ -481,7 +481,7 @@ Filtered rollouts still appear in W&B distributions, just not in the trainer bat
 
 ## Multi-Turn Trajectories
 
-Multi-turn rollouts (tool use, browser environments, long conversations) used to be stitched into a single fake "single-turn" sample, which silently corrupted the importance ratio when chat templates didn't roundtrip. Since [`verifiers` v0.1.8](https://github.com/PrimeIntellect-ai/verifiers/releases/tag/v0.1.8), `prime-rl` records each LLM request/response as an independent **trajectory step** and merges them at training time using best-effort interleaving — with [renderers](#renderers) as the mechanism that keeps the merge safe by construction.
+For multi-turn rollouts (tool use, browser environments, long conversations), `prime-rl` records each LLM request/response as an independent **trajectory step** and merges them at training time using best-effort interleaving — with [renderers](#renderers) as the mechanism that keeps the merge safe by construction.
 
 ### Extension Property
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,7 @@ name = "gsm8k"
 ratio = 3  # 75% of batches
 
 [orchestrator.train.source.env.taskset]
-id = "gsm8k-v1"
+id = "gsm8k"
 split = "train"
 
 [orchestrator.train.source.env.agent.harness]
@@ -169,7 +169,7 @@ name = "reverse-text"
 ratio = 1  # default — 25% of batches
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -181,7 +181,7 @@ type = "subprocess"
 name = "gsm8k-eval"
 
 [orchestrator.eval.source.env.taskset]
-id = "gsm8k-v1"
+id = "gsm8k"
 split = "test"
 
 [orchestrator.eval.source.env.agent.harness]

--- a/docs/training.md
+++ b/docs/training.md
@@ -90,7 +90,7 @@ The RL entrypoint supports several training algorithms, switched via `[orchestra
 |---|---|---|
 | `grpo` (default) | None | Standard group-relative RL |
 | `max_rl` | None | [MaxRL](https://arxiv.org/abs/2602.02710): GRPO with mean-normalized advantages (maximum-likelihood RL) |
-| `rae` | None | [SPIRAL](https://arxiv.org/abs/2506.24119)'s role-conditioned advantage estimation: reward minus a per-agent EMA baseline, for multi-agent self-play envs (e.g. `kuhn-poker-v1`) |
+| `rae` | None | [SPIRAL](https://arxiv.org/abs/2506.24119)'s role-conditioned advantage estimation: reward minus a per-agent EMA baseline, for multi-agent self-play envs (e.g. `kuhn-poker`) |
 | `hierarchical_grpo` | None | GRPO for proposer-solver envs: compare solvers only with attempts on the same proposed problem, and compare proposers with the other proposals in the group |
 | `opd` | Required, must be vLLM (needs `prompt_logprobs`) | [On-policy distillation](https://thinkingmachines.ai/blog/on-policy-distillation/): the policy generates rollouts, the trainer minimizes per-token reverse KL to a reference model |
 | `sft` | Required, any OpenAI-compatible endpoint | Hard-distill: a frozen model generates rollouts, the policy trains on its tokens |

--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -109,7 +109,7 @@ idle_timeout = "None"
 labels = ["glm45air-search"]
 
 [orchestrator.train.source.env.taskset]
-id = "openseeker-v1"
+id = "openseeker"
 
 [[orchestrator.train.source.env.taskset.task.judges]]
 id = "reference"
@@ -142,7 +142,7 @@ idle_timeout = "None"
 labels = ["glm45air-search"]
 
 [orchestrator.train.source.env.taskset]
-id = "redsearcher-v1" # optional `difficulty` filter (easy/medium/hard)
+id = "redsearcher" # optional `difficulty` filter (easy/medium/hard)
 
 [[orchestrator.train.source.env.taskset.task.judges]]
 id = "reference"
@@ -184,7 +184,7 @@ labels = ["glm45air-search"]
 rollout = 3600
 
 [orchestrator.eval.source.env.taskset]
-id = "browsecomp-v1"
+id = "browsecomp"
 
 [orchestrator.eval.source.env.taskset.task.judge]
 model = "Qwen/Qwen3-235B-A22B-Instruct-2507"

--- a/examples/advanced/glm-4.5-air/swe.toml
+++ b/examples/advanced/glm-4.5-air/swe.toml
@@ -1,4 +1,4 @@
-# v1 RL: GLM-4.5-Air (100B MoE) on the v1 `scaleswe-v1` SWE taskset, rlm harness on a prime sandbox
+# v1 RL: GLM-4.5-Air (100B MoE) on the v1 `scaleswe` SWE taskset, rlm harness on a prime sandbox
 # runtime; eval on SWE-Bench Verified. Router replay is enabled (trainer.enable_router_replay replays
 # the routed-expert decisions returned by inference via enable_return_routed_experts) — GLM-4.5-Air is
 # a glm4_moe model, which supports routed_experts.
@@ -101,7 +101,7 @@ thinking_retention = "all"
 name = "scaleswe"
 
 [orchestrator.train.source.env.taskset]
-id = "scaleswe-v1"
+id = "scaleswe"
 
 [orchestrator.train.source.env.agent.harness]
 id = "rlm"
@@ -124,7 +124,7 @@ interval = 20
 name = "swebench-verified"
 
 [orchestrator.eval.source.env.taskset]
-id = "swebench-verified-v1"
+id = "swebench-verified"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "rlm"

--- a/examples/advanced/glm-4.5-air/terminal.toml
+++ b/examples/advanced/glm-4.5-air/terminal.toml
@@ -105,7 +105,7 @@ idle_timeout = "None"
 labels = ["glm45air-terminal"]
 
 [orchestrator.train.source.env.taskset]
-id = "tmax-v1"
+id = "tmax"
 
 # # Metric-only monitors (weight 0): rlm harness-mechanics + swe code-usage rubrics, judged by GLM-5.2.
 # [[orchestrator.train.source.env.taskset.judges]]
@@ -144,7 +144,7 @@ labels = ["glm45air-terminal"]
 rollout = 3600
 
 [orchestrator.eval.source.env.taskset]
-id = "swebench-verified-v1"
+id = "swebench-verified"
 
 # [[orchestrator.eval.source.env.taskset.judges]]
 # id = "rubric"
@@ -178,7 +178,7 @@ labels = ["glm45air-terminal"]
 rollout = 3600
 
 [orchestrator.eval.source.env.taskset]
-id = "terminal-bench-2-v1"
+id = "terminal-bench-2"
 
 # [[orchestrator.eval.source.env.taskset.judges]]
 # id = "rubric"

--- a/examples/advanced/glm-5.2/swe-llmd.toml
+++ b/examples/advanced/glm-5.2/swe-llmd.toml
@@ -131,7 +131,7 @@ clear_thinking = false
 name = "r2e"
 
 [orchestrator.train.source.env.taskset]
-id = "r2e-gym-v1"
+id = "r2e-gym"
 
 [orchestrator.train.source.env.agent.harness]
 id = "rlm"

--- a/examples/advanced/glm-5.2/swe.toml
+++ b/examples/advanced/glm-5.2/swe.toml
@@ -79,7 +79,7 @@ interval = 20
 name = "swe-bench-verified"
 
 [orchestrator.eval.source.env.taskset]
-id = "swebench-verified-v1"
+id = "swebench-verified"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "bash"

--- a/examples/advanced/intellect-3.1/rl.toml
+++ b/examples/advanced/intellect-3.1/rl.toml
@@ -52,7 +52,7 @@ name = "swe"
 ratio = 0.3
 
 [orchestrator.train.source.env.taskset]
-id = "r2e-gym-v1"
+id = "r2e-gym"
 
 [orchestrator.train.source.env.agent.harness]
 id = "bash"
@@ -66,7 +66,7 @@ name = "deepdive"
 ratio = 0.2
 
 [orchestrator.train.source.env.taskset]
-id = "deepdive-v1"
+id = "deepdive"
 
 [orchestrator.train.source.env.agent.harness]
 id = "rlm"
@@ -82,7 +82,7 @@ name = "math"
 ratio = 0.3
 
 [orchestrator.train.source.env.taskset]
-id = "i3_math_v1"
+id = "i3_math"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -95,7 +95,7 @@ name = "logic"
 ratio = 0.2
 
 [orchestrator.train.source.env.taskset]
-id = "i3_logic_v1"
+id = "i3_logic"
 
 [orchestrator.train.source.env.taskset.filter]
 max = 0.874
@@ -111,7 +111,7 @@ name = "code"
 ratio = 0.2
 
 [orchestrator.train.source.env.taskset]
-id = "i3_code_v1"
+id = "i3_code"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -130,7 +130,7 @@ interval = 25
 name = "swe-bench-verified"
 
 [orchestrator.eval.source.env.taskset]
-id = "swebench-verified-v1"
+id = "swebench-verified"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "bash"
@@ -143,7 +143,7 @@ labels = ["intellect-3.1", "swe-bench-verified"]
 name = "aime2025"
 
 [orchestrator.eval.source.env.taskset]
-id = "aime25-v1"
+id = "aime25"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/examples/advanced/minimax-m2.5/swe.toml
+++ b/examples/advanced/minimax-m2.5/swe.toml
@@ -52,7 +52,7 @@ max_off_policy_steps = 16
 name = "swe"
 
 [orchestrator.train.source.env.taskset]
-id = "r2e-gym-v1"
+id = "r2e-gym"
 
 [orchestrator.train.source.env.agent.harness]
 id = "bash"
@@ -68,7 +68,7 @@ interval = 25
 name = "swe-bench-verified"
 
 [orchestrator.eval.source.env.taskset]
-id = "swebench-verified-v1"
+id = "swebench-verified"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "bash"

--- a/examples/advanced/nemotron-3-super/swe.toml
+++ b/examples/advanced/nemotron-3-super/swe.toml
@@ -85,7 +85,7 @@ truncate_history_thinking = false
 name = "scaleswe"
 
 [orchestrator.train.source.env.taskset]
-id = "scaleswe-v1"
+id = "scaleswe"
 
 [orchestrator.train.source.env.agent.harness]
 id = "rlm"
@@ -106,7 +106,7 @@ interval = 20
 name = "swebench-verified"
 
 [orchestrator.eval.source.env.taskset]
-id = "swebench-verified-v1"
+id = "swebench-verified"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "rlm"

--- a/examples/advanced/qwen3-30b-a3b/math.toml
+++ b/examples/advanced/qwen3-30b-a3b/math.toml
@@ -52,7 +52,7 @@ max_completion_tokens = 32768
 name = "math"
 
 [orchestrator.train.source.env.taskset]
-id = "i3_math_v1"
+id = "i3_math"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -67,7 +67,7 @@ interval = 25
 name = "aime2025"
 
 [orchestrator.eval.source.env.taskset]
-id = "aime25-v1"
+id = "aime25"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/examples/advanced/qwen3-30b-a3b/swe.toml
+++ b/examples/advanced/qwen3-30b-a3b/swe.toml
@@ -50,7 +50,7 @@ max_off_policy_steps = 16
 name = "swe"
 
 [orchestrator.train.source.env.taskset]
-id = "r2e-gym-v1"
+id = "r2e-gym"
 
 [orchestrator.train.source.env.agent.harness]
 id = "bash"
@@ -66,7 +66,7 @@ interval = 25
 name = "swe-bench-verified"
 
 [orchestrator.eval.source.env.taskset]
-id = "swebench-verified-v1"
+id = "swebench-verified"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "bash"

--- a/examples/advanced/qwen3-30b-a3b/tool.toml
+++ b/examples/advanced/qwen3-30b-a3b/tool.toml
@@ -38,7 +38,7 @@ max_off_policy_steps = 32
 [[orchestrator.train.source]]
 
 [orchestrator.train.source.env.taskset]
-id = "general-agent-v1"
+id = "general-agent"
 min_tier = 1
 
 [orchestrator.train.source.env.taskset.task.tools]

--- a/examples/basic/alphabet-sort/README.md
+++ b/examples/basic/alphabet-sort/README.md
@@ -1,6 +1,6 @@
 # Alphabet Sort
 
-In this example, we demonstrate how to train `Qwen3-4B-Instruct-2507` to sort names alphabetically using LoRA. Unlike other examples, this task doesn't require SFT warmup as the base model already understands the conversation format. We proceed directly to multi-turn RL against the `alphabet-sort-v1` taskset.
+In this example, we demonstrate how to train `Qwen3-4B-Instruct-2507` to sort names alphabetically using LoRA. Unlike other examples, this task doesn't require SFT warmup as the base model already understands the conversation format. We proceed directly to multi-turn RL against the `alphabet-sort` taskset.
 
 > This example runs on a single H100 GPU.
 
@@ -9,7 +9,7 @@ In this example, we demonstrate how to train `Qwen3-4B-Instruct-2507` to sort na
 The taskset is included through the Verifiers workspace. After syncing the repository, verify it with:
 
 ```bash
-uv run python -c "import alphabet_sort_v1"
+uv run python -c "import alphabet_sort"
 ```
 
 Start the tmux session:
@@ -38,7 +38,7 @@ uv run inference --vllm.enable-lora --vllm.model Qwen/Qwen3-4B-Instruct-2507
 Evaluate the base model:
 ```bash
 # In the `Trainer` pane
-uv run eval alphabet-sort-v1 --harness.id null \
+uv run eval alphabet-sort --harness.id null \
   -m Qwen/Qwen3-4B-Instruct-2507 \
   --client.base-url http://localhost:8000/v1 \
   -n 20 \
@@ -115,7 +115,7 @@ uv run inference --vllm.enable-lora --vllm.model PrimeIntellect/Qwen3-4B-Instruc
 
 ```bash
 # In the `Trainer` pane
-uv run eval alphabet-sort-v1 --harness.id null \
+uv run eval alphabet-sort --harness.id null \
   -m PrimeIntellect/Qwen3-4B-Instruct-AlphabetSort-RL \
   --client.base-url http://localhost:8000/v1 \
   -n 20 \

--- a/examples/basic/alphabet-sort/rl.toml
+++ b/examples/basic/alphabet-sort/rl.toml
@@ -35,7 +35,7 @@ max_completion_tokens = 768
 name = "alphabet-sort"
 
 [orchestrator.train.source.env.taskset]
-id = "alphabet-sort-v1"
+id = "alphabet-sort"
 min_turns = 3
 max_turns = 5
 

--- a/examples/basic/hendrycks-sanity/rl.toml
+++ b/examples/basic/hendrycks-sanity/rl.toml
@@ -20,7 +20,7 @@ seq_len = 8192
 name = "hendrycks-math"
 
 [orchestrator.train.source.env.taskset]
-id = "math-env-v1"
+id = "math-env"
 dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B"
 dataset_subset = "default"
 
@@ -38,7 +38,7 @@ name = "aime2024"
 group_size = 32
 
 [orchestrator.eval.source.env.taskset]
-id = "aime24-v1"
+id = "aime24"
 
 [orchestrator.eval.source.env.agent.harness]
 id = "null"

--- a/examples/basic/reverse-text/README.md
+++ b/examples/basic/reverse-text/README.md
@@ -1,15 +1,15 @@
 # Reverse Text
 
-We demonstrate how to train `Qwen3-0.6B` to reverse a small chunk of text. We will use a SFT warmup to learn the skill of text reversal on longer documents and then a quick RL run on the `reverse-text-v1` taskset. We use a similar setup in our CI and for development.
+We demonstrate how to train `Qwen3-0.6B` to reverse a small chunk of text. We will use a SFT warmup to learn the skill of text reversal on longer documents and then a quick RL run on the `reverse-text` taskset. We use a similar setup in our CI and for development.
 
 > The commands in this example were designed to be run on 2 GPUs (one trainer and one inference GPU). It is possible to run on less or more GPUs using different deployment strategies. If you run on a different setup, you may need to adjust the start commands.
 
 ## Setup
 
-The `reverse-text-v1` taskset is included through the Verifiers workspace. After syncing the repository, verify it with:
+The `reverse-text` taskset is included through the Verifiers workspace. After syncing the repository, verify it with:
 
 ```bash
-uv run python -c "import reverse_text_v1"
+uv run python -c "import reverse_text"
 ```
 
 First, let's start a `tmux` session which we will use throughout the experiment.
@@ -27,7 +27,7 @@ uv run inference --vllm.model Qwen/Qwen3-0.6B
 
 ```bash
 # Run this in the `Trainer` pane
-uv run eval reverse-text-v1 --harness.id null -m Qwen/Qwen3-0.6B --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
+uv run eval reverse-text --harness.id null -m Qwen/Qwen3-0.6B --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
 ```
 
 This is of course just a quick vibe check and no full-fledged evaluation, but we can see that the model struggles with this task. In this specific instance, we got an **average reward of ~0.05** across the 20x3 rollouts. Let's do some training!
@@ -100,7 +100,7 @@ uv run inference --vllm.model PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL
 
 ```bash
 # Run this in the `Trainer` pane
-uv run eval reverse-text-v1 --harness.id null -m PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
+uv run eval reverse-text --harness.id null -m PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
 ```
 
 Way better! Now we get an **average reward of ~0.8**.
@@ -213,7 +213,7 @@ kubectl exec -it my-exp-inference-0 -- bash
 uv run inference --vllm.model /data/outputs/weights/step_20
 
 # Back in trainer pod, run evaluation
-uv run eval reverse-text-v1 --harness.id null \
+uv run eval reverse-text --harness.id null \
   -m /data/outputs/weights/step_20 \
   --client.base-url $INFERENCE_URL \
   -n 20 -r 3 --sampling.max-tokens 1024 --no-push

--- a/examples/basic/reverse-text/rl.toml
+++ b/examples/basic/reverse-text/rl.toml
@@ -19,7 +19,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"

--- a/examples/basic/wiki-search/README.md
+++ b/examples/basic/wiki-search/README.md
@@ -16,7 +16,7 @@ In this example, we demonstrate how to train `Qwen3-4B-Instruct-2507` to answer 
 The taskset is included through the Verifiers workspace. After syncing the repository, verify it with:
 
 ```bash
-uv run python -c "import wiki_search_v1"
+uv run python -c "import wiki_search"
 ```
 
 Set up the credentials for the configured reference judge:
@@ -77,7 +77,7 @@ Evaluate the base model:
 
 ```bash
 # In the `Trainer` pane
-uv run eval wiki-search-v1 --harness.id null \
+uv run eval wiki-search --harness.id null \
   -m Qwen/Qwen3-4B-Instruct-2507 \
   --client.base-url http://localhost:8000/v1 \
   -n 20 \
@@ -119,7 +119,7 @@ uv run inference --vllm.enable-lora --vllm.model <user>/Qwen3-4B-Instruct-WikiSe
 
 ```bash
 # In the `Trainer` pane
-uv run eval wiki-search-v1 --harness.id null \
+uv run eval wiki-search --harness.id null \
   -m <user>/Qwen3-4B-Instruct-WikiSearch-RL \
   --client.base-url http://localhost:8000/v1 \
   -n 20 \
@@ -135,7 +135,7 @@ The V1 taskset fixes the question bank and searchable corpus. You can replace it
 ```toml
 [[orchestrator.train.source]]
 name = "wiki-search"
-taskset = { id = "wiki-search-v1", task = { judges = [{ id = "reference", model = "openai/gpt-5.4-nano" }] } }
+taskset = { id = "wiki-search", task = { judges = [{ id = "reference", model = "openai/gpt-5.4-nano" }] } }
 harness = { id = "null" }
 runtime = { type = "subprocess" }
 ```

--- a/examples/basic/wiki-search/rl.toml
+++ b/examples/basic/wiki-search/rl.toml
@@ -44,7 +44,7 @@ max_completion_tokens = 512
 name = "wiki-search"
 
 [orchestrator.train.source.env.taskset]
-id = "wiki-search-v1"
+id = "wiki-search"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"

--- a/examples/basic/wordle/README.md
+++ b/examples/basic/wordle/README.md
@@ -1,6 +1,6 @@
 # Wordle
 
-In this example, we demonstrate how to train `Qwen3-1.7B` to play Wordle. This will require a SFT warmup to learn the format and, finally, multi-turn RL against the `wordle-v1` taskset to improve performance.
+In this example, we demonstrate how to train `Qwen3-1.7B` to play Wordle. This will require a SFT warmup to learn the format and, finally, multi-turn RL against the `wordle` taskset to improve performance.
 
 > The commands in this example were designed to be run on 2 GPUs (one trainer and one inference GPU). It is possible to run on less or more GPUs using different deployment strategies. If you run on a different setup, you may need to adjust the start commands.
 
@@ -9,7 +9,7 @@ In this example, we demonstrate how to train `Qwen3-1.7B` to play Wordle. This w
 The taskset is included through the Verifiers workspace. After syncing the repository, verify it with:
 
 ```bash
-uv run python -c "import wordle_v1"
+uv run python -c "import wordle"
 ```
 
 Start the pre-layouted `tmux` session which we will use to run all experiments and view logs conveniently
@@ -29,7 +29,7 @@ Then, use the `eval` entrypoint to evaluate the model in the `wordle` environmen
 
 ```bash
 # Run this in the `Trainer` pane
-uv run eval wordle-v1 --harness.id null -m Qwen/Qwen3-1.7B --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
+uv run eval wordle --harness.id null -m Qwen/Qwen3-1.7B --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
 ```
 
 We got an **average reward of ~0.2** across the 20x3 rollouts. From the summary, we can see that the most of the reward is coming from format and partial rewards. In fact, the model does not guess the correct word within any game, leading to a win rate of **0%**. Looking at some samples, it is evident repeatedly submitting guesses in the wrong format and is not able to revise its strategy from the environment feedback. Let's do some SFT warmup to get the model to learn the format of the environment.
@@ -103,7 +103,7 @@ uv run inference --vllm.model PrimeIntellect/Qwen3-1.7B-Wordle-RL
 
 ```bash
 # Run this in the `Trainer` pane
-uv run eval wordle-v1 --harness.id null -m PrimeIntellect/Qwen3-1.7B-Wordle-RL --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
+uv run eval wordle --harness.id null -m PrimeIntellect/Qwen3-1.7B-Wordle-RL --client.base-url http://localhost:8000/v1 -n 20 -r 3 --sampling.max-tokens 1024 --no-push
 ```
 
 Way better! Our model now wins **~60%** and gets an average reward of **~1.5**.

--- a/examples/basic/wordle/rl.toml
+++ b/examples/basic/wordle/rl.toml
@@ -22,7 +22,7 @@ group_size = 16
 name = "wordle"
 
 [orchestrator.train.source.env.taskset]
-id = "wordle-v1"
+id = "wordle"
 
 [orchestrator.train.source.env.player.harness]
 id = "null"

--- a/k8s/prime-rl/examples/reverse-text/orch.toml
+++ b/k8s/prime-rl/examples/reverse-text/orch.toml
@@ -17,7 +17,7 @@ max_completion_tokens = 128
 name = "reverse-text"
 
 [train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [train.source.env.agent.harness]
 id = "null"

--- a/packages/prime-rl-configs/src/prime_rl/configs/algorithm.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/algorithm.py
@@ -246,7 +246,7 @@ class RAEAlgoConfig(BaseAlgoConfig):
     https://arxiv.org/abs/2506.24119): scalar advantage = reward minus a
     per-agent EMA baseline of that agent's own rewards, consumed by the ``rl``
     loss component. The advantage estimator for multi-agent self-play envs
-    (``kuhn-poker-v1`` and friends): in a zero-sum game the group mean is ~0
+    (``kuhn-poker`` and friends): in a zero-sum game the group mean is ~0
     whatever the policy does, so a group-relative baseline mixes the agents'
     opposite reward scales — a structural first-mover edge would read as
     permanent credit. Per-agent baselines measure each agent against its own
@@ -274,16 +274,16 @@ class HierarchicalGRPOAlgoConfig(BaseAlgoConfig):
 
     episode_agents: list[str] = Field(min_length=1)
     """Roles compared within one proposed problem. Use ``["solver"]`` for
-    ``proposer-solver-v1``."""
+    ``proposer-solver``."""
 
     def validate_env(self, env_config: vf.EnvConfig) -> None:
         """Require the proposer-solver structure used by the comparisons."""
         try:
-            from proposer_solver_v1 import ProposerSolverEnvConfig
+            from proposer_solver import ProposerSolverEnvConfig
         except ImportError as e:
             raise ValueError(
                 "algorithm 'hierarchical_grpo' requires a proposer-solver env, but the "
-                "proposer-solver-v1 package is not installed (`uv sync --all-packages`)."
+                "proposer-solver package is not installed (`uv sync --all-packages`)."
             ) from e
         if not isinstance(env_config, ProposerSolverEnvConfig):
             raise ValueError(

--- a/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
@@ -8,18 +8,15 @@ from prime_rl.utils.config import BaseConfig
 
 
 class EnvServerConfig(BaseConfig):
-    """``uv run env-server``: what to serve (``[env]``, or ``[legacy]`` for a classic v0
-    env) and how it's hosted (``[serve]``). The ``rl`` launcher writes one of these per
-    train/eval source, with ``serve.address`` set to the source's derived address."""
+    """``uv run env-server``: what to serve (``[env]``) and how it's hosted (``[serve]``).
+    The ``rl`` launcher writes one of these per train/eval source, with ``serve.address``
+    set to the source's derived address."""
 
     env: SerializeAsAny[vf.EnvConfig] = vf.SingleAgentEnvConfig()
     """The environment — which env, its seed taskset, each agent, its knobs. Narrowed to the selected env's config class by the env id, else the taskset id."""
 
     serve: vf.ServeConfig = vf.ServeConfig()
     """How it's served: the worker pool, the bind address, each worker's episode bound."""
-
-    legacy: vf.LegacyEnvConfig = vf.LegacyEnvConfig()
-    """A classic (v0) environment to serve through the bridge instead of ``env``."""
 
     log: LogConfig = LogConfig()
 
@@ -33,34 +30,11 @@ class EnvServerConfig(BaseConfig):
         return vf.resolve_env_field(data, vf.narrowed_env_annotation(cls))
 
     @property
-    def is_legacy(self) -> bool:
-        """Whether this serves the v0 bridge: a legacy id and no v1 taskset."""
-        return self.legacy.id is not None and not self.env.taskset.id
-
-    @property
     def env_id(self) -> str:
-        """The served env's identifier: the v1 env's, else the v0 env id."""
-        return self.env.env_id or self.legacy.id or ""
+        return self.env.env_id or ""
 
     @model_validator(mode="after")
     def validate_env(self):
-        # A v0 id next to any v1 env identity leaves one of the two going nowhere, and
-        # which one depends on `is_legacy`: a taskset makes it False, so the v0 env never
-        # loads; a bare `env.id` leaves it True, so the v0 env runs under the v1 name.
-        if self.legacy.id is not None and self.env.env_id:
-            if self.env.taskset.id:
-                raise ValueError(
-                    f"legacy.id {self.legacy.id!r} is a classic (v0) env and can't combine with "
-                    f"the v1 taskset {self.env.taskset.id!r}. Pairing a reusable env with a taskset "
-                    f"is env.id = {self.legacy.id!r}; to run the v0 env instead, drop the taskset."
-                )
-            raise ValueError(
-                f"legacy.id {self.legacy.id!r} is a classic (v0) env and can't combine with the "
-                f"v1 env.id {self.env.id!r}: the v0 env is what would run, stamped with the v1 "
-                "env's name. Keep whichever one you meant to run."
-            )
         if not self.env_id:
-            raise ValueError(
-                'no env configured — set env = { taskset = { id = "<id>" } } (v1) or legacy = { id = "<id>" } (v0)'
-            )
+            raise ValueError('no env configured — set env = { taskset = { id = "<id>" } }')
         return self

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -119,17 +119,13 @@ class EvalSamplingConfig(BaseConfig):
 
 class EnvConfig(BaseConfig):
     """One environment a run pulls from: the verifiers blocks it composes (``env`` — what
-    runs, ``serve`` — how it's hosted, ``legacy`` — a classic v0 env instead) plus this
-    orchestrator's own per-env knobs."""
+    runs, ``serve`` — how it's hosted) plus this orchestrator's own per-env knobs."""
 
     env: SerializeAsAny[vf.EnvConfig] = vf.SingleAgentEnvConfig()
     """The verifiers environment — which env, its seed taskset, each agent, its knobs. Narrowed to the selected env's config class by the env id, else the taskset id."""
 
     serve: vf.ServeConfig = vf.ServeConfig()
     """How this source's env server is hosted. The sizing knobs are consumed by the launcher, which writes each source's env-server config with an unset ``address`` filled in as the derived ``tcp://127.0.0.1:<env_server_base_port + index>``. Setting ``address`` marks the server externally managed: the launchers neither write its env-server TOML nor spawn a server for it, and the orchestrator connects to the given address — e.g. a k8s deployment running env servers in their own pods."""
-
-    legacy: vf.LegacyEnvConfig = vf.LegacyEnvConfig()
-    """A classic (v0) environment to run through the bridge instead of ``env``."""
 
     name: str | None = None
     """Display name for this environment in logs, metrics, and buffer keys. Defaults to the taskset id. Must be unique across all envs in the same group."""
@@ -144,14 +140,8 @@ class EnvConfig(BaseConfig):
         return vf.resolve_env_field(data, vf.narrowed_env_annotation(cls))
 
     @property
-    def is_legacy(self) -> bool:
-        """A classic (v0) env run through the bridge: a legacy id and no v1 taskset."""
-        return self.legacy.id is not None and not self.env.taskset.id
-
-    @property
     def env_id(self) -> str:
-        """The env's identifier: the v1 env's, else the v0 env id."""
-        return self.env.env_id or self.legacy.id or ""
+        return self.env.env_id or ""
 
     @property
     def resolved_name(self) -> str:
@@ -159,45 +149,12 @@ class EnvConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_env(self):
-        # A v0 id next to any v1 env identity leaves one of the two going nowhere, and
-        # which one depends on `is_legacy`: a taskset makes it False, so the v0 env never
-        # loads; a bare `env.id` leaves it True, so the v0 env runs under the v1 name.
-        if self.legacy.id is not None and self.env.env_id:
-            if self.env.taskset.id:
-                raise ValueError(
-                    f"legacy.id {self.legacy.id!r} is a classic (v0) env and can't combine with "
-                    f"the v1 taskset {self.env.taskset.id!r}. Pairing a reusable env with a taskset "
-                    f"is env.id = {self.legacy.id!r}; to run the v0 env instead, drop the taskset."
-                )
-            raise ValueError(
-                f"legacy.id {self.legacy.id!r} is a classic (v0) env and can't combine with the "
-                f"v1 env.id {self.env.id!r}: the v0 env is what would run, stamped with the v1 "
-                "env's name. Keep whichever one you meant to run."
-            )
         if not self.env_id:
-            raise ValueError(
-                'no env configured — set env = { taskset = { id = "<id>" } } (v1) or legacy = { id = "<id>" } (v0)'
-            )
+            raise ValueError('no env configured — set env = { taskset = { id = "<id>" } }')
         if self.resolved_name == "agg":
             raise ValueError(
                 'Environment name "agg" is reserved for cross-env metric aggregation. Use a different name or id.'
             )
-        return self
-
-    @model_validator(mode="after")
-    def resolve_legacy_env_kwargs(self):
-        """For a v0/legacy env, surface the v1 knobs the legacy bridge applies via
-        ``legacy.extra_env_kwargs`` (``env.set_kwargs(...)``): the per-rollout wall-clock
-        timeout and the multi-turn completion-token budget, read off ``env.agent``.
-        (``max_seq_len`` is added per train run in ``OrchestratorConfig.resolve_env_config``,
-        which knows ``seq_len``.)"""
-        if self.is_legacy:
-            agent = getattr(self.env, "agent", None)
-            if agent is not None:
-                if agent.timeout.rollout is not None:
-                    self.legacy.extra_env_kwargs["timeout_seconds"] = agent.timeout.rollout
-                if agent.max_output_tokens is not None:
-                    self.legacy.extra_env_kwargs["max_total_completion_tokens"] = agent.max_output_tokens
         return self
 
 
@@ -508,7 +465,7 @@ class OrchestratorConfig(BaseConfig):
     """Directory to write outputs to — checkpoints, weights, rollouts, and logs are written as subdirectories. Shared with the trainer; should be a persistent directory with enough disk space and unique per experiment running on a single node."""
 
     tasks_per_minute: int | None = Field(None, ge=1)
-    """Rate limit per environment worker, in tasks per minute. Recommended for sandbox-backed environments to prevent sandbox-not-ready errors during autoscaling. With multiple workers, the effective total rate is ``workers × this value``. None disables rate limiting."""
+    """Global rate limit on task dispatch, in tasks per minute. Recommended for sandbox-backed environments to prevent sandbox-not-ready errors during autoscaling. None disables rate limiting."""
 
     env_server_base_port: int = Field(5000, ge=1, le=65535)
     """First port of the env-server port range: the source at position ``i`` (train, then eval) is served at ``tcp://127.0.0.1:<base + i>``. Sources with an explicit ``serve.address`` keep it instead, without shifting the other sources' ports (indices stay positional). Give concurrent runs on one host distinct bases (e.g. one per multi-run orchestrator)."""
@@ -697,7 +654,7 @@ class OrchestratorConfig(BaseConfig):
 
     @model_validator(mode="after")
     def resolve_env_config(self):
-        """Set vLLM sampling defaults + legacy env kwargs on each train env from top-level fields."""
+        """Set vLLM sampling defaults on each train env from top-level fields."""
         for env in self.train.source:
             # Policy-sourced rollouts hit our vLLM server; frozen-sourced
             # rollouts may hit external OAI endpoints that reject these knobs.
@@ -706,10 +663,6 @@ class OrchestratorConfig(BaseConfig):
                 env.sampling.extra_body.setdefault("top_k", -1)
                 env.sampling.extra_body.setdefault("min_p", 0.0)
                 env.sampling.extra_body.setdefault("return_token_ids", True)
-            if env.is_legacy:
-                # v0 env: cap per-turn response tokens to the training budget (the legacy
-                # bridge applies legacy.extra_env_kwargs via env.set_kwargs).
-                env.legacy.extra_env_kwargs["max_seq_len"] = self.seq_len
         return self
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "setproctitle>=1.3.0",
     "uvloop>=0.21.0",
     "torchtitan",
-    "verifiers[harbor]>=0.3.1.dev13",
+    "verifiers[harbor]>=0.3.1.dev14",
     "renderers",
     "dion",
     "tilelang>=0.1.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "setproctitle>=1.3.0",
     "uvloop>=0.21.0",
     "torchtitan",
-    "verifiers[harbor]>=0.3.0",
+    "verifiers[harbor]>=0.3.1.dev12",
     "renderers",
     "dion",
     "tilelang>=0.1.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "setproctitle>=1.3.0",
     "uvloop>=0.21.0",
     "torchtitan",
-    "verifiers[harbor]>=0.3.1.dev12",
+    "verifiers[harbor]>=0.3.1.dev13",
     "renderers",
     "dion",
     "tilelang>=0.1.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,20 +136,20 @@ override-dependencies = [
 [tool.uv.workspace]
 members = [
     "deps/research-environments/environments/*/*",
-    "deps/verifiers/environments/alphabet_sort_v1",
-    "deps/verifiers/environments/color_codeword_v1",
-    "deps/verifiers/environments/gsm8k_v1",
-    "deps/verifiers/environments/kuhn_poker_v1",
-    "deps/verifiers/environments/proposer_solver_v1",
-    "deps/verifiers/environments/reverse_text_v1",
-    "deps/verifiers/environments/wiki_search_v1",
-    "deps/verifiers/environments/wordle_v1",
+    "deps/verifiers/environments/alphabet_sort",
+    "deps/verifiers/environments/color_codeword",
+    "deps/verifiers/environments/gsm8k",
+    "deps/verifiers/environments/kuhn_poker",
+    "deps/verifiers/environments/proposer_solver",
+    "deps/verifiers/environments/reverse_text",
+    "deps/verifiers/environments/wiki_search",
+    "deps/verifiers/environments/wordle",
 ]
-# tau2-synth-v1 and tau3-bench-v1 pin `tau2` forks/revs that conflict with the
-# canonical tau2-bench-v1; a workspace shares one lock, so these can't coexist.
+# tau2-synth and tau3-bench pin `tau2` forks/revs that conflict with the
+# canonical tau2-bench; a workspace shares one lock, so these can't coexist.
 exclude = [
-    "deps/research-environments/environments/tool_use/tau2_synth_v1",
-    "deps/research-environments/environments/tool_use/tau3_bench_v1",
+    "deps/research-environments/environments/tool_use/tau2_synth",
+    "deps/research-environments/environments/tool_use/tau3_bench",
 ]
 
 # ModelExpress 0.3.0 publishes protobuf<6 metadata, but its generated proto is
@@ -195,10 +195,8 @@ torchao = false
 
 [tool.uv.sources]
 prime-rl-configs = { path = "packages/prime-rl-configs", editable = true }
-# prime-rl depends on the one `verifiers` package (v0 + v1 + the legacy bridge + the built-in v1
-# harnesses/tasksets, now bundled in verifiers.v1). v0 envs resolve from
-# deps/{verifiers,research-environments}/environments; v1 tasksets (`-v1`) and the `compact`
-# example live under deps/{verifiers,research-environments}/environments.
+# prime-rl consumes `verifiers.v1` (incl. the built-in harnesses/tasksets); env tasksets
+# live under deps/{verifiers,research-environments}/environments.
 verifiers = { path = "deps/verifiers", editable = true }
 renderers = { path = "deps/renderers", editable = true }
 prime-pydantic-config = { path = "deps/pydantic-config", editable = true }

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -47,7 +47,7 @@ Incompatible combinations (e.g. CP requires flash attention) must raise in a `mo
 name = "reverse-text"
 
 [orchestrator.train.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 
 [orchestrator.train.source.env.agent.harness]
 id = "null"
@@ -59,7 +59,7 @@ type = "subprocess"
 name = "reverse-text-eval"
 
 [orchestrator.eval.source.env.taskset]
-id = "reverse-text-v1"
+id = "reverse-text"
 split = "test"
 
 [orchestrator.eval.source.env.agent.harness]
@@ -69,7 +69,7 @@ id = "null"
 type = "subprocess"
 ```
 
-CLI: `--orchestrator.train.source.0.env.taskset.id reverse-text-v1` or `--orchestrator.eval.source.0.env.taskset.id reverse-text-v1`.
+CLI: `--orchestrator.train.source.0.env.taskset.id reverse-text` or `--orchestrator.eval.source.0.env.taskset.id reverse-text`.
 
 **Dicts** — TOML uses a section; CLI takes a JSON string: `--trainer.env-vars '{"key1": "value1"}'`. This works for plain `dict` fields only — nested pydantic-model fields (e.g. `algo`) reject JSON strings; use dotted keys (`--orchestrator.algo.type max_rl`) or a TOML overlay file.
 

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -26,7 +26,7 @@ uv sync                                    # core only
 uv sync --group dev                        # + pytest, ruff, pre-commit
 uv sync --all-extras                       # + extras (flash-attn, flash-attn-cute, …)
 uv sync --all-extras --all-packages        # + all env packages (needed to train on them)
-uv sync --package prime-rl --package gsm8k-v1  # core + just one env
+uv sync --package prime-rl --package gsm8k  # core + just one env
 ```
 
 Environment packages are uv **workspace members**. Those under `deps/research-environments/environments/*/*` are auto-discovered — adding a new env there needs no `pyproject.toml` change. verifiers' example envs are enumerated explicitly in `[tool.uv.workspace].members` (only the ones prime-rl trains or tests on) — to use another, add its path to the list. Members are opt-in: a plain `uv sync` / `--all-extras` does not install them (and would remove them if already present — re-run with `--all-packages`, or `--inexact` to keep them). Install all with `--all-packages`, or a subset with repeated `--package <env>` (include `--package prime-rl` to keep the core). If two envs pin conflicting transitive versions (all members share one lock), add the loser to `[tool.uv.workspace].exclude`.

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -35,7 +35,7 @@ uv run rl @ examples/basic/reverse-text/rl.toml --dry-run                       
 - SLURM: single- and multi-node
 - Environment packages: before launching a config with a non-core verifier env id,
   verify the package imports under `uv run` (for example
-  `uv run python -c "import importlib.util; print(importlib.util.find_spec('r2e_gym_v1'))"`).
+  `uv run python -c "import importlib.util; print(importlib.util.find_spec('r2e_gym'))"`).
   If a local env exists under `deps/research-environments/environments/` or
   `deps/verifiers/environments/` but does not import, install the env workspace
   members with `uv sync --all-packages` (all) or `uv sync --package prime-rl

--- a/src/prime_rl/entrypoints/env_server.py
+++ b/src/prime_rl/entrypoints/env_server.py
@@ -12,21 +12,14 @@ from prime_rl.utils.utils import clean_exit
 
 @clean_exit
 def run_server(config: EnvServerConfig):
-    # ``serve.pool`` (static or elastic) sizes the server; a v0/legacy env runs through
-    # the bridge, a v1 env is a native env block — both speak the same serve protocol,
-    # so the orchestrator is agnostic. serve_env applies the logging setup in this process
-    # and in every spawned worker.
-    server_kwargs = (
-        {"env_id": config.env_id, "env_args": config.legacy.args, "extra_env_kwargs": config.legacy.extra_env_kwargs}
-        if config.is_legacy
-        else {"config_data": env_config_data(config.env), "max_concurrent": config.serve.max_concurrent}
-    )
+    # ``serve.pool`` (static or elastic) sizes the server. serve_env applies the logging
+    # setup in this process and in every spawned worker.
     serve_env(
         **pool_serve_kwargs(config.serve.pool),
-        legacy=config.is_legacy,
         address=config.serve.address,
         log_setup=partial(setup_env_server_logging, config.log.level, config.log.json_logging),
-        **server_kwargs,
+        config_data=env_config_data(config.env),
+        max_concurrent=config.serve.max_concurrent,
     )
 
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -105,7 +105,7 @@ def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
 
     # One EnvServerConfig TOML per launcher-managed source: `env-server @ <path>` binds
     # at the source's deterministic address, where the orchestrator connects. The source's
-    # env/serve/legacy blocks carry over; its other knobs (sampling, algo, name, ...) are
+    # env/serve blocks carry over; its other knobs (sampling, algo, name, ...) are
     # orchestrator-side.
     for split, source, address in env_servers(config):
         env_dir = output_dir / ENVS_DIR / split
@@ -114,7 +114,6 @@ def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
         env_server_dict = {
             "env": source_dict["env"],
             "serve": {**source_dict.get("serve", {}), "address": address},
-            "legacy": source_dict.get("legacy", {}),
             "log": {"level": config.orchestrator.log.vf_level, "json_logging": config.orchestrator.log.json_logging},
         }
         with open(env_dir / f"{source.resolved_name}.toml", "wb") as f:

--- a/src/prime_rl/orchestrator/algo/rae.py
+++ b/src/prime_rl/orchestrator/algo/rae.py
@@ -15,7 +15,7 @@ class RAEAlgorithm(Algorithm):
     """Role-conditioned advantage estimation (SPIRAL, arXiv:2506.24119):
     credit = reward minus a per-agent EMA baseline of that agent's rewards.
 
-    The advantage estimator for multi-agent self-play envs (kuhn-poker-v1 and
+    The advantage estimator for multi-agent self-play envs (kuhn-poker and
     friends): in a zero-sum game the group mean is ~0 whatever the policy does,
     and centering all agents against it mixes their opposite reward scales — a
     structural first-mover edge would read as permanent credit for one agent.

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -1,9 +1,7 @@
 """RolloutDispatcher: schedules rollouts under a shared permit counter.
 
 - Capacity (``max_inflight_episodes``) is shared across train + eval. One permit is
-  one episode: for a v1 env one ``run`` request, and a group-scoring task that runs
-  N rollouts in one call reserves N permits (each bridged v0 rollout is its own
-  single-agent episode).
+  one episode: one ``run`` request against an env server.
 - Optional rate limiting via ``AsyncLimiter(tasks_per_minute, 60)``.
 - Emit-everything invariant: every dispatched episode eventually reaches
   ``out_q`` exactly once, as a ``list[Rollout]``. Failures
@@ -183,11 +181,11 @@ class RolloutDispatcher:
 
     @property
     def inflight_train_count(self) -> int:
-        return sum(m.rollout_count for m in self.inflight.values() if m.kind == "train")
+        return sum(1 for m in self.inflight.values() if m.kind == "train")
 
     @property
     def inflight_eval_count(self) -> int:
-        return sum(m.rollout_count for m in self.inflight.values() if m.kind == "eval")
+        return sum(1 for m in self.inflight.values() if m.kind == "eval")
 
     @property
     def available_permits(self) -> int:
@@ -197,7 +195,7 @@ class RolloutDispatcher:
     def inflight_by_env(self) -> dict[tuple[RolloutKind, str], int]:
         counts: dict[tuple[RolloutKind, str], int] = defaultdict(int)
         for meta in self.inflight.values():
-            counts[(meta.kind, meta.env_name)] += meta.rollout_count
+            counts[(meta.kind, meta.env_name)] += 1
         return dict(counts)
 
     @property
@@ -356,10 +354,7 @@ class RolloutDispatcher:
         for gid, group in list(self.groups.items()):
             if group.kind != kind or group.rollouts_to_schedule <= 0:
                 continue
-            env = envs.get(group.env_name)
-            cost = group.rollouts_to_schedule if env.requires_group_scoring else 1
-            if cost <= self.available_permits:
-                return await self.schedule_group_rollout(gid, group)
+            return await self.schedule_group_rollout(gid, group)
 
         fresh = self.next_fresh_group(kind, envs)
         if fresh is None:
@@ -370,14 +365,13 @@ class RolloutDispatcher:
 
     def next_fresh_group(self, kind: RolloutKind, envs) -> GroupState | None:
         """Pop the next example from the corresponding source and wrap it in
-        a ``GroupState``. Returns ``None`` if the source is empty or the
-        picked env's permit cost doesn't fit."""
+        a ``GroupState``. Returns ``None`` if the source is empty."""
         if kind == "train":
             source = self.train_source
         else:
             assert self.eval_source is not None
             source = self.eval_source
-        example = source.next_example(self.available_permits)
+        example = source.next_example()
         if example is None:
             return None
 
@@ -388,8 +382,7 @@ class RolloutDispatcher:
         return GroupState(
             kind=kind,
             env_name=env_name,
-            task_idx=example["task_idx"],
-            task=example.get("task"),
+            task=example["task"],
             rollouts_to_schedule=group_size,
             target_rollouts=group_size,
             eval_step=eval_step,
@@ -397,7 +390,7 @@ class RolloutDispatcher:
         )
 
     async def schedule_group_rollout(self, group_id: uuid.UUID, group: GroupState) -> bool:
-        """Dispatch one ``run`` / ``run_group`` task for this group.
+        """Dispatch one ``run`` task for this group.
 
         Returns False only if we couldn't even schedule one rollout (no clients
         ready, no permits). Returns True after issuing one task — the caller
@@ -405,8 +398,8 @@ class RolloutDispatcher:
         """
         # Train rollouts use the env sampler's pool via the
         # renderer/token train client. Eval always evaluates the policy and
-        # goes through the eval client (chat-completions) — the same path the
-        # legacy orchestrator used, so eval scores stay comparable.
+        # goes through the eval client (chat-completions) so eval scores stay
+        # comparable.
         if group.kind == "eval":
             pool, model_name = self.policy_pool, self.policy.model_name
             live_sourced = True
@@ -429,73 +422,48 @@ class RolloutDispatcher:
         else:
             cache_salt = None
 
-        if env.requires_group_scoring:
-            # Legacy-only route (a v1 env never group-scores) — addressed by row.
-            permits = group.rollouts_to_schedule
-            group.rollouts_to_schedule = 0
-            await self.acquire(permits)
-            task: asyncio.Task = asyncio.create_task(
-                env.run_group(
-                    client=client,
-                    task_idx=group.task_idx,
-                    model_name=model_name,
-                    group_size=permits,
-                    cache_salt=cache_salt,
-                )
+        group.rollouts_to_schedule -= 1
+        await self.acquire()
+        task = asyncio.create_task(
+            env.run(
+                client=client,
+                model_name=model_name,
+                cache_salt=cache_salt,
+                task_data=group.task.data.model_dump(mode="json"),
             )
-        else:
-            # A v1 env takes the task itself; the legacy bridge its dataset row.
-            if group.task is not None:
-                addressing = {"task_data": group.task.data.model_dump(mode="json")}
-            else:
-                addressing = {"task_idx": group.task_idx}
-            permits = 1
-            group.rollouts_to_schedule -= 1
-            await self.acquire(permits)
-            task = asyncio.create_task(
-                env.run(
-                    client=client,
-                    model_name=model_name,
-                    cache_salt=cache_salt,
-                    **addressing,
-                )
-            )
+        )
 
         self.inflight[task] = InflightRollout(
             kind=group.kind,
             env_name=group.env_name,
             group_id=group_id,
             policy_version=group.policy_version_at_start,
-            rollout_count=permits,
             client_config=client,
             eval_step=group.eval_step,
         )
         return True
 
-    async def acquire(self, n: int) -> None:
-        """Reserve ``n`` permits + rate-limit each one. Caller must precheck
-        ``available_permits >= n``; this is not a blocking acquire."""
-        for _ in range(n):
-            if self.rate_limiter is not None:
-                await self.rate_limiter.acquire()
-            self.inflight_permits += 1
+    async def acquire(self) -> None:
+        """Reserve one permit + rate-limit it. Caller must precheck
+        ``available_permits >= 1``; this is not a blocking acquire."""
+        if self.rate_limiter is not None:
+            await self.rate_limiter.acquire()
+        self.inflight_permits += 1
 
-    def release(self, n: int) -> None:
-        self.inflight_permits -= n
+    def release(self) -> None:
+        self.inflight_permits -= 1
 
     async def handle_completed_rollout(self, task: asyncio.Task) -> None:
-        """Emit every dispatched episode exactly once to ``out_q``: a ``run``
-        result as one episode, a legacy ``run_group`` result as ``rollout_count``
-        single-trace episodes. Task exceptions synthesize ``rollout_count``
-        error-marker episodes so the sink's count-to-``group_size`` finalization
-        still triggers. Cancelled tasks (popped by ``drop_group``) raise
-        ``CancelledError`` and are discarded — ``drop_group`` already emitted
-        their markers.
+        """Emit every dispatched episode exactly once to ``out_q``. Task
+        exceptions synthesize an error-marker episode so the sink's
+        count-to-``group_size`` finalization still triggers. Cancelled tasks
+        (popped by ``drop_group``) raise ``CancelledError`` and are discarded —
+        ``drop_group`` already emitted their markers.
         """
         meta = self.inflight.pop(task, None)
         if meta is None:
             return  # already handled by drop_group / cancel_inflight_rollouts
-        self.release(meta.rollout_count)
+        self.release()
         group = self.groups.get(meta.group_id)
 
         is_synth_exception = False
@@ -508,13 +476,12 @@ class RolloutDispatcher:
             return
         except Exception as exc:
             get_logger().warning(f"Rollout task failed in group {meta.group_id} ({meta.env_name}): {exc!r}")
-            task_idx = group.task_idx if group is not None else -1
+            task_idx = group.task.data.idx if group is not None else -1
             rollouts = [
                 Rollout(
                     task=vf.TraceTask(type="Task", data=vf.TaskData(idx=task_idx, prompt=None)),
                     agent=vf.AgentInfo(config=vf.AgentConfig()),
                 )
-                for _ in range(meta.rollout_count)
             ]
             for r in rollouts:
                 r.record_error(exc)
@@ -533,13 +500,7 @@ class RolloutDispatcher:
                     get_logger().warning(
                         f"Rollout failed in group {meta.group_id} ({meta.env_name}) — {r.last_error.type}: {r.last_error.message}"
                     )
-        if meta.rollout_count == 1:
-            # A ``run`` task: the whole result is one episode.
-            await self.emit_episode(meta, group, rollouts)
-        else:
-            # A legacy ``run_group`` task: one single-trace episode per trace.
-            for r in rollouts:
-                await self.emit_episode(meta, group, [r])
+        await self.emit_episode(meta, group, rollouts)
 
     async def emit_episode(self, meta: InflightRollout, group: GroupState | None, rollouts: list[Rollout]) -> None:
         """Stamp prime-rl metadata onto one completed episode and put it on
@@ -571,7 +532,7 @@ class RolloutDispatcher:
         (both in-flight and not-yet-scheduled). Returns the count for
         off-policy metrics."""
         group = self.groups.pop(group_id, None)
-        task_idx = group.task_idx if group is not None else -1
+        task_idx = group.task.data.idx if group is not None else -1
 
         # Sync claim phase: pop matching tasks from ``self.inflight`` and
         # release their permits in one non-yielding sweep. After this loop
@@ -583,26 +544,25 @@ class RolloutDispatcher:
             if meta.group_id != group_id:
                 continue
             del self.inflight[task]
-            self.release(meta.rollout_count)
+            self.release()
             claimed.append((task, meta))
 
         tasks_to_cancel = [task for task, _ in claimed]
-        inflight_cancelled = sum(meta.rollout_count for _, meta in claimed)
+        inflight_cancelled = len(claimed)
         last_meta: InflightRollout | None = claimed[-1][1] if claimed else None
         for _, meta in claimed:
-            for _ in range(meta.rollout_count):
-                trace = Rollout(
-                    task=vf.TraceTask(type="Task", data=vf.TaskData(idx=task_idx, prompt=None)),
-                    agent=vf.AgentInfo(config=vf.AgentConfig()),
-                    ok=False,
-                    errors=[vf.Error(type="Cancelled", message="Off-policy cancel")],
-                    stop_condition="error",
-                )
-                await self.emit_episode(meta, group, [trace])
+            trace = Rollout(
+                task=vf.TraceTask(type="Task", data=vf.TaskData(idx=task_idx, prompt=None)),
+                agent=vf.AgentInfo(config=vf.AgentConfig()),
+                ok=False,
+                errors=[vf.Error(type="Cancelled", message="Off-policy cancel")],
+                stop_condition="error",
+            )
+            await self.emit_episode(meta, group, [trace])
 
-        # For non-group-scoring envs, the group may have rollouts that
-        # were never dispatched (``rollouts_to_schedule > 0``). Emit
-        # markers for those too so the sink hits ``target_rollouts``
+        # The group may have rollouts that were never dispatched
+        # (``rollouts_to_schedule > 0``). Emit markers for those too so the
+        # sink hits ``target_rollouts``
         #
         # ``last_meta`` can be ``None`` if the only inflight task for this
         # group completed naturally between ``on_version_pending``'s snapshot
@@ -614,7 +574,6 @@ class RolloutDispatcher:
                 env_name=group.env_name,
                 group_id=group_id,
                 policy_version=group.policy_version_at_start,
-                rollout_count=1,
                 eval_step=group.eval_step,
             )
             unscheduled_cancelled = group.rollouts_to_schedule
@@ -636,7 +595,6 @@ class RolloutDispatcher:
                     env_name=group.env_name,
                     group_id=group_id,
                     policy_version=group.policy_version_at_start if group else 0,
-                    rollout_count=1,
                     eval_step=group.eval_step,
                 )
                 if group is not None
@@ -657,8 +615,8 @@ class RolloutDispatcher:
         """Cancel all in-flight rollouts. Used on shutdown — doesn't emit
         markers since the sinks are being torn down anyway."""
         for meta in self.inflight.values():
-            self.metrics.record_cancellation(kind=meta.kind, env_name=meta.env_name, n=meta.rollout_count)
-            self.release(meta.rollout_count)
+            self.metrics.record_cancellation(kind=meta.kind, env_name=meta.env_name)
+            self.release()
         tasks = list(self.inflight.keys())
         self.inflight.clear()
         self.groups.clear()
@@ -676,9 +634,9 @@ class RolloutDispatcher:
             if meta.kind != "train":
                 continue
             self.inflight.pop(task, None)
-            self.release(meta.rollout_count)
-            self.metrics.record_cancellation(kind="train", env_name=meta.env_name, n=meta.rollout_count)
-            cancelled += meta.rollout_count
+            self.release()
+            self.metrics.record_cancellation(kind="train", env_name=meta.env_name)
+            cancelled += 1
             train_tasks.append(task)
             train_group_ids.add(meta.group_id)
         for gid in train_group_ids:

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -10,9 +10,7 @@ once, and each dispatched episode ships its task's data on the request
 (``task_data``); the server pydantic-validates it into the taskset's declared
 ``TaskData`` type and runs it. That keeps the server (and every worker in its
 pool) stateless about data — no per-worker dataset loads, no idx-addressed task
-cache — and gives the orchestrator real tasks to cycle, shuffle, and filter. Only
-the legacy (v0) bridge, whose dataset genuinely lives server-side, is still driven
-by ``task_idx`` (its count comes from ``info``).
+cache — and gives the orchestrator real tasks to cycle, shuffle, and filter.
 
 The server answers one ``Episode`` per run request, whose traces we validate into
 ``Trace[WireTaskData]`` — real ``vf.Trace``\\ s (never loose dicts) whose task
@@ -41,7 +39,7 @@ from prime_rl.utils.logger import get_logger
 ROLLOUT_TYPE = Rollout[vf.WireTaskData]
 
 # Max wait for the env server to answer health. Generous because the launcher spawns
-# servers concurrently with the orchestrator, and a legacy server loads its dataset
+# servers concurrently with the orchestrator, and a server imports its env package
 # before serving.
 ENV_SERVER_STARTUP_TIMEOUT = 600.0
 
@@ -56,12 +54,11 @@ class Env:
         self.sampling_args: dict = {}
         self.num_tasks: int | None = 0
         """Task count; ``None`` means the taskset is infinite."""
-        self.requires_group_scoring: bool = False
         self.tasks: Iterator[vf.Task] | None = None
-        """The env's tasks, client-side; ``None`` for legacy (its dataset lives on the
-        server). A finite taskset is materialized at ``start()`` (``num_tasks`` is its
-        count) and iterated from there; an infinite one streams off its generator.
-        Consumed once — by ``TrainSource`` (train) or ``EvalEnv.start`` (eval)."""
+        """The env's tasks, client-side, set at ``start()``. A finite taskset is
+        materialized (``num_tasks`` is its count) and iterated from there; an infinite
+        one streams off its generator. Consumed once — by ``TrainSource`` (train) or
+        ``EvalEnv.start`` (eval)."""
         self._env_client: EnvClient | None = None
 
     @property
@@ -75,29 +72,23 @@ class Env:
         return self._env_client
 
     async def start(self) -> None:
-        """Connect to the env server and load the taskset client-side (legacy instead
-        asks the server for ``info`` — its dataset is server-side)."""
+        """Connect to the env server and load the taskset client-side."""
         get_logger().debug(f"Connecting {self.name} to env server {self.address}")
         self._env_client = EnvClient(address=self.address)
         # The server may still be coming up (the launcher spawns it concurrently with
         # the orchestrator), so poll until it answers.
         await self.env_client.wait_for_server_startup(timeout=ENV_SERVER_STARTUP_TIMEOUT)
-        if self.config.is_legacy:
-            info = await self.env_client.info()
-            self.num_tasks = info.num_tasks
-            self.requires_group_scoring = info.requires_group_scoring
+        taskset = vf.load_taskset(self.config.env.taskset)
+        if type(taskset).INFINITE:
+            self.tasks = iter(taskset.load())
+            self.num_tasks = None
         else:
-            taskset = vf.load_taskset(self.config.env.taskset)
-            if type(taskset).INFINITE:
-                self.tasks = iter(taskset.load())
-                self.num_tasks = None
-            else:
-                # Materialize off the event loop — load() may pull a dataset.
-                materialized = await asyncio.to_thread(lambda: list(taskset.load()))
-                self.tasks = iter(materialized)
-                self.num_tasks = len(materialized)
+            # Materialize off the event loop — load() may pull a dataset.
+            materialized = await asyncio.to_thread(lambda: list(taskset.load()))
+            self.tasks = iter(materialized)
+            self.num_tasks = len(materialized)
         num_tasks = self.num_tasks if self.num_tasks is not None else "infinite"
-        get_logger().info(f"Env {self.name} ready: num_tasks={num_tasks} group_scoring={self.requires_group_scoring}")
+        get_logger().info(f"Env {self.name} ready: num_tasks={num_tasks}")
 
     def _sampling(self, cache_salt: str | None) -> vf.SamplingConfig:
         sampling = {**self.sampling_args}
@@ -110,17 +101,13 @@ class Env:
         client: vf.ClientConfig,
         model_name: str,
         cache_salt: str | None,
-        task_data: dict | None = None,
-        task_idx: int | None = None,
+        task_data: dict,
     ) -> list[Rollout]:
-        """Run one episode; return its typed Traces. A v1 env takes the task itself
-        (``task_data``); the legacy bridge is addressed by dataset row (``task_idx``).
-        A zero-trace episode raises (the dispatcher synthesizes the error marker); a
-        not-``ok`` episode marks its clean traces failed so partial episodes never
-        train."""
+        """Run one episode; return its typed Traces. A zero-trace episode raises (the
+        dispatcher synthesizes the error marker); a not-``ok`` episode marks its clean
+        traces failed so partial episodes never train."""
         episode = await self.env_client.run(
             task_data=task_data,
-            task_idx=task_idx,
             client=client,
             model=model_name,
             sampling=self._sampling(cache_salt),
@@ -139,19 +126,6 @@ class Env:
                 rollout.errors = [*rollout.errors, error]
                 rollout.ok = False
         return rollouts
-
-    async def run_group(
-        self, client: vf.ClientConfig, task_idx: int, model_name: str, group_size: int, cache_salt: str | None
-    ) -> list[Rollout]:
-        """Run a group of rollouts for ``task_idx`` (group-scoring envs); return typed Traces."""
-        wires = await self.env_client.run_group(
-            task_idx=task_idx,
-            n=group_size,
-            client=client,
-            model=model_name,
-            sampling=self._sampling(cache_salt),
-        )
-        return [ROLLOUT_TYPE.model_construct(**dict(wire)) for wire in wires]
 
 
 class TrainEnv(Env):
@@ -175,15 +149,11 @@ class EvalEnv(Env):
     async def start(self) -> None:
         await super().start()
         n = self.config.num_examples
-        if self.tasks is None:  # legacy: the dataset lives on the server — address it by row
-            count = self.num_tasks if n < 0 else min(n, self.num_tasks)
-            self.examples = [{"task_idx": i} for i in range(count)]
-            return
         if self.num_tasks is None and n < 0:
             raise ValueError(f"Eval env {self.name} has an infinite taskset — set num_examples to bound it")
         # A fixed eval set, pulled off the tasks once and reused every epoch.
         tasks = list(self.tasks) if n < 0 else list(islice(self.tasks, n))
-        self.examples = [{"task_idx": task.data.idx, "task": task} for task in tasks]
+        self.examples = [{"task": task} for task in tasks]
 
 
 EnvT = TypeVar("EnvT", bound=Env)

--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -63,15 +63,13 @@ class EvalSink:
         """One entry per accumulating ``(env, eval_step)`` batch:
         ``(env_name, eval_step, batch_count, expected, buffered)``.
         ``batch_count`` is finalized-group episodes in ``pending_batches``;
-        ``buffered`` is partial-group episode arrivals from non-group-scoring envs."""
+        ``buffered`` is partial-group episode arrivals."""
         batch_counts: dict[tuple[str, int], int] = dict(self.pending_batch_episodes)
         buffered: dict[tuple[str, int], int] = {}
         for group_id, rollouts in self.pending_groups.items():
             if not rollouts:
                 continue
             env_name = rollouts[0].env_name
-            if self.eval_envs.get(env_name).requires_group_scoring:
-                continue
             bkey = (env_name, rollouts[0].eval_step)
             buffered[bkey] = buffered.get(bkey, 0) + self.pending_group_episodes.get(group_id, 0)
         return [

--- a/src/prime_rl/orchestrator/eval_source.py
+++ b/src/prime_rl/orchestrator/eval_source.py
@@ -1,9 +1,8 @@
 """EvalSource: trigger-driven, finite-per-epoch pull of eval examples.
 
 The orchestrator pokes ``trigger(step)`` after each ship + once at
-startup; the dispatcher pulls via ``next_example(available_permits)``
-until ``bool(source) == False``. Constructed only when eval is
-configured."""
+startup; the dispatcher pulls via ``next_example()`` until
+``bool(source) == False``. Constructed only when eval is configured."""
 
 from __future__ import annotations
 
@@ -68,15 +67,9 @@ class EvalSource:
                 self.queue.append(row)
         return fired
 
-    def next_example(self, available_permits: int) -> dict | None:
-        """Pop the next eval example if the head's permit cost fits in
-        ``available_permits``; otherwise leave it for a later call."""
+    def next_example(self) -> dict | None:
+        """Pop the next eval example, or ``None`` when the queue is empty."""
         if not self.queue:
-            return None
-        head = self.queue[0]
-        env = self.eval_envs.get(head["env_name"])
-        cost = env.config.group_size if env.requires_group_scoring else 1
-        if cost > available_permits:
             return None
         return self.queue.popleft()
 

--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -271,7 +271,7 @@ class EpisodeMetrics:
 
     def episodes(self) -> list[list[Rollout]]:
         """The subset's rollouts grouped into their episodes. A rollout without an
-        ``episode_id`` (legacy envs, synthesized error markers) is its own episode."""
+        ``episode_id`` (synthesized error markers) is its own episode."""
         grouped: dict[str, list[Rollout]] = {}
         for r in self.rollouts:
             grouped.setdefault(r.episode_id or r.id, []).append(r)

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -108,13 +108,9 @@ class TrainSink:
         return self.pending_tokens, self.token_batch_size, "tokens"
 
     def buffered_count(self) -> int:
-        """Episodes that have arrived but sit in not-yet-complete groups
-        (non-group-scoring envs) — buffered in the sink ahead of the batch."""
-        return sum(
-            self.pending_group_episodes.get(group_id, 0)
-            for group_id, rollouts in self.pending_groups.items()
-            if rollouts and not self.train_envs.get(rollouts[0].env_name).requires_group_scoring
-        )
+        """Episodes that have arrived but sit in not-yet-complete groups —
+        buffered in the sink ahead of the batch."""
+        return sum(self.pending_group_episodes.values())
 
     def pending_batch_by_env(self) -> dict[str, int]:
         """Per-env breakdown of ``batch_progress()`` (``pending_batch`` only);
@@ -170,8 +166,7 @@ class TrainSink:
         await self.train_envs.get(rollout.env_name).algorithm.finalize_rollout(rollout)
 
     async def process_group(self, group_id: uuid.UUID) -> None:
-        """Finalize one GRPO group: drop errored rollouts (the whole group
-        when ``requires_group_scoring`` and any failed), assign advantages,
+        """Finalize one GRPO group: drop errored rollouts, assign advantages,
         run pre-batch filters, append survivors to ``pending_batch``."""
         group = self.pending_groups.pop(group_id, [])
         self.pending_group_episodes.pop(group_id, None)
@@ -188,15 +183,7 @@ class TrainSink:
         survivors = [r for r in group if not r.has_error]
         num_errored = len(group) - len(survivors)
 
-        # Group-scoring envs: any failure makes survivors' rewards unsafe
-        # (computed relative to the missing ones)
         env = self.train_envs.get(env_name)
-        if num_errored > 0 and env.requires_group_scoring:
-            get_logger().debug(
-                f"Finished group | env={env_name} task_idx={task_idx} | "
-                f"rollouts={len(group)} (errored={num_errored}) | dropped: group-scored partial"
-            )
-            return
         # Untrainable traces carry no samples and must not skew the group baseline.
         survivors = [r for r in survivors if r.agent.trainable]
         if not survivors:

--- a/src/prime_rl/orchestrator/train_source.py
+++ b/src/prime_rl/orchestrator/train_source.py
@@ -1,12 +1,10 @@
 """TrainSource: weighted round-robin across train envs, infinite pull.
 
 Weights are each env's configured ``ratio`` (default 1, i.e. equal weight
-per env). A v1 env serves the tasks the orchestrator loaded client-side: a
+per env). An env serves the tasks the orchestrator loaded client-side: a
 finite one as a shuffled table (reshuffled with ``seed=epoch`` on cursor
 exhaustion), an infinite one (``num_tasks is None``) straight off its
-generator — every pull is a fresh task and there are no epochs to shuffle.
-A legacy env's dataset lives on its server, so it serves shuffled task
-*indices*."""
+generator — every pull is a fresh task and there are no epochs to shuffle."""
 
 from __future__ import annotations
 
@@ -19,11 +17,9 @@ from prime_rl.orchestrator.envs import TrainEnvs
 
 
 class TrainSource:
-    """``next_example(available_permits)`` picks a weighted-RR env and
-    returns its next example (or ``None`` when the env's per-call permit
-    cost doesn't fit — the dispatch loop retries when permits free up).
-    Returned dicts carry ``env_name`` + ``task_idx`` (+ ``task`` for v1 envs,
-    whose data is shipped to the env server at dispatch).
+    """``next_example()`` picks a weighted-RR env and returns its next
+    example. Returned dicts carry ``env_name`` + ``task``, whose data is
+    shipped to the env server at dispatch.
 
     The data position round-trips through a checkpoint via ``state_dict()``
     / ``load_state_dict()``: per-env ``{epoch, cursor}`` plus the env-choice
@@ -37,10 +33,6 @@ class TrainSource:
 
     def __init__(self, train_envs: TrainEnvs) -> None:
         self.rng = random.Random(42)
-        # The drawn-but-undispatched env. A draw whose permit cost doesn't fit
-        # is held here (head-of-line) rather than redrawn, so the choice stream
-        # advances exactly once per dispatched example and stays reproducible.
-        self.pending_env: str | None = None
         self.envs = list(train_envs)
         if not self.envs:
             raise ValueError("TrainSource needs at least one train env")
@@ -53,22 +45,17 @@ class TrainSource:
         self.iters: dict[str, Iterator[vf.Task]] = {}
         self.epochs: dict[str, int] = {}
         self.cursors: dict[str, int] = {}
-        # Group-scoring envs reserve ``group_size`` permits up front;
-        # per-rollout envs need 1
-        self.env_costs: dict[str, int] = {}
         for env in self.envs:
-            if env.tasks is None:  # legacy: sample over the index range from info()
-                rows: list[dict] | None = [{"task_idx": i, "env_name": env.name} for i in range(env.num_tasks)]
-            elif env.num_tasks is None:  # infinite: pull the generator per example
-                rows = None
+            assert env.tasks is not None, f"env {env.name} not started"
+            if env.num_tasks is None:  # infinite: pull the generator per example
+                rows: list[dict] | None = None
                 self.iters[env.name] = env.tasks
             else:
-                rows = [{"task_idx": task.data.idx, "task": task, "env_name": env.name} for task in env.tasks]
+                rows = [{"task": task, "env_name": env.name} for task in env.tasks]
             self.base_rows[env.name] = rows
             self.epochs[env.name] = 1
             self.cursors[env.name] = 0
             self.examples[env.name] = self._shuffle(env.name)
-            self.env_costs[env.name] = env.config.group_size if env.requires_group_scoring else 1
 
         self.env_names = [e.name for e in self.envs]
         self.weights: list[float] = [float(e.config.ratio) for e in self.envs]
@@ -85,17 +72,14 @@ class TrainSource:
         return rows
 
     def state_dict(self) -> dict:
-        """Env-choice RNG state + pending draw + per-env ``{epoch, cursor}``."""
+        """Env-choice RNG state + per-env ``{epoch, cursor}``."""
         return {
             "rng": self.rng.getstate(),
-            "pending_env": self.pending_env,
             "envs": {name: {"epoch": self.epochs[name], "cursor": self.cursors[name]} for name in self.epochs},
         }
 
     def load_state_dict(self, state_dict: dict) -> None:
         self.rng.setstate(state_dict["rng"])
-        pending = state_dict["pending_env"]
-        self.pending_env = pending if pending in self.env_costs else None
         for name, position in state_dict["envs"].items():
             if name not in self.base_rows:
                 continue
@@ -107,19 +91,14 @@ class TrainSource:
             else:
                 self.examples[name] = self._shuffle(name)
 
-    def next_example(self, available_permits: int) -> dict | None:
-        if self.pending_env is None:
-            self.pending_env = self.rng.choices(self.env_names, weights=self.weights, k=1)[0]
-        env_name = self.pending_env
-        if self.env_costs[env_name] > available_permits:
-            return None
-        self.pending_env = None
+    def next_example(self) -> dict | None:
+        env_name = self.rng.choices(self.env_names, weights=self.weights, k=1)[0]
         rows = self.examples[env_name]
         cursor = self.cursors[env_name]
         if rows is None:  # infinite env: pull the next generated task
             task = next(self.iters[env_name])
             self.cursors[env_name] = cursor + 1
-            return {"task_idx": task.data.idx, "task": task, "env_name": env_name}
+            return {"task": task, "env_name": env_name}
         if cursor >= len(rows):
             self.epochs[env_name] += 1
             rows = self._shuffle(env_name)

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -41,13 +41,12 @@ RolloutKind = Literal["train", "eval"]
 @dataclass
 class InflightRollout:
     """Per-task scheduling state in the dispatcher; one entry per in-flight
-    ``run`` / ``run_group`` task."""
+    ``run`` task."""
 
     kind: RolloutKind
     env_name: str
     group_id: uuid.UUID
     policy_version: int
-    rollout_count: int
     client_config: vf.ClientConfig | None = None
     off_policy_steps: int = 0
     eval_step: int | None = None
@@ -60,12 +59,10 @@ class GroupState:
 
     kind: RolloutKind
     env_name: str
-    task_idx: int
+    task: vf.Task
+    """The group's task — its data is shipped on every dispatch."""
     rollouts_to_schedule: int
     target_rollouts: int
-    task: vf.Task | None = None
-    """The group's task (v1 envs — its data is shipped on every dispatch). ``None`` for
-    legacy envs, which are addressed by ``task_idx`` alone."""
     emitted: int = 0
     eval_step: int | None = None
     pinned_client: vf.ClientConfig | None = None

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -2,8 +2,8 @@ import msgspec
 
 
 # Encoded tensor: {dtype: "float32", shape: [...], data: <bytes>}.
-# Mirrors verifiers.utils.serve_utils.msgpack_encoder so the same wire
-# shape is used end-to-end from renderer → orchestrator → trainer.
+# Mirrors verifiers' env-serve msgpack encoder so the same wire shape is
+# used end-to-end from renderer → orchestrator → trainer.
 class EncodedTensor(msgspec.Struct, array_like=True, gc=False):
     dtype: str
     shape: list[int]

--- a/src/prime_rl/utils/async_utils.py
+++ b/src/prime_rl/utils/async_utils.py
@@ -23,10 +23,7 @@ async def safe_cancel_all(tasks: list[asyncio.Task]) -> None:
 
 
 class EventLoopLagMonitor:
-    """Monitors how busy the main event loop is by timing short sleeps.
-
-    Vendored from verifiers.utils.async_utils (the orchestrator now runs on
-    v1 and no longer depends on v1 verifiers)."""
+    """Monitors how busy the main event loop is by timing short sleeps."""
 
     def __init__(self, measure_interval: float = 0.1, max_measurements: int = 1000):
         assert measure_interval > 0 and max_measurements > 0

--- a/tests/unit/orchestrator/test_qwen3_vl_e2e.py
+++ b/tests/unit/orchestrator/test_qwen3_vl_e2e.py
@@ -1,10 +1,10 @@
 """End-to-end integration test for the Qwen3-VL renderer path.
 
-Walks a multimodal request through the full client stack — RendererClient
-→ renderers.client.generate → /inference/v1/generate features payload —
-with the HTTP layer mocked, and verifies that vLLM can deserialize the
-features back into engine inputs identical to what its own server-side
-processor would have produced for the same messages.
+Walks a multimodal request through ``renderers.client.generate`` — the
+tokenize + /inference/v1/generate features payload path the v1 train
+client drives — with the HTTP layer mocked, and verifies that vLLM can
+deserialize the features back into engine inputs identical to what its
+own server-side processor would have produced for the same messages.
 
 This is the strongest end-to-end check we can run without a GPU. The
 remaining missing piece (vLLM actually consuming the engine input,
@@ -17,7 +17,6 @@ import asyncio
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -43,9 +42,9 @@ pytestmark = pytest.mark.skipif(
 class _FakeOpenAI:
     """Minimal AsyncOpenAI stand-in that captures POST bodies.
 
-    The renderer client calls ``client.post(absolute_url, body=...)``;
-    we capture the body for assertions and return a canned generate
-    response so the parse-side of the flow runs.
+    ``renderers.client.generate`` calls ``client.post(absolute_url,
+    body=...)``; we capture the body for assertions and return a canned
+    generate response so the parse-side of the flow runs.
     """
 
     def __init__(self):
@@ -76,9 +75,9 @@ class _FakeOpenAI:
         return httpx.Response(200, content=json.dumps(payload).encode())
 
 
-def test_renderer_client_qwen3_vl_e2e_features_payload_roundtrips_through_vllm():
-    """Walk a Qwen3-VL multimodal turn through the renderer client and
-    verify the resulting ``/inference/v1/generate`` body has a valid
+def test_generate_qwen3_vl_e2e_features_payload_roundtrips_through_vllm():
+    """Walk a Qwen3-VL multimodal turn through ``renderers.client.generate``
+    and verify the resulting ``/inference/v1/generate`` body has a valid
     ``features`` payload that:
 
     1. parses through vLLM's ``GenerateRequest`` pydantic model,
@@ -89,13 +88,9 @@ def test_renderer_client_qwen3_vl_e2e_features_payload_roundtrips_through_vllm()
     """
     from PIL import Image
     from renderers.base import load_tokenizer
+    from renderers.client import generate
     from renderers.qwen3_vl import Qwen3VLRenderer
     from transformers import AutoProcessor
-    from verifiers.clients.renderer_client import RendererClient
-    from verifiers.types import (
-        ClientConfig,
-        UserMessage,
-    )
     from vllm.entrypoints.scale_out.token_in_token_out.mm_serde import decode_mm_kwargs_item
     from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateRequest
 
@@ -106,47 +101,37 @@ def test_renderer_client_qwen3_vl_e2e_features_payload_roundtrips_through_vllm()
 
     image_pad_id = tokenizer.convert_tokens_to_ids("<|image_pad|>")
 
-    # ── Manually wire a RendererClient bypassing the pool factory. ──────
-    client_cfg = ClientConfig(client_type="renderer", base_url="http://fake-host:8000/v1")
-    rc = object.__new__(RendererClient)
-    rc._config = client_cfg
-    rc._renderer = renderer
-    rc._pool_size = 1
-    rc._client = _FakeOpenAI()
-    rc.logger = MagicMock()
+    fake = _FakeOpenAI()
 
-    # ── Build a verifiers-shaped user message with an image. ────────────
+    # ── Build a user message with an image (OpenAI content-part shape). ─
     img = Image.new("RGB", (224, 224), color=(64, 128, 255))
-    # The renderer accepts the OpenAI ``image_url`` content-part shape —
-    # the same shape verifiers' UserMessage carries through.
-    user = UserMessage(
-        content=[
-            {"type": "text", "text": "What's in this picture?"},
-            # Embed the PIL image directly. The verifiers→renderer message
-            # converter forwards content unchanged for our purposes.
-            {"type": "image", "image": img},
-        ]
-    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's in this picture?"},
+                # Embed the PIL image directly; the renderer consumes it as-is.
+                {"type": "image", "image": img},
+            ],
+        }
+    ]
 
-    # to_native_prompt converts to renderer-shaped messages.
-    prompt, _ = asyncio.run(rc.to_native_prompt([user]))
-    sampling = {"max_tokens": 16}
-
-    response = asyncio.run(
-        rc.get_native_response(
-            prompt=prompt,
+    result = asyncio.run(
+        generate(
+            client=fake,
+            renderer=renderer,
+            messages=messages,
             model=_MODEL,
-            sampling_args=sampling,
-            tools=None,
+            sampling_params={"max_tokens": 16},
+            # Explicit cap so generate() skips the /v1/models discovery round-trip.
+            max_prompt_len=1_000_000,
         )
     )
 
     # ── The HTTP body should carry a features payload. ──────────────────
-    fake = rc.client
-    assert isinstance(fake, _FakeOpenAI)
     assert len(fake.calls) == 1
     body = fake.calls[0]["body"]
-    assert "features" in body, "RendererClient should ship features for image content"
+    assert "features" in body, "generate should ship features for image content"
     features = body["features"]
 
     # ── Pydantic-roundtrip through vLLM's GenerateRequest model. ────────
@@ -184,7 +169,7 @@ def test_renderer_client_qwen3_vl_e2e_features_payload_roundtrips_through_vllm()
     assert item["image_grid_thw"].data.tolist() == expected_grid
 
     # ── Response parsed through renderer's parse_response. ──────────────
-    assert response["completion_ids"] == [50, 60, 151645]
+    assert result["completion_ids"] == [50, 60, 151645]
     # multi_modal_data surfaces on the result so the caller can persist it.
-    assert response["multi_modal_data"] is not None
-    assert len(response["multi_modal_data"].mm_items["image"]) == 1
+    assert result["multi_modal_data"] is not None
+    assert len(result["multi_modal_data"].mm_items["image"]) == 1

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -182,7 +182,12 @@ def test_env_algo_overrides_top_level():
         {
             "renderer": {"name": "qwen3"},  # echo needs the renderer's role attribution
             "algo": {"type": "echo"},
-            "train": {"source": [{"legacy": {"id": "a"}, "algo": {"type": "grpo"}}, {"legacy": {"id": "b"}}]},
+            "train": {
+                "source": [
+                    {"env": {"taskset": {"id": "reverse-text"}}, "algo": {"type": "grpo"}},
+                    {"env": {"taskset": {"id": "reverse-text"}}, "name": "b"},
+                ]
+            },
         }
     )
     env_a, env_b = config.train.source
@@ -199,7 +204,7 @@ def test_env_algo_overrides_top_level():
         OrchestratorConfig.model_validate(
             {
                 "renderer": {"name": "qwen3"},
-                "train": {"env": [{"legacy": {"id": "removed"}}]},
+                "train": {"env": [{"env": {"taskset": {"id": "removed"}}}]},
             }
         )
 
@@ -207,7 +212,7 @@ def test_env_algo_overrides_top_level():
         OrchestratorConfig.model_validate(
             {
                 "renderer": {"name": "qwen3"},
-                "eval": {"env": [{"legacy": {"id": "removed"}}]},
+                "eval": {"env": [{"env": {"taskset": {"id": "removed"}}}]},
             }
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ members = [
     "alphabet-sort",
     "apex-shortlist",
     "arxivmath",
-    "automationbench",
+    "automationbench-env",
     "bfcl-v3",
     "browsecomp",
     "browsecomp-plus",
@@ -445,9 +445,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "automationbench"
+name = "automationbench-env"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/tool_use/automationbench" }
+source = { editable = "deps/research-environments/environments/tool_use/automationbench_env" }
 dependencies = [
     { name = "automation-bench" },
     { name = "datasets" },

--- a/uv.lock
+++ b/uv.lock
@@ -38,6 +38,7 @@ members = [
     "aime24",
     "aime25",
     "aime26",
+    "alphabet-sort",
     "apex-shortlist",
     "arxivmath",
     "automationbench-env",
@@ -46,6 +47,7 @@ members = [
     "browsecomp-plus",
     "charxiv",
     "clbench",
+    "color-codeword",
     "deepdive",
     "deepseek-prover",
     "drug-discovery-bench",
@@ -56,6 +58,7 @@ members = [
     "goedel-pset",
     "gpqa",
     "graphwalks",
+    "gsm8k",
     "hle",
     "humaneval",
     "i3-code",
@@ -65,6 +68,7 @@ members = [
     "ifbench",
     "ifeval",
     "kimina",
+    "kuhn-poker",
     "lab",
     "livecodebench",
     "longbenchpro",
@@ -95,9 +99,11 @@ members = [
     "prime-rl",
     "programbench-env",
     "prolog",
+    "proposer-solver",
     "proverbench",
     "r2e-gym",
     "redsearcher",
+    "reverse-text",
     "s1-deepresearch",
     "scaleswe",
     "scicode",
@@ -120,7 +126,9 @@ members = [
     "verbatim-copy",
     "virl39k",
     "wideseek",
+    "wiki-search",
     "wikispeedia",
+    "wordle",
 ]
 overrides = [
     { name = "nvidia-cudnn-cu12", specifier = ">=9.15" },
@@ -257,6 +265,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "alphabet-sort"
+version = "0.1.0"
+source = { editable = "deps/verifiers/environments/alphabet_sort" }
+dependencies = [
+    { name = "datasets" },
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "datasets" },
+    { name = "verifiers" },
 ]
 
 [[package]]
@@ -458,6 +481,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/76/60/aae0bb54f9af5e0128ba90eb83d8d0d506ee8f0475c4fdda3deeda20b1d2/bashlex-0.18.tar.gz", hash = "sha256:5bb03a01c6d5676338c36fd1028009c8ad07e7d61d8a1ce3f513b7fff52796ee", size = 68742, upload-time = "2023-01-18T15:21:26.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/be/6985abb1011fda8a523cfe21ed9629e397d6e06fb5bae99750402b25c95b/bashlex-0.18-py2.py3-none-any.whl", hash = "sha256:91d73a23a3e51711919c1c899083890cdecffc91d8c088942725ac13e9dcfffa", size = 69539, upload-time = "2023-01-18T15:21:24.167Z" },
+]
+
+[[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
 ]
 
 [[package]]
@@ -801,6 +852,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/93/09/7d04d7581ae3bb8b598017941781bceb7959dd1b13e3ebf7b6a2cd843bc9/chess-1.11.2.tar.gz", hash = "sha256:a8b43e5678fdb3000695bdaa573117ad683761e5ca38e591c4826eba6d25bb39", size = 6131385, upload-time = "2025-02-25T19:10:27.328Z" }
 
 [[package]]
+name = "chromadb"
+version = "1.5.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bcrypt" },
+    { name = "build" },
+    { name = "grpcio" },
+    { name = "httpx" },
+    { name = "importlib-resources" },
+    { name = "jsonschema" },
+    { name = "kubernetes" },
+    { name = "mmh3" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-sdk" },
+    { name = "orjson" },
+    { name = "overrides" },
+    { name = "pybase64" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pypika" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "tenacity" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/d1/5e33b26985f0c7046a0be1cee2158ada1748ee700d2545057fde1468d74d/chromadb-1.5.9.tar.gz", hash = "sha256:5c20e62a455c28bacac927f26116a73fd8e1799e0d908be8e8a4f02197a54731", size = 2595635, upload-time = "2026-05-05T05:54:51.713Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/4e/937bc4d2e6f8ab9664ec79931fbbd69efff47e513ec2924b071e4b0ff774/chromadb-1.5.9-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9192d111bd662241625867962333d99369a00769a50f8b2f58cb388731274d7e", size = 22680924, upload-time = "2026-05-05T05:54:36.25Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ec/0c42039e80b9acc534f67b73b7a42471948042859b3a64867b50a4a77fa3/chromadb-1.5.9-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc09b3df76e5a5cb386aed2715a2eea152e3949f9e1ba93c7119505377749929", size = 23316203, upload-time = "2026-05-05T05:54:41.157Z" },
+]
+
+[[package]]
 name = "clbench"
 version = "0.2.0"
 source = { editable = "deps/research-environments/environments/long_context/clbench" }
@@ -861,6 +951,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/23/cbb8ef34b8395ecea3cef2464d6abcb25174853fe8ad948841204f81f9a8/cohere-7.0.5.tar.gz", hash = "sha256:7fc682bb5c408402fc5ce59322bfa3f6aae27bde1ecc2450b0a25370040707ed", size = 208820, upload-time = "2026-06-29T20:30:53.132Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/eb/64ca464baa34d0fa8144fc09ec7a35c8fcdeea1be878a518e901b0a6032b/cohere-7.0.5-py3-none-any.whl", hash = "sha256:fd98f82be28c969da7625adddede0bb85f8f84de399daf3a98c40c0e7b93e104", size = 352049, upload-time = "2026-06-29T20:30:51.472Z" },
+]
+
+[[package]]
+name = "color-codeword"
+version = "0.1.0"
+source = { editable = "deps/verifiers/environments/color_codeword" }
+dependencies = [
+    { name = "pillow" },
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pillow", specifier = ">=11.0.0" },
+    { name = "verifiers" },
 ]
 
 [[package]]
@@ -1384,6 +1489,15 @@ requires-dist = [
 ]
 
 [[package]]
+name = "durationpy"
+version = "0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
 name = "einops"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1722,6 +1836,14 @@ wheels = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.63.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2025,6 +2147,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a2
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
 ]
+
+[[package]]
+name = "gsm8k"
+version = "0.1.0"
+source = { editable = "deps/verifiers/environments/gsm8k" }
+dependencies = [
+    { name = "datasets" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "datasets" }]
 
 [[package]]
 name = "gymnasium"
@@ -2443,6 +2576,15 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
+]
+
+[[package]]
 name = "inflect"
 version = "7.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2781,6 +2923,38 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/34/8aefdd0be9cfd00a44509251ba864f5caf2991e36772e61c408007e7f417/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9", size = 2294947, upload-time = "2026-03-09T13:13:43.343Z" },
     { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
 ]
+
+[[package]]
+name = "kubernetes"
+version = "36.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/57/b07b96353f902aa1bdbe00e878e3a12a137977d03a962479785576aa8ec9/kubernetes-36.0.3.tar.gz", hash = "sha256:36993ed25ce59b789c9341473a228fcf268504a2fec7c2b2b1531d73072e5ce7", size = 2337528, upload-time = "2026-07-13T20:38:12.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/30/a96d47df739689ac0001ade0afefc16e3b477fc2fb426b568515fdc8afce/kubernetes-36.0.3-py2.py3-none-any.whl", hash = "sha256:8fde9241c4b298e6374a069dcf728359b4e72c2fb29489a975ba4e1c047cf10f", size = 4618066, upload-time = "2026-07-13T20:38:10.172Z" },
+]
+
+[[package]]
+name = "kuhn-poker"
+version = "0.1.0"
+source = { editable = "deps/verifiers/environments/kuhn_poker" }
+dependencies = [
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "lab"
@@ -3297,6 +3471,18 @@ sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
     { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+]
+
+[[package]]
+name = "mmh3"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/1a/edb23803a168f070ded7a3014c6d706f63b90c84ccc024f89d794a3b7a6d/mmh3-5.2.1.tar.gz", hash = "sha256:bbea5b775f0ac84945191fb83f845a6fd9a21a03ea7f2e187defac7e401616ad", size = 33775, upload-time = "2026-03-05T15:55:57.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/e2/51ed62063b44d10b06d975ac87af287729eeb5e3ed9772f7584a17983e90/mmh3-5.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e6c219e375f6341d0959af814296372d265a8ca1af63825f65e2e87c618f006", size = 103274, upload-time = "2026-03-05T15:54:26.44Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ce/12a7524dca59eec92e5b31fdb13ede1e98eda277cf2b786cf73bfbc24e81/mmh3-5.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26fb5b9c3946bf7f1daed7b37e0c03898a6f062149127570f8ede346390a0825", size = 106158, upload-time = "2026-03-05T15:54:28.578Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/70b73923fd0284c439860ff5c871b20210dfdbe9a6b9dd0ee6496d77f174/mmh3-5.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b3f99e1756fc48ad507b95e5d86f2fb21b3d495012ff13e6592ebac14033f166", size = 99111, upload-time = "2026-03-05T15:54:32.353Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ac/ca8e0c19a34f5b71390171d2ff0b9f7f187550d66801a731bb68925126a4/mmh3-5.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d74a03fb57757ece25aa4b3c1c60157a1cece37a020542785f942e2f827eed5", size = 97507, upload-time = "2026-03-05T15:54:37.804Z" },
 ]
 
 [[package]]
@@ -3978,6 +4164,30 @@ sdist = { url = "https://files.pythonhosted.org/packages/92/dd/692765e87de30bae1
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/07/698355285a03a366ef63ea9762fc1feef3f9f25483e1655408f72d827090/nvtx-0.2.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2cc530cd0f1a2c14a3a7e683833db509888ac5ed4ead94e5c9e2c7317c6937a7", size = 807159, upload-time = "2026-03-18T10:09:49.232Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d1/08f22448d83481408d663065764ba583df091a7de629ed38fc97e522f1af/nvtx-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3ca8030a6d197952318013dd1c12c22da1d4b9feb76ba72e0fcd449961183c2c", size = 806187, upload-time = "2026-03-18T10:13:32.972Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/5b/1d77e62097fdbe07e2dc827f389b1c4c0c275f6fab0369a8f46d2461af27/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e81a23df16e7acb9d51b06d30cc098e49315ef9180f97bc2221d167b4b04d9c", size = 17050628, upload-time = "2026-07-25T01:21:40.481Z" },
+    { url = "https://files.pythonhosted.org/packages/95/df/5486ab03e9be288d5268867054c8b04bebcf95bfd12e801c05cc67703dab/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a83bdb70d143cede762b677789bf2a7acca54b3fb82565601d5c30695aa933c", size = 19214257, upload-time = "2026-07-25T01:22:01.695Z" },
 ]
 
 [[package]]
@@ -4932,6 +5142,17 @@ wheels = [
 ]
 
 [[package]]
+name = "proposer-solver"
+version = "0.1.0"
+source = { editable = "deps/verifiers/environments/proposer_solver" }
+dependencies = [
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -5226,6 +5447,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pypika"
+version = "0.51.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/78/cbaebba88e05e2dcda13ca203131b38d3640219f20ebb49676d26714861b/pypika-0.51.1.tar.gz", hash = "sha256:c30c7c1048fbf056fd3920c5a2b88b0c29dd190a9b2bee971fd17e4abe4d0ebe", size = 80919, upload-time = "2026-02-04T11:27:48.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/83/c77dfeed04022e8930b08eedca2b6e5efed256ab3321396fde90066efb65/pypika-0.51.1-py2.py3-none-any.whl", hash = "sha256:77985b4d7ce71b9905255bf12468cf598349e98837c037541cfc240e528aec46", size = 60585, upload-time = "2026-02-04T11:27:46.251Z" },
 ]
 
 [[package]]
@@ -5593,6 +5823,30 @@ sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179a
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "reverse-text"
+version = "0.1.0"
+source = { editable = "deps/verifiers/environments/reverse_text" }
+dependencies = [
+    { name = "datasets" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "datasets" }]
 
 [[package]]
 name = "rich"
@@ -6455,6 +6709,24 @@ requires-dist = [
 ]
 
 [[package]]
+name = "textarena"
+version = "0.7.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chess" },
+    { name = "nltk" },
+    { name = "openai" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/04/4a3ca42093d0be2a9c377ae3335a6c6baac1d278ae932562ec69f339d172/textarena-0.7.4.tar.gz", hash = "sha256:28bb9170d7718f2ae05e4515bea82262422731e563fc7318a9e7983de0cadd4f", size = 954969, upload-time = "2025-10-16T14:41:55.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/b4/9a9ba65154aff853c75b3d7324319d168ad9c69c6097f4aa3c16da7d9ef3/textarena-0.7.4-py3-none-any.whl", hash = "sha256:684784e78278e518066f67557ee93b47c238d16cbbd15d3abdaa3147562d3024", size = 1073570, upload-time = "2025-10-16T14:41:53.965Z" },
+]
+
+[[package]]
 name = "textual"
 version = "8.2.7"
 source = { registry = "https://pypi.org/simple" }
@@ -7162,6 +7434,10 @@ dependencies = [
 harbor = [
     { name = "harbor" },
 ]
+ta = [
+    { name = "nltk" },
+    { name = "textarena" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -7221,20 +7497,20 @@ dev = [
     { name = "ty", specifier = ">=0.0.63" },
 ]
 examples = [
-    { name = "alphabet-sort-v1", editable = "deps/verifiers/environments/alphabet_sort_v1" },
-    { name = "code-golf-v1", editable = "deps/verifiers/environments/code_golf_v1" },
-    { name = "color-codeword-v1", editable = "deps/verifiers/environments/color_codeword_v1" },
+    { name = "alphabet-sort", editable = "deps/verifiers/environments/alphabet_sort" },
+    { name = "code-golf", editable = "deps/verifiers/environments/code_golf" },
+    { name = "color-codeword", editable = "deps/verifiers/environments/color_codeword" },
     { name = "compact", editable = "deps/verifiers/environments/compact" },
-    { name = "deepwiki-v1", editable = "deps/verifiers/environments/deepwiki_v1" },
-    { name = "glossary-v1", editable = "deps/verifiers/environments/glossary_v1" },
-    { name = "gsm8k-v1", editable = "deps/verifiers/environments/gsm8k_v1" },
-    { name = "kuhn-poker-v1", editable = "deps/verifiers/environments/kuhn_poker_v1" },
-    { name = "openenv-wordle-v1", editable = "deps/verifiers/environments/openenv_wordle_v1" },
-    { name = "proposer-solver-v1", editable = "deps/verifiers/environments/proposer_solver_v1" },
-    { name = "reverse-text-v1", editable = "deps/verifiers/environments/reverse_text_v1" },
-    { name = "scratchpad-v1", editable = "deps/verifiers/environments/scratchpad_v1" },
-    { name = "wiki-search-v1", editable = "deps/verifiers/environments/wiki_search_v1" },
-    { name = "wordle-v1", editable = "deps/verifiers/environments/wordle_v1" },
+    { name = "deepwiki", editable = "deps/verifiers/environments/deepwiki" },
+    { name = "glossary", editable = "deps/verifiers/environments/glossary" },
+    { name = "gsm8k", editable = "deps/verifiers/environments/gsm8k" },
+    { name = "kuhn-poker", editable = "deps/verifiers/environments/kuhn_poker" },
+    { name = "openenv-wordle", editable = "deps/verifiers/environments/openenv_wordle" },
+    { name = "proposer-solver", editable = "deps/verifiers/environments/proposer_solver" },
+    { name = "reverse-text", editable = "deps/verifiers/environments/reverse_text" },
+    { name = "scratchpad", editable = "deps/verifiers/environments/scratchpad" },
+    { name = "wiki-search", editable = "deps/verifiers/environments/wiki_search" },
+    { name = "wordle", editable = "deps/verifiers/environments/wordle" },
 ]
 
 [[package]]
@@ -7883,6 +8159,23 @@ wheels = [
 ]
 
 [[package]]
+name = "wiki-search"
+version = "0.1.0"
+source = { editable = "deps/verifiers/environments/wiki_search" }
+dependencies = [
+    { name = "chromadb" },
+    { name = "datasets" },
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "chromadb", specifier = ">=0.4.13" },
+    { name = "datasets" },
+    { name = "verifiers" },
+]
+
+[[package]]
 name = "wikispeedia"
 version = "0.1.0"
 source = { editable = "deps/research-environments/environments/reasoning/wikispeedia" }
@@ -7892,6 +8185,17 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "verifiers", specifier = ">=0.2.2.dev65" }]
+
+[[package]]
+name = "wordle"
+version = "0.1.0"
+source = { editable = "deps/verifiers/environments/wordle" }
+dependencies = [
+    { name = "verifiers", extra = ["ta"] },
+]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers", extras = ["ta"] }]
 
 [[package]]
 name = "wrapt"

--- a/uv.lock
+++ b/uv.lock
@@ -38,7 +38,6 @@ members = [
     "aime24",
     "aime25",
     "aime26",
-    "alphabet-sort",
     "apex-shortlist",
     "arxivmath",
     "automationbench-env",
@@ -47,7 +46,6 @@ members = [
     "browsecomp-plus",
     "charxiv",
     "clbench",
-    "color-codeword",
     "deepdive",
     "deepseek-prover",
     "drug-discovery-bench",
@@ -58,7 +56,6 @@ members = [
     "goedel-pset",
     "gpqa",
     "graphwalks",
-    "gsm8k",
     "hle",
     "humaneval",
     "i3-code",
@@ -68,7 +65,6 @@ members = [
     "ifbench",
     "ifeval",
     "kimina",
-    "kuhn-poker",
     "lab",
     "livecodebench",
     "longbenchpro",
@@ -99,11 +95,9 @@ members = [
     "prime-rl",
     "programbench-env",
     "prolog",
-    "proposer-solver",
     "proverbench",
     "r2e-gym",
     "redsearcher",
-    "reverse-text",
     "s1-deepresearch",
     "scaleswe",
     "scicode",
@@ -126,9 +120,7 @@ members = [
     "verbatim-copy",
     "virl39k",
     "wideseek",
-    "wiki-search",
     "wikispeedia",
-    "wordle",
 ]
 overrides = [
     { name = "nvidia-cudnn-cu12", specifier = ">=9.15" },
@@ -265,21 +257,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
-]
-
-[[package]]
-name = "alphabet-sort"
-version = "0.1.0"
-source = { editable = "deps/verifiers/environments/alphabet_sort" }
-dependencies = [
-    { name = "datasets" },
-    { name = "verifiers" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "datasets" },
-    { name = "verifiers" },
 ]
 
 [[package]]
@@ -481,34 +458,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/76/60/aae0bb54f9af5e0128ba90eb83d8d0d506ee8f0475c4fdda3deeda20b1d2/bashlex-0.18.tar.gz", hash = "sha256:5bb03a01c6d5676338c36fd1028009c8ad07e7d61d8a1ce3f513b7fff52796ee", size = 68742, upload-time = "2023-01-18T15:21:26.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/be/6985abb1011fda8a523cfe21ed9629e397d6e06fb5bae99750402b25c95b/bashlex-0.18-py2.py3-none-any.whl", hash = "sha256:91d73a23a3e51711919c1c899083890cdecffc91d8c088942725ac13e9dcfffa", size = 69539, upload-time = "2023-01-18T15:21:24.167Z" },
-]
-
-[[package]]
-name = "bcrypt"
-version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
-    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
-    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
-    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
-    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
-    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
-    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
-    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
-    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
-    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
-    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
-    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
 ]
 
 [[package]]
@@ -852,45 +801,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/93/09/7d04d7581ae3bb8b598017941781bceb7959dd1b13e3ebf7b6a2cd843bc9/chess-1.11.2.tar.gz", hash = "sha256:a8b43e5678fdb3000695bdaa573117ad683761e5ca38e591c4826eba6d25bb39", size = 6131385, upload-time = "2025-02-25T19:10:27.328Z" }
 
 [[package]]
-name = "chromadb"
-version = "1.5.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bcrypt" },
-    { name = "build" },
-    { name = "grpcio" },
-    { name = "httpx" },
-    { name = "importlib-resources" },
-    { name = "jsonschema" },
-    { name = "kubernetes" },
-    { name = "mmh3" },
-    { name = "numpy" },
-    { name = "onnxruntime" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-sdk" },
-    { name = "orjson" },
-    { name = "overrides" },
-    { name = "pybase64" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pypika" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "tenacity" },
-    { name = "tokenizers" },
-    { name = "tqdm" },
-    { name = "typer" },
-    { name = "typing-extensions" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/d1/5e33b26985f0c7046a0be1cee2158ada1748ee700d2545057fde1468d74d/chromadb-1.5.9.tar.gz", hash = "sha256:5c20e62a455c28bacac927f26116a73fd8e1799e0d908be8e8a4f02197a54731", size = 2595635, upload-time = "2026-05-05T05:54:51.713Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/4e/937bc4d2e6f8ab9664ec79931fbbd69efff47e513ec2924b071e4b0ff774/chromadb-1.5.9-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9192d111bd662241625867962333d99369a00769a50f8b2f58cb388731274d7e", size = 22680924, upload-time = "2026-05-05T05:54:36.25Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/ec/0c42039e80b9acc534f67b73b7a42471948042859b3a64867b50a4a77fa3/chromadb-1.5.9-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc09b3df76e5a5cb386aed2715a2eea152e3949f9e1ba93c7119505377749929", size = 23316203, upload-time = "2026-05-05T05:54:41.157Z" },
-]
-
-[[package]]
 name = "clbench"
 version = "0.2.0"
 source = { editable = "deps/research-environments/environments/long_context/clbench" }
@@ -951,21 +861,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/23/cbb8ef34b8395ecea3cef2464d6abcb25174853fe8ad948841204f81f9a8/cohere-7.0.5.tar.gz", hash = "sha256:7fc682bb5c408402fc5ce59322bfa3f6aae27bde1ecc2450b0a25370040707ed", size = 208820, upload-time = "2026-06-29T20:30:53.132Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/eb/64ca464baa34d0fa8144fc09ec7a35c8fcdeea1be878a518e901b0a6032b/cohere-7.0.5-py3-none-any.whl", hash = "sha256:fd98f82be28c969da7625adddede0bb85f8f84de399daf3a98c40c0e7b93e104", size = 352049, upload-time = "2026-06-29T20:30:51.472Z" },
-]
-
-[[package]]
-name = "color-codeword"
-version = "0.1.0"
-source = { editable = "deps/verifiers/environments/color_codeword" }
-dependencies = [
-    { name = "pillow" },
-    { name = "verifiers" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pillow", specifier = ">=11.0.0" },
-    { name = "verifiers" },
 ]
 
 [[package]]
@@ -1489,15 +1384,6 @@ requires-dist = [
 ]
 
 [[package]]
-name = "durationpy"
-version = "0.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
-]
-
-[[package]]
 name = "einops"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1836,14 +1722,6 @@ wheels = [
 ]
 
 [[package]]
-name = "flatbuffers"
-version = "25.12.19"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
-]
-
-[[package]]
 name = "fonttools"
 version = "4.63.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2147,17 +2025,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a2
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
 ]
-
-[[package]]
-name = "gsm8k"
-version = "0.1.0"
-source = { editable = "deps/verifiers/environments/gsm8k" }
-dependencies = [
-    { name = "datasets" },
-]
-
-[package.metadata]
-requires-dist = [{ name = "datasets" }]
 
 [[package]]
 name = "gymnasium"
@@ -2576,15 +2443,6 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-resources"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
-]
-
-[[package]]
 name = "inflect"
 version = "7.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2923,38 +2781,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/34/8aefdd0be9cfd00a44509251ba864f5caf2991e36772e61c408007e7f417/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9", size = 2294947, upload-time = "2026-03-09T13:13:43.343Z" },
     { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
 ]
-
-[[package]]
-name = "kubernetes"
-version = "36.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "certifi" },
-    { name = "durationpy" },
-    { name = "python-dateutil" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "requests-oauthlib" },
-    { name = "six" },
-    { name = "urllib3" },
-    { name = "websocket-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/57/8b538af5076bc3372949d76f70ba3449bdfe52f9e6488170fa5d4f7cbe70/kubernetes-36.0.2.tar.gz", hash = "sha256:03551fcb49cae1f708f63624041e37403545b7aaed10cbf54e2b01a37a5438e3", size = 2336738, upload-time = "2026-06-01T18:20:30.785Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/5c160dbdef7123f8cc97fd8ece7e0198627a426a2a49614845e9086feb8d/kubernetes-36.0.2-py2.py3-none-any.whl", hash = "sha256:faf9b5241b58de0c4a5069f2a0ffc8ac06fece7215156cd3d3ba081a78a858b6", size = 4617568, upload-time = "2026-06-01T18:20:28.737Z" },
-]
-
-[[package]]
-name = "kuhn-poker"
-version = "0.1.0"
-source = { editable = "deps/verifiers/environments/kuhn_poker" }
-dependencies = [
-    { name = "verifiers" },
-]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "lab"
@@ -3471,18 +3297,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
     { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
-]
-
-[[package]]
-name = "mmh3"
-version = "5.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/91/1a/edb23803a168f070ded7a3014c6d706f63b90c84ccc024f89d794a3b7a6d/mmh3-5.2.1.tar.gz", hash = "sha256:bbea5b775f0ac84945191fb83f845a6fd9a21a03ea7f2e187defac7e401616ad", size = 33775, upload-time = "2026-03-05T15:55:57.716Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/e2/51ed62063b44d10b06d975ac87af287729eeb5e3ed9772f7584a17983e90/mmh3-5.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e6c219e375f6341d0959af814296372d265a8ca1af63825f65e2e87c618f006", size = 103274, upload-time = "2026-03-05T15:54:26.44Z" },
-    { url = "https://files.pythonhosted.org/packages/75/ce/12a7524dca59eec92e5b31fdb13ede1e98eda277cf2b786cf73bfbc24e81/mmh3-5.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26fb5b9c3946bf7f1daed7b37e0c03898a6f062149127570f8ede346390a0825", size = 106158, upload-time = "2026-03-05T15:54:28.578Z" },
-    { url = "https://files.pythonhosted.org/packages/76/b3/70b73923fd0284c439860ff5c871b20210dfdbe9a6b9dd0ee6496d77f174/mmh3-5.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b3f99e1756fc48ad507b95e5d86f2fb21b3d495012ff13e6592ebac14033f166", size = 99111, upload-time = "2026-03-05T15:54:32.353Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/ac/ca8e0c19a34f5b71390171d2ff0b9f7f187550d66801a731bb68925126a4/mmh3-5.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d74a03fb57757ece25aa4b3c1c60157a1cece37a020542785f942e2f827eed5", size = 97507, upload-time = "2026-03-05T15:54:37.804Z" },
 ]
 
 [[package]]
@@ -4164,30 +3978,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/92/dd/692765e87de30bae1
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/07/698355285a03a366ef63ea9762fc1feef3f9f25483e1655408f72d827090/nvtx-0.2.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2cc530cd0f1a2c14a3a7e683833db509888ac5ed4ead94e5c9e2c7317c6937a7", size = 807159, upload-time = "2026-03-18T10:09:49.232Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d1/08f22448d83481408d663065764ba583df091a7de629ed38fc97e522f1af/nvtx-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3ca8030a6d197952318013dd1c12c22da1d4b9feb76ba72e0fcd449961183c2c", size = 806187, upload-time = "2026-03-18T10:13:32.972Z" },
-]
-
-[[package]]
-name = "oauthlib"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
-]
-
-[[package]]
-name = "onnxruntime"
-version = "1.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "flatbuffers" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "protobuf" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/a0/3f9d896a0385a36bd04345d6d0b802821a5782adde562e7e135f6bb71c73/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:91f2bb870a4b9224eba0a6728c1fa7a9e552b8e59e1083c51fbbc3d013f2b5c0", size = 16052692, upload-time = "2026-05-08T19:07:13.829Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/43/2a4e04f8dbeffad19bbcced4bcd4289bf478921518437404d6b92bdf213b/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b6dd70599005bd1bf29779f04a91978b92b5e719c11a20068a8f8e535f725b6", size = 18185439, upload-time = "2026-05-08T19:07:36.299Z" },
 ]
 
 [[package]]
@@ -5142,17 +4932,6 @@ wheels = [
 ]
 
 [[package]]
-name = "proposer-solver"
-version = "0.1.0"
-source = { editable = "deps/verifiers/environments/proposer_solver" }
-dependencies = [
-    { name = "verifiers" },
-]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
-
-[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -5447,15 +5226,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
-]
-
-[[package]]
-name = "pypika"
-version = "0.51.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/78/cbaebba88e05e2dcda13ca203131b38d3640219f20ebb49676d26714861b/pypika-0.51.1.tar.gz", hash = "sha256:c30c7c1048fbf056fd3920c5a2b88b0c29dd190a9b2bee971fd17e4abe4d0ebe", size = 80919, upload-time = "2026-02-04T11:27:48.304Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/83/c77dfeed04022e8930b08eedca2b6e5efed256ab3321396fde90066efb65/pypika-0.51.1-py2.py3-none-any.whl", hash = "sha256:77985b4d7ce71b9905255bf12468cf598349e98837c037541cfc240e528aec46", size = 60585, upload-time = "2026-02-04T11:27:46.251Z" },
 ]
 
 [[package]]
@@ -5823,30 +5593,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179a
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
-
-[[package]]
-name = "requests-oauthlib"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "oauthlib" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
-]
-
-[[package]]
-name = "reverse-text"
-version = "0.1.0"
-source = { editable = "deps/verifiers/environments/reverse_text" }
-dependencies = [
-    { name = "datasets" },
-]
-
-[package.metadata]
-requires-dist = [{ name = "datasets" }]
 
 [[package]]
 name = "rich"
@@ -6709,24 +6455,6 @@ requires-dist = [
 ]
 
 [[package]]
-name = "textarena"
-version = "0.7.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "chess" },
-    { name = "nltk" },
-    { name = "openai" },
-    { name = "python-dotenv" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/04/4a3ca42093d0be2a9c377ae3335a6c6baac1d278ae932562ec69f339d172/textarena-0.7.4.tar.gz", hash = "sha256:28bb9170d7718f2ae05e4515bea82262422731e563fc7318a9e7983de0cadd4f", size = 954969, upload-time = "2025-10-16T14:41:55.981Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/b4/9a9ba65154aff853c75b3d7324319d168ad9c69c6097f4aa3c16da7d9ef3/textarena-0.7.4-py3-none-any.whl", hash = "sha256:684784e78278e518066f67557ee93b47c238d16cbbd15d3abdaa3147562d3024", size = 1073570, upload-time = "2025-10-16T14:41:53.965Z" },
-]
-
-[[package]]
 name = "textual"
 version = "8.2.7"
 source = { registry = "https://pypi.org/simple" }
@@ -7434,10 +7162,6 @@ dependencies = [
 harbor = [
     { name = "harbor" },
 ]
-ta = [
-    { name = "nltk" },
-    { name = "textarena" },
-]
 
 [package.metadata]
 requires-dist = [
@@ -7497,20 +7221,20 @@ dev = [
     { name = "ty", specifier = ">=0.0.63" },
 ]
 examples = [
-    { name = "alphabet-sort", editable = "deps/verifiers/environments/alphabet_sort" },
-    { name = "code-golf", editable = "deps/verifiers/environments/code_golf" },
-    { name = "color-codeword", editable = "deps/verifiers/environments/color_codeword" },
+    { name = "alphabet-sort-v1", editable = "deps/verifiers/environments/alphabet_sort_v1" },
+    { name = "code-golf-v1", editable = "deps/verifiers/environments/code_golf_v1" },
+    { name = "color-codeword-v1", editable = "deps/verifiers/environments/color_codeword_v1" },
     { name = "compact", editable = "deps/verifiers/environments/compact" },
-    { name = "deepwiki", editable = "deps/verifiers/environments/deepwiki" },
-    { name = "glossary", editable = "deps/verifiers/environments/glossary" },
-    { name = "gsm8k", editable = "deps/verifiers/environments/gsm8k" },
-    { name = "kuhn-poker", editable = "deps/verifiers/environments/kuhn_poker" },
-    { name = "openenv-wordle", editable = "deps/verifiers/environments/openenv_wordle" },
-    { name = "proposer-solver", editable = "deps/verifiers/environments/proposer_solver" },
-    { name = "reverse-text", editable = "deps/verifiers/environments/reverse_text" },
-    { name = "scratchpad", editable = "deps/verifiers/environments/scratchpad" },
-    { name = "wiki-search", editable = "deps/verifiers/environments/wiki_search" },
-    { name = "wordle", editable = "deps/verifiers/environments/wordle" },
+    { name = "deepwiki-v1", editable = "deps/verifiers/environments/deepwiki_v1" },
+    { name = "glossary-v1", editable = "deps/verifiers/environments/glossary_v1" },
+    { name = "gsm8k-v1", editable = "deps/verifiers/environments/gsm8k_v1" },
+    { name = "kuhn-poker-v1", editable = "deps/verifiers/environments/kuhn_poker_v1" },
+    { name = "openenv-wordle-v1", editable = "deps/verifiers/environments/openenv_wordle_v1" },
+    { name = "proposer-solver-v1", editable = "deps/verifiers/environments/proposer_solver_v1" },
+    { name = "reverse-text-v1", editable = "deps/verifiers/environments/reverse_text_v1" },
+    { name = "scratchpad-v1", editable = "deps/verifiers/environments/scratchpad_v1" },
+    { name = "wiki-search-v1", editable = "deps/verifiers/environments/wiki_search_v1" },
+    { name = "wordle-v1", editable = "deps/verifiers/environments/wordle_v1" },
 ]
 
 [[package]]
@@ -8159,23 +7883,6 @@ wheels = [
 ]
 
 [[package]]
-name = "wiki-search"
-version = "0.1.0"
-source = { editable = "deps/verifiers/environments/wiki_search" }
-dependencies = [
-    { name = "chromadb" },
-    { name = "datasets" },
-    { name = "verifiers" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "chromadb", specifier = ">=0.4.13" },
-    { name = "datasets" },
-    { name = "verifiers" },
-]
-
-[[package]]
 name = "wikispeedia"
 version = "0.1.0"
 source = { editable = "deps/research-environments/environments/reasoning/wikispeedia" }
@@ -8185,17 +7892,6 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "verifiers", specifier = ">=0.2.2.dev65" }]
-
-[[package]]
-name = "wordle"
-version = "0.1.0"
-source = { editable = "deps/verifiers/environments/wordle" }
-dependencies = [
-    { name = "verifiers", extra = ["ta"] },
-]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers", extras = ["ta"] }]
 
 [[package]]
 name = "wrapt"

--- a/uv.lock
+++ b/uv.lock
@@ -35,98 +35,98 @@ prime = false
 
 [manifest]
 members = [
-    "aime24-v1",
-    "aime25-v1",
-    "aime26-v1",
-    "alphabet-sort-v1",
-    "apex-shortlist-v1",
-    "arxivmath-v1",
-    "automationbench-v1",
-    "bfcl-v3-v1",
-    "browsecomp-plus-v1",
-    "browsecomp-v1",
-    "charxiv-v1",
-    "clbench-v1",
-    "color-codeword-v1",
-    "deepdive-v1",
-    "deepseek-prover-v1",
-    "enterprise-ops-gym-v1",
-    "forth-lang-v1",
-    "frontierscience-v1",
-    "general-agent-v1",
-    "goedel-pset-v1",
-    "gpqa-v1",
-    "graphwalks-v1",
-    "gsm8k-v1",
-    "hle-v1",
-    "humaneval-v1",
-    "i3-code-v1",
-    "i3-logic-v1",
-    "i3-math-v1",
-    "i3-science-v1",
-    "ifbench-v1",
-    "ifeval-v1",
-    "kimina-v1",
-    "kuhn-poker-v1",
-    "livecodebench-v1",
-    "longbenchpro-v1",
-    "longcot-mini-v1",
-    "longcot-v1",
-    "longpdfs-v1",
-    "math-env-v1",
-    "math500-v1",
-    "mcp-atlas-v1",
-    "minif2f-v1",
-    "mmk12-v1",
-    "mmlu-pro-v1",
-    "mmmu-pro-v1",
-    "mmmu-v1",
-    "mrcr-v2-v1",
-    "multiswe-v1",
-    "nl2repobench-v1",
-    "numina-v1",
-    "oolong-pairs-v1",
-    "oolong-real-v1",
-    "oolong-synth-v1",
-    "openseeker-v1",
-    "openswe-v1",
-    "openthoughts-tblite-v1",
-    "papersearchqa-v1",
-    "patterned-needle-in-haystack-v1",
-    "pinchbench-v1",
+    "aime24",
+    "aime25",
+    "aime26",
+    "alphabet-sort",
+    "apex-shortlist",
+    "arxivmath",
+    "automationbench",
+    "bfcl-v3",
+    "browsecomp",
+    "browsecomp-plus",
+    "charxiv",
+    "clbench",
+    "color-codeword",
+    "deepdive",
+    "deepseek-prover",
+    "enterprise-ops-gym",
+    "forth-lang",
+    "frontierscience",
+    "general-agent",
+    "goedel-pset",
+    "gpqa",
+    "graphwalks",
+    "gsm8k",
+    "hle",
+    "humaneval",
+    "i3-code",
+    "i3-logic",
+    "i3-math",
+    "i3-science",
+    "ifbench",
+    "ifeval",
+    "kimina",
+    "kuhn-poker",
+    "livecodebench",
+    "longbenchpro",
+    "longcot-env",
+    "longcot-mini",
+    "longpdfs",
+    "math-env",
+    "math500",
+    "mcp-atlas",
+    "minif2f",
+    "mmk12",
+    "mmlu-pro",
+    "mmmu",
+    "mmmu-pro",
+    "mrcr-v2",
+    "multiswe",
+    "nl2repobench",
+    "numina",
+    "oolong-pairs",
+    "oolong-real",
+    "oolong-synth",
+    "openseeker",
+    "openswe",
+    "openthoughts-tblite",
+    "papersearchqa",
+    "patterned-needle-in-haystack",
+    "pinchbench",
     "prime-rl",
-    "programbench-v1",
-    "prolog-v1",
-    "proposer-solver-v1",
-    "proverbench-v1",
-    "r2e-gym-v1",
-    "redsearcher-v1",
-    "reverse-text-v1",
-    "s1-deepresearch-v1",
-    "scaleswe-v1",
-    "scicode-v1",
-    "senior-swe-bench-v1",
-    "simpleqa-v1",
-    "simpleqa-verified-v1",
-    "swebench-multilingual-v1",
-    "swebench-pro-v1",
-    "swebench-verified-v1",
-    "swelego-v1",
-    "swerebench-v2-v1",
-    "swesmith-v1",
-    "tau2-bench-v1",
-    "terminal-bench-2-v1",
-    "terminal-lego-v1",
-    "tmax-v1",
-    "triviaqa-v1",
-    "unscramble-v1",
-    "uuid-ctf-v1",
-    "verbatim-copy-v1",
-    "virl39k-v1",
-    "wideseek-v1",
-    "wiki-search-v1",
-    "wikispeedia-v1",
-    "wordle-v1",
+    "programbench-env",
+    "prolog",
+    "proposer-solver",
+    "proverbench",
+    "r2e-gym",
+    "redsearcher",
+    "reverse-text",
+    "s1-deepresearch",
+    "scaleswe",
+    "scicode",
+    "senior-swe-bench",
+    "simpleqa",
+    "simpleqa-verified",
+    "swebench-multilingual",
+    "swebench-pro",
+    "swebench-verified",
+    "swelego",
+    "swerebench-v2",
+    "swesmith-env",
+    "tau2-bench",
+    "terminal-bench-2",
+    "terminal-lego",
+    "tmax",
+    "triviaqa",
+    "unscramble",
+    "uuid-ctf",
+    "verbatim-copy",
+    "virl39k",
+    "wideseek",
+    "wiki-search",
+    "wikispeedia",
+    "wordle",
 ]
 overrides = [
     { name = "nvidia-cudnn-cu12", specifier = ">=9.15" },
@@ -160,9 +160,9 @@ wheels = [
 ]
 
 [[package]]
-name = "aime24-v1"
+name = "aime24"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/math/aime24_v1" }
+source = { editable = "deps/research-environments/environments/math/aime24" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -175,9 +175,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "aime25-v1"
+name = "aime25"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/math/aime25_v1" }
+source = { editable = "deps/research-environments/environments/math/aime25" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -190,9 +190,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "aime26-v1"
+name = "aime26"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/math/aime26_v1" }
+source = { editable = "deps/research-environments/environments/math/aime26" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -266,9 +266,9 @@ wheels = [
 ]
 
 [[package]]
-name = "alphabet-sort-v1"
+name = "alphabet-sort"
 version = "0.1.0"
-source = { editable = "deps/verifiers/environments/alphabet_sort_v1" }
+source = { editable = "deps/verifiers/environments/alphabet_sort" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -355,9 +355,9 @@ wheels = [
 ]
 
 [[package]]
-name = "apex-shortlist-v1"
+name = "apex-shortlist"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/math/apex_shortlist_v1" }
+source = { editable = "deps/research-environments/environments/math/apex_shortlist" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -388,9 +388,9 @@ wheels = [
 ]
 
 [[package]]
-name = "arxivmath-v1"
+name = "arxivmath"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/math/arxivmath_v1" }
+source = { editable = "deps/research-environments/environments/math/arxivmath" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -443,9 +443,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "automationbench-v1"
+name = "automationbench"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/tool_use/automationbench_v1" }
+source = { editable = "deps/research-environments/environments/tool_use/automationbench" }
 dependencies = [
     { name = "automation-bench" },
     { name = "datasets" },
@@ -571,9 +571,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "bfcl-v3-v1"
+name = "bfcl-v3"
 version = "0.3.0"
-source = { editable = "deps/research-environments/environments/tool_use/bfcl_v3_v1" }
+source = { editable = "deps/research-environments/environments/tool_use/bfcl_v3" }
 dependencies = [
     { name = "bfcl-eval" },
     { name = "soundfile" },
@@ -673,9 +673,26 @@ wheels = [
 ]
 
 [[package]]
-name = "browsecomp-plus-v1"
+name = "browsecomp"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/search/browsecomp_plus_v1" }
+source = { editable = "deps/research-environments/environments/search/browsecomp" }
+dependencies = [
+    { name = "httpx" },
+    { name = "openai" },
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx" },
+    { name = "openai" },
+    { name = "verifiers", specifier = ">=0.2.0" },
+]
+
+[[package]]
+name = "browsecomp-plus"
+version = "0.1.0"
+source = { editable = "deps/research-environments/environments/search/browsecomp_plus" }
 dependencies = [
     { name = "bm25s" },
     { name = "datasets" },
@@ -695,23 +712,6 @@ requires-dist = [
     { name = "pystemmer" },
     { name = "tokenizers" },
     { name = "verifiers", specifier = ">=0.2.2.dev65" },
-]
-
-[[package]]
-name = "browsecomp-v1"
-version = "0.1.0"
-source = { editable = "deps/research-environments/environments/search/browsecomp_v1" }
-dependencies = [
-    { name = "httpx" },
-    { name = "openai" },
-    { name = "verifiers" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx" },
-    { name = "openai" },
-    { name = "verifiers", specifier = ">=0.2.0" },
 ]
 
 [[package]]
@@ -827,9 +827,9 @@ wheels = [
 ]
 
 [[package]]
-name = "charxiv-v1"
+name = "charxiv"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/multimodal/charxiv_v1" }
+source = { editable = "deps/research-environments/environments/multimodal/charxiv" }
 dependencies = [
     { name = "datasets" },
     { name = "pillow" },
@@ -889,9 +889,9 @@ wheels = [
 ]
 
 [[package]]
-name = "clbench-v1"
+name = "clbench"
 version = "0.2.0"
-source = { editable = "deps/research-environments/environments/long_context/clbench_v1" }
+source = { editable = "deps/research-environments/environments/long_context/clbench" }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },
@@ -952,9 +952,9 @@ wheels = [
 ]
 
 [[package]]
-name = "color-codeword-v1"
+name = "color-codeword"
 version = "0.1.0"
-source = { editable = "deps/verifiers/environments/color_codeword_v1" }
+source = { editable = "deps/verifiers/environments/color_codeword" }
 dependencies = [
     { name = "pillow" },
     { name = "verifiers" },
@@ -1315,9 +1315,9 @@ wheels = [
 ]
 
 [[package]]
-name = "deepdive-v1"
+name = "deepdive"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/search/deepdive_v1" }
+source = { editable = "deps/research-environments/environments/search/deepdive" }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },
@@ -1332,9 +1332,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "deepseek-prover-v1"
+name = "deepseek-prover"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/lean/deepseek_prover_v1" }
+source = { editable = "deps/research-environments/environments/lean/deepseek_prover" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -1512,9 +1512,9 @@ wheels = [
 ]
 
 [[package]]
-name = "enterprise-ops-gym-v1"
+name = "enterprise-ops-gym"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/tool_use/enterprise_ops_gym_v1" }
+source = { editable = "deps/research-environments/environments/tool_use/enterprise_ops_gym" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -1840,9 +1840,9 @@ wheels = [
 ]
 
 [[package]]
-name = "forth-lang-v1"
+name = "forth-lang"
 version = "0.2.0"
-source = { editable = "deps/research-environments/environments/code/forth_lang_v1" }
+source = { editable = "deps/research-environments/environments/code/forth_lang" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -1855,9 +1855,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "frontierscience-v1"
+name = "frontierscience"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/science/frontierscience_v1" }
+source = { editable = "deps/research-environments/environments/science/frontierscience" }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },
@@ -1913,9 +1913,9 @@ http = [
 ]
 
 [[package]]
-name = "general-agent-v1"
+name = "general-agent"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/tool_use/general_agent_v1" }
+source = { editable = "deps/research-environments/environments/tool_use/general_agent" }
 dependencies = [
     { name = "pydantic" },
     { name = "verifiers", extra = ["harbor"] },
@@ -1988,9 +1988,9 @@ wheels = [
 ]
 
 [[package]]
-name = "goedel-pset-v1"
+name = "goedel-pset"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/lean/goedel_pset_v1" }
+source = { editable = "deps/research-environments/environments/lean/goedel_pset" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -2063,9 +2063,9 @@ wheels = [
 ]
 
 [[package]]
-name = "gpqa-v1"
+name = "gpqa"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/science/gpqa_v1" }
+source = { editable = "deps/research-environments/environments/science/gpqa" }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },
@@ -2080,9 +2080,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "graphwalks-v1"
+name = "graphwalks"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/long_context/graphwalks_v1" }
+source = { editable = "deps/research-environments/environments/long_context/graphwalks" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -2132,9 +2132,9 @@ wheels = [
 ]
 
 [[package]]
-name = "gsm8k-v1"
+name = "gsm8k"
 version = "0.1.0"
-source = { editable = "deps/verifiers/environments/gsm8k_v1" }
+source = { editable = "deps/verifiers/environments/gsm8k" }
 dependencies = [
     { name = "datasets" },
 ]
@@ -2224,9 +2224,9 @@ wheels = [
 ]
 
 [[package]]
-name = "hle-v1"
+name = "hle"
 version = "0.3.0"
-source = { editable = "deps/research-environments/environments/knowledge/hle_v1" }
+source = { editable = "deps/research-environments/environments/knowledge/hle" }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },
@@ -2335,9 +2335,9 @@ wheels = [
 ]
 
 [[package]]
-name = "humaneval-v1"
+name = "humaneval"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/code/humaneval_v1" }
+source = { editable = "deps/research-environments/environments/code/humaneval" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -2388,9 +2388,9 @@ wheels = [
 ]
 
 [[package]]
-name = "i3-code-v1"
+name = "i3-code"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/code/i3_code_v1" }
+source = { editable = "deps/research-environments/environments/code/i3_code" }
 dependencies = [
     { name = "datasets" },
     { name = "orjson" },
@@ -2405,9 +2405,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "i3-logic-v1"
+name = "i3-logic"
 version = "0.2.0"
-source = { editable = "deps/research-environments/environments/reasoning/i3_logic_v1" }
+source = { editable = "deps/research-environments/environments/reasoning/i3_logic" }
 dependencies = [
     { name = "datasets" },
     { name = "markdown" },
@@ -2426,9 +2426,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "i3-math-v1"
+name = "i3-math"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/math/i3_math_v1" }
+source = { editable = "deps/research-environments/environments/math/i3_math" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -2441,9 +2441,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "i3-science-v1"
+name = "i3-science"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/science/i3_science_v1" }
+source = { editable = "deps/research-environments/environments/science/i3_science" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -2474,9 +2474,9 @@ wheels = [
 ]
 
 [[package]]
-name = "ifbench-v1"
+name = "ifbench"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/if/ifbench_v1" }
+source = { editable = "deps/research-environments/environments/if/ifbench" }
 dependencies = [
     { name = "datasets" },
     { name = "emoji" },
@@ -2505,9 +2505,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "ifeval-v1"
+name = "ifeval"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/if/ifeval_v1" }
+source = { editable = "deps/research-environments/environments/if/ifeval" }
 dependencies = [
     { name = "datasets" },
     { name = "immutabledict" },
@@ -2880,9 +2880,9 @@ wheels = [
 ]
 
 [[package]]
-name = "kimina-v1"
+name = "kimina"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/lean/kimina_v1" }
+source = { editable = "deps/research-environments/environments/lean/kimina" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -2929,9 +2929,9 @@ wheels = [
 ]
 
 [[package]]
-name = "kuhn-poker-v1"
+name = "kuhn-poker"
 version = "0.1.0"
-source = { editable = "deps/verifiers/environments/kuhn_poker_v1" }
+source = { editable = "deps/verifiers/environments/kuhn_poker" }
 dependencies = [
     { name = "verifiers" },
 ]
@@ -3025,9 +3025,9 @@ wheels = [
 ]
 
 [[package]]
-name = "livecodebench-v1"
+name = "livecodebench"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/code/livecodebench_v1" }
+source = { editable = "deps/research-environments/environments/code/livecodebench" }
 dependencies = [
     { name = "datasets" },
     { name = "huggingface-hub" },
@@ -3086,9 +3086,9 @@ wheels = [
 ]
 
 [[package]]
-name = "longbenchpro-v1"
+name = "longbenchpro"
 version = "0.2.0"
-source = { editable = "deps/research-environments/environments/long_context/longbenchpro_v1" }
+source = { editable = "deps/research-environments/environments/long_context/longbenchpro" }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },
@@ -3119,9 +3119,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "longcot-mini-v1"
+name = "longcot-env"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/long_context/longcot_mini_v1" }
+source = { editable = "deps/research-environments/environments/long_context/longcot_env" }
 dependencies = [
     { name = "datasets" },
     { name = "longcot" },
@@ -3136,9 +3136,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "longcot-v1"
+name = "longcot-mini"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/long_context/longcot_v1" }
+source = { editable = "deps/research-environments/environments/long_context/longcot_mini" }
 dependencies = [
     { name = "datasets" },
     { name = "longcot" },
@@ -3153,9 +3153,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "longpdfs-v1"
+name = "longpdfs"
 version = "0.0.1"
-source = { editable = "deps/research-environments/environments/long_context/longpdfs_v1" }
+source = { editable = "deps/research-environments/environments/long_context/longpdfs" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -3233,9 +3233,9 @@ wheels = [
 ]
 
 [[package]]
-name = "math-env-v1"
+name = "math-env"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/math/math_env_v1" }
+source = { editable = "deps/research-environments/environments/math/math_env" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -3260,9 +3260,9 @@ wheels = [
 ]
 
 [[package]]
-name = "math500-v1"
+name = "math500"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/math/math500_v1" }
+source = { editable = "deps/research-environments/environments/math/math500" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -3333,9 +3333,9 @@ wheels = [
 ]
 
 [[package]]
-name = "mcp-atlas-v1"
+name = "mcp-atlas"
 version = "0.3.0"
-source = { editable = "deps/research-environments/environments/tool_use/mcp_atlas_v1" }
+source = { editable = "deps/research-environments/environments/tool_use/mcp_atlas" }
 dependencies = [
     { name = "datasets" },
     { name = "httpx" },
@@ -3373,9 +3373,9 @@ wheels = [
 ]
 
 [[package]]
-name = "minif2f-v1"
+name = "minif2f"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/lean/minif2f_v1" }
+source = { editable = "deps/research-environments/environments/lean/minif2f" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -3458,9 +3458,9 @@ wheels = [
 ]
 
 [[package]]
-name = "mmk12-v1"
+name = "mmk12"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/multimodal/mmk12_v1" }
+source = { editable = "deps/research-environments/environments/multimodal/mmk12" }
 dependencies = [
     { name = "datasets" },
     { name = "math-verify" },
@@ -3477,9 +3477,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "mmlu-pro-v1"
+name = "mmlu-pro"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/knowledge/mmlu_pro_v1" }
+source = { editable = "deps/research-environments/environments/knowledge/mmlu_pro" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -3492,9 +3492,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "mmmu-pro-v1"
+name = "mmmu"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/multimodal/mmmu_pro_v1" }
+source = { editable = "deps/research-environments/environments/knowledge/mmmu" }
 dependencies = [
     { name = "datasets" },
     { name = "pillow" },
@@ -3509,9 +3509,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "mmmu-v1"
+name = "mmmu-pro"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/knowledge/mmmu_v1" }
+source = { editable = "deps/research-environments/environments/multimodal/mmmu_pro" }
 dependencies = [
     { name = "datasets" },
     { name = "pillow" },
@@ -3616,9 +3616,9 @@ wheels = [
 ]
 
 [[package]]
-name = "mrcr-v2-v1"
+name = "mrcr-v2"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/long_context/mrcr_v2_v1" }
+source = { editable = "deps/research-environments/environments/long_context/mrcr_v2" }
 dependencies = [
     { name = "filelock" },
     { name = "httpx" },
@@ -3706,9 +3706,9 @@ wheels = [
 ]
 
 [[package]]
-name = "multiswe-v1"
+name = "multiswe"
 version = "0.1.2"
-source = { editable = "deps/research-environments/environments/swe/multiswe_v1" }
+source = { editable = "deps/research-environments/environments/swe/multiswe" }
 dependencies = [
     { name = "datasets" },
     { name = "multi-swe-bench" },
@@ -3837,9 +3837,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "nl2repobench-v1"
+name = "nl2repobench"
 version = "0.2.0"
-source = { editable = "deps/research-environments/environments/code/nl2repobench_v1" }
+source = { editable = "deps/research-environments/environments/code/nl2repobench" }
 dependencies = [
     { name = "datasets" },
     { name = "prime-sandboxes" },
@@ -3892,9 +3892,9 @@ wheels = [
 ]
 
 [[package]]
-name = "numina-v1"
+name = "numina"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/lean/numina_v1" }
+source = { editable = "deps/research-environments/environments/lean/numina" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -4163,9 +4163,9 @@ wheels = [
 ]
 
 [[package]]
-name = "oolong-pairs-v1"
+name = "oolong-pairs"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/long_context/oolong_pairs_v1" }
+source = { editable = "deps/research-environments/environments/long_context/oolong_pairs" }
 dependencies = [
     { name = "datasets" },
     { name = "huggingface-hub" },
@@ -4180,9 +4180,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "oolong-real-v1"
+name = "oolong-real"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/long_context/oolong_real_v1" }
+source = { editable = "deps/research-environments/environments/long_context/oolong_real" }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },
@@ -4197,9 +4197,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "oolong-synth-v1"
+name = "oolong-synth"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/long_context/oolong_synth_v1" }
+source = { editable = "deps/research-environments/environments/long_context/oolong_synth" }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },
@@ -4283,9 +4283,9 @@ wheels = [
 ]
 
 [[package]]
-name = "openseeker-v1"
+name = "openseeker"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/search/openseeker_v1" }
+source = { editable = "deps/research-environments/environments/search/openseeker" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -4298,9 +4298,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "openswe-v1"
+name = "openswe"
 version = "0.1.3"
-source = { editable = "deps/research-environments/environments/swe/openswe_v1" }
+source = { editable = "deps/research-environments/environments/swe/openswe" }
 dependencies = [
     { name = "datasets" },
     { name = "huggingface-hub" },
@@ -4440,9 +4440,9 @@ wheels = [
 ]
 
 [[package]]
-name = "openthoughts-tblite-v1"
+name = "openthoughts-tblite"
 version = "0.1.1"
-source = { editable = "deps/research-environments/environments/terminal/openthoughts_tblite_v1" }
+source = { editable = "deps/research-environments/environments/terminal/openthoughts_tblite" }
 dependencies = [
     { name = "verifiers", extra = ["harbor"] },
 ]
@@ -4516,9 +4516,9 @@ wheels = [
 ]
 
 [[package]]
-name = "papersearchqa-v1"
+name = "papersearchqa"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/search/papersearchqa_v1" }
+source = { editable = "deps/research-environments/environments/search/papersearchqa" }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },
@@ -4560,9 +4560,9 @@ wheels = [
 ]
 
 [[package]]
-name = "patterned-needle-in-haystack-v1"
+name = "patterned-needle-in-haystack"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/long_context/patterned_needle_in_haystack_v1" }
+source = { editable = "deps/research-environments/environments/long_context/patterned_needle_in_haystack" }
 dependencies = [
     { name = "nltk" },
     { name = "verifiers" },
@@ -4601,9 +4601,9 @@ wheels = [
 ]
 
 [[package]]
-name = "pinchbench-v1"
+name = "pinchbench"
 version = "0.2.0"
-source = { editable = "deps/research-environments/environments/tool_use/pinchbench_v1" }
+source = { editable = "deps/research-environments/environments/tool_use/pinchbench" }
 dependencies = [
     { name = "openai" },
     { name = "prime-sandboxes" },
@@ -5035,9 +5035,9 @@ wheels = [
 ]
 
 [[package]]
-name = "programbench-v1"
+name = "programbench-env"
 version = "0.2.0"
-source = { editable = "deps/research-environments/environments/code/programbench_v1" }
+source = { editable = "deps/research-environments/environments/code/programbench_env" }
 dependencies = [
     { name = "datasets" },
     { name = "huggingface-hub" },
@@ -5056,9 +5056,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "prolog-v1"
+name = "prolog"
 version = "0.5.0"
-source = { editable = "deps/research-environments/environments/reasoning/prolog_v1" }
+source = { editable = "deps/research-environments/environments/reasoning/prolog" }
 dependencies = [
     { name = "verifiers" },
 ]
@@ -5114,9 +5114,9 @@ wheels = [
 ]
 
 [[package]]
-name = "proposer-solver-v1"
+name = "proposer-solver"
 version = "0.1.0"
-source = { editable = "deps/verifiers/environments/proposer_solver_v1" }
+source = { editable = "deps/verifiers/environments/proposer_solver" }
 dependencies = [
     { name = "verifiers" },
 ]
@@ -5136,9 +5136,9 @@ wheels = [
 ]
 
 [[package]]
-name = "proverbench-v1"
+name = "proverbench"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/lean/proverbench_v1" }
+source = { editable = "deps/research-environments/environments/lean/proverbench" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -5642,9 +5642,9 @@ wheels = [
 ]
 
 [[package]]
-name = "r2e-gym-v1"
+name = "r2e-gym"
 version = "0.1.2"
-source = { editable = "deps/research-environments/environments/swe/r2e_gym_v1" }
+source = { editable = "deps/research-environments/environments/swe/r2e_gym" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -5705,9 +5705,9 @@ wheels = [
 ]
 
 [[package]]
-name = "redsearcher-v1"
+name = "redsearcher"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/search/redsearcher_v1" }
+source = { editable = "deps/research-environments/environments/search/redsearcher" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -5810,9 +5810,9 @@ wheels = [
 ]
 
 [[package]]
-name = "reverse-text-v1"
+name = "reverse-text"
 version = "0.1.0"
-source = { editable = "deps/verifiers/environments/reverse_text_v1" }
+source = { editable = "deps/verifiers/environments/reverse_text" }
 dependencies = [
     { name = "datasets" },
 ]
@@ -5893,9 +5893,9 @@ wheels = [
 ]
 
 [[package]]
-name = "s1-deepresearch-v1"
+name = "s1-deepresearch"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/search/s1_deepresearch_v1" }
+source = { editable = "deps/research-environments/environments/search/s1_deepresearch" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "verifiers" },
@@ -5932,9 +5932,9 @@ wheels = [
 ]
 
 [[package]]
-name = "scaleswe-v1"
+name = "scaleswe"
 version = "0.1.2"
-source = { editable = "deps/research-environments/environments/swe/scaleswe_v1" }
+source = { editable = "deps/research-environments/environments/swe/scaleswe" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -5960,9 +5960,9 @@ wheels = [
 ]
 
 [[package]]
-name = "scicode-v1"
+name = "scicode"
 version = "0.3.0"
-source = { editable = "deps/research-environments/environments/code/scicode_v1" }
+source = { editable = "deps/research-environments/environments/code/scicode" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -6021,9 +6021,9 @@ wheels = [
 ]
 
 [[package]]
-name = "senior-swe-bench-v1"
+name = "senior-swe-bench"
 version = "0.1.1"
-source = { editable = "deps/research-environments/environments/swe/senior_swe_bench_v1" }
+source = { editable = "deps/research-environments/environments/swe/senior_swe_bench" }
 dependencies = [
     { name = "verifiers", extra = ["harbor"] },
 ]
@@ -6113,9 +6113,9 @@ wheels = [
 ]
 
 [[package]]
-name = "simpleqa-v1"
+name = "simpleqa"
 version = "0.2.0"
-source = { editable = "deps/research-environments/environments/knowledge/simpleqa_v1" }
+source = { editable = "deps/research-environments/environments/knowledge/simpleqa" }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },
@@ -6130,9 +6130,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "simpleqa-verified-v1"
+name = "simpleqa-verified"
 version = "0.2.0"
-source = { editable = "deps/research-environments/environments/knowledge/simpleqa_verified_v1" }
+source = { editable = "deps/research-environments/environments/knowledge/simpleqa_verified" }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },
@@ -6439,9 +6439,9 @@ wheels = [
 ]
 
 [[package]]
-name = "swebench-multilingual-v1"
+name = "swebench-multilingual"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/swe/swebench_multilingual_v1" }
+source = { editable = "deps/research-environments/environments/swe/swebench_multilingual" }
 dependencies = [
     { name = "verifiers", extra = ["harbor"] },
 ]
@@ -6450,9 +6450,9 @@ dependencies = [
 requires-dist = [{ name = "verifiers", extras = ["harbor"], specifier = ">=0.2.2.dev65" }]
 
 [[package]]
-name = "swebench-pro-v1"
+name = "swebench-pro"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/swe/swebench_pro_v1" }
+source = { editable = "deps/research-environments/environments/swe/swebench_pro" }
 dependencies = [
     { name = "verifiers", extra = ["harbor"] },
 ]
@@ -6461,9 +6461,9 @@ dependencies = [
 requires-dist = [{ name = "verifiers", extras = ["harbor"], specifier = ">=0.2.2.dev27" }]
 
 [[package]]
-name = "swebench-verified-v1"
+name = "swebench-verified"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/swe/swebench_verified_v1" }
+source = { editable = "deps/research-environments/environments/swe/swebench_verified" }
 dependencies = [
     { name = "verifiers", extra = ["harbor"] },
 ]
@@ -6472,9 +6472,9 @@ dependencies = [
 requires-dist = [{ name = "verifiers", extras = ["harbor"], specifier = ">=0.2.2.dev65" }]
 
 [[package]]
-name = "swelego-v1"
+name = "swelego"
 version = "0.1.2"
-source = { editable = "deps/research-environments/environments/swe/swelego_v1" }
+source = { editable = "deps/research-environments/environments/swe/swelego" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -6487,9 +6487,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "swerebench-v2-v1"
+name = "swerebench-v2"
 version = "0.1.2"
-source = { editable = "deps/research-environments/environments/swe/swerebench_v2_v1" }
+source = { editable = "deps/research-environments/environments/swe/swerebench_v2" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -6507,9 +6507,9 @@ version = "0.0.9"
 source = { git = "https://github.com/SWE-bench/SWE-smith.git?rev=9b74ac0#9b74ac08118a85c39c356802f7961893af73e07f" }
 
 [[package]]
-name = "swesmith-v1"
+name = "swesmith-env"
 version = "0.1.2"
-source = { editable = "deps/research-environments/environments/swe/swesmith_v1" }
+source = { editable = "deps/research-environments/environments/swe/swesmith_env" }
 dependencies = [
     { name = "datasets" },
     { name = "swebench" },
@@ -6601,9 +6601,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "tau2-bench-v1"
+name = "tau2-bench"
 version = "0.3.0"
-source = { editable = "deps/research-environments/environments/tool_use/tau2_bench_v1" }
+source = { editable = "deps/research-environments/environments/tool_use/tau2_bench" }
 dependencies = [
     { name = "tau2" },
     { name = "verifiers" },
@@ -6655,9 +6655,9 @@ wheels = [
 ]
 
 [[package]]
-name = "terminal-bench-2-v1"
+name = "terminal-bench-2"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/terminal/terminal_bench_2_v1" }
+source = { editable = "deps/research-environments/environments/terminal/terminal_bench_2" }
 dependencies = [
     { name = "verifiers", extra = ["harbor"] },
 ]
@@ -6666,9 +6666,9 @@ dependencies = [
 requires-dist = [{ name = "verifiers", extras = ["harbor"], specifier = ">=0.2.1" }]
 
 [[package]]
-name = "terminal-lego-v1"
+name = "terminal-lego"
 version = "0.1.1"
-source = { editable = "deps/research-environments/environments/terminal/terminal_lego_v1" }
+source = { editable = "deps/research-environments/environments/terminal/terminal_lego" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "verifiers", extra = ["harbor"] },
@@ -6816,9 +6816,9 @@ wheels = [
 ]
 
 [[package]]
-name = "tmax-v1"
+name = "tmax"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/terminal/tmax_v1" }
+source = { editable = "deps/research-environments/environments/terminal/tmax" }
 dependencies = [
     { name = "verifiers", extra = ["harbor"] },
 ]
@@ -7148,9 +7148,9 @@ wheels = [
 ]
 
 [[package]]
-name = "triviaqa-v1"
+name = "triviaqa"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/knowledge/triviaqa_v1" }
+source = { editable = "deps/research-environments/environments/knowledge/triviaqa" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -7286,9 +7286,9 @@ wheels = [
 ]
 
 [[package]]
-name = "unscramble-v1"
+name = "unscramble"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/reasoning/unscramble_v1" }
+source = { editable = "deps/research-environments/environments/reasoning/unscramble" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },
@@ -7310,9 +7310,9 @@ wheels = [
 ]
 
 [[package]]
-name = "uuid-ctf-v1"
+name = "uuid-ctf"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/reasoning/uuid_ctf_v1" }
+source = { editable = "deps/research-environments/environments/reasoning/uuid_ctf" }
 dependencies = [
     { name = "verifiers" },
 ]
@@ -7356,9 +7356,9 @@ wheels = [
 ]
 
 [[package]]
-name = "verbatim-copy-v1"
+name = "verbatim-copy"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/long_context/verbatim_copy_v1" }
+source = { editable = "deps/research-environments/environments/long_context/verbatim_copy" }
 dependencies = [
     { name = "faker" },
     { name = "verifiers" },
@@ -7469,26 +7469,26 @@ dev = [
     { name = "ty", specifier = ">=0.0.63" },
 ]
 examples = [
-    { name = "alphabet-sort-v1", editable = "deps/verifiers/environments/alphabet_sort_v1" },
-    { name = "code-golf-v1", editable = "deps/verifiers/environments/code_golf_v1" },
-    { name = "color-codeword-v1", editable = "deps/verifiers/environments/color_codeword_v1" },
+    { name = "alphabet-sort", editable = "deps/verifiers/environments/alphabet_sort" },
+    { name = "code-golf", editable = "deps/verifiers/environments/code_golf" },
+    { name = "color-codeword", editable = "deps/verifiers/environments/color_codeword" },
     { name = "compact", editable = "deps/verifiers/environments/compact" },
-    { name = "deepwiki-v1", editable = "deps/verifiers/environments/deepwiki_v1" },
-    { name = "glossary-v1", editable = "deps/verifiers/environments/glossary_v1" },
-    { name = "gsm8k-v1", editable = "deps/verifiers/environments/gsm8k_v1" },
-    { name = "kuhn-poker-v1", editable = "deps/verifiers/environments/kuhn_poker_v1" },
-    { name = "openenv-wordle-v1", editable = "deps/verifiers/environments/openenv_wordle_v1" },
-    { name = "proposer-solver-v1", editable = "deps/verifiers/environments/proposer_solver_v1" },
-    { name = "reverse-text-v1", editable = "deps/verifiers/environments/reverse_text_v1" },
-    { name = "scratchpad-v1", editable = "deps/verifiers/environments/scratchpad_v1" },
-    { name = "wiki-search-v1", editable = "deps/verifiers/environments/wiki_search_v1" },
-    { name = "wordle-v1", editable = "deps/verifiers/environments/wordle_v1" },
+    { name = "deepwiki", editable = "deps/verifiers/environments/deepwiki" },
+    { name = "glossary", editable = "deps/verifiers/environments/glossary" },
+    { name = "gsm8k", editable = "deps/verifiers/environments/gsm8k" },
+    { name = "kuhn-poker", editable = "deps/verifiers/environments/kuhn_poker" },
+    { name = "openenv-wordle", editable = "deps/verifiers/environments/openenv_wordle" },
+    { name = "proposer-solver", editable = "deps/verifiers/environments/proposer_solver" },
+    { name = "reverse-text", editable = "deps/verifiers/environments/reverse_text" },
+    { name = "scratchpad", editable = "deps/verifiers/environments/scratchpad" },
+    { name = "wiki-search", editable = "deps/verifiers/environments/wiki_search" },
+    { name = "wordle", editable = "deps/verifiers/environments/wordle" },
 ]
 
 [[package]]
-name = "virl39k-v1"
+name = "virl39k"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/multimodal/virl39k_v1" }
+source = { editable = "deps/research-environments/environments/multimodal/virl39k" }
 dependencies = [
     { name = "datasets" },
     { name = "huggingface-hub" },
@@ -8105,9 +8105,9 @@ wheels = [
 ]
 
 [[package]]
-name = "wideseek-v1"
+name = "wideseek"
 version = "0.2.0"
-source = { editable = "deps/research-environments/environments/search/wideseek_v1" }
+source = { editable = "deps/research-environments/environments/search/wideseek" }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },
@@ -8131,9 +8131,9 @@ wheels = [
 ]
 
 [[package]]
-name = "wiki-search-v1"
+name = "wiki-search"
 version = "0.1.0"
-source = { editable = "deps/verifiers/environments/wiki_search_v1" }
+source = { editable = "deps/verifiers/environments/wiki_search" }
 dependencies = [
     { name = "chromadb" },
     { name = "datasets" },
@@ -8148,9 +8148,9 @@ requires-dist = [
 ]
 
 [[package]]
-name = "wikispeedia-v1"
+name = "wikispeedia"
 version = "0.1.0"
-source = { editable = "deps/research-environments/environments/reasoning/wikispeedia_v1" }
+source = { editable = "deps/research-environments/environments/reasoning/wikispeedia" }
 dependencies = [
     { name = "verifiers" },
 ]
@@ -8159,9 +8159,9 @@ dependencies = [
 requires-dist = [{ name = "verifiers", specifier = ">=0.2.2.dev65" }]
 
 [[package]]
-name = "wordle-v1"
+name = "wordle"
 version = "0.1.0"
-source = { editable = "deps/verifiers/environments/wordle_v1" }
+source = { editable = "deps/verifiers/environments/wordle" }
 dependencies = [
     { name = "verifiers", extra = ["ta"] },
 ]


### PR DESCRIPTION
## Summary

Companion to the verifiers v1-legacy-bridge removal and the research-environments `_v1` rename. prime-rl drops every v0 compat path:

- **Configs**: `EnvConfig`/`EnvServerConfig` lose the `[legacy]` block, `is_legacy`, the legacy/env conflict validators, and `resolve_legacy_env_kwargs`; the launcher no longer copies a `legacy` section into per-source env-server TOMLs; `resolve_env_config` no longer injects `max_seq_len` into legacy kwargs.
- **Env server entrypoint**: always serves a taskset (`serve_env(config_data=..., max_concurrent=...)`) — the bridge fork is gone.
- **Orchestrator**: `Env` always loads its taskset client-side — `info()`, `run_group()`, and `task_idx` addressing are gone with the protocol. `requires_group_scoring` and all its consumers go: permit cost is always one episode (`acquire()`/`release()` are unit-valued, `InflightRollout.rollout_count` removed, the `run_group` fan-out in `handle_completed_rollout` removed), the group-scored-partial drop policy in the train sink is gone, and the eval sink's buffered-count carve-out simplifies.
- **TrainSource / EvalSource**: rows always carry the `task`; `next_example()` takes no permit argument, and the pending-draw head-of-line hold (which only existed for multi-permit group draws) is removed — `pending_env` leaves the checkpoint state (old checkpoints load fine; the key is ignored).
- **`GroupState.task` is required**; `task_idx` derives from `task.data.idx` for error markers.
- **Env renames**: all taskset ids drop the `-v1` suffix across `configs/`, `examples/`, `k8s/`, docs, skills, and the uv workspace members; `proposer_solver_v1` import in the algorithm config follows.
- Ports the qwen3-vl features-payload test from the v0 `RendererClient` to `renderers.client.generate` — the path the v1 train client actually drives.
- Pins the `deps/verifiers` and `deps/research-environments` submodules to the merged companion commits, floors `verifiers>=0.3.1.dev14`, and relocks. Unit suite passes against the renamed packages (596 tests; the `tests/unit/train` modules need the `flash-attn` extra and were skipped locally).

## Breaking

- **`[legacy]` config blocks are rejected**: any TOML with `legacy = { id = ... }` under a train/eval source or env-server config fails validation. Migration: port the env to a v1 taskset and set `env = { taskset = { id = "<id>" } }`.
- **Taskset ids drop `-v1`** in all configs (e.g. `reverse-text-v1` → `reverse-text`).
- **Checkpoint note**: `TrainSource.state_dict()` no longer records `pending_env`; resuming an old checkpoint ignores the key (only ever set for group-scoring v0 envs).

Both companions are merged: `deps/verifiers` pins main `d53ab56f` (verifiers#2303 + #2311 + the #2314 catalog revert, released as `0.3.1.dev14` — the floor here) and `deps/research-environments` pins main `c0a0d1d7a` (research-environments#754).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Removes legacy env and task id compatibility across orchestration, configs, and checkpoints (`pending_env` ignored on resume); misconfigured or unmigrated TOMLs will fail validation or resolve wrong tasksets at runtime.
> 
> **Overview**
> **Breaking change** that aligns prime-rl with verifiers v1-only envs and renamed tasksets: configs must use `env.taskset.id` (no `[legacy]`), and ids like `reverse-text-v1` become `reverse-text` everywhere (configs, examples, docs, workspace members).
> 
> **Orchestrator** is simplified to a single dispatch path: tasksets load client-side, each rollout is one `run` with `task_data` (no `task_idx`, `run_group`, or `requires_group_scoring`). Permit accounting is one episode per in-flight task; train/eval sources no longer gate scheduling on permit cost or hold a `pending_env` draw.
> 
> **Config/runtime**: `EnvConfig` / `EnvServerConfig` drop legacy fields and validators; env-server and RL launcher TOMLs no longer emit `legacy`. `hierarchical_grpo` imports `proposer_solver` instead of `proposer_solver_v1`. `tasks_per_minute` is documented as a global dispatch limit.
> 
> **Deps/tests**: `verifiers>=0.3.1.dev14`, workspace env package paths renamed; Qwen3-VL e2e test uses `renderers.client.generate` instead of v0 `RendererClient`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2583a10b79f02dc9bff9c5d6f018036a9e88dca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->