### PR TITLE
feat: default vllm-router balancing to cache_aware

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -181,7 +181,7 @@ non_cached_tokens = 16          # llm-d only: below this many non-cached prompt 
 "kv-cache-utilization-scorer" = 2.0
 ```
 
-- **`vllm-router`** (default) — our fork of [vllm-router](https://github.com/PrimeIntellect-ai/router). Knob: `policy`. The only backend supported for single-node (local) deployments.
+- **`vllm-router`** (default) — our fork of [vllm-router](https://github.com/PrimeIntellect-ai/router). Knobs: `policy` plus the `cache_aware` thresholds (`cache_threshold`, `balance_abs_threshold`, `balance_rel_threshold`). The only backend supported for single-node (local) deployments.
 - **`llm-d`** — the upstream [llm-d](https://llm-d.ai) Endpoint Picker (EPP) + Envoy proxy (multi-node / disaggregated SLURM deployments only). Routing combines **prefix-cache affinity** (grouped rollouts reuse a cached prefix and skip prefill) with the **`active-request-scorer`** — an in-flight load balancer that spreads requests across ranks immediately, unlike the metrics-scraped `queue-scorer` / `kv-cache-utilization-scorer` / `load-aware-scorer` (which lag and concentrate bursts of same-prefix requests). The scorer weights follow the upstream llm-d P/D guide; tune via `scorers` (base) + `prefill_scorer_overrides` / `decode_scorer_overrides` (per-profile, P/D). Does not support `enable_return_routed_experts` (router replay).
 
 Both backends support the 2 most important things:
@@ -189,18 +189,16 @@ Both backends support the 2 most important things:
 - P/D disaggregation - handling the prefill and decode stages separately
 
 ### Routing policies
-The 2 policies you might want to configure are:
-- `consistent_hash` - this is the default policy that optimizes for KV cache re-use across turns - this works by hashing a request header to determine where to route the request to. You can configure what to hash by setting
-`orchestrator.model.client.extra_headers_from_state` to the header the `router` expects to be set.
-
-We set it to a sensible default, that works with all verifiers environments.
+Set the policy via `inference.router.policy`. The policies you might want to configure are:
+- `cache_aware` (default) - routes by prefix affinity: requests whose token prefix matches a worker's recent traffic go to that worker, so a rollout's turns stay on one engine and re-use its KV cache. When engine load is imbalanced (in-flight spread exceeds `balance_abs_threshold` and `balance_rel_threshold`), it switches to shortest-queue routing until load evens out - this prevents a saturated engine from hoarding sticky sessions while the others idle. Tune via `inference.router.cache_threshold` / `balance_abs_threshold` / `balance_rel_threshold` (unset fields use the router defaults).
+- `consistent_hash` - sticky routing by request header hash: all requests with the same `X-Session-ID` go to the same engine, with no load awareness. The orchestrator sends each rollout's `trajectory_id` in this header by default; configure what to hash by setting `orchestrator.model.client.extra_headers_from_state`.
 
 ```toml
 [orchestrator.model.client.extra_headers_from_state]
 X-Session-ID = "trajectory_id" # this is the default - each rollout has a unique trajectory_id and router expects X-Session-ID
 ```
 
-- `round_robin` - this policy will round-robin the requests between the available replicas. This is useful if you want to balance the load between the replicas. This might give you better results if you don't have enough rollouts to make `consistent_hash` hashing saturated.
+- `round_robin` - this policy will round-robin the requests between the available replicas. This is useful if you want to balance the load between the replicas.
 
 
 ## Advanced Configuration

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -308,8 +308,17 @@ class VllmRouterConfig(BaseConfig):
 
     type: Literal["vllm-router"] = "vllm-router"
 
-    policy: str = "consistent_hash"
-    """Routing policy, e.g. ``consistent_hash`` or ``round_robin``."""
+    policy: str = "cache_aware"
+    """Routing policy: ``cache_aware`` (prefix affinity, falls back to shortest-queue when engine load is imbalanced), ``consistent_hash`` (sticky per X-Session-ID, no load awareness), ``round_robin``, ``power_of_two``, or ``random``."""
+
+    cache_threshold: float | None = Field(None, ge=0.0, le=1.0)
+    """``cache_aware`` only: minimum prefix-match rate to route by cache affinity; below it, routes to the worker with the most available cache space. ``None`` uses the router default."""
+
+    balance_abs_threshold: int | None = Field(None, ge=0)
+    """``cache_aware`` only: switch to shortest-queue routing when (max - min) in-flight requests across workers exceeds this. ``None`` uses the router default."""
+
+    balance_rel_threshold: float | None = Field(None, ge=1.0)
+    """``cache_aware`` only: switch to shortest-queue routing when max in-flight > rel * min in-flight (combined with ``balance_abs_threshold``). ``None`` uses the router default."""
 
 
 class LlmdRouterConfig(BaseConfig):

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -308,7 +308,7 @@ class VllmRouterConfig(BaseConfig):
 
     type: Literal["vllm-router"] = "vllm-router"
 
-    policy: str = "cache_aware"
+    policy: Literal["cache_aware", "consistent_hash", "round_robin", "power_of_two", "random"] = "cache_aware"
     """Routing policy: ``cache_aware`` (prefix affinity, falls back to shortest-queue when engine load is imbalanced), ``consistent_hash`` (sticky per X-Session-ID, no load awareness), ``round_robin``, ``power_of_two``, or ``random``."""
 
     cache_threshold: float | None = Field(None, ge=0.0, le=1.0)

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -178,6 +178,12 @@ def start_router(config: InferenceConfig) -> subprocess.Popen:
         "--prometheus-port",
         str(config.server.port + 21000),
     ]
+    if config.router.cache_threshold is not None:
+        cmd += ["--cache-threshold", str(config.router.cache_threshold)]
+    if config.router.balance_abs_threshold is not None:
+        cmd += ["--balance-abs-threshold", str(config.router.balance_abs_threshold)]
+    if config.router.balance_rel_threshold is not None:
+        cmd += ["--balance-rel-threshold", str(config.router.balance_rel_threshold)]
     return subprocess.Popen(cmd)
 
 

--- a/src/prime_rl/templates/_launch_router.sh.j2
+++ b/src/prime_rl/templates/_launch_router.sh.j2
@@ -75,6 +75,15 @@ LLMD_EOF
         --request-id-headers x-session-id
         --prometheus-port "$((port + 21000))"
         --worker-startup-timeout-secs 4200 --log-level debug)
+{%- if router.cache_threshold is not none %}
+    cmd+=(--cache-threshold {{ router.cache_threshold }})
+{%- endif %}
+{%- if router.balance_abs_threshold is not none %}
+    cmd+=(--balance-abs-threshold {{ router.balance_abs_threshold }})
+{%- endif %}
+{%- if router.balance_rel_threshold is not none %}
+    cmd+=(--balance-rel-threshold {{ router.balance_rel_threshold }})
+{%- endif %}
     if [ "$mode" = pd ]; then
         cmd+=(--vllm-pd-disaggregation $worker_args)
     else


### PR DESCRIPTION
## Summary

- Default the vllm-router balancing policy to `cache_aware` (was `consistent_hash`), for both single-node (local `start_router`) and multi-node/disaggregated (SLURM `launch_router`) deployments.
- Expose the `cache_aware` tuning knobs on `VllmRouterConfig` — `cache_threshold`, `balance_abs_threshold`, `balance_rel_threshold` — and plumb them through both launch paths. Unset fields use the router binary's defaults.
- Type `policy` as a `Literal` of the policies the router binary supports today (`cache_aware`, `consistent_hash`, `round_robin`, `power_of_two`, `random`), so typos fail at config validation.
- Update `docs/inference.md` routing-policies section accordingly.

Motivation: post-mortem of two 4-node GLM Air runs showed `consistent_hash` locking a saturated engine into a KV thrash spiral — preemption → re-prefill churn → prefix-cache eviction (98% → 5% hit rate) → ~4× slower generation — while its hash-pinned sessions kept it saturated and the other three engines drained idle. `consistent_hash` never looks at load, so no work migrates.

`cache_aware` keeps the property we want from stickiness (a rollout's turns follow their own growing token prefix, so KV re-use survives) but monitors per-worker in-flight counts and switches to shortest-queue routing while load is imbalanced (`max − min > balance_abs_threshold` and `max > balance_rel_threshold × min`), so a saturated engine sheds new work instead of hoarding it. `consistent_hash` remains available via `inference.router.policy`.

Stacked on #3240 to allow side-by-side comparison of per-engine metrics.

## Breaking

- The default routing policy changes from `consistent_hash` to `cache_aware`. Affinity is now derived from request token prefixes instead of the `X-Session-ID` header (the header is ignored by `cache_aware`; the orchestrator still sends it). To keep the old behavior, set `inference.router.policy = "consistent_hash"`.

## Verification

All on this change (verified atop main before restacking onto #3240 — the stack adds only the metrics passthrough), fork router v0.1.26 binary:

- **Multi-node (render)**: `uv run inference --slurm --deployment.type multi_node --dry-run` renders `launch_router regular ... "cache_aware"`; with `--router.cache-threshold 0.7 --router.balance-abs-threshold 16` the sbatch gains `cmd+=(--cache-threshold 0.7)` / `cmd+=(--balance-abs-threshold 16)`; without knobs, no extra flags.
- **Single-node (live)**: standalone `uv run inference --vllm.model Qwen/Qwen3-0.6B --router.type vllm-router --router.balance-abs-threshold 16` starts the router with `policy: CacheAware { balance_abs_threshold: 16, ... }`; chat completions through it succeed.
- **RL e2e**: reverse-text example (`uv run rl @ examples/basic/reverse-text/rl.toml`), 20/20 steps through the `cache_aware` router, 0% errors, reward 0.14 → 0.73, clean shutdown.
