### PR TITLE
chore: replace vllm-router fork with upstream release

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -181,7 +181,7 @@ non_cached_tokens = 16          # llm-d only: below this many non-cached prompt 
 "kv-cache-utilization-scorer" = 2.0
 ```
 
-- **`vllm-router`** (default) — our fork of [vllm-router](https://github.com/PrimeIntellect-ai/router). Knob: `policy`. The only backend supported for single-node (local) deployments.
+- **`vllm-router`** (default) — [vllm-router](https://github.com/vllm-project/router). Knob: `policy`. The only backend supported for single-node (local) deployments.
 - **`llm-d`** — the upstream [llm-d](https://llm-d.ai) Endpoint Picker (EPP) + Envoy proxy (multi-node / disaggregated SLURM deployments only). Routing combines **prefix-cache affinity** (grouped rollouts reuse a cached prefix and skip prefill) with the **`active-request-scorer`** — an in-flight load balancer that spreads requests across ranks immediately, unlike the metrics-scraped `queue-scorer` / `kv-cache-utilization-scorer` / `load-aware-scorer` (which lag and concentrate bursts of same-prefix requests). The scorer weights follow the upstream llm-d P/D guide; tune via `scorers` (base) + `prefill_scorer_overrides` / `decode_scorer_overrides` (per-profile, P/D). Does not support `enable_return_routed_experts` (router replay).
 
 Both backends support the 2 most important things:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ disagg = [
     "deep-gemm",
     "nixl",
     "nixl-cu12 ; platform_machine == 'x86_64'",
-    "vllm-router",
+    "vllm-router>=0.1.15",
 ]
 gpt-oss = [
     "kernels",
@@ -186,7 +186,6 @@ verifiers = false
 renderers = false
 prime-pydantic-config = false
 # Trusted git/URL sources pinned by rev or wheel URL (defensive: belt-and-suspenders)
-vllm-router = false
 dion = false
 deep-ep = false
 deep-gemm = false
@@ -207,10 +206,6 @@ torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "23e4dfc" }
 torchao = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.6.0/torchao-0.17.0+git02105d46c-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 flash-attn-4 = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "96bd151" }
-vllm-router = [
-    { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl", marker = "platform_machine == 'x86_64'" },
-    { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
-]
 vllm = [
     { url = "https://github.com/vllm-project/vllm/releases/download/v0.26.0/vllm-0.26.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl", marker = "platform_machine == 'x86_64'" },
     { url = "https://github.com/vllm-project/vllm/releases/download/v0.26.0/vllm-0.26.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -178,7 +178,9 @@ def start_router(config: InferenceConfig) -> subprocess.Popen:
         "--prometheus-port",
         str(config.server.port + 21000),
     ]
-    return subprocess.Popen(cmd)
+    # New session so a terminal Ctrl-C only signals the server process: the
+    # engine drains first, then inference_local's finally terminates the router.
+    return subprocess.Popen(cmd, start_new_session=True)
 
 
 def inference_local(config: InferenceConfig):
@@ -211,9 +213,14 @@ def inference_local(config: InferenceConfig):
 
         def watch_router():
             router_process.wait()
-            if not router_stopping.is_set():
-                logger.error(f"Router exited with code {router_process.returncode} - shutting down")
-                os.kill(os.getpid(), signal.SIGTERM)
+            if router_stopping.is_set():
+                return
+            # A zero exit is an external shutdown racing ours (e.g. the rl
+            # launcher SIGTERMs the whole tree, router first) - not a crash.
+            code = router_process.returncode
+            log = logger.warning if code == 0 else logger.error
+            log(f"Router exited with code {code} - shutting down")
+            os.kill(os.getpid(), signal.SIGTERM)
 
         Thread(target=watch_router, daemon=True).start()
     else:

--- a/uv.lock
+++ b/uv.lock
@@ -7458,7 +7458,7 @@ requires-dist = [
     { name = "openai-agents", specifier = ">=0.8.2" },
     { name = "openenv", marker = "extra == 'openenv'", specifier = ">=0.4.1" },
     { name = "prime-pydantic-config", extras = ["toml"], specifier = ">=0.4.2" },
-    { name = "prime-sandboxes", specifier = ">=0.2.36" },
+    { name = "prime-sandboxes", specifier = ">=0.2.35" },
     { name = "prime-tunnel", specifier = ">=0.1.8" },
     { name = "pydantic", specifier = ">=2.12.3" },
     { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -18,10 +18,9 @@ exclude-newer-span = "P7D"
 vllm = false
 verifiers = false
 prime-pydantic-config = false
-vllm-router = false
 dion = false
-nixl-cu12 = false
 fastokens = false
+nixl-cu12 = false
 flash-attn-3 = false
 prime-tunnel = false
 deep-gemm = false
@@ -4866,8 +4865,7 @@ all = [
     { name = "nixl" },
     { name = "nixl-cu12", version = "0.10.1", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
     { name = "quack-kernels" },
-    { name = "vllm-router", version = "0.1.26", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64'" },
-    { name = "vllm-router", version = "0.1.26", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
+    { name = "vllm-router" },
 ]
 disagg = [
     { name = "deep-ep", version = "1.1.0+1fd57b0", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.1.0+1fd57b0-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine != 'x86_64'" },
@@ -4876,8 +4874,7 @@ disagg = [
     { name = "deep-gemm", version = "2.5.0+891d57b", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
     { name = "nixl" },
     { name = "nixl-cu12", version = "0.10.1", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
-    { name = "vllm-router", version = "0.1.26", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64'" },
-    { name = "vllm-router", version = "0.1.26", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
+    { name = "vllm-router" },
 ]
 flash-attn = [
     { name = "flash-attn", version = "2.8.3+cu128torch2.11", source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.22/flash_attn-2.8.3+cu128torch2.11-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine != 'x86_64'" },
@@ -4970,9 +4967,7 @@ requires-dist = [
     { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'", specifier = ">=0.26.0" },
     { name = "vllm", marker = "platform_machine == 'aarch64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.26.0/vllm-0.26.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" },
     { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.26.0/vllm-0.26.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" },
-    { name = "vllm-router", marker = "platform_machine == 'aarch64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl" },
-    { name = "vllm-router", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'disagg'" },
-    { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl" },
+    { name = "vllm-router", marker = "extra == 'disagg'", specifier = ">=0.1.15" },
     { name = "wandb", specifier = ">=0.26.1" },
     { name = "wandb-workspaces", specifier = ">=0.4.3" },
 ]
@@ -7925,11 +7920,8 @@ provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttens
 
 [[package]]
 name = "vllm-router"
-version = "0.1.26"
-source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl" }
-resolution-markers = [
-    "platform_machine == 'aarch64' and sys_platform == 'linux'",
-]
+version = "0.1.15"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "fastapi" },
@@ -7938,56 +7930,11 @@ dependencies = [
     { name = "setproctitle" },
     { name = "uvicorn" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/ec/ece6b9ea89faa9cd5b7f0447f05fa053d7f78177acd320f2306b278ee6c4/vllm_router-0.1.15.tar.gz", hash = "sha256:af8efa64a97d58f13f37f73ca8216057cab806dff2b822f96c68386ecec9ffd4", size = 248820, upload-time = "2026-07-13T11:03:58.364Z" }
 wheels = [
-    { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ab8d0da61faa588fd5a7ed947bd58ddb31f5836cf55518bdd0122cfbc83989f4" },
+    { url = "https://files.pythonhosted.org/packages/96/dc/62a45ba798a435706631614197427548f40cdc5c403b1214f029e693668b/vllm_router-0.1.15-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c30070b2f8559fc33da4b114e58d28881775585dd6f6e1ac173ea494c8fbe20e", size = 8050336, upload-time = "2026-07-13T11:03:55.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8f/ea7aced147c8c2e50271550765470bdb5d5342b4422fe1114aa76aa65584/vllm_router-0.1.15-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2f268b001a546d7921c2e87b510869134a212f0ab2faf138b78eb554c93a2241", size = 8435363, upload-time = "2026-07-13T11:03:56.857Z" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp" },
-    { name = "fastapi" },
-    { name = "orjson" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "requests", specifier = ">=2.25.0" },
-    { name = "setproctitle" },
-    { name = "uvicorn" },
-]
-provides-extras = ["dev"]
-
-[[package]]
-name = "vllm-router"
-version = "0.1.26"
-source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl" }
-resolution-markers = [
-    "platform_machine == 'x86_64' and sys_platform == 'linux'",
-]
-dependencies = [
-    { name = "aiohttp" },
-    { name = "fastapi" },
-    { name = "orjson" },
-    { name = "requests" },
-    { name = "setproctitle" },
-    { name = "uvicorn" },
-]
-wheels = [
-    { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:db0c9410a4c130da8ffeea22f569faca7c85c58c5e183be1ebf758076361a6ec" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp" },
-    { name = "fastapi" },
-    { name = "orjson" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "requests", specifier = ">=2.25.0" },
-    { name = "setproctitle" },
-    { name = "uvicorn" },
-]
-provides-extras = ["dev"]
 
 [[package]]
 name = "wadler-lindig"


### PR DESCRIPTION
## Summary

- Consume `vllm-router` from PyPI ([vllm-project/router](https://github.com/vllm-project/router), `>=0.1.15`) instead of the pinned wheel from our [PrimeIntellect-ai/router](https://github.com/PrimeIntellect-ai/router) fork (v0.1.26).
- Drop the `[tool.uv.sources]` wheel URLs and the `exclude-newer-package` exemption; the dependency now resolves through the normal registry path.
- Update `docs/inference.md` to stop calling the router backend "our fork".
- Shut down the router cleanly on Ctrl-C: the router now runs in its own session, so a terminal SIGINT only reaches the server — the engine drains first, then `inference_local` terminates the router. Previously the router died instantly with the foreground group and the watcher thread logged a spurious `ERROR Router exited with code 0 - shutting down` plus a redundant SIGTERM. The watcher also logs a zero exit as a warning now (an external shutdown racing ours, not a crash).

Upstream 0.1.15 covers everything prime-rl invokes: the `consistent_hash` policy, `--intra-node-data-parallel-size`, `--vllm-pd-disaggregation`, `--request-id-headers`, `--worker-startup-timeout-secs`, `--prometheus-port`, and a typed `/inference/v1/generate` route. Extra request fields (e.g. `return_routed_experts`) pass through via a serde-flatten catch-all, and response bytes are forwarded verbatim, so single-replica router replay keeps working.

## Breaking

Fork-only router features are gone with this swap:

- **Routed-experts merge for P/D disaggregation**: upstream does not merge prefill/decode routed-experts payloads. Router replay (`trainer.enable_router_replay`) with a `disaggregated` deployment will not return merged expert traces. Single-replica replay is unaffected.
- **JWT auth and per-run usage metrics**: platform-side features of the fork; not used by prime-rl entrypoints. Platform deployments that need them should keep deploying the fork binary independently of prime-rl's dependency.

## Verification

Ran the reverse-text RL example end-to-end from this branch on 2 GPUs:

```
uv run rl @ examples/basic/reverse-text/rl.toml --no-wandb --output-dir outputs/router-smoke
```

- Router started from the upstream wheel: `vllm_router_rs::server: Starting router on 0.0.0.0:8000 | mode: Regular { worker_urls: ["http://localhost:8100"] } | policy: ConsistentHash`.
- All rollouts flowed through the router's `/inference/v1/generate` route: 20/20 steps, 128/128 trainable per step, 0.0% errors, reward 0.15 → 0.70.
- Clean shutdown, final checkpoint written at `step_20`.

Ctrl-C shutdown, verified with a standalone `uv run inference --vllm.model Qwen/Qwen3-0.6B` and SIGINT to its foreground process group:

- Before: router died with the group; watcher logged `ERROR Router exited with code 0 - shutting down` and re-signalled the process.
- After: engine drains first, then the router logs `Received terminate signal, starting graceful shutdown`; no ERROR lines, no leftover processes.
