### PR TITLE
feat(deps): add opt-in flashinfer-aot group for air-gapped installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ uv sync --all-extras
 
 > *NOTE*: Environments are opt-in uv workspace members — `uv sync --all-extras` does not install them. To train on them, install all with `uv sync --all-extras --all-packages`, or a subset with `uv sync --package prime-rl --package <env>`.
 
+> *NOTE*: For offline / air-gapped deployments, add `--group flashinfer-aot` to also install the pre-built FlashInfer kernel artifacts (`flashinfer-cubin`, `flashinfer-jit-cache`). Without them, vLLM downloads cubins and JIT-compiles kernels on first run, which fails without internet access. Not installed by default as the wheels are ~2GB.
+
 3.1. Optional: Install Flash Attention 3 (on Hopper GPUs only, for flash_attention_3 attention backend)
 
 > *NOTE*: This step will take a while, as it builds the Flash Attention 3 extension from source, as it has no wheels prebuilt.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,16 @@ all = [
 mamba-ssm = [
     "mamba-ssm>=2.3.0",
 ]
+# Pre-built FlashInfer kernel artifacts for offline / air-gapped deployments: without
+# them vLLM downloads cubins and JIT-compiles kernels on first run. Versions must match
+# the locked flashinfer-python (mismatched artifact packages are ignored at runtime and
+# vLLM falls back to downloading) — re-pin when bumping vLLM. A dependency group, not an
+# extra, so `uv sync --all-extras` doesn't pull in ~2GB of wheels by default; opt in
+# with `uv sync --all-extras --group flashinfer-aot`.
+flashinfer-aot = [
+    "flashinfer-cubin==0.6.14",
+    "flashinfer-jit-cache==0.6.14",
+]
 dev = [
     "ipykernel>=6.29.5",
     "ipywidgets>=8.1.7",
@@ -187,6 +197,8 @@ renderers = false
 prime-pydantic-config = false
 # Trusted git/URL sources pinned by rev or wheel URL (defensive: belt-and-suspenders)
 vllm-router = false
+flashinfer-cubin = false
+flashinfer-jit-cache = false
 dion = false
 deep-ep = false
 deep-gemm = false
@@ -224,6 +236,13 @@ deep-gemm = [
     { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_aarch64.whl", marker = "platform_machine == 'aarch64'" },
 ]
 nixl-cu12 = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }
+# 0.6.14 is not published to PyPI (only up to 0.6.13); the jit-cache wheels are only
+# ever distributed per-CUDA-version outside PyPI (cu129 matches the vLLM wheel).
+flashinfer-cubin = { url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_cubin-0.6.14-py3-none-any.whl" }
+flashinfer-jit-cache = [
+    { url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_jit_cache-0.6.14+cu129-cp39-abi3-manylinux_2_28_x86_64.whl", marker = "platform_machine == 'x86_64'" },
+    { url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_jit_cache-0.6.14+cu129-cp39-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
+]
 flash-linear-attention = { git = "https://github.com/fla-org/flash-linear-attention" }
 flash_attn_3 = { index = "pytorch-cu128-test" }
 

--- a/uv.lock
+++ b/uv.lock
@@ -27,8 +27,10 @@ prime-tunnel = false
 deep-gemm = false
 prime-evals = false
 torchao = false
+flashinfer-jit-cache = false
 tokenspeed-mla = false
 deep-ep = false
+flashinfer-cubin = false
 prime-sandboxes = false
 renderers = false
 prime = false
@@ -1808,6 +1810,36 @@ source = { git = "https://github.com/fla-org/flash-linear-attention#a95475391465
 dependencies = [
     { name = "einops" },
     { name = "transformers" },
+]
+
+[[package]]
+name = "flashinfer-cubin"
+version = "0.6.14"
+source = { url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_cubin-0.6.14-py3-none-any.whl" }
+wheels = [
+    { url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_cubin-0.6.14-py3-none-any.whl", hash = "sha256:7bbed9f3851b59f3f6f6cb344810775bbce8a1c012ecf9a502bebd91cfb6433e" },
+]
+
+[[package]]
+name = "flashinfer-jit-cache"
+version = "0.6.14+cu129"
+source = { url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_jit_cache-0.6.14+cu129-cp39-abi3-manylinux_2_28_aarch64.whl" }
+resolution-markers = [
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
+wheels = [
+    { url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_jit_cache-0.6.14+cu129-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:04c6ce06e1f321f2043f895f355c4c9735c3360663c0ebf0de4dee5ac8d33528" },
+]
+
+[[package]]
+name = "flashinfer-jit-cache"
+version = "0.6.14+cu129"
+source = { url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_jit_cache-0.6.14+cu129-cp39-abi3-manylinux_2_28_x86_64.whl" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+]
+wheels = [
+    { url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_jit_cache-0.6.14+cu129-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:66817e5c13668910b197da3881414f9561a9a83e4dd6121b367fbf342580282c" },
 ]
 
 [[package]]
@@ -4905,6 +4937,11 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+flashinfer-aot = [
+    { name = "flashinfer-cubin" },
+    { name = "flashinfer-jit-cache", version = "0.6.14+cu129", source = { url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_jit_cache-0.6.14+cu129-cp39-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64'" },
+    { name = "flashinfer-jit-cache", version = "0.6.14+cu129", source = { url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_jit_cache-0.6.14+cu129-cp39-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
+]
 mamba-ssm = [
     { name = "mamba-ssm" },
 ]
@@ -4986,6 +5023,12 @@ dev = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "ruff", specifier = ">=0.12.1" },
+]
+flashinfer-aot = [
+    { name = "flashinfer-cubin", url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_cubin-0.6.14-py3-none-any.whl" },
+    { name = "flashinfer-jit-cache", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'", specifier = "==0.6.14" },
+    { name = "flashinfer-jit-cache", marker = "platform_machine == 'aarch64'", url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_jit_cache-0.6.14+cu129-cp39-abi3-manylinux_2_28_aarch64.whl" },
+    { name = "flashinfer-jit-cache", marker = "platform_machine == 'x86_64'", url = "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_jit_cache-0.6.14+cu129-cp39-abi3-manylinux_2_28_x86_64.whl" },
 ]
 mamba-ssm = [{ name = "mamba-ssm", specifier = ">=2.3.0" }]
 


### PR DESCRIPTION
## Motivation

The vLLM 0.26 bump (9f0d41e23, #3166) dropped `flashinfer-cubin` from the lock file because vLLM no longer depends on it. For air-gapped deployments (GPU fleet with no internet access), this broke first runs: vLLM now tries to download cubins and JIT-compile kernels at runtime, forcing users to trial-and-error rebuild their venv with the missing packages ([Slack thread](https://primeintellect.slack.com/archives/C0BEZPW5XTQ/p1786549468161619)).

## Change

Add a `flashinfer-aot` **dependency group** (following the existing `mamba-ssm` pattern) with the pre-built FlashInfer kernel artifacts:

- `flashinfer-cubin==0.6.14` — pre-downloaded cubins
- `flashinfer-jit-cache==0.6.14+cu129` — pre-built JIT cache, so nothing compiles on first run

Opt in with:

```bash
uv sync --all-extras --group flashinfer-aot
```

## Notes

- A dependency group rather than a project extra, so the documented `uv sync --all-extras` setup doesn't pull ~2GB of kernel wheels by default — the thread explicitly asked for this to stay opt-in.
- Versions must match the locked `flashinfer-python` (0.6.14) — mismatched artifact packages are ignored at runtime and vLLM falls back to downloading. Pins need re-checking on vLLM bumps (comment added in `pyproject.toml`).
- Wheels come from flashinfer's GitHub releases (0.6.14 isn't on PyPI; `flashinfer-jit-cache` never is — it's published per-CUDA-version, cu129 here to match the vLLM wheel). Both x86_64 and aarch64 are covered.
- Lock diff is purely additive; `uv lock --check` passes and `uv export --group flashinfer-aot` resolves the two wheels on both arches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and documentation only; no runtime code paths change, though version pins must stay in sync with vLLM/flashinfer-python on future bumps.
> 
> **Overview**
> Adds an opt-in **`flashinfer-aot`** uv dependency group so offline fleets can install pre-built FlashInfer artifacts (`flashinfer-cubin` and `flashinfer-jit-cache` at **0.6.14**, aligned with locked `flashinfer-python`) without pulling ~2GB into the default `uv sync --all-extras` flow.
> 
> Wiring includes GitHub-release wheel URLs for cubin and cu129 jit-cache on **x86_64** and **aarch64**, `tool.uv.sources` / exclude-newer entries for those packages, and lockfile updates. **README** documents opting in via `uv sync --all-extras --group flashinfer-aot` and why it matters when vLLM would otherwise download cubins or JIT-compile on first run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff76ecf31864aeb7fa9bd2cfe25e31654e3a1741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->