### PR TITLE
chore: remove the control/ output subdir

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -27,7 +27,6 @@ import time
 import uuid
 from typing import TYPE_CHECKING
 
-import tomli_w
 import verifiers.v1 as vf
 from modelexpress import p2p_pb2
 from modelexpress.client import MxClient
@@ -78,7 +77,6 @@ from prime_rl.trainer.rl.broadcast.nixl.model_express import ModelExpressSession
 from prime_rl.transport import setup_micro_batch_sender
 from prime_rl.utils.async_utils import EventLoopLagMonitor, EventLoopLagStats, safe_cancel
 from prime_rl.utils.client import init_nccl_broadcast, init_nixl_broadcast
-from prime_rl.utils.config import to_toml_dict
 from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.logger import format_time, get_logger, setup_logger
 from prime_rl.utils.monitor import setup_monitor
@@ -206,12 +204,6 @@ class Orchestrator:
         construct the pipeline components."""
         config = self.config
         set_default_executor()
-
-        # Persist the resolved config alongside the run
-        config_dir = config.output_dir / "control"
-        config_dir.mkdir(parents=True, exist_ok=True)
-        with open(config_dir / "orch.toml", "wb") as f:
-            tomli_w.dump(to_toml_dict(config), f)
 
         get_logger().info(f"Initializing tokenizer ({config.tokenizer})")
         self.tokenizer = setup_tokenizer(config.tokenizer)


### PR DESCRIPTION
## Summary

- Remove the orchestrator's dump of its resolved config to `<output_dir>/control/orch.toml` — a relict of the deprecated multi-tenant setup.
- Nothing read from `control/`; the launcher already persists the resolved orchestrator config (and all other subconfigs) under the output directory via `write_subconfigs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code cleanup only; nothing reads from `control/`, and config persistence remains via the launcher.
> 
> **Overview**
> Removes the orchestrator's leftover dump of its resolved config to `<output_dir>/control/orch.toml`.
> 
> This was unused after the multi-tenant setup was deprecated. The launcher already persists the resolved orchestrator (and other) configs via `write_subconfigs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb1ceee162e6a4c72ee308f5145e2d4cdd1f65f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->