### PR TITLE
chore: bump verifiers for prime-sandboxes 0.2.36

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -5014,19 +5014,21 @@ requires-dist = [
 
 [[package]]
 name = "prime-sandboxes"
-version = "0.2.35"
+version = "0.2.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
+    { name = "certifi" },
     { name = "connect-python" },
     { name = "httpx" },
     { name = "protobuf" },
     { name = "pydantic" },
+    { name = "pyqwest" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/cc/287c0db192ddbe003bd5882d1aab5461cdb3912d0c92db7b39734a9e828e/prime_sandboxes-0.2.35.tar.gz", hash = "sha256:e716bfccdcb51aefd5e2d48fdfc3a79bea8c6825bce1871f49f095ced03efc94", size = 86226, upload-time = "2026-08-05T14:29:53.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/c8/ca5261ff5d5c2e944e198866ead91b09bc88eb0390a905925bb6d7f9cd28/prime_sandboxes-0.2.36.tar.gz", hash = "sha256:3a5c8a7912b1ea0fb775674650835f7f86aac1a05aa8566c2db129b9a622fe55", size = 88415, upload-time = "2026-08-12T23:30:15.214Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/07/c186395925f780b1a18b350f562ebc4e8a64a182c37bd1e3db3948f297e2/prime_sandboxes-0.2.35-py3-none-any.whl", hash = "sha256:29d7057532b21545be5938d3aee822ae3a54085a45934d5c3ac55190e06c5bbb", size = 47189, upload-time = "2026-08-05T14:29:52.142Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/26/081296fc8e6d8ce962f2aee0e47ac843982094dedb34a1fad22d10086f37/prime_sandboxes-0.2.36-py3-none-any.whl", hash = "sha256:a5db92d927cf4a3dd37ce230027a9d83dbf21804d4f6ed2255d276c1962fa8f2", size = 49316, upload-time = "2026-08-12T23:30:14.047Z" },
 ]
 
 [[package]]
@@ -7461,7 +7463,7 @@ requires-dist = [
     { name = "openai-agents", specifier = ">=0.8.2" },
     { name = "openenv", marker = "extra == 'openenv'", specifier = ">=0.4.1" },
     { name = "prime-pydantic-config", extras = ["toml"], specifier = ">=0.4.2" },
-    { name = "prime-sandboxes", specifier = ">=0.2.35" },
+    { name = "prime-sandboxes", specifier = ">=0.2.36" },
     { name = "prime-tunnel", specifier = ">=0.1.8" },
     { name = "pydantic", specifier = ">=2.12.3" },
     { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary

- Point the `deps/verifiers` submodule at verifiers main (includes [vf#2344](https://github.com/PrimeIntellect-ai/verifiers/pull/2344)) and re-lock (`prime-sandboxes` 0.2.35 → 0.2.36).
- 0.2.36 gives each live ACP process its own HTTP transport ([prime#831](https://github.com/PrimeIntellect-ai/prime/pull/831)). This fixes rlm rollouts on prime VM sandboxes failing with `process stdin RPC failed (deadline_exceeded)` above ~100 concurrency (gateway h2 stream cap).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump with no application code changes; risk is limited to behavior introduced in the upstream sandbox client at rollout time.
> 
> **Overview**
> **Locks `prime-sandboxes` from 0.2.35 → 0.2.36** in `uv.lock`, including updated wheel/sdist hashes and raising the **verifiers** lower bound to `>=0.2.36`.
> 
> The resolved **0.2.36** package now pulls in **`certifi`** and **`pyqwest`** as new transitive dependencies. This aligns the workspace with the release that gives each live ACP process its own HTTP transport, addressing high-concurrency RLM rollout failures (`process stdin RPC failed (deadline_exceeded)`) on Prime VM sandboxes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bae0a1b64747c68606d193de2fdd88ba8b17370f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->