### PR TITLE
feat: auto-resolve parsers for Nemotron 3.5 (Lightning)

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/utils/parsers.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/parsers.py
@@ -14,7 +14,6 @@ TOOL_CALL_PARSER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^openai/gpt-oss"), "openai"),
     (re.compile(r"^poolside/Laguna"), "poolside_v1"),
     (re.compile(r"^PrimeIntellect/INTELLECT-3"), "qwen3_coder"),
-    # Covers Nemotron 3 and 3.5 — both use the same <tool_call> XML format.
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3"), "qwen3_coder"),
     (re.compile(r"^stepfun-ai/Step-3\.5"), "step3p5"),
     # Qwen3.5 and Qwen3-Coder use qwen3_coder — must be before the Qwen3 catch-all.
@@ -33,9 +32,6 @@ REASONING_PARSER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^poolside/Laguna"), "poolside_v1"),
     (re.compile(r"^PrimeIntellect/INTELLECT-3"), "deepseek_r1"),
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3-Super"), "nemotron_v3"),
-    # Nemotron 3 Nano and 3.5 Lightning prefill <think>\n in the generation
-    # prompt; nano_v3 (patched DeepSeekR1 parser) handles that plus the
-    # enable_thinking=False content swap.
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3-Nano"), "nano_v3"),
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3\.5"), "nano_v3"),
     (re.compile(r"^stepfun-ai/Step-3\.5"), "step3p5"),

--- a/packages/prime-rl-configs/src/prime_rl/utils/parsers.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/parsers.py
@@ -14,6 +14,7 @@ TOOL_CALL_PARSER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^openai/gpt-oss"), "openai"),
     (re.compile(r"^poolside/Laguna"), "poolside_v1"),
     (re.compile(r"^PrimeIntellect/INTELLECT-3"), "qwen3_coder"),
+    # Covers Nemotron 3 and 3.5 — both use the same <tool_call> XML format.
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3"), "qwen3_coder"),
     (re.compile(r"^stepfun-ai/Step-3\.5"), "step3p5"),
     # Qwen3.5 and Qwen3-Coder use qwen3_coder — must be before the Qwen3 catch-all.
@@ -32,7 +33,11 @@ REASONING_PARSER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^poolside/Laguna"), "poolside_v1"),
     (re.compile(r"^PrimeIntellect/INTELLECT-3"), "deepseek_r1"),
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3-Super"), "nemotron_v3"),
+    # Nemotron 3 Nano and 3.5 Lightning prefill <think>\n in the generation
+    # prompt; nano_v3 (patched DeepSeekR1 parser) handles that plus the
+    # enable_thinking=False content swap.
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3-Nano"), "nano_v3"),
+    (re.compile(r"^nvidia/NVIDIA-Nemotron-3\.5"), "nano_v3"),
     (re.compile(r"^stepfun-ai/Step-3\.5"), "step3p5"),
     # Only Qwen3 Thinking models reason — Instruct/base models do not.
     (re.compile(r"^Qwen/Qwen3-.*Thinking"), "deepseek_r1"),

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -54,7 +54,6 @@ EXPECTED_PARSERS: list[tuple[str, str | None, str | None]] = [
     ("nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16", "qwen3_coder", "nemotron_v3"),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "qwen3_coder", "nano_v3"),
     ("nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16", "qwen3_coder", "nano_v3"),
-    ("nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4", "qwen3_coder", "nano_v3"),
     # StepFun
     ("stepfun-ai/Step-3.5-Flash", "step3p5", "step3p5"),
     # Qwen3 dense

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -53,6 +53,8 @@ EXPECTED_PARSERS: list[tuple[str, str | None, str | None]] = [
     # NemotronH
     ("nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16", "qwen3_coder", "nemotron_v3"),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "qwen3_coder", "nano_v3"),
+    ("nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16", "qwen3_coder", "nano_v3"),
+    ("nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4", "qwen3_coder", "nano_v3"),
     # StepFun
     ("stepfun-ai/Step-3.5-Flash", "step3p5", "step3p5"),
     # Qwen3 dense


### PR DESCRIPTION
Adds vLLM parser auto-resolution for [NVIDIA-Nemotron-3.5-Lightning-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16) (BF16).

## Context

Nemotron 3.5 Lightning is the same `nemotron_h` architecture as Nemotron 3 Nano (identical 52-layer hybrid backbone; the only checkpoint deltas are an MTP head, which `converting_nemotron_h.py` already drops, and config-form differences the existing `NemotronHConfig` already accepts). Trainer and inference support it as-is — the only gap was parser resolution:

- **Tool-call parser**: the existing `^nvidia/NVIDIA-Nemotron-3` prefix already matched the 3.5 name, but only by accident of the unescaped prefix. Now documented as intentional (3 and 3.5 share the `<tool_call>` XML format, handled by `qwen3_coder`).
- **Reasoning parser**: the patterns only matched `-3-Super` / `-3-Nano`, so Lightning resolved to `None` and `reasoning_content` was never split. Added `^nvidia/NVIDIA-Nemotron-3\.5` → `nano_v3`: Lightning's template prefills `<think>\n` in the generation prompt exactly like Nano (verified against the upstream `chat_template.jinja`), and `nano_v3` also handles the `enable_thinking=False` content swap.

Renderer support for the new chat-template variant lands separately in PrimeIntellect-ai/renderers#124 (to be picked up by a future renderers pin bump).

## Tests

- `tests/unit/test_parsers.py`: added BF16 + NVFP4 expectations; all 141 cases pass.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted parser-table and test updates with no auth, data, or infrastructure impact.
> 
> **Overview**
> Adds **reasoning parser auto-resolution** for **NVIDIA Nemotron 3.5** (e.g. Lightning) by registering `^nvidia/NVIDIA-Nemotron-3\.5` → **`nano_v3`** in `REASONING_PARSER_PATTERNS`, so vLLM can split `reasoning_content` the same way as Nemotron 3 Nano.
> 
> Tool-call parsing for these model IDs is unchanged (still **`qwen3_coder`** via the existing Nemotron-3 prefix). Unit expectations in `test_parsers.py` cover the Lightning BF16 checkpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a09c5615055ca3288195053fa097bc133ed841e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->