### PR TITLE
chore(ruff): pin path-dep import classification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,6 +261,7 @@ select = ["F", "I"]
 # Without this, ruff classifies prime_rl.configs.* as third-party because it
 # doesn't live under src/.
 known-first-party = ["prime_rl"]
+known-third-party = ["verifiers", "renderers", "pydantic_config"]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
ruff's isort classifies a module as first-party if it resolves under a source root of the working tree — so classification depends on what happens to exist in a checkout, and local hooks vs CI can disagree (a stray untracked `verifiers/` dir at the repo root did exactly that: pre-commit kept re-sorting imports into a layout CI rejects). Pin the `deps/` path dependencies as `known-third-party`, mirroring the existing `known-first-party = ["prime_rl"]`, so import grouping is a property of the repo.

One line in pyproject.toml, no code changes. Verified with ruff 0.13.0 (CI's pin) and 0.15.x (lockfile), with and without the stray dir present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only Ruff/isort configuration with no runtime or application logic changes.
> 
> **Overview**
> Pins **isort** classification for editable **`deps/`** packages so Ruff no longer treats `verifiers`, `renderers`, and `pydantic_config` as first-party when a matching directory happens to exist in a developer checkout.
> 
> Adds `known-third-party = ["verifiers", "renderers", "pydantic_config"]` under `[tool.ruff.lint.isort]`, alongside the existing `known-first-party = ["prime_rl"]` workaround. **No application code changes**—only `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7eed71388eedbd24be8e815de9f747f1c8308b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->