### PR TITLE
perf!: remove the zero-gradient-ratio metric

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -50,7 +50,6 @@ from prime_rl.trainer.utils import (
     Tensors,
     export_benchmark_json,
     filter_rl_trainer_tensor_stats_for_wandb,
-    get_zero_gradient_ratio,
     get_ckpt_disk_metrics,
     setup_torch_distributed,
     print_benchmark,
@@ -544,8 +543,6 @@ def train(config: TrainerConfig):
             if grad_norm.device.type == "cpu":
                 grad_norm = grad_norm.to(torch.device("cuda"))
 
-        zero_grad_ratio = get_zero_gradient_ratio(model.parameters(), parallel_dims.dp_replicate)
-
         # Update the model parameters
         optimizer.step()
         optimizer.zero_grad()
@@ -650,7 +647,6 @@ def train(config: TrainerConfig):
         # Log optimizer metrics
         optim_metrics = {
             "optim/lr": current_lr,
-            "optim/zero_grad_ratio": zero_grad_ratio,
             "step": progress.step,
         }
         if grad_norm is not None:
@@ -695,7 +691,6 @@ def train(config: TrainerConfig):
                 mfu=mfu,
                 entropy=tensor_stats.get("entropy/all/mean", 0.0),
                 mismatch_kl=tensor_stats.get("mismatch_kl/all/mean", 0.0),
-                zero_grad_ratio=zero_grad_ratio,
             )
 
         # Send heartbeat if configured

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -40,7 +40,6 @@ from prime_rl.trainer.utils import (
     GarbageCollection,
     MemoryProfiler,
     export_benchmark_json,
-    get_zero_gradient_ratio,
     get_ckpt_disk_metrics,
     print_sample,
     setup_torch_distributed,
@@ -470,8 +469,6 @@ def train(config: SFTConfig):
             )
             if grad_norm.device.type == "cpu":
                 grad_norm = grad_norm.to(torch.device("cuda"))
-        zero_grad_ratio = get_zero_gradient_ratio(model.parameters(), parallel_dims.dp_replicate)
-
         logger.debug("Optimizer step")
         optimizer.step()
         optimizer.zero_grad()
@@ -578,7 +575,6 @@ def train(config: SFTConfig):
         # Log optimizer metrics
         optim_metrics = {
             "optim/lr": current_lr,
-            "optim/zero_grad_ratio": zero_grad_ratio,
             "step": progress.step,
         }
         if grad_norm is not None:

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -4,7 +4,6 @@ import pickle
 import shutil
 import time
 from collections import defaultdict
-from collections.abc import Iterable
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -16,8 +15,7 @@ from rich import print as rich_print
 from rich.console import Console
 from rich.table import Table
 from rich.text import Text
-from torch import Tensor, nn
-from torch.distributed.tensor import DTensor
+from torch import Tensor
 from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.trainer.world import get_world
@@ -53,62 +51,6 @@ class GarbageCollection:
         begin = time.monotonic()
         gc.collect(generation)
         get_logger().info(f"[GC] collection took {time.monotonic() - begin:.2f}s")
-
-
-def _to_local_tensor(tensor: Tensor | DTensor) -> Tensor:
-    if isinstance(tensor, DTensor):
-        return tensor.to_local()
-    return tensor
-
-
-def count_zero_gradient_elements(parameters: Iterable[nn.Parameter]) -> tuple[Tensor, Tensor]:
-    """Count zero-gradient parameter elements on the local distributed shards.
-
-    Parameters that require gradients but did not receive one in the current step
-    are counted as fully zero. This makes inactive MoE experts visible in the
-    metric instead of silently dropping them from the count.
-    """
-
-    device = torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
-    num_zeros = torch.zeros((), dtype=torch.long, device=device)
-    num_tracked = torch.zeros((), dtype=torch.long, device=device)
-
-    for param in parameters:
-        if not param.requires_grad:
-            continue
-
-        local_param = _to_local_tensor(param.detach())
-        if local_param.numel() == 0:
-            continue
-
-        if local_param.device != num_zeros.device:
-            num_zeros = num_zeros.to(local_param.device)
-            num_tracked = num_tracked.to(local_param.device)
-
-        local_numel = torch.tensor(local_param.numel(), dtype=torch.long, device=local_param.device)
-        num_tracked += local_numel
-
-        if param.grad is None:
-            num_zeros += local_numel
-            continue
-
-        local_grad = _to_local_tensor(param.grad.detach())
-        if local_grad.numel() != local_param.numel():
-            raise ValueError("Local gradient shape does not match the local parameter shape")
-
-        num_zeros += local_numel - torch.count_nonzero(local_grad)
-
-    return num_zeros, num_tracked
-
-
-def get_zero_gradient_ratio(parameters: Iterable[nn.Parameter], dp_replicate: int = 1) -> float:
-    num_zero_grad, num_grad_elements = count_zero_gradient_elements(parameters)
-    dist.all_reduce(num_zero_grad, op=dist.ReduceOp.SUM)
-    dist.all_reduce(num_grad_elements, op=dist.ReduceOp.SUM)
-    if dp_replicate > 1:
-        num_zero_grad = torch.div(num_zero_grad, dp_replicate, rounding_mode="floor")
-        num_grad_elements = torch.div(num_grad_elements, dp_replicate, rounding_mode="floor")
-    return (num_zero_grad.float() / num_grad_elements.clamp_min(1).float()).item()
 
 
 def get_ckpt_disk_metrics(output_dir: Path) -> dict[str, float]:

--- a/src/prime_rl/utils/metrics_server.py
+++ b/src/prime_rl/utils/metrics_server.py
@@ -103,11 +103,6 @@ class MetricsServer(HealthServer):
             "trainer_mismatch_kl", "KL divergence between trainer and inference model", registry=self._registry
         )
         self._kl_ent_ratio = Gauge("trainer_kl_ent_ratio", "Ratio of mismatch KL to entropy", registry=self._registry)
-        self._zero_grad_ratio = Gauge(
-            "trainer_zero_grad_ratio",
-            "Fraction of tracked parameter elements with zero gradient",
-            registry=self._registry,
-        )
 
     def _make_handler(self) -> type[BaseHTTPRequestHandler]:
         """Create handler with /metrics and /health endpoints."""
@@ -164,7 +159,6 @@ class MetricsServer(HealthServer):
         mfu: float = 0.0,
         entropy: float = 0.0,
         mismatch_kl: float = 0.0,
-        zero_grad_ratio: float = 0.0,
     ) -> None:
         """Update metrics after a training step."""
         self._step.set(step)
@@ -177,7 +171,6 @@ class MetricsServer(HealthServer):
         self._mfu.set(mfu)
         self._entropy.set(entropy)
         self._mismatch_kl.set(mismatch_kl)
-        self._zero_grad_ratio.set(zero_grad_ratio)
         if entropy > 0:
             self._kl_ent_ratio.set(mismatch_kl / entropy)
         self._last_step_ts.set(time.time())


### PR DESCRIPTION
## Summary

Removes the `zero_grad_ratio` metric entirely: `count_zero_gradient_elements` / `get_zero_gradient_ratio`, both trainer call sites, the `optim/zero_grad_ratio` log key, and the `trainer_zero_grad_ratio` Prometheus gauge.

**Why remove it:**
1. **The metric appears broken**: it reported `zero_grad_ratio = 1.0` (all gradients zero) on every validation run — Qwen3-30B-A3B actively training on 8×H200 — so it is likely not reading FSDP2 DTensor gradients correctly.
2. **It's pure per-step overhead**: a Python loop with a host→device scalar copy and a `count_nonzero` kernel per parameter tensor (thousands on MoE models), two all-reduces, and an `.item()` sync, every step.

**Measured cost** (Qwen3-30B-A3B, 8×H200, fake data, no offload, paired same-session runs, median of steps 2–5):

| | seq 8K | seq 16K |
| --- | ---: | ---: |
| with scan | 3.47 s | 5.84 s |
| without scan | 3.18 s | 6.23 s |
| scan cost | **0.29 s (8% of step)** | within noise |

An earlier revision of this PR claimed ~1.4 s/step based on a cross-session comparison; that did not replicate in paired runs and is withdrawn — the honest number is ~8% at short sequences on many-tensor models, shrinking into noise as compute grows. The primary motivation is the metric's unreliable output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only removal with no changes to optimizer, loss, or gradient math; dashboards/alerts referencing `optim/zero_grad_ratio` or `trainer_zero_grad_ratio` will stop updating.
> 
> **Overview**
> **Removes** the `zero_grad_ratio` observability path end-to-end: `count_zero_gradient_elements` / `get_zero_gradient_ratio` in `trainer/utils.py`, the post–grad-clip computation in **RL** and **SFT** trainers, the `optim/zero_grad_ratio` monitor key, and the `trainer_zero_grad_ratio` Prometheus gauge plus `MetricsServer.update(..., zero_grad_ratio=...)`.
> 
> Training steps no longer pay the per-parameter gradient scan (Python loop, `count_nonzero`, all-reduces, sync) that existed only to populate that metric. Related unused imports (`Iterable`, `nn`, `DTensor`) are dropped with the helper code.
> 
> **Note:** `docs/training.md` still documents `optim/zero_grad_ratio`; that file is unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95261f85dd72ab579d1d7e12c59d3b7e7538e4c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->