### PR TITLE
fix: never fast-forward an infinite env's generator on resume

### DIFF
--- a/src/prime_rl/orchestrator/train_source.py
+++ b/src/prime_rl/orchestrator/train_source.py
@@ -25,11 +25,12 @@ class TrainSource:
     / ``load_state_dict()``: per-env ``{epoch, cursor}`` plus the env-choice
     RNG state, making the dispatch sequence reproducible across resumes. For
     a finite env, epochs are 1-indexed and seed that epoch's shuffle; for an
-    infinite env the epoch stays 1 and the cursor counts generator pulls,
-    replayed on restore by fast-forwarding the generator (exact iff it's
-    deterministic). Cursors advance at dispatch time (ahead of shipped
-    batches), so a resume skips the tasks that were in flight at checkpoint
-    time."""
+    infinite env the epoch stays 1 and the cursor counts generator pulls —
+    restored as a counter only, never by fast-forwarding the generator, since
+    an infinite taskset may be backed by live external state whose every pull
+    is a real draw with side effects. Cursors advance at dispatch time (ahead
+    of shipped batches), so a finite env's resume skips the tasks that were in
+    flight at checkpoint time."""
 
     def __init__(self, train_envs: TrainEnvs) -> None:
         self.rng = random.Random(42)
@@ -85,11 +86,14 @@ class TrainSource:
                 continue
             self.epochs[name] = position["epoch"]
             self.cursors[name] = position["cursor"]
-            if self.base_rows[name] is None:
-                for _ in range(position["cursor"]):
-                    next(self.iters[name])
-            else:
+            if self.base_rows[name] is not None:
                 self.examples[name] = self._shuffle(name)
+            # An infinite env restores its cursor as a counter only — never by
+            # fast-forwarding the generator. A fresh iterator is not the old one:
+            # replay is exact only for a pure deterministic generator, and for a
+            # taskset backed by live external state (a task server, a curriculum
+            # stream) every next() is a real draw with side effects, so replaying
+            # a thousands-deep cursor leaks work and stalls resume for hours.
 
     def next_example(self) -> dict | None:
         env_name = self.rng.choices(self.env_names, weights=self.weights, k=1)[0]

--- a/tests/unit/orchestrator/test_train_source.py
+++ b/tests/unit/orchestrator/test_train_source.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+from prime_rl.orchestrator.train_source import TrainSource
+
+
+class _CountingStream:
+    """Stands in for an infinite taskset generator backed by live external
+    state: every next() is a real draw the source must not replay."""
+
+    def __init__(self):
+        self.pulls = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self.pulls += 1
+        return SimpleNamespace(data=SimpleNamespace(idx=self.pulls))
+
+
+def _infinite_env(stream: _CountingStream, name: str = "stream"):
+    return SimpleNamespace(name=name, tasks=stream, num_tasks=None, config=SimpleNamespace(ratio=1))
+
+
+def _finite_env(name: str = "table", n: int = 5):
+    tasks = [SimpleNamespace(data=SimpleNamespace(idx=i)) for i in range(n)]
+    return SimpleNamespace(name=name, tasks=tasks, num_tasks=n, config=SimpleNamespace(ratio=1))
+
+
+def test_infinite_env_resume_does_not_replay_the_generator():
+    stream = _CountingStream()
+    source = TrainSource([_infinite_env(stream)])
+    for _ in range(7):
+        source.next_example()
+    assert stream.pulls == 7
+    state = source.state_dict()
+
+    fresh_stream = _CountingStream()
+    resumed = TrainSource([_infinite_env(fresh_stream)])
+    resumed.load_state_dict(state)
+    assert fresh_stream.pulls == 0, "resume must not consume the generator"
+    assert resumed.cursors["stream"] == 7
+
+    resumed.next_example()
+    assert fresh_stream.pulls == 1
+    assert resumed.cursors["stream"] == 8
+
+
+def test_finite_env_resume_replays_epoch_shuffle_and_position():
+    source = TrainSource([_finite_env()])
+    drawn = [source.next_example()["task"].data.idx for _ in range(3)]
+    state = source.state_dict()
+
+    resumed = TrainSource([_finite_env()])
+    resumed.load_state_dict(state)
+    continued = [resumed.next_example()["task"].data.idx for _ in range(2)]
+    baseline = [source.next_example()["task"].data.idx for _ in range(2)]
+    assert continued == baseline
+    assert len(set(drawn)) == 3

--- a/uv.lock
+++ b/uv.lock
@@ -11,8 +11,7 @@ supported-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
+exclude-newer = "2026-08-05T07:00:00Z"
 
 [options.exclude-newer-package]
 vllm = false
@@ -21,16 +20,19 @@ prime-pydantic-config = false
 vllm-router = false
 dion = false
 nixl-cu12 = false
+prime-rl = "2100-01-01T08:00:00Z"
 fastokens = false
 flash-attn-3 = false
 prime-tunnel = false
 deep-gemm = false
 prime-evals = false
 torchao = false
+tasksets = "2100-01-01T08:00:00Z"
 tokenspeed-mla = false
 deep-ep = false
 prime-sandboxes = false
 renderers = false
+harnesses = "2100-01-01T08:00:00Z"
 prime = false
 
 [manifest]


### PR DESCRIPTION
## Problem

`TrainSource.load_state_dict` restores an infinite env's data position by calling `next()` on the generator cursor-many times. That replay is only correct for a pure deterministic generator — an assumption nowhere declared. An infinite taskset backed by live external state (a task server, a curriculum stream) does a real draw on every pull.

Hit on live runs: resuming a run whose infinite env had drawn thousands of episodes made the orchestrator grind at 60% CPU for what projected to hours, leaking hundreds of claimed-but-never-run generation assignments into the external task server, while the trainer sat blocked in the startup weight broadcast until its 3600s timeout killed the job. No log line is emitted during the replay, so the run looks silently wedged (field workaround: `--orchestrator.ckpt.skip-progress`, which also drops the RNG/cursor state).

## Fix

Restore the infinite env's cursor as a counter only — never by consuming the generator. A fresh iterator is not the old one; for stateful streams the position is owned by the stream itself. Finite envs keep the exact epoch-shuffle position replay, which is pure.

Trade-off: a taskset whose generator IS a pure seeded function no longer replays to its old position and will restart its sequence after resume (possible repeats). If that matters, the cleaner contract is an explicit replayability attribute on the taskset — happy to do that instead if preferred.

## Tests

`tests/unit/orchestrator/test_train_source.py`: resume of an infinite env consumes zero generator pulls and continues from the restored counter; finite-env resume still replays the exact epoch-shuffle position. Verified on ar-cluster (2 passed).

🤖 Prepared with [Claude Code](https://claude.com/claude-code) (draft per Parker)