### PR TITLE
feat(orchestrator): add curriculum examples

### DIFF
--- a/configs/ci/nightly-fft/wiki-search.toml
+++ b/configs/ci/nightly-fft/wiki-search.toml
@@ -21,6 +21,7 @@ oversampling_factor = 2.0
 
 [[orchestrator.train.source]]
 name = "wiki-search"
+curriculum = { import_path = "prime_rl.orchestrator.curricula.AdvantageRangeGate" }
 
 [orchestrator.train.source.env.taskset]
 id = "wiki-search"

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -483,6 +483,30 @@ curriculum = { import_path = "my_package.MyCurriculum", kwargs = { seed = 7 } }
 
 Override `state_dict` and `load_state_dict` for additional mutable state, calling the base implementations when using its RNG or iteration state. `metrics` returns unprefixed metric names.
 
+Two small implementations are included as examples:
+
+- `DifficultyPools` samples every finite task once, tracks its latest mean group reward, then samples a named reward pool by weight and a task uniformly within that pool.
+- `AdvantageRangeGate` rejects a group when every trainable-token advantage falls inside `reject_min` through `reject_max`. Its default `[0, 0]` range rejects zero-advantage groups. Groups without an advantage stream are admitted.
+
+```toml
+[orchestrator.train.source.curriculum]
+import_path = "prime_rl.orchestrator.curricula.DifficultyPools"
+
+[orchestrator.train.source.curriculum.kwargs.thresholds]
+hard = 0.25
+medium = 0.75
+easy = 1.0
+
+[orchestrator.train.source.curriculum.kwargs.weights]
+hard = 0.2
+medium = 0.6
+easy = 0.2
+```
+
+```toml
+curriculum = { import_path = "prime_rl.orchestrator.curricula.AdvantageRangeGate", kwargs = { reject_min = -0.05, reject_max = 0.05 } }
+```
+
 ## Multi-Turn Trajectories
 
 For multi-turn rollouts (tool use, browser environments, long conversations), `prime-rl` records each LLM request/response as an independent **trajectory step** and merges them at training time using best-effort interleaving — with [renderers](#renderers) as the mechanism that keeps the merge safe by construction.

--- a/examples/advanced/intellect-3.1/rl.toml
+++ b/examples/advanced/intellect-3.1/rl.toml
@@ -50,6 +50,7 @@ oversampling_factor = 2
 [[orchestrator.train.source]]
 name = "swe"
 ratio = 0.3
+curriculum = { import_path = "prime_rl.orchestrator.curricula.AdvantageRangeGate" }
 
 [orchestrator.train.source.env.taskset]
 id = "r2e-gym"
@@ -64,6 +65,7 @@ labels = ["intellect-3.1", "swe"]
 [[orchestrator.train.source]]
 name = "deepdive"
 ratio = 0.2
+curriculum = { import_path = "prime_rl.orchestrator.curricula.AdvantageRangeGate" }
 
 [orchestrator.train.source.env.taskset]
 id = "deepdive"
@@ -80,6 +82,7 @@ labels = ["intellect-3.1", "deepdive"]
 [[orchestrator.train.source]]
 name = "math"
 ratio = 0.3
+curriculum = { import_path = "prime_rl.orchestrator.curricula.AdvantageRangeGate" }
 
 [orchestrator.train.source.env.taskset]
 id = "i3_math"
@@ -93,6 +96,7 @@ type = "subprocess"
 [[orchestrator.train.source]]
 name = "logic"
 ratio = 0.2
+curriculum = { import_path = "prime_rl.orchestrator.curricula.AdvantageRangeGate" }
 
 [orchestrator.train.source.env.taskset]
 id = "i3_logic"
@@ -109,6 +113,7 @@ type = "subprocess"
 [[orchestrator.train.source]]
 name = "code"
 ratio = 0.2
+curriculum = { import_path = "prime_rl.orchestrator.curricula.AdvantageRangeGate" }
 
 [orchestrator.train.source.env.taskset]
 id = "i3_code"

--- a/examples/basic/wiki-search/rl.toml
+++ b/examples/basic/wiki-search/rl.toml
@@ -42,6 +42,7 @@ max_completion_tokens = 512
 
 [[orchestrator.train.source]]
 name = "wiki-search"
+curriculum = { import_path = "prime_rl.orchestrator.curricula.AdvantageRangeGate" }
 
 [orchestrator.train.source.env.taskset]
 id = "wiki-search"

--- a/src/prime_rl/orchestrator/curricula.py
+++ b/src/prime_rl/orchestrator/curricula.py
@@ -1,0 +1,122 @@
+"""Small curriculum implementations built on the user-space surface."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+import verifiers.v1 as vf
+
+from prime_rl.orchestrator.curriculum import Curriculum, CurriculumResult
+
+
+class DifficultyPools(Curriculum):
+    """Sample finite tasks through named pools based on the latest group mean.
+
+    Unseen tasks are sampled first. Afterwards, a nonempty pool is selected by
+    its configured weight and a task is sampled uniformly from that pool.
+    ``thresholds`` maps each pool name to its inclusive maximum mean reward.
+    """
+
+    def __init__(
+        self,
+        tasks: Sequence[vf.Task] | Iterator[vf.Task],
+        *,
+        thresholds: dict[str, float] | None = None,
+        weights: dict[str, float] | None = None,
+        seed: int = 42,
+    ) -> None:
+        super().__init__(tasks, seed=seed)
+        if self.tasks is None:
+            raise ValueError("DifficultyPools requires a finite taskset")
+        self.thresholds = {"hard": 0.25, "medium": 0.75, "easy": 1.0} if thresholds is None else thresholds
+        self.weights = dict.fromkeys(self.thresholds, 1.0) if weights is None else weights
+        if not self.thresholds:
+            raise ValueError("DifficultyPools requires at least one pool")
+        if self.thresholds.keys() != self.weights.keys():
+            raise ValueError("Difficulty pool thresholds and weights must name the same pools")
+        if any(weight <= 0 for weight in self.weights.values()):
+            raise ValueError("Difficulty pool weights must be positive")
+        ordered = sorted(self.thresholds.items(), key=lambda item: item[1])
+        if len({maximum for _, maximum in ordered}) != len(ordered):
+            raise ValueError("Difficulty pool thresholds must be unique")
+        self._ordered_pools = tuple(ordered)
+        self.task_rewards: dict[str, float] = {}
+
+    def _pool(self, task_key: str) -> str:
+        score = self.task_rewards[task_key]
+        for name, maximum in self._ordered_pools:
+            if score <= maximum:
+                return name
+        raise ValueError(f"Task {task_key!r} has mean reward {score} above every difficulty threshold")
+
+    def sample(self) -> vf.Task:
+        unseen = [task for task in self.tasks_by_key.values() if task.key not in self.task_rewards]
+        if unseen:
+            return self.rng.choice(unseen)
+
+        tasks_by_pool: dict[str, list[vf.Task]] = defaultdict(list)
+        for task_key, task in self.tasks_by_key.items():
+            tasks_by_pool[self._pool(task_key)].append(task)
+        nonempty = [name for name in self.weights if tasks_by_pool[name]]
+        pool = self.rng.choices(nonempty, weights=[self.weights[name] for name in nonempty], k=1)[0]
+        return self.rng.choice(tasks_by_pool[pool])
+
+    def on_result(self, result: CurriculumResult) -> bool:
+        rewards = [rollout.reward for rollout in result.rollouts if not rollout.has_error and rollout.agent.trainable]
+        if not rewards:
+            return True
+        self.task_rewards[result.task_key] = sum(rewards) / len(rewards)
+        return True
+
+    def state_dict(self) -> dict[str, Any]:
+        return super().state_dict() | {
+            "task_rewards": dict(self.task_rewards),
+        }
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        super().load_state_dict(state_dict)
+        self.task_rewards = dict(state_dict["task_rewards"])
+
+    def metrics(self) -> dict[str, float]:
+        occupancy = dict.fromkeys(self.thresholds, 0)
+        for task_key in self.task_rewards:
+            occupancy[self._pool(task_key)] += 1
+        return {
+            "pool/unseen": float(len(self.tasks_by_key) - len(self.task_rewards)),
+            **{f"pool/{name}": float(count) for name, count in occupancy.items()},
+        }
+
+
+class AdvantageRangeGate(Curriculum):
+    """Reject groups whose trainable-token advantages all fall inside a range.
+
+    The default ``[0, 0]`` interval implements zero-advantage rejection.
+    Groups without an advantage stream are admitted.
+    """
+
+    def __init__(
+        self,
+        tasks: Sequence[vf.Task] | Iterator[vf.Task],
+        *,
+        reject_min: float = 0.0,
+        reject_max: float = 0.0,
+        seed: int = 42,
+    ) -> None:
+        super().__init__(tasks, seed=seed)
+        if reject_min > reject_max:
+            raise ValueError("reject_min must be less than or equal to reject_max")
+        self.reject_min = reject_min
+        self.reject_max = reject_max
+
+    def on_result(self, result: CurriculumResult) -> bool:
+        advantages: list[float] = []
+        for rollout in result.rollouts:
+            if rollout.advantages is None:
+                continue
+            trainable = [value for sample in rollout.samples for value in sample.mask]
+            advantages.extend(advantage for advantage, keep in zip(rollout.advantages, trainable, strict=True) if keep)
+        if not advantages:
+            return True
+        return not all(self.reject_min <= advantage <= self.reject_max for advantage in advantages)

--- a/tests/unit/orchestrator/test_curriculum.py
+++ b/tests/unit/orchestrator/test_curriculum.py
@@ -5,16 +5,36 @@ import pytest
 import verifiers.v1 as vf
 
 from prime_rl.configs.orchestrator import CurriculumConfig
+from prime_rl.orchestrator.curricula import AdvantageRangeGate, DifficultyPools
 from prime_rl.orchestrator.curriculum import Curriculum, CurriculumResult
 from prime_rl.orchestrator.train_source import TrainSource
 from prime_rl.orchestrator.types import Rollout
+from prime_rl.transport import TrainingSample
 
 
 def make_task(idx: int) -> vf.Task:
     return vf.Task(vf.TaskData(idx=idx, prompt=f"task {idx}"))
 
 
-def make_rollout(task: vf.Task, *, env_name: str = "test") -> Rollout:
+def make_rollout(
+    task: vf.Task,
+    *,
+    env_name: str = "test",
+    reward: float = 0.0,
+    advantages: list[float] | None = None,
+) -> Rollout:
+    samples = []
+    if advantages is not None:
+        samples = [
+            TrainingSample(
+                token_ids=list(range(len(advantages))),
+                mask=[True] * len(advantages),
+                logprobs=[0.0] * len(advantages),
+                temperatures=[1.0] * len(advantages),
+                advantages=advantages,
+                env_name=env_name,
+            )
+        ]
     return Rollout(
         task=vf.TraceTask(
             type=type(task).__name__,
@@ -24,6 +44,10 @@ def make_rollout(task: vf.Task, *, env_name: str = "test") -> Rollout:
         ),
         agent=vf.AgentInfo(config=vf.AgentConfig()),
         env_name=env_name,
+        rewards={"reward": vf.Reward(score=reward)},
+        advantages=advantages,
+        samples=samples,
+        ok=True,
     )
 
 
@@ -100,3 +124,43 @@ def test_train_source_hosts_user_curriculum_admission_state_and_metrics() -> Non
     restored = TrainSource([SimpleNamespace(name="test", tasks=iter(tasks), num_tasks=len(tasks), config=config)])
     restored.load_state_dict(state)
     assert restored.curricula["test"].state_dict()["seen"] == 1
+
+
+def test_difficulty_pools_track_group_reward_and_resume_sampling() -> None:
+    tasks = [make_task(i) for i in range(3)]
+    pools = DifficultyPools(tasks, seed=7)
+    rewards = {0: 0.1, 1: 0.5, 2: 0.9}
+    for _ in tasks:
+        task = pools.sample()
+        pools.on_result(CurriculumResult.from_rollouts([make_rollout(task, reward=rewards[task.data.idx])]))
+
+    assert pools.metrics() == {
+        "pool/unseen": 0.0,
+        "pool/hard": 1.0,
+        "pool/medium": 1.0,
+        "pool/easy": 1.0,
+    }
+    state = pools.state_dict()
+    expected = [pools.sample().key for _ in range(10)]
+    restored = DifficultyPools(tasks, seed=7)
+    restored.load_state_dict(state)
+    assert [restored.sample().key for _ in range(10)] == expected
+
+
+def test_advantage_range_gate_generalizes_zero_advantage_rejection() -> None:
+    task = make_task(0)
+    zero_gate = AdvantageRangeGate([task])
+    assert zero_gate.on_result(CurriculumResult.from_rollouts([make_rollout(task, advantages=[0.0, 0.0])])) is False
+    assert zero_gate.on_result(CurriculumResult.from_rollouts([make_rollout(task, advantages=[0.0, 0.2])])) is True
+    assert zero_gate.on_result(CurriculumResult.from_rollouts([make_rollout(task)])) is True
+
+    tolerance_gate = AdvantageRangeGate([task], reject_min=-0.1, reject_max=0.1)
+    assert (
+        tolerance_gate.on_result(CurriculumResult.from_rollouts([make_rollout(task, advantages=[-0.05, 0.0, 0.05])]))
+        is False
+    )
+
+    masked = make_rollout(task, advantages=[0.0, 0.5])
+    masked.samples[0].mask = [False, True]
+    positive_gate = AdvantageRangeGate([task], reject_min=0.5, reject_max=0.5)
+    assert positive_gate.on_result(CurriculumResult.from_rollouts([masked])) is False


### PR DESCRIPTION
Stacked on #3261. This PR adds only two small policies on the user-space curriculum surface:

- `DifficultyPools`: for finite tasksets, sample every task once, track each task's latest group-mean reward by stable `Task.key`, choose a nonempty named pool by its configured weight, then sample uniformly within the pool. RNG and pool state round-trip through checkpoints.
- `AdvantageRangeGate`: reject a group when all trainable-token advantages fall inside `[reject_min, reject_max]`. The default `[0, 0]` implements zero-advantage rejection; algorithms without an advantage stream pass through.

The existing dynamic-sampling wiki-search and Intellect configs now select `AdvantageRangeGate` per source. No weighting framework, posterior estimator, built-in component registry, rejection sampler, exploration floor, or custom mini-protocol is introduced—the examples are ordinary `Curriculum` subclasses intended to be copied or extended in user code.

## Validation

- `uv run ruff format src/prime_rl/orchestrator/curricula.py tests/unit/orchestrator/test_curriculum.py`
- `uv run ruff check src/prime_rl/orchestrator/curricula.py tests/unit/orchestrator/test_curriculum.py`
- `uv run pytest tests/unit/orchestrator --ignore=tests/unit/orchestrator/test_qwen3_vl_e2e.py -q` — 79 passed
- updated TOML configs parsed with `tomllib`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> AdvantageRangeGate changes which groups train and increases resampling under oversampling; mis-tuned reject ranges could starve batches. DifficultyPools only affects task selection on finite tasksets.
> 
> **Overview**
> Adds **built-in curriculum policies** in `prime_rl.orchestrator.curricula` and wires the advantage gate into example training configs.
> 
> **`DifficultyPools`** changes finite-task sampling after each task has been seen once: it keeps the latest mean group reward per task, buckets tasks into named pools via `thresholds`, then picks a pool by `weights` and a task uniformly inside it. Unseen tasks are still drawn first. Pool occupancy and checkpoint state (`task_rewards`) are exposed through `metrics` and `state_dict`.
> 
> **`AdvantageRangeGate`** changes which rollout groups enter the training batch: `on_result` rejects a group when every **trainable-token** advantage lies in `[reject_min, reject_max]` (default `[0, 0]` drops all-zero-advantage groups). Groups with no advantage stream are still admitted.
> 
> `docs/algorithms.md` documents both with TOML examples. Wiki-search and intellect-3.1 example sources (plus CI nightly wiki-search) now set `curriculum = { import_path = "prime_rl.orchestrator.curricula.AdvantageRangeGate" }`. Unit tests cover pool metrics/checkpoint resume and gate behavior (tolerance band, trainable mask).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 825f622700ae2e6b16ec2884fef601e517168716. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
