### PR TITLE
chore: bump research-environments for the toolset register() fix

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -460,7 +460,7 @@ requires-dist = [
     { name = "datasets" },
     { name = "mcp", specifier = "<2" },
     { name = "openai" },
-    { name = "verifiers", specifier = ">=0.2.2.dev65" },
+    { name = "verifiers", specifier = ">=0.3.0" },
 ]
 
 [[package]]
@@ -584,7 +584,7 @@ dependencies = [
 requires-dist = [
     { name = "bfcl-eval", git = "https://github.com/mikasenghaas/gorilla.git?subdirectory=berkeley-function-call-leaderboard&rev=898763a" },
     { name = "soundfile", specifier = ">=0.13.0" },
-    { name = "verifiers", specifier = ">=0.2.2.dev65" },
+    { name = "verifiers", specifier = ">=0.3.0" },
 ]
 
 [[package]]
@@ -694,7 +694,7 @@ requires-dist = [
     { name = "openai" },
     { name = "pystemmer" },
     { name = "tokenizers" },
-    { name = "verifiers", specifier = ">=0.2.2.dev65" },
+    { name = "verifiers", specifier = ">=0.3.0" },
 ]
 
 [[package]]
@@ -1523,7 +1523,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "datasets", specifier = ">=4.0.0,<5" },
-    { name = "verifiers", specifier = ">=0.2.2.dev65" },
+    { name = "verifiers", specifier = ">=0.3.0" },
 ]
 
 [[package]]
@@ -1924,7 +1924,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic" },
-    { name = "verifiers", extras = ["harbor"], specifier = ">=0.2.2.dev65" },
+    { name = "verifiers", extras = ["harbor"], specifier = ">=0.3.0" },
 ]
 
 [[package]]
@@ -3348,7 +3348,7 @@ requires-dist = [
     { name = "datasets", specifier = ">=4.0.0,<5" },
     { name = "httpx" },
     { name = "prime-sandboxes", specifier = ">=0.2.19" },
-    { name = "verifiers", specifier = ">=0.2.2.dev65" },
+    { name = "verifiers", specifier = ">=0.3.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `deps/research-environments` `b10db764` → `ae5f051c`, picking up research-environments #755 and #756.

## Why

verifiers [`54132ccc`](https://github.com/PrimeIntellect-ai/verifiers/commit/54132ccc) (#2212) renamed the toolset registration hook `Toolset._register` → `Toolset.register`. Six environments override that hook and still defined `_register`, so their registration silently became dead code:

- `ServerBase._serve()` calls `self.register(mcp)`
- `Toolset.register()`'s default body only picks up `@vf.tool`-decorated methods, and these six register dynamically (config/task-dependent tool sets)

Result: the MCP tool server starts perfectly healthy and serves **zero tools**, with no error at any layer — `list_tools` returns `[]`, so the `bash` harness's `connect_mcp` adds no tools and `rlm`'s `generate_mcp_skills` generates no skills.

The failure is silent and the scores look plausible, which is the dangerous part. On `browsecomp-plus-v1` an agent with no corpus tool but unrestricted egress scraped DuckDuckGo from its sandbox and answered 2/3 correctly — with `num_search_calls=0` and `recall=0`. Off-corpus, so neither reproducible nor comparable to published numbers.

The rename shipped in verifiers `v0.3.0` and reached this repo via `6e33f3f82`, so evals of these six envs have been invalid since.

## Verification

Ran on `internal/nemotron-3-ultra` before/after the fix:

| Env | Before | After |
|---|---|---|
| `browsecomp-plus-v1` (bash) | `tools=['bash','edit']`, `num_search_calls=0`, `recall=0` | `tools=['bash','edit','browsecomp_plus_search']`, 14 search calls, **recall 1.0**, reward 1.0 |
| `browsecomp-plus-v1` (rlm) | no skills line in prompt, `num_ptc_calls_*=0` | ``Installed skills (pre-imported): `browsecomp_plus_search` `` |
| `automationbench-v1` (null) | `tools=[]` | `tools=['api_search','base64_encode','api_fetch']`, partial_credit 0.4 / 0.33 |

`mcp-atlas-v1`, `bfcl-v3-v1`, `general-agent-v1` and `enterprise-ops-gym-v1` carry the identical one-word rename but were not run.

## Lockfile

The `uv.lock` change is only those six envs' verifiers floor moving `>=0.2.2.dev65` → `>=0.3.0`. Required rather than cosmetic: code implementing `register` against a pre-rename verifiers would have its hook ignored, reproducing the same silent zero-tools bug in mirror image. `v0.3.0` is the first tag containing `54132ccc`. No package versions move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches eval/tooling dependency constraints for environments where silent zero-tool MCP registration was a real correctness issue; lockfile-only but directly affects benchmark validity.
> 
> **Overview**
> **Lockfile-only change:** raises the `verifiers` minimum from `>=0.2.2.dev65` to `>=0.3.0` for six editable research-environment packages (e.g. automation-bench, BFCL, browsecomp-plus, enterprise-ops-gym, general-agent, and related search/tool envs). No resolved package versions change in the diff—only the declared floors.
> 
> This pairs with bumping `deps/research-environments` so environments override **`Toolset.register`** instead of the removed **`_register`** hook. Without that code fix, MCP servers could start with **no tools** and eval scores could look valid while being wrong; the new floor keeps installs on verifiers **v0.3.0+**, where the rename landed, so the fixed `register` overrides are actually invoked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aaad5485b6b978b09961541faca5c8eef4f944f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->