### PR TITLE
fix: revert default DPPO masking thresholds to 0.2

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -234,7 +234,7 @@ The knobs (under `[trainer.loss]` with `type = "default"`):
 
 | Knob | Default | What it does |
 |---|---|---|
-| `dppo_mask_low` / `dppo_mask_high` | 0.1 / 0.1 | Lower / upper thresholds for DPPO-style token-level masking. |
+| `dppo_mask_low` / `dppo_mask_high` | 0.2 / 0.2 | Lower / upper thresholds for DPPO-style token-level masking. |
 | `adv_tau` | 1.0 | Temperature on the advantage term. Set to 0 to drop the policy-gradient term, leaving only the KL regularizer. |
 | `kl_tau` | 1e-3 | Temperature on the KL regularizer. Set to 0 to disable. |
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -456,10 +456,10 @@ class CheckpointConfig(BaseConfig):
 class DefaultLossConfig(BaseConfig):
     type: Literal["default"] = "default"
 
-    dppo_mask_low: float = Field(0.1, ge=0)
+    dppo_mask_low: float = Field(0.2, ge=0)
     """Lower DPPO masking threshold."""
 
-    dppo_mask_high: float = Field(0.1, ge=0)
+    dppo_mask_high: float = Field(0.2, ge=0)
     """Upper DPPO masking threshold."""
 
     adv_tau: float = Field(1.0, ge=0)


### PR DESCRIPTION
## Summary

- Revert the default DPPO masking thresholds (`dppo_mask_low` / `dppo_mask_high` on `DefaultLossConfig`) from 0.1 back to 0.2, reverting #3236
- Restore the defaults table in `docs/algorithms.md` to match

Since #3236 landed, the `reverse_text_lora` integration test has failed on every main CI run (`test_reward_in_range`: final reward 0.58–0.60 < 0.65). Token-export analysis of the failing config shows the 0.1 threshold masks only ~2% of loss tokens (no effective-batch collapse, mismatch KL ≤ 0.014), but the masked tokens are concentrated on the few reward-critical decision tokens — 69% of positive-advantage masked tokens are the `<reversed_text>` tag tokens and 44% of negative-advantage masked tokens are `<think>`. Under up to 3 steps of off-policy staleness these tokens legitimately move more than 0.1 in absolute probability per sampling round, so the tighter trust region caps their movement at half the 0.2 rate and slows convergence (truncation stays at ~30% at step 15 instead of collapsing to ~3%).

## Verification

15-step reverse-text LoRA smoke (`configs/ci/integration/reverse-text-lora/start.toml`), reward at step 15:

- 0.1 defaults (current main): 0.50 / 0.57 local, 0.58 / 0.58 / 0.60 on main CI — all below the 0.65 test threshold
- 0.2 defaults (this PR): 0.80 local

## Breaking

- Runs using the default loss without explicitly setting `dppo_mask_low` / `dppo_mask_high` train with the wider 0.2 trust region again, masking fewer tokens. Set both to `0.1` under `[trainer.loss]` to keep the 0.1 behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default RL loss hyperparameters that affect token masking and training dynamics for all runs not explicitly overriding them. Not security-critical, but it alters convergence behavior.
> 
> **Overview**
> Reverts the default DPPO token-masking thresholds on `DefaultLossConfig` from **0.1 → 0.2**, undoing the tighter trust region introduced in #3236.
> 
> The 0.1 defaults were over-masking reward-critical tokens under off-policy staleness, which slowed convergence and broke the `reverse_text_lora` integration test. Docs in `algorithms.md` are updated to match.
> 
> Runs that rely on the default loss without explicitly setting these knobs will again use the wider 0.2 trust region (masking fewer tokens).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6667d6a65f844b85c8b64f2d64d903006f77a26f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->