### PR TITLE
feat: Nemotron 3.5 (Lightning) support on hrl

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/utils/parsers.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/parsers.py
@@ -9,6 +9,7 @@ TOOL_CALL_PARSER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^zai-org/GLM-5"), "glm47"),
     (re.compile(r"^MiniMaxAI/MiniMax-M2"), "minimax_m2"),
     (re.compile(r"^PrimeIntellect/INTELLECT-3"), "qwen3_coder"),
+    # Covers Nemotron 3 and 3.5 — both use the same <tool_call> XML format.
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3"), "qwen3_coder"),
     (re.compile(r"^stepfun-ai/Step-3\.5"), "step3p5"),
     # Qwen3.5 and Qwen3-Coder use qwen3_coder — must be before the Qwen3 catch-all.
@@ -23,7 +24,11 @@ REASONING_PARSER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^MiniMaxAI/MiniMax-M2"), "minimax_m2_append_think"),
     (re.compile(r"^PrimeIntellect/INTELLECT-3"), "deepseek_r1"),
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3-Super"), "nemotron_v3"),
+    # Nemotron 3 Nano and 3.5 Lightning prefill <think>\n in the generation
+    # prompt; nano_v3 (patched DeepSeekR1 parser) handles that plus the
+    # enable_thinking=False content swap.
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3-Nano"), "nano_v3"),
+    (re.compile(r"^nvidia/NVIDIA-Nemotron-3\.5"), "nano_v3"),
     (re.compile(r"^stepfun-ai/Step-3\.5"), "step3p5"),
     # Only Qwen3 Thinking models reason — Instruct/base models do not.
     (re.compile(r"^Qwen/Qwen3-.*Thinking"), "deepseek_r1"),

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -41,7 +41,6 @@ EXPECTED_PARSERS: list[tuple[str, str | None, str | None]] = [
     ("nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16", "qwen3_coder", "nemotron_v3"),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "qwen3_coder", "nano_v3"),
     ("nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16", "qwen3_coder", "nano_v3"),
-    ("nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4", "qwen3_coder", "nano_v3"),
     # StepFun
     ("stepfun-ai/Step-3.5-Flash", "step3p5", "step3p5"),
     # Qwen3 dense

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -40,6 +40,8 @@ EXPECTED_PARSERS: list[tuple[str, str | None, str | None]] = [
     # NemotronH
     ("nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16", "qwen3_coder", "nemotron_v3"),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "qwen3_coder", "nano_v3"),
+    ("nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16", "qwen3_coder", "nano_v3"),
+    ("nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4", "qwen3_coder", "nano_v3"),
     # StepFun
     ("stepfun-ai/Step-3.5-Flash", "step3p5", "step3p5"),
     # Qwen3 dense


### PR DESCRIPTION
Brings Nemotron 3.5 (Lightning) support to the hosted-training branch. Backport of #3237 plus the renderers pin bump.

## Changes

- Cherry-picks from `feat/nemotron-3.5-parsers` (#3237, applied cleanly with no conflicts):
  - `feat: auto-resolve parsers for Nemotron 3.5 (Lightning)` — `^nvidia/NVIDIA-Nemotron-3\.5` → `nano_v3` reasoning parser; tool-call side documented as intentionally covered by the existing `^nvidia/NVIDIA-Nemotron-3` prefix (`qwen3_coder`).
  - `test: drop NVFP4 expectation, BF16 only`
- Bumps `deps/renderers` d470786 (`renderers-v0.1.9`) → 2846a3d (renderers main, merge of PrimeIntellect-ai/renderers#124) for the `nemotron-3.5` renderer. The jump also picks up the Laguna M.1 renderer (renderers#120), which is additive. `uv lock --check` passes unchanged — the lockfile references the editable path dep without a pinned version.

## Compatibility

Everything else Lightning needs is already on `hrl`: the `nano_v3` parser patch in `inference/patches.py`, the `nemotron_h` custom trainer impl (whose conversion chain drops the checkpoint's `mtp.*` weights), vLLM 0.26.0, and transformers 5.6.2.

## Tests

- `tests/unit/test_parsers.py` on this branch: all 118 cases pass.
- Renderer parity was validated in renderers#124 (27 byte-parity cases vs `apply_chat_template` for the Lightning template, plus the shared barrage).
