### PR TITLE
feat(laguna): support per-element attention gating

### DIFF
--- a/src/prime_rl/trainer/models/laguna/configuration_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/configuration_laguna.py
@@ -64,6 +64,7 @@ class LagunaConfig(PretrainedConfig):
         eos_token_id: int | list[int] | None = None,
         head_dim: int = 128,
         attention_bias: bool = False,
+        gating: bool | str = True,
         partial_rotary_factor: float | None = None,
         num_attention_heads_per_layer: list[int] | None = None,
         mlp_layer_types: list[str] | None = None,
@@ -98,6 +99,7 @@ class LagunaConfig(PretrainedConfig):
         self.layer_types = layer_types or ["full_attention"] * num_hidden_layers
         self.head_dim = head_dim
         self.attention_bias = attention_bias
+        self.gating = gating
         self.partial_rotary_factor = partial_rotary_factor
         self.num_attention_heads_per_layer = num_attention_heads_per_layer or [num_attention_heads] * num_hidden_layers
         self.mlp_layer_types = mlp_layer_types or ["dense"] + ["sparse"] * (num_hidden_layers - 1)

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -106,7 +106,16 @@ class LagunaFlashAttention(FlashAttention):
         self.attention_dropout = config.attention_dropout
         self.is_local_attention = config.layer_types[layer_idx] == "sliding_attention"
         self.sliding_window = config.sliding_window if self.is_local_attention else None
-        self.g_proj = nn.Linear(config.hidden_size, num_heads, bias=False)
+        # Attention output gating, mirroring the upstream Laguna implementation:
+        #   True / "per-element" (Laguna M): one gate per (head, head_dim) channel
+        #   "per-head"           (Laguna S): one gate per head, broadcast across head_dim
+        #   False:                           no gating
+        gating = getattr(config, "gating", True)
+        self.gating = bool(gating)
+        self.gate_per_head = gating == "per-head"
+        if self.gating:
+            gate_size = num_heads if self.gate_per_head else num_heads * self.head_dim
+            self.g_proj = nn.Linear(config.hidden_size, gate_size, bias=False)
         self.o_proj = nn.Linear(num_heads * self.head_dim, config.hidden_size, bias=config.attention_bias)
 
     def forward(
@@ -127,8 +136,13 @@ class LagunaFlashAttention(FlashAttention):
         )
         input_shape = hidden_states.shape[:-1]
         attn_output = attn_output.view(*input_shape, self.num_heads, self.head_dim)
-        gate = F.softplus(self.g_proj(hidden_states).float()).to(attn_output.dtype)
-        attn_output = (attn_output * gate.unsqueeze(-1)).view(*input_shape, -1)
+        if self.gating:
+            gate = F.softplus(self.g_proj(hidden_states).float()).to(attn_output.dtype)
+            # per-head gates broadcast across head_dim; per-element gates are already
+            # one-per-channel and line up with the [..., num_heads, head_dim] view.
+            gate = gate.unsqueeze(-1) if self.gate_per_head else gate.view(*attn_output.shape)
+            attn_output = attn_output * gate
+        attn_output = attn_output.view(*input_shape, -1)
         return self.o_proj(attn_output), None
 
 


### PR DESCRIPTION
Laguna's config carries a `gating` field that prime-rl's port drops entirely, so `g_proj` is always sized for per-head gating:

```python
self.g_proj = nn.Linear(config.hidden_size, num_heads, bias=False)
```

That matches **Laguna S** (`gating = "per-head"`) and is wrong for **Laguna M** (`gating = "per-element"`), where the gate is one-per-channel and `g_proj` is `head_dim` times wider:

| checkpoint | `gating` | `g_proj.weight` |
|---|---|---|
| `poolside/Laguna-S-2.1` | `per-head` | `[48, 3072]` = `[num_heads, hidden]` |
| `poolside/Laguna-M.1` | `per-element` | `[8192, 4096]` = `[num_heads × head_dim, hidden]` |

Loading M.1 fails at model construction:

```
ValueError: Size mismatch between saved torch.Size([8192, 4096]) and current:
torch.Size([64, 4096]) for model.layers.0.self_attn.g_proj.weight
```

## Change

Carry `gating` on `LagunaConfig` and size `g_proj` from it, following upstream's semantics exactly (`poolside/Laguna-M.1` `modeling_laguna.py`):

| value | behaviour |
|---|---|
| `True` / `"per-element"` | one gate per (head, head_dim) channel |
| `"per-head"` | one gate per head, broadcast across `head_dim` |
| `False` | no gating |

Two details worth calling out, both taken from upstream rather than guessed:

- **The default is `True`, not `"per-head"`.** A checkpoint that omits the field gets per-element upstream, so defaulting the other way would silently mis-size it.
- **`bool` and `str` are both accepted**, because upstream does `bool(gating)` for the on/off decision and `gating == "per-head"` for the mode.

## Verification

**Shapes match both checkpoints** (built on `meta`, compared against the real safetensors headers):

```
Laguna-S-2.1   gating=per-head     ckpt=[48, 3072]    model=[48, 3072]    MATCH
Laguna-M.1     gating=per-element  ckpt=[8192, 4096]  model=[8192, 4096]  MATCH
```

**Gate math is bit-identical to upstream** in both modes — same softplus, same broadcast, same reshape:

```
per-head      max|ours - upstream| = 0.000e+00  EQUIVALENT
per-element   max|ours - upstream| = 0.000e+00  EQUIVALENT
```

**End to end**: a 4-node trainer probe loads the real 452 GB M.1 checkpoint through `load_dcp_from_hf` with `Size mismatch: 0`, where it previously died at model construction. S-2.1 is unaffected — it takes the same `per-head` path as before, and its `g_proj` shape is unchanged.

`ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes attention module weight shapes and forward gating math for Laguna only; incorrect defaults would silently mis-load checkpoints, but scope is narrow and S behavior is preserved for per-head.
> 
> **Overview**
> Adds upstream **`gating`** on `LagunaConfig` (default `True`) and wires it through **`LagunaFlashAttention`** so `g_proj` and the gate multiply match Poolside Laguna checkpoints.
> 
> **`g_proj`** is now sized as `num_heads` for **`"per-head"`** (Laguna S) or **`num_heads × head_dim`** for **`True` / `"per-element"`** (Laguna M). Forward applies softplus gating only when enabled, with per-head gates broadcast across `head_dim` and per-element gates aligned to the attention output channels. **`gating=False`** skips creating `g_proj` entirely.
> 
> This fixes **Laguna-M.1** weight load failures from a mismatched `g_proj` shape; **Laguna-S-2.1** keeps the same per-head path as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb24ea383ffb4bf136f9a33318299eec51f2a908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->