### PR TITLE
fix: skip weight pre-download for random-init debug runs

### DIFF
--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -647,7 +647,7 @@ def rl(config: RLConfig):
     if not config.dry_run:
         from prime_rl.trainer.model import pre_download_model
 
-        pre_download_model(config.trainer.model.name)
+        pre_download_model(config.trainer.model.name, skip_weights=config.trainer.model.debug.random_init)
 
     if config.slurm is not None:
         rl_slurm(config)

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -214,7 +214,7 @@ def sft(config: SFTConfig):
     if not config.dry_run:
         from prime_rl.trainer.model import pre_download_model
 
-        pre_download_model(config.model.name)
+        pre_download_model(config.model.name, skip_weights=config.model.debug.random_init)
 
     if config.slurm is not None:
         sft_slurm(config)

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -68,14 +68,23 @@ from prime_rl.utils.utils import format_time
 from prime_rl.utils.vlm import get_language_model, get_vision_encoder, is_vlm_architecture
 
 
-def pre_download_model(model_name: str) -> None:
-    """Pre-download model from HuggingFace Hub so all nodes have cached weights before training."""
+def pre_download_model(model_name: str, *, skip_weights: bool = False) -> None:
+    """Pre-download model from HuggingFace Hub so all nodes have cached weights before training.
+
+    With ``skip_weights`` (random-init debug runs), only config and tokenizer files are fetched.
+    """
     if Path(model_name).exists():
         get_logger().info(f"Model {model_name} found at local path, skipping download")
         return
-    get_logger().info(f"Pre-downloading model {model_name}")
     t0 = time.perf_counter()
-    path = snapshot_download(repo_id=model_name, repo_type="model")
+    if skip_weights:
+        get_logger().info(f"Pre-downloading config and tokenizer for {model_name} (random init, skipping weights)")
+        path = snapshot_download(
+            repo_id=model_name, repo_type="model", allow_patterns=["*.json", "*.txt", "tokenizer*", "*.jinja"]
+        )
+    else:
+        get_logger().info(f"Pre-downloading model {model_name}")
+        path = snapshot_download(repo_id=model_name, repo_type="model")
     get_logger().debug(
         f"Finished pre-downloading model {model_name} to {path} in {format_time(time.perf_counter() - t0)}"
     )


### PR DESCRIPTION
## Summary

`pre_download_model` fetched the full weight snapshot even when `debug.random_init` never reads the weights — for large models that pulls hundreds of GB into the shared HF cache before a fake-data debug run (a GLM-5 debug run downloads ~1.4 TB, which filled the shared NFS on the dev cluster). Random-init runs now fetch only config and tokenizer files (`*.json`, `*.txt`, `tokenizer*`, `*.jinja`).

Applies to both the `sft` and `rl` entrypoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Launcher-only HF cache behavior change for an existing debug flag; no change to weight loading for standard training runs.
> 
> **Overview**
> When **`debug.random_init`** is enabled, **`pre_download_model`** no longer pulls the full Hugging Face weight snapshot during RL/SFT launch. It only caches **config and tokenizer** files (`*.json`, `*.txt`, `tokenizer*`, `*.jinja`) via `snapshot_download` `allow_patterns`.
> 
> Both **`rl`** and **`sft`** entrypoints pass `skip_weights=config.*.debug.random_init` into `pre_download_model`, matching training behavior where weights are not loaded anyway. Normal runs still perform a full model download.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f820a9b59430491e49d269ca698553ba8dc16ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->