### PR TITLE
docs: remove retired zero-gradient metric

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -199,7 +199,7 @@ Pulled from the console log and mirrored to W&B.
 **Stability and optimization:**
 
 - `optim/grad_norm` — spikes precede divergence.
-- `optim/lr`, `optim/zero_grad_ratio` — LR schedule and the fraction of params that received zero gradients (high → dead path or wrong loss masking).
+- `optim/lr` — LR schedule.
 - For MoE: `max_vio/mean` (load-balancing violation), `routing_confidence/mean` — both are logged when non-zero.
 
 **Performance:**


### PR DESCRIPTION
## Description

I removed the retired `optim/zero_grad_ratio` metric from the SFT metrics reference.

## Why

PR #3249 removed the metric from the trainers and Prometheus, so the documentation should no longer direct users to monitor it.

## Verification

- Confirmed current `main` has no `optim/zero_grad_ratio`, `trainer_zero_grad_ratio`, or `get_zero_gradient_ratio` source references.
- Ran `git diff --check`.