### PR TITLE
feat: change default DPPO masking thresholds to 0.1

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -234,7 +234,7 @@ The knobs (under `[trainer.loss]` with `type = "default"`):
 
 | Knob | Default | What it does |
 |---|---|---|
-| `dppo_mask_low` / `dppo_mask_high` | 0.2 / 0.2 | Lower / upper thresholds for DPPO-style token-level masking. |
+| `dppo_mask_low` / `dppo_mask_high` | 0.1 / 0.1 | Lower / upper thresholds for DPPO-style token-level masking. |
 | `adv_tau` | 1.0 | Temperature on the advantage term. Set to 0 to drop the policy-gradient term, leaving only the KL regularizer. |
 | `kl_tau` | 1e-3 | Temperature on the KL regularizer. Set to 0 to disable. |
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -456,10 +456,10 @@ class CheckpointConfig(BaseConfig):
 class DefaultLossConfig(BaseConfig):
     type: Literal["default"] = "default"
 
-    dppo_mask_low: float = Field(0.2, ge=0)
+    dppo_mask_low: float = Field(0.1, ge=0)
     """Lower DPPO masking threshold."""
 
-    dppo_mask_high: float = Field(0.2, ge=0)
+    dppo_mask_high: float = Field(0.1, ge=0)
     """Upper DPPO masking threshold."""
 
     adv_tau: float = Field(1.0, ge=0)


### PR DESCRIPTION
## Summary

- Change the default DPPO masking thresholds (`dppo_mask_low` / `dppo_mask_high` on `DefaultLossConfig`) from 0.2 to 0.1
- Update the defaults table in `docs/algorithms.md` to match

## Breaking

- Runs using the default loss without explicitly setting `dppo_mask_low` / `dppo_mask_high` now train with a tighter trust region (0.1 instead of 0.2), masking more tokens. Set both to `0.2` under `[trainer.loss]` to keep the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 71a5572a1300725c25fe4ee582c630d12c995a77. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->