### PR TITLE
fix: keep zero-element dummy params out of the optimizer (NemotronH MoE resume)

### DIFF
--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -896,8 +896,11 @@ class NonGatedGroupedExperts(nn.Module):
         self.num_experts = num_experts
         self.w1 = nn.Parameter(torch.empty(num_experts, intermediate_dim, input_dim))
         self.w2 = nn.Parameter(torch.empty(num_experts, input_dim, intermediate_dim))
-        # Dummy w3 for @expert_parallel decorator compatibility (expects w1, w2, w3 signature)
-        self.w3 = nn.Parameter(torch.empty(0))
+        # Dummy w3 for @expert_parallel decorator compatibility (expects w1, w2, w3 signature).
+        # Frozen: a 0-element param must stay out of the optimizer, or strict checkpoint
+        # resume fails — the save only has state for stepped params, while DCP load
+        # materializes state for every optimizer param, demanding keys that don't exist.
+        self.w3 = nn.Parameter(torch.empty(0), requires_grad=False)
         self.use_grouped_mm = use_grouped_mm
         self.fp8 = fp8
         self.ep_comm_backend: EPCommBackend = "torch"

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -133,8 +133,11 @@ def _create_optimizer(
     # Only hand trainable params to the optimizer. Frozen params (e.g. the DSA sparse
     # indexer, which runs under no_grad) carry no optimizer state, and including them
     # breaks strict checkpoint resume (DCP materializes state for every requires_grad
-    # param at load time, mismatching the saved state). Muon filters internally below.
-    trainable_params = [p for _, p in named_params if p.requires_grad]
+    # param at load time, mismatching the saved state). Zero-element params (e.g. the
+    # dummy expert w3 that NonGatedGroupedExperts registers for the @expert_parallel
+    # signature) break resume the same way: they never step, so the save has no state
+    # for them. Muon filters internally below.
+    trainable_params = [p for _, p in named_params if p.requires_grad and p.numel() > 0]
     match config.type:
         case "sgd":
             return SGD(
@@ -181,6 +184,9 @@ def _create_muon_optimizer(
     router_params = []
     adamw_params = []
     for n, p in named_params:
+        if p.numel() == 0:
+            # Zero-element dummies (see _create_optimizer) carry no optimizer state.
+            continue
         if p.requires_grad and muon_enabled(n, p):
             if "mlp.experts" in n:
                 expert_params.append(p)

--- a/tests/unit/train/test_optim.py
+++ b/tests/unit/train/test_optim.py
@@ -1,0 +1,46 @@
+import torch
+import torch.nn as nn
+
+from prime_rl.configs.trainer import AdamWConfig
+from prime_rl.trainer.models.layers.moe import NonGatedGroupedExperts
+from prime_rl.trainer.optim import _create_optimizer
+
+
+class _DummyW3Model(nn.Module):
+    """A model with a zero-element placeholder param, like the dummy expert w3
+    that NonGatedGroupedExperts registers for the @expert_parallel signature."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4, bias=False)
+        self.w3 = nn.Parameter(torch.empty(0))
+
+
+def _optimizer_params(optimizer) -> list[torch.Tensor]:
+    return [p for group in optimizer.param_groups for p in group["params"]]
+
+
+def test_zero_numel_params_stay_out_of_the_optimizer():
+    """A param that can never step must not enter param groups: the checkpoint
+    save has no optimizer state for it, while DCP load materializes state for
+    every optimizer param, so resume fails with a missing key."""
+    model = _DummyW3Model()
+    optimizer = _create_optimizer(AdamWConfig(), list(model.named_parameters()), parallel_dims=None)
+    params = _optimizer_params(optimizer)
+    assert model.linear.weight in set(params)
+    assert not any(p.numel() == 0 for p in params)
+
+
+def test_frozen_params_stay_out_of_the_optimizer():
+    model = nn.Sequential(nn.Linear(4, 4, bias=False), nn.Linear(4, 4, bias=False))
+    model[0].weight.requires_grad_(False)
+    optimizer = _create_optimizer(AdamWConfig(), list(model.named_parameters()), parallel_dims=None)
+    assert _optimizer_params(optimizer) == [model[1].weight]
+
+
+def test_nongated_experts_dummy_w3_is_frozen():
+    """The dummy w3 itself must be untrainable, so every optimizer path (incl.
+    Muon's internal grouping) excludes it without special-casing."""
+    experts = NonGatedGroupedExperts(input_dim=8, intermediate_dim=16, num_experts=2, use_grouped_mm=False)
+    assert experts.w3.numel() == 0
+    assert not experts.w3.requires_grad


### PR DESCRIPTION
## Problem

Checkpoint resume fails on every NemotronH MoE run:

```
RuntimeError: Missing key in checkpoint state_dict: app.optimizers.state.model.layers.1.mlp.experts.w3.step.
```

`NonGatedGroupedExperts` registers a dummy 0-element `w3` param for the `@expert_parallel` signature. It never receives a gradient, so AdamW never creates state for it and the checkpoint save writes none — but DCP load materializes optimizer state for every param in the param groups, so the load plan demands `w3` keys that were never saved.

Hit on live runs: two Nemotron-3-Nano-30B-A3B runs could not resume from their step-10/step-20 checkpoints (workaround in the field: `--trainer.ckpt.skip-optimizer`, which discards Adam moments).

## Fix

- Register the dummy `w3` with `requires_grad=False` — a placeholder is untrainable by definition, and the existing frozen-param filter (added for exactly this DCP failure mode, see the comment in `_create_optimizer`) then excludes it everywhere, including Muon's internal grouping.
- Belt and braces: exclude zero-element params in `_create_optimizer` and the Muon param grouping, so any future dummy param cannot re-introduce the asymmetry even if left trainable.

## Tests

`tests/unit/train/test_optim.py`: zero-numel params stay out of param groups; frozen params stay out; the NonGated dummy `w3` is frozen at registration. Verified on ar-cluster (3 passed).

Note: checkpoints saved before this fix still lack `w3` optimizer state; resuming them with a fixed build works because the optimizer no longer contains `w3` at load time.

🤖 Prepared with [Claude Code](https://claude.com/claude-code) (draft per Parker)