### PR TITLE
docs(k8s): drop dead docs links and fix PVC name in Helm README

### DIFF
--- a/examples/basic/reverse-text/README.md
+++ b/examples/basic/reverse-text/README.md
@@ -223,8 +223,8 @@ uv run eval reverse-text --harness.id null \
 
 ```bash
 helm uninstall my-exp
-# Optionally delete shared data:
-kubectl delete pvc prime-rl-shared-data
+# Optionally delete shared data. The PVC is named <release-name>-shared-data:
+kubectl delete pvc my-exp-shared-data
 ```
 
 **What the Helm chart provides:**

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -2,8 +2,6 @@
 
 This directory contains a Helm chart for deploying prime-rl training infrastructure on Kubernetes clusters.
 
-For complete documentation, see the [Kubernetes guide](https://docs.primeintellect.ai/prime-rl/kubernetes).
-
 ## Quick Start
 
 ```bash
@@ -64,11 +62,11 @@ helm install my-exp ./prime-rl \
 
 ```bash
 helm uninstall my-exp
-kubectl delete pvc prime-rl-shared-data  # Warning: deletes data!
+
+# The PVC is named <release-name>-shared-data (see templates/pvc.yaml)
+kubectl delete pvc my-exp-shared-data  # Warning: deletes data!
 ```
 
 ## Learn More
 
-- [Full Kubernetes documentation](https://docs.primeintellect.ai/prime-rl/kubernetes) - Architecture, configuration, distributed training
-- [Deployment guide](https://docs.primeintellect.ai/prime-rl/deployment) - Non-Kubernetes deployments
-- [Troubleshooting](https://docs.primeintellect.ai/prime-rl/troubleshooting) - Common issues
+- [Scaling guide](https://docs.primeintellect.ai/prime-rl/scaling) - Non-Kubernetes multi-node deployment (SLURM), parallelism, benchmarking


### PR DESCRIPTION
`k8s/README.md` links to three docs pages that no longer exist. `/prime-rl/kubernetes` (the link #3054 reports, linked twice), `/prime-rl/deployment` and `/prime-rl/troubleshooting` all return 404, and none of them is in `docs/` or in the `docs/mint.json` nav.

- Drop both Kubernetes links and the troubleshooting bullet. Neither has a successor page, and the README's own sections already document the chart.
- Retarget the deployment bullet at `/prime-rl/scaling` (200), which is where the multi-node and SLURM content lives now.

The same README also prints the wrong PVC name. `k8s/prime-rl/templates/pvc.yaml` names the claim `{{ .Release.Name }}-shared-data`, so after the documented `helm install my-exp`, `kubectl delete pvc prime-rl-shared-data` fails `NotFound` and reads as if the data were already deleted. Fixed here and in `examples/basic/reverse-text/README.md`, the other place that prints that command.

Every URL left in `k8s/README.md` resolves 200.

Closes #3054
