### PR TITLE
fix(slurm): run the router at the configured log level, not always debug

### DIFF
--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -78,6 +78,7 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
         num_nodes=getattr(config.deployment, "num_nodes", 1),
         port=config.server.port,
         router=config.router,
+        router_log_level=config.log.level,
         router_port=config.server.port,
         is_disaggregated=is_disaggregated,
         kv_offload=offload is not None,
@@ -177,6 +178,8 @@ def start_router(config: InferenceConfig) -> subprocess.Popen:
         "4200",
         "--prometheus-port",
         str(config.server.port + 21000),
+        "--log-level",
+        config.log.level,
     ]
     return subprocess.Popen(cmd)
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -480,6 +480,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
         script = template.render(
             **config.slurm.template_vars,
             is_disaggregated=True,
+            router_log_level=config.inference.log.level if config.inference else "info",
             config_dir=config_dir,
             output_dir=config.output_dir,
             num_train_nodes=config.deployment.num_train_nodes,
@@ -520,6 +521,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
         script = template.render(
             **config.slurm.template_vars,
             is_disaggregated=False,
+            router_log_level=config.inference.log.level if config.inference else "info",
             config_dir=config_dir,  # TODO: should prob have each subconfig path separately
             output_dir=config.output_dir,
             num_train_nodes=config.deployment.num_train_nodes,

--- a/src/prime_rl/templates/_launch_router.sh.j2
+++ b/src/prime_rl/templates/_launch_router.sh.j2
@@ -74,7 +74,7 @@ LLMD_EOF
     local -a cmd=(vllm-router --policy "$policy" --host 0.0.0.0 --port "$port"
         --request-id-headers x-session-id
         --prometheus-port "$((port + 21000))"
-        --worker-startup-timeout-secs 4200 --log-level debug)
+        --worker-startup-timeout-secs 4200 --log-level {{ router_log_level }})
     if [ "$mode" = pd ]; then
         cmd+=(--vllm-pd-disaggregation $worker_args)
     else


### PR DESCRIPTION
`_launch_router.sh.j2` hardcoded `--log-level debug`, so **every** SLURM launch ran `vllm-router` at debug regardless of `inference.log.level`.

## Cost

On a 6-node SWE RL run, that produced **218 MB / 811,780 lines** of `router.log` in **46 minutes** — a DEBUG line per routing decision, per request:

```
DEBUG vllm_router_rs::policies::consistent_hash: Consistent hash: key='header:x-session-id:...'
INFO  vllm_router_rs::policies::consistent_hash: CONSISTENT_HASH_DEBUG: Hash key '...'
DEBUG vllm_router_rs::policies::consistent_hash: CONSISTENT_HASH_DEBUG: Target worker URL: ...
DEBUG vllm_router_rs::policies::consistent_hash: CONSISTENT_HASH_DEBUG: Selected worker at index 0: ...
INFO  vllm_router_rs::policies::consistent_hash: Consistent hash routing: key='...'
DEBUG vllm_router_rs::routers::http::router: Transparent proxy: forwarding to ...
```

Six lines per forwarded request, ~40k requests. It lands on the shared NFS export, which is already the slowest thing on the cluster for metadata — and it scales with every concurrent run.

## It was also inconsistent

The non-SLURM path disagreed with the SLURM one: `start_router()` passed no `--log-level` at all, so a local run got the router's own default while an otherwise identical SLURM run got debug.

## Change

Thread `inference.log.level` through to both paths:

- `_launch_router.sh.j2` takes a `router_log_level` variable instead of the literal `debug`
- supplied by the two `rl.py` renders that include the router partial (disaggregated and multi-node) and by `inference.py`'s `template_vars`
- `start_router()` passes `--log-level` explicitly, so local and SLURM now agree

## Verification

Rendered the sbatch both ways:

```
default                            -> --log-level info
--inference.log.level debug        -> --log-level debug
```

So the old behaviour is one flag away when a routing problem actually needs it. `bash -n` on the rendered script still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
