### PR TITLE
feat: run dir + resume from path

### DIFF
--- a/configs/ci/integration/reverse-text-lora/resume.toml
+++ b/configs/ci/integration/reverse-text-lora/resume.toml
@@ -2,7 +2,9 @@ max_steps = 20
 seq_len = 2048
 
 [ckpt]
-resume_step = 15
+
+[resume]
+step = 15
 
 [model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"

--- a/configs/ci/integration/reverse-text-sft-lora/resume.toml
+++ b/configs/ci/integration/reverse-text-sft-lora/resume.toml
@@ -1,7 +1,9 @@
 max_steps = 10
 
 [ckpt]
-resume_step = 5
+
+[resume]
+step = 5
 
 [ckpt.weights]
 save_adapter_separately = true

--- a/configs/ci/integration/reverse-text-sft/resume.toml
+++ b/configs/ci/integration/reverse-text-sft/resume.toml
@@ -1,7 +1,9 @@
 max_steps = 10
 
 [ckpt]
-resume_step = 5
+
+[resume]
+step = 5
 
 [model]
 name = "PrimeIntellect/Qwen3-0.6B"

--- a/configs/ci/integration/reverse-text/resume.toml
+++ b/configs/ci/integration/reverse-text/resume.toml
@@ -8,7 +8,9 @@ seq_len = 2048
 type = "filesystem"
 
 [ckpt]
-resume_step = 15
+
+[resume]
+step = 15
 
 [model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"

--- a/configs/debug/algo/README.md
+++ b/configs/debug/algo/README.md
@@ -32,7 +32,7 @@ CUDA_VISIBLE_DEVICES=1 uv run inference \
 
 ## Run the debug configs
 
-Every config writes to the default `outputs/` directory, so running two back-to-back — or re-running one — fails with `FileExistsError`. Pass a distinct `--output-dir outputs/<algo>` per config (recommended for a sweep) or `--clean-output-dir` to wipe and restart.
+Every config writes to the default `outputs/` directory, so running two back-to-back — or re-running one — fails with `FileExistsError`. Pass a distinct `--output-dir outputs/<algo>` per config (recommended for a sweep) or `--clean` to wipe and restart.
 
 ```bash
 # GRPO (no frozen model)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ CLI flags mirror the TOML tree using dots:
 
 ```bash
 uv run rl --help                                       # full schema
-uv run rl @ rl.toml --dry-run --output-dir /tmp --run.name check  # write resolved configs to /tmp/check/configs
+uv run rl @ rl.toml --dry-run --output-dir /tmp --run.name check  # write resolved configs (JSON) to /tmp/check/configs
 ```
 
 ## Syntax
@@ -268,7 +268,7 @@ Then inspect the resolved config:
 
 ```bash
 ls /tmp/reverse-dry/check/configs/
-# rl.toml  trainer.toml  orchestrator.toml  inference.toml
+# rl.json  trainer.json  orchestrator.json  inference.json
 ```
 
-Each per-process TOML reflects the final, validated configuration that the actual run would consume — exactly what each process sees when started standalone (`uv run trainer @ /tmp/reverse-dry/check/configs/trainer.toml`, etc.). This is the easiest way to bisect a misbehaving config: dry-run a known-good base, dry-run your overlay, diff the two.
+Each per-process TOML reflects the final, validated configuration that the actual run would consume — exactly what each process sees when started standalone (`uv run trainer @ /tmp/reverse-dry/check/configs/trainer.json`, etc.). This is the easiest way to bisect a misbehaving config: dry-run a known-good base, dry-run your overlay, diff the two.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ CLI flags mirror the TOML tree using dots:
 
 ```bash
 uv run rl --help                                       # full schema
-uv run rl @ rl.toml --dry-run --output-dir /tmp/check  # write resolved configs
+uv run rl @ rl.toml --dry-run --output-dir /tmp/check --run.name check  # write resolved configs
 ```
 
 ## Syntax
@@ -260,14 +260,15 @@ uv run rl @ examples/basic/reverse-text/rl.toml \
   --wandb.name my-experiment \
   --trainer.optim.lr 5e-6 \
   --output-dir /tmp/reverse-dry \
+  --run.name check \
   --dry-run
 ```
 
 Then inspect the resolved config:
 
 ```bash
-ls /tmp/reverse-dry/configs/
+ls /tmp/reverse-dry/check/configs/
 # rl.toml  trainer.toml  orchestrator.toml  inference.toml
 ```
 
-Each per-process TOML reflects the final, validated configuration that the actual run would consume — exactly what each process sees when started standalone (`uv run trainer @ /tmp/reverse-dry/configs/trainer.toml`, etc.). This is the easiest way to bisect a misbehaving config: dry-run a known-good base, dry-run your overlay, diff the two.
+Each per-process TOML reflects the final, validated configuration that the actual run would consume — exactly what each process sees when started standalone (`uv run trainer @ /tmp/reverse-dry/check/configs/trainer.toml`, etc.). This is the easiest way to bisect a misbehaving config: dry-run a known-good base, dry-run your overlay, diff the two.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,12 +71,12 @@ uv run rl @ rl.toml --dry-run --output-dir /tmp/check --run.name check  # write 
 CLI uses paired flags: bare `--flag` sets `True`, `--no-flag` sets `False`. TOML must be explicit:
 
 ```bash
-uv run rl @ rl.toml --clean-output-dir       # True
-uv run rl @ rl.toml --no-clean-output-dir    # False
+uv run rl @ rl.toml --clean       # True
+uv run rl @ rl.toml --no-clean    # False
 ```
 
 ```toml
-clean_output_dir = true
+clean = true
 ```
 
 ### Lists

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ CLI flags mirror the TOML tree using dots:
 
 ```bash
 uv run rl --help                                       # full schema
-uv run rl @ rl.toml --dry-run --output-dir /tmp/check --run.name check  # write resolved configs
+uv run rl @ rl.toml --dry-run --output-dir /tmp --run.name check  # write resolved configs to /tmp/check/configs
 ```
 
 ## Syntax

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -32,7 +32,7 @@ Train an SFT-warmed `Qwen3-0.6B` on the `reverse-text` task — the env is bundl
 uv run rl @ examples/basic/reverse-text/rl.toml
 ```
 
-The `rl` entrypoint reads `examples/basic/reverse-text/rl.toml`, splits it into per-process sub-configs, picks GPU 0 for inference and GPU 1 for the trainer, launches all three processes, and tees their stdout into the run directory at `outputs/<run_name>/logs/{trainer,orchestrator,inference}.log` (`run.name` defaults to a random UUID; pass `--run.name <name>` for a predictable path). Within a minute the trainer should log `step 1` and a reward sample; after 20 steps the run completes and final HF-compatible weights land at `outputs/<run_name>/weights/step_20`.
+The `rl` entrypoint reads `examples/basic/reverse-text/rl.toml`, splits it into per-process sub-configs, picks GPU 0 for inference and GPU 1 for the trainer, launches all three processes, and tees their stdout into the run directory at `outputs/<run_name>/logs/{trainer,orchestrator,inference}.log` (`run.name` auto-generates as `<envs>--<model>--<short-id>`; pass `--run.name <name>` for a predictable path). Within a minute the trainer should log `step 1` and a reward sample; after 20 steps the run completes and final HF-compatible weights land at `outputs/<run_name>/weights/step_20`.
 
 ## Documentation
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -32,7 +32,7 @@ Train an SFT-warmed `Qwen3-0.6B` on the `reverse-text` task — the env is bundl
 uv run rl @ examples/basic/reverse-text/rl.toml
 ```
 
-The `rl` entrypoint reads `examples/basic/reverse-text/rl.toml`, splits it into per-process sub-configs, picks GPU 0 for inference and GPU 1 for the trainer, launches all three processes, and tees their stdout into `outputs/logs/{trainer,orchestrator,inference}.log`. Within a minute the trainer should log `step 1` and a reward sample; after 20 steps the run completes and final HF-compatible weights land at `outputs/weights/step_20`.
+The `rl` entrypoint reads `examples/basic/reverse-text/rl.toml`, splits it into per-process sub-configs, picks GPU 0 for inference and GPU 1 for the trainer, launches all three processes, and tees their stdout into the run directory at `outputs/<run_name>/logs/{trainer,orchestrator,inference}.log` (`run.name` defaults to a random UUID; pass `--run.name <name>` for a predictable path). Within a minute the trainer should log `step 1` and a reward sample; after 20 steps the run completes and final HF-compatible weights land at `outputs/<run_name>/weights/step_20`.
 
 ## Documentation
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -48,14 +48,14 @@ For quick A/B ablations on the same node, run two RL instances side-by-side in s
 ```bash
 # session 1, GPUs 0–1, default port 8000
 bash scripts/tmux.sh -s exp1 -o outputs/exp1
-CUDA_VISIBLE_DEVICES=0,1 uv run rl @ rl.toml --output-dir outputs/exp1
+CUDA_VISIBLE_DEVICES=0,1 uv run rl @ rl.toml --run.name exp1
 
 # session 2, GPUs 2–3, port 8001
 bash scripts/tmux.sh -s exp2 -o outputs/exp2
 CUDA_VISIBLE_DEVICES=2,3 uv run rl @ rl.toml \
   --inference.server.port 8001 \
   --orchestrator.model.client.base-url http://localhost:8001/v1 \
-  --output-dir outputs/exp2
+  --run.name exp2
 ```
 
 #### SFT and Torchrun
@@ -69,7 +69,7 @@ uv run torchrun \
   src/prime_rl/trainer/sft/train.py @ sft.toml
 ```
 
-`--local-ranks-filter 0` keeps console output to rank 0 only; per-rank stdout/stderr is still captured in `<output_dir>/logs/trainer/torchrun/`.
+`--local-ranks-filter 0` keeps console output to rank 0 only; per-rank stdout/stderr is still captured in `<run_dir>/logs/trainer/torchrun/`.
 
 ### Multi-Node
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -236,14 +236,17 @@ uv run rl @ rl.toml --ckpt.interval 25 --ckpt.keep-interval 100  # …plus perma
 
 ### Resuming a Run
 
-Re-run the same launch command and pass `--ckpt.resume-step <N>` (or `-1` for "latest"). Resuming reuses the run directory, so the run needs a name you can point back at — launch with `--run.name` (or pass the first run's auto-generated name). Make sure `--max-steps` is at least the target final step, not the remaining delta:
+Re-run the same launch command and pass `--resume` (latest checkpoint) or `--resume.step <N>`. Resuming reuses the run directory, so the run needs a name you can point back at — launch with `--run.name` (or pass the first run's auto-generated name). Make sure `--max-steps` is at least the target final step, not the remaining delta:
 
 ```bash
 # First run: steps 1–10
 uv run rl @ rl.toml --max-steps 10 --ckpt --run.name my-run
 
-# Resume: continue to step 20
-uv run rl @ rl.toml --max-steps 20 --ckpt.resume-step 10 --run.name my-run
+# Resume from the latest checkpoint: continue to step 20
+uv run rl @ rl.toml --max-steps 20 --ckpt --resume --run.name my-run
+
+# ...or from a specific step
+uv run rl @ rl.toml --max-steps 20 --ckpt --resume.step 10 --run.name my-run
 ```
 
 ### Serving Checkpoints

--- a/docs/training.md
+++ b/docs/training.md
@@ -78,7 +78,7 @@ A condensed view of the knobs you'll most often tune. For trainer-side paralleli
 | Knob | What it does |
 |---|---|
 | `--output-dir outputs` | Directory that groups related runs. Each run writes its artifacts to its own run directory `<output_dir>/<run_name>` (`<run_dir>` below). |
-| `--run.name <name>` | Name of the run directory under `<output_dir>`. Defaults to a random UUID, so every launch gets a fresh run directory. Set an explicit name to give the run directory a predictable path — required to resume the run later. |
+| `--run.name <name>` | Run name, also the run directory name under `<output_dir>` (override the directory separately via `--run.dir`). Auto-generated as `<envs>--<model>--<short-id>` when unset, so every launch gets a fresh, readable run directory. Set an explicit name for a predictable path — required to resume the run later. |
 | `--clean-output-dir` | Wipe the run directory before starting. Useful when re-running a named run during iteration. |
 | `--max-steps N` | Stop after `N` trainer steps. Overrides the config value. |
 | `--dry-run` | Resolve + validate the full config, write per-process TOMLs to `<run_dir>/configs/`, and exit without launching. The fastest way to debug a misbehaving config. |
@@ -236,7 +236,7 @@ uv run rl @ rl.toml --ckpt.interval 25 --ckpt.keep-interval 100  # …plus perma
 
 ### Resuming a Run
 
-Re-run the same launch command and pass `--ckpt.resume-step <N>` (or `-1` for "latest"). Resuming reuses the run directory, so the run needs a name you can point back at — launch with `--run.name` (or pass the first run's generated UUID). Make sure `--max-steps` is at least the target final step, not the remaining delta:
+Re-run the same launch command and pass `--ckpt.resume-step <N>` (or `-1` for "latest"). Resuming reuses the run directory, so the run needs a name you can point back at — launch with `--run.name` (or pass the first run's auto-generated name). Make sure `--max-steps` is at least the target final step, not the remaining delta:
 
 ```bash
 # First run: steps 1–10
@@ -342,5 +342,5 @@ Requires `PRIME_API_KEY` (set via `prime login` or env var) and an allowlisted t
 - **Start small.** Run `examples/basic/reverse-text/rl.toml` end-to-end on 2 GPUs before scaling. If the smoke run finishes cleanly, your install is good.
 - **Batch size ≥ 64.** Smaller batches give noisy gradient estimates and the trainer's overhead-per-step dominates throughput. 64 is the practical floor; 128–512 is the range for quick ablations; production RL often runs at 1024+.
 - **Group size ≥ 8.** Bigger groups (`orchestrator.group_size`) make it more likely that a task produces a mix of high- and low-reward rollouts, which is what gives the trainer a usable signal — if all rollouts in a group succeed or all fail, the within-group advantage collapses to zero and the trainer learns nothing from that task. Bigger groups also tighten advantage normalization. 8 is the floor; 16–32 is common.
-- **Runs never share a directory.** Every launch writes to its own run directory `<output_dir>/<run_name>`, with a fresh UUID name by default. Name runs you want to find again or resume with `--run.name <name>`; re-using a name blocks unless you resume or pass `--clean-output-dir`.
+- **Runs never share a directory.** Every launch writes to its own run directory `<output_dir>/<run_name>`, auto-named `<envs>--<model>--<short-id>` by default. Name runs you want to find again or resume with `--run.name <name>`; re-using a name blocks unless you resume or pass `--clean-output-dir`.
 - **Use `--dry-run` before SLURM.** Validators (e.g. CP needs flash-attention) fail fast in dry-run and slow in queue.

--- a/docs/training.md
+++ b/docs/training.md
@@ -77,10 +77,11 @@ A condensed view of the knobs you'll most often tune. For trainer-side paralleli
 
 | Knob | What it does |
 |---|---|
-| `--clean-output-dir` | Wipe `<output_dir>` before starting. Useful when re-running an experiment with the same name during iteration. |
-| `--output-dir outputs/<name>` | Per-run output directory. Always set this when running more than one experiment in parallel. |
+| `--output-dir outputs` | Directory that groups related runs. Each run writes its artifacts to its own run directory `<output_dir>/<run_name>` (`<run_dir>` below). |
+| `--run.name <name>` | Name of the run directory under `<output_dir>`. Defaults to a random UUID, so every launch gets a fresh run directory. Set an explicit name to give the run directory a predictable path — required to resume the run later. |
+| `--clean-output-dir` | Wipe the run directory before starting. Useful when re-running a named run during iteration. |
 | `--max-steps N` | Stop after `N` trainer steps. Overrides the config value. |
-| `--dry-run` | Resolve + validate the full config, write per-process TOMLs to `<output_dir>/configs/`, and exit without launching. The fastest way to debug a misbehaving config. |
+| `--dry-run` | Resolve + validate the full config, write per-process TOMLs to `<run_dir>/configs/`, and exit without launching. The fastest way to debug a misbehaving config. |
 
 ### Algorithms
 
@@ -217,10 +218,10 @@ Checkpointing is split across processes because the orchestrator and trainer can
 
 | Process | What's saved | Where |
 |---|---|---|
-| Trainer | FSDP-sharded model (DCP), optimizer, scheduler, progress | `<output_dir>/checkpoints/step_N/trainer/` |
-| Orchestrator | Progress, per-env data state | `<output_dir>/checkpoints/step_N/orchestrator/` |
+| Trainer | FSDP-sharded model (DCP), optimizer, scheduler, progress | `<run_dir>/checkpoints/step_N/trainer/` |
+| Orchestrator | Progress, per-env data state | `<run_dir>/checkpoints/step_N/orchestrator/` |
 | Inference | _nothing_ — re-pushed from the latest checkpoint on restart | n/a |
-| Trainer (HF weights) | HF-compatible weight snapshot for serving | `<output_dir>/weights/step_N/` |
+| Trainer (HF weights) | HF-compatible weight snapshot for serving | `<run_dir>/weights/step_N/` |
 
 ### Enabling Checkpoints
 
@@ -235,22 +236,22 @@ uv run rl @ rl.toml --ckpt.interval 25 --ckpt.keep-interval 100  # …plus perma
 
 ### Resuming a Run
 
-Re-run the same launch command and pass `--ckpt.resume-step <N>` (or `-1` for "latest"). Make sure `--max-steps` is at least the target final step, not the remaining delta:
+Re-run the same launch command and pass `--ckpt.resume-step <N>` (or `-1` for "latest"). Resuming reuses the run directory, so the run needs a name you can point back at — launch with `--run.name` (or pass the first run's generated UUID). Make sure `--max-steps` is at least the target final step, not the remaining delta:
 
 ```bash
 # First run: steps 1–10
-uv run rl @ rl.toml --max-steps 10 --ckpt
+uv run rl @ rl.toml --max-steps 10 --ckpt --run.name my-run
 
 # Resume: continue to step 20
-uv run rl @ rl.toml --max-steps 20 --ckpt.resume-step 10
+uv run rl @ rl.toml --max-steps 20 --ckpt.resume-step 10 --run.name my-run
 ```
 
 ### Serving Checkpoints
 
-HF-compatible weight snapshots are written under `<output_dir>/weights/step_N/` whenever a full checkpoint runs (or you can write weights-only via `--ckpt.weights-only` for cheaper snapshots). Upload directly:
+HF-compatible weight snapshots are written under `<run_dir>/weights/step_N/` whenever a full checkpoint runs (or you can write weights-only via `--ckpt.weights-only` for cheaper snapshots). Upload directly:
 
 ```bash
-uv run hf upload <user>/<model>-RL outputs/weights/step_100
+uv run hf upload <user>/<model>-RL outputs/<run_name>/weights/step_100
 ```
 
 For LoRA runs, set `ckpt.weights.save_adapter_separately = true` to also write the raw adapter alongside the merged weights — useful when serving the adapter through a separate `/load_lora_adapter` call.
@@ -259,10 +260,10 @@ For LoRA runs, set `ckpt.weights.save_adapter_separately = true` to also write t
 
 ### Log Files
 
-The launcher tees every process's stdout/stderr into `<output_dir>/logs/`. The full layout (single-node runs skip the `node_*.log` and `router.log` files — there the router logs into `inference.log`):
+The launcher tees every process's stdout/stderr into `<run_dir>/logs/`. The full layout (single-node runs skip the `node_*.log` and `router.log` files — there the router logs into `inference.log`):
 
 ```
-<output_dir>/logs/
+<run_dir>/logs/
 ├── trainer.log                  # rank 0 only; symlink → trainer/node_0.log on multi-node
 ├── orchestrator.log             # single instance, single file
 ├── inference.log                # symlink → inference/node_0.log on multi-node
@@ -280,9 +281,9 @@ Env logs are the first place to look for env-side errors (most user code lives t
 Live tailing from a single point (works on the head node for multi-node runs over a shared filesystem):
 
 ```bash
-tail -F <output_dir>/logs/{trainer,orchestrator,inference}.log
-tail -F <output_dir>/logs/trainer/node_*.log     # multi-node only
-tail -F <output_dir>/logs/inference/router.log   # multi-node only
+tail -F <run_dir>/logs/{trainer,orchestrator,inference}.log
+tail -F <run_dir>/logs/trainer/node_*.log       # multi-node only
+tail -F <run_dir>/logs/inference/router.log     # multi-node only
 ```
 
 ### Console Output
@@ -290,12 +291,12 @@ tail -F <output_dir>/logs/inference/router.log   # multi-node only
 `scripts/tmux.sh` opens a 4-pane tmux session that follows `trainer.log`, `orchestrator.log`, `inference.log`, and the union of env worker logs. Start it before launching:
 
 ```bash
-bash scripts/tmux.sh
+bash scripts/tmux.sh -o outputs/my-run
 # then in the Launcher window:
-uv run rl @ ... --output-dir outputs/my-run
+uv run rl @ ... --run.name my-run
 ```
 
-Pass `-s <session>` and `-o <output_dir>` to run multiple parallel experiments side-by-side in different sessions. The helper also works on a SLURM head node — `bash scripts/tmux.sh my-rl-job /shared/outputs/my-rl-job`.
+Pass `-s <session>` and `-o <run_dir>` (the run directory, `<output_dir>/<run_name>`) to run multiple parallel experiments side-by-side in different sessions. The helper also works on a SLURM head node — `bash scripts/tmux.sh my-rl-job /shared/outputs/my-rl-job`.
 
 ### Weights & Biases
 
@@ -341,5 +342,5 @@ Requires `PRIME_API_KEY` (set via `prime login` or env var) and an allowlisted t
 - **Start small.** Run `examples/basic/reverse-text/rl.toml` end-to-end on 2 GPUs before scaling. If the smoke run finishes cleanly, your install is good.
 - **Batch size ≥ 64.** Smaller batches give noisy gradient estimates and the trainer's overhead-per-step dominates throughput. 64 is the practical floor; 128–512 is the range for quick ablations; production RL often runs at 1024+.
 - **Group size ≥ 8.** Bigger groups (`orchestrator.group_size`) make it more likely that a task produces a mix of high- and low-reward rollouts, which is what gives the trainer a usable signal — if all rollouts in a group succeed or all fail, the within-group advantage collapses to zero and the trainer learns nothing from that task. Bigger groups also tighten advantage normalization. 8 is the floor; 16–32 is common.
-- **Pin `output_dir` per run.** Sharing a directory across runs will mix rollouts and break resumes. `--output-dir outputs/<unique-name>` is the simplest discipline.
+- **Runs never share a directory.** Every launch writes to its own run directory `<output_dir>/<run_name>`, with a fresh UUID name by default. Name runs you want to find again or resume with `--run.name <name>`; re-using a name blocks unless you resume or pass `--clean-output-dir`.
 - **Use `--dry-run` before SLURM.** Validators (e.g. CP needs flash-attention) fail fast in dry-run and slow in queue.

--- a/docs/training.md
+++ b/docs/training.md
@@ -247,6 +247,10 @@ uv run rl @ rl.toml --max-steps 20 --ckpt --resume --run.name my-run
 
 # ...or from a specific step
 uv run rl @ rl.toml --max-steps 20 --ckpt --resume.step 10 --run.name my-run
+
+# ...or fork another run's checkpoint into a fresh run
+uv run rl @ rl.toml --max-steps 20 --ckpt --run.name my-fork \
+  --resume.dir outputs/my-run/checkpoints/step_10
 ```
 
 ### Serving Checkpoints

--- a/docs/training.md
+++ b/docs/training.md
@@ -79,7 +79,7 @@ A condensed view of the knobs you'll most often tune. For trainer-side paralleli
 |---|---|
 | `--output-dir outputs` | Directory that groups related runs. Each run writes its artifacts to its own run directory `<output_dir>/<run_name>` (`<run_dir>` below). |
 | `--run.name <name>` | Run name, also the run directory name under `<output_dir>` (override the directory separately via `--run.dir`). Auto-generated as `<envs>--<model>--<short-id>` when unset, so every launch gets a fresh, readable run directory. Set an explicit name for a predictable path — required to resume the run later. |
-| `--clean-output-dir` | Wipe the run directory before starting. Useful when re-running a named run during iteration. |
+| `--clean` | Wipe the run directory before starting. Useful when re-running a named run during iteration. |
 | `--max-steps N` | Stop after `N` trainer steps. Overrides the config value. |
 | `--dry-run` | Resolve + validate the full config, write per-process TOMLs to `<run_dir>/configs/`, and exit without launching. The fastest way to debug a misbehaving config. |
 
@@ -342,5 +342,5 @@ Requires `PRIME_API_KEY` (set via `prime login` or env var) and an allowlisted t
 - **Start small.** Run `examples/basic/reverse-text/rl.toml` end-to-end on 2 GPUs before scaling. If the smoke run finishes cleanly, your install is good.
 - **Batch size ≥ 64.** Smaller batches give noisy gradient estimates and the trainer's overhead-per-step dominates throughput. 64 is the practical floor; 128–512 is the range for quick ablations; production RL often runs at 1024+.
 - **Group size ≥ 8.** Bigger groups (`orchestrator.group_size`) make it more likely that a task produces a mix of high- and low-reward rollouts, which is what gives the trainer a usable signal — if all rollouts in a group succeed or all fail, the within-group advantage collapses to zero and the trainer learns nothing from that task. Bigger groups also tighten advantage normalization. 8 is the floor; 16–32 is common.
-- **Runs never share a directory.** Every launch writes to its own run directory `<output_dir>/<run_name>`, auto-named `<envs>--<model>--<short-id>` by default. Name runs you want to find again or resume with `--run.name <name>`; re-using a name blocks unless you resume or pass `--clean-output-dir`.
+- **Runs never share a directory.** Every launch writes to its own run directory `<output_dir>/<run_name>`, auto-named `<envs>--<model>--<short-id>` by default. Name runs you want to find again or resume with `--run.name <name>`; re-using a name blocks unless you resume or pass `--clean`.
 - **Use `--dry-run` before SLURM.** Validators (e.g. CP needs flash-attention) fail fast in dry-run and slow in queue.

--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -32,7 +32,8 @@ timeout = 3600
 [ckpt]
 interval = 50
 keep_last = 1
-resume_step = -1
+
+[resume]
 
 [model]
 name = "zai-org/GLM-4.5-Air"

--- a/examples/advanced/glm-4.5-air/swe.toml
+++ b/examples/advanced/glm-4.5-air/swe.toml
@@ -43,7 +43,8 @@ timeout = 3600
 [ckpt]
 interval = 50
 keep_last = 1
-resume_step = -1
+
+[resume]
 
 [model]
 name = "zai-org/GLM-4.5-Air"

--- a/examples/advanced/glm-4.5-air/terminal.toml
+++ b/examples/advanced/glm-4.5-air/terminal.toml
@@ -33,7 +33,8 @@ timeout = 3600
 [ckpt]
 interval = 50
 keep_last = 1
-resume_step = -1
+
+[resume]
 
 [model]
 name = "zai-org/GLM-4.5-Air"

--- a/examples/advanced/glm-5.2/swe-llmd.toml
+++ b/examples/advanced/glm-5.2/swe-llmd.toml
@@ -1,7 +1,7 @@
 max_steps = 10000000
 seq_len = 131072
 output_dir = "/shared/outputs/glm5-llmd" # FILL IN: point at your shared filesystem
-clean_output_dir = true
+clean = true
 
 [log]
 level = "debug"

--- a/examples/advanced/glm-5.2/swe-llmd.toml
+++ b/examples/advanced/glm-5.2/swe-llmd.toml
@@ -1,7 +1,10 @@
 max_steps = 10000000
 seq_len = 131072
-output_dir = "/shared/outputs/glm5-llmd" # FILL IN: point at your shared filesystem
+output_dir = "/shared/outputs" # FILL IN: point at your shared filesystem
 clean = true
+
+[run]
+name = "glm5-llmd"
 
 [log]
 level = "debug"

--- a/examples/advanced/nemotron-3-super/swe.toml
+++ b/examples/advanced/nemotron-3-super/swe.toml
@@ -29,7 +29,8 @@ timeout = 3600
 [ckpt]
 interval = 50
 keep_last = 1
-resume_step = -1
+
+[resume]
 
 [model]
 name = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"

--- a/examples/basic/alphabet-sort/README.md
+++ b/examples/basic/alphabet-sort/README.md
@@ -93,14 +93,15 @@ We train with LoRA (rank 32, alpha 64) for 100 steps.
 ```bash
 # In the `Trainer` pane
 uv run rl @ examples/basic/alphabet-sort/rl.toml \
+  --run.name rl \
   --wandb.project ... \
   --wandb.name ...
 ```
 
-This will write a weight checkpoint in `outputs/weights/step_100`. Upload it to HF to be able to use it as the final model for evaluation.
+This will write a weight checkpoint in `outputs/rl/weights/step_100`. Upload it to HF to be able to use it as the final model for evaluation.
 
 ```bash
-uv run hf upload <user>/Qwen3-4B-Instruct-AlphabetSort-RL outputs/weights/step_100
+uv run hf upload <user>/Qwen3-4B-Instruct-AlphabetSort-RL outputs/rl/weights/step_100
 ```
 
 We have uploaded the final model as [`PrimeIntellect/Qwen3-4B-Instruct-AlphabetSort-RL`](https://huggingface.co/PrimeIntellect/Qwen3-4B-Instruct-AlphabetSort-RL).

--- a/examples/basic/reverse-text/README.md
+++ b/examples/basic/reverse-text/README.md
@@ -43,6 +43,7 @@ To train on a single GPU, run
 ```bash
 # In the `Trainer` pane
 uv run sft @ examples/basic/reverse-text/sft.toml \
+  --run.name sft \
   --wandb.project ... \
   --wandb.name ...
 ```
@@ -59,10 +60,10 @@ uv run torchrun \
   --wandb.name ...
 ```
 
-This should write a weight checkpoint in `outputs/weights/step_100`. Upload it to HF to be able to use it as the base model for RL.
+This should write a weight checkpoint in `outputs/sft/weights/step_100`. Upload it to HF to be able to use it as the base model for RL.
 
 ```bash
-uv run hf upload <user>/Qwen3-0.6B-Reverse-Text-SFT outputs/weights/step_100
+uv run hf upload <user>/Qwen3-0.6B-Reverse-Text-SFT outputs/sft/weights/step_100
 ```
 
 We have uploaded the final model as [`PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT`](https://huggingface.co/PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT).
@@ -77,14 +78,15 @@ For the RL we will only do 20 steps at 8x16 rollouts, for a total batch size of 
 # Run this in the `Trainer` pane
 uv run rl @ examples/basic/reverse-text/rl.toml \
   --model.name ... \
+  --run.name rl \
   --wandb.project ... \
   --wandb.name ...
 ```
 
-This will write a weight checkpoint in `outputs/weights/step_20`. As before, let's upload it to HF.
+This will write a weight checkpoint in `outputs/rl/weights/step_20`. As before, let's upload it to HF.
 
 ```bash
-uv run hf upload <user>/Qwen3-0.6B-Reverse-Text-RL outputs/weights/step_20
+uv run hf upload <user>/Qwen3-0.6B-Reverse-Text-RL outputs/rl/weights/step_20
 ```
 
 We have uploaded the final model as [`PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL`](https://huggingface.co/PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL).
@@ -131,18 +133,18 @@ Exec into the trainer pod and run SFT:
 
 ```bash
 kubectl exec -it my-exp-trainer-0 -- bash
-uv run sft @ /app/examples/basic/reverse-text/sft.toml --output-dir /data/outputs
-# This will save checkpoints to /data/outputs/weights/step_100
+uv run sft @ /app/examples/basic/reverse-text/sft.toml --output-dir /data/outputs --run.name sft
+# This will save checkpoints to /data/outputs/sft/weights/step_100
 ```
 
 Upload the checkpoint to HuggingFace or use it directly from shared storage:
 
 ```bash
 # Option 1: Upload to HuggingFace (from within the pod)
-uv run hf upload <user>/Qwen3-0.6B-Reverse-Text-SFT /data/outputs/weights/step_100
+uv run hf upload <user>/Qwen3-0.6B-Reverse-Text-SFT /data/outputs/sft/weights/step_100
 
 # Option 2: Use local checkpoint path in RL config
-# Update the model.name in the RL configs to point to /data/outputs/weights/step_100
+# Update the model.name in the RL configs to point to /data/outputs/sft/weights/step_100
 ```
 
 ### Step 3: Deploy RL Training

--- a/examples/basic/wiki-search/README.md
+++ b/examples/basic/wiki-search/README.md
@@ -93,6 +93,7 @@ Train with the unified config file:
 ```bash
 # In the `Trainer` pane
 uv run rl @ examples/basic/wiki-search/rl.toml \
+  --run.name rl \
   --wandb.project your-project-name \
   --wandb.name your-run-name
 ```
@@ -102,10 +103,10 @@ The unified config file automatically configures:
 - **Orchestrator**: Rollout generation with tool calling enabled
 - **Inference**: vLLM server for Qwen3-4B-Instruct-2507 with tool parsing enabled
 
-This will write weight checkpoints in `outputs/weights/step_*`. Upload the final checkpoint to HuggingFace:
+This will write weight checkpoints in `outputs/rl/weights/step_*`. Upload the final checkpoint to HuggingFace:
 
 ```bash
-uv run hf upload <user>/Qwen3-4B-Instruct-WikiSearch-RL outputs/weights/step_500
+uv run hf upload <user>/Qwen3-4B-Instruct-WikiSearch-RL outputs/rl/weights/step_500
 ```
 
 ## Evaluation

--- a/examples/basic/wordle/README.md
+++ b/examples/basic/wordle/README.md
@@ -45,6 +45,7 @@ To train on a single GPU, run
 ```bash
 # In the `Trainer` pane
 uv run sft @ examples/basic/wordle/sft.toml \
+  --run.name sft \
   --wandb.project ... \
   --wandb.name ...
 ```
@@ -61,10 +62,10 @@ uv run torchrun \
   --wandb.name ... 
 ```
 
-After training completes, you will find the final weight checkpoint in `outputs/weights/step_20`. Upload it to HF to be able to use it as the base model for RL we will do in the next section.
+After training completes, you will find the final weight checkpoint in `outputs/sft/weights/step_20`. Upload it to HF to be able to use it as the base model for RL we will do in the next section.
 
 ```bash
-uv run hf upload <user>/Qwen3-1.7B-Wordle-SFT outputs/weights/step_20
+uv run hf upload <user>/Qwen3-1.7B-Wordle-SFT outputs/sft/weights/step_20
 ```
 
 We have uploaded the final model as [`PrimeIntellect/Qwen3-1.7B-Wordle-SFT`](https://huggingface.co/PrimeIntellect/Qwen3-1.7B-Wordle-SFT).
@@ -80,14 +81,15 @@ Finally, we will do multi-turn RL against the `wordle` environment using the mod
 # Run this in the `Trainer` pane
 uv run rl @ examples/basic/wordle/rl.toml \
   --model.name ... \
+  --run.name rl \
   --wandb.project ... \
   --wandb.name ... 
 ```
 
-This will write a weight checkpoint in `outputs/weights/step_100`. As before, let's upload it to HF.
+This will write a weight checkpoint in `outputs/rl/weights/step_100`. As before, let's upload it to HF.
 
 ```bash
-uv run hf upload <user>/Qwen3-1.7B-Wordle-RL outputs/weights/step_100
+uv run hf upload <user>/Qwen3-1.7B-Wordle-RL outputs/rl/weights/step_100
 ```
 
 We have uploaded the final model as [`PrimeIntellect/Qwen3-1.7B-Wordle-RL`](https://huggingface.co/PrimeIntellect/Qwen3-1.7B-Wordle-RL).

--- a/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import verifiers.v1 as vf
 from pydantic import SerializeAsAny, model_validator
 
-from prime_rl.configs.shared import LogConfig
+from prime_rl.configs.shared import LogConfig, RunInfoConfig
 from prime_rl.utils.config import BaseConfig
 
 
@@ -20,8 +20,8 @@ class EnvServerConfig(BaseConfig):
 
     log: LogConfig = LogConfig()
 
-    sandbox_labels: list[str] = []
-    """Base labels attached to every Prime sandbox created by this server's workers, extended by each runtime's own labels. The ``rl`` launcher stamps the run name here."""
+    run: RunInfoConfig = RunInfoConfig()
+    """Run identity, injected by the ``rl`` launcher. The run name becomes a base label on every Prime sandbox created by this server's workers, extended by each runtime's own labels."""
 
     output_dir: Path = Path("outputs")
     """Directory to write outputs to — logs and any generated artifacts are written as subdirectories."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
@@ -20,6 +20,9 @@ class EnvServerConfig(BaseConfig):
 
     log: LogConfig = LogConfig()
 
+    sandbox_labels: list[str] = []
+    """Base labels attached to every Prime sandbox created by this server's workers, extended by each runtime's own labels. The ``rl`` launcher stamps the run name here."""
+
     output_dir: Path = Path("outputs")
     """Directory to write outputs to — logs and any generated artifacts are written as subdirectories."""
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import verifiers.v1 as vf
 from pydantic import SerializeAsAny, model_validator
 
-from prime_rl.configs.shared import LogConfig, RunInfoConfig
+from prime_rl.configs.shared import LogConfig
 from prime_rl.utils.config import BaseConfig
 
 
@@ -19,9 +19,6 @@ class EnvServerConfig(BaseConfig):
     """How it's served: the worker pool, the bind address, each worker's episode bound."""
 
     log: LogConfig = LogConfig()
-
-    run: RunInfoConfig = RunInfoConfig()
-    """Run identity, injected by the ``rl`` launcher. The run name becomes a base label on every Prime sandbox created by this server's workers, extended by each runtime's own labels."""
 
     output_dir: Path = Path("outputs")
     """Directory to write outputs to — logs and any generated artifacts are written as subdirectories."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -453,7 +453,7 @@ class OrchestratorConfig(BaseConfig):
     ckpt: CheckpointConfig | None = None
 
     resume: ResumeConfig | None = None
-    """Resume the orchestrator from a checkpoint (requires ``ckpt``). None starts from scratch; an empty block resumes from the latest checkpoint, ``resume.step`` from that step, ``resume.dir`` from an external checkpoint step directory."""
+    """Resume the orchestrator from a checkpoint. None starts from scratch; an empty block resumes from the latest checkpoint, ``resume.step`` from that step, ``resume.dir`` from an external checkpoint step directory. Without ``ckpt`` the run loads but saves no new checkpoints."""
     """Checkpoint configuration."""
 
     weight_broadcast: WeightBroadcastConfig = FileSystemWeightBroadcastConfig()

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -17,6 +17,7 @@ from prime_rl.configs.shared import (
     HeartbeatConfig,
     LogConfig,
     PrimeMonitorConfig,
+    RunConfig,
     TransportConfig,
     WandbWithExtrasConfig,
     ZMQTransportConfig,
@@ -438,6 +439,9 @@ class OrchestratorConfig(BaseConfig):
 
     env_vars: EnvVars = {}
     """Extra environment variables for the orchestrator process(es). Merged on top of the launcher defaults."""
+
+    run: RunConfig = Field(default_factory=RunConfig)
+    """Run identity (name + id). Propagated from the rl entrypoint; stamped on rollout traces."""
 
     wandb: WandbWithExtrasConfig | None = None
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -18,7 +18,6 @@ from prime_rl.configs.shared import (
     LogConfig,
     PrimeMonitorConfig,
     ResumeConfig,
-    RunInfoConfig,
     TransportConfig,
     WandbWithExtrasConfig,
     ZMQTransportConfig,
@@ -440,9 +439,6 @@ class OrchestratorConfig(BaseConfig):
 
     env_vars: EnvVars = {}
     """Extra environment variables for the orchestrator process(es). Merged on top of the launcher defaults."""
-
-    run: RunInfoConfig = Field(default_factory=RunInfoConfig)
-    """Run identity, injected by the rl entrypoint; stamped on rollout traces."""
 
     wandb: WandbWithExtrasConfig | None = None
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -287,9 +287,6 @@ class CheckpointConfig(BaseConfig):
     interval: int | None = Field(None, ge=1)
     """Step interval at which to save the orchestrator checkpoint."""
 
-    resume: ResumeConfig | None = None
-    """Resume the orchestrator from a checkpoint. None starts from scratch; an empty block resumes from the latest checkpoint, ``resume.step`` from that step."""
-
     wait_for_weights_timeout: int | None = Field(None, ge=1)
     """Wait up to this many seconds for the startup weight directory to appear (the trainer broadcasts the incoming policy — v0 from scratch, the resumed step's version on resume — before the first step). If None, fall back to a default timeout. Raise this for large models on slow shared filesystems."""
 
@@ -454,6 +451,9 @@ class OrchestratorConfig(BaseConfig):
     """Role for each policy admin client when collecting P/D inference metrics."""
 
     ckpt: CheckpointConfig | None = None
+
+    resume: ResumeConfig | None = None
+    """Resume the orchestrator from a checkpoint (requires ``ckpt``). None starts from scratch; an empty block resumes from the latest checkpoint, ``resume.step`` from that step, ``resume.dir`` from an external checkpoint step directory."""
     """Checkpoint configuration."""
 
     weight_broadcast: WeightBroadcastConfig = FileSystemWeightBroadcastConfig()

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -17,7 +17,7 @@ from prime_rl.configs.shared import (
     HeartbeatConfig,
     LogConfig,
     PrimeMonitorConfig,
-    RunConfig,
+    RunInfoConfig,
     TransportConfig,
     WandbWithExtrasConfig,
     ZMQTransportConfig,
@@ -440,8 +440,8 @@ class OrchestratorConfig(BaseConfig):
     env_vars: EnvVars = {}
     """Extra environment variables for the orchestrator process(es). Merged on top of the launcher defaults."""
 
-    run: RunConfig = Field(default_factory=RunConfig)
-    """Run identity (name + id). Propagated from the rl entrypoint; stamped on rollout traces."""
+    run: RunInfoConfig = Field(default_factory=RunInfoConfig)
+    """Run identity, injected by the rl entrypoint; stamped on rollout traces."""
 
     wandb: WandbWithExtrasConfig | None = None
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -17,6 +17,7 @@ from prime_rl.configs.shared import (
     HeartbeatConfig,
     LogConfig,
     PrimeMonitorConfig,
+    ResumeConfig,
     RunInfoConfig,
     TransportConfig,
     WandbWithExtrasConfig,
@@ -287,11 +288,11 @@ class CheckpointConfig(BaseConfig):
     interval: int | None = Field(None, ge=1)
     """Step interval at which to save the orchestrator checkpoint."""
 
-    resume_step: int | None = Field(None, ge=-1)
-    """Step to resume the orchestrator from. None starts from scratch; ``-1`` resumes from the latest checkpoint available."""
+    resume: ResumeConfig | None = None
+    """Resume the orchestrator from a checkpoint. None starts from scratch; an empty block resumes from the latest checkpoint, ``resume.step`` from that step."""
 
     wait_for_weights_timeout: int | None = Field(None, ge=1)
-    """Wait up to this many seconds for the startup weight directory to appear (the trainer broadcasts the incoming policy — v0 from scratch, v{resume_step} on resume — before the first step). If None, fall back to a default timeout. Raise this for large models on slow shared filesystems."""
+    """Wait up to this many seconds for the startup weight directory to appear (the trainer broadcasts the incoming policy — v0 from scratch, the resumed step's version on resume — before the first step). If None, fall back to a default timeout. Raise this for large models on slow shared filesystems."""
 
     keep_last: int | None = Field(None, ge=1)
     """Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints based on recency."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -259,7 +259,7 @@ class RLConfig(BaseConfig):
     """Shared checkpoint config. If None, falls back to the sub-config checkpoint settings."""
 
     resume: ResumeConfig | None = None
-    """Resume the run from a checkpoint (requires ``[ckpt]`` and the previous run's ``run.name``). If None, does not resume."""
+    """Resume the run from a checkpoint (point at it with the previous run's ``run.name``). Without ``[ckpt]`` the run loads the checkpoint but saves no new ones. If None, does not resume."""
 
     wandb: SharedWandbConfig | None = None
     """Shared W&B config. If None, falls back to the sub-config W&B settings."""
@@ -404,8 +404,6 @@ class RLConfig(BaseConfig):
         """Propagate the top-level resume onto the sub-configs."""
         if self.resume is None:
             return self
-        if self.trainer.ckpt is None or self.orchestrator.ckpt is None:
-            raise ValueError("resume requires checkpointing — add the [ckpt] block")
         self.trainer.resume = self.resume.model_copy()
         self.orchestrator.resume = self.resume.model_copy()
         return self

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -22,6 +22,7 @@ from prime_rl.configs.orchestrator import (
 from prime_rl.configs.shared import (
     EnvVars,
     FileMonitorConfig,
+    ResumeConfig,
     RunConfig,
     SlurmConfig,
     TransportConfig,
@@ -100,9 +101,6 @@ class SharedCheckpointConfig(BaseConfig):
 
     interval: int | None = None
     """Interval at which to save checkpoints."""
-
-    resume_step: int | None = None
-    """Step to resume from. If None, does not resume from a checkpoint."""
 
     keep_last: int | None = Field(None, ge=1)
     """Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints based on recency."""
@@ -260,6 +258,9 @@ class RLConfig(BaseConfig):
     ckpt: SharedCheckpointConfig | None = None
     """Shared checkpoint config. If None, falls back to the sub-config checkpoint settings."""
 
+    resume: ResumeConfig | None = None
+    """Resume the run from a checkpoint (requires ``[ckpt]`` and the previous run's ``run.name``). If None, does not resume."""
+
     wandb: SharedWandbConfig | None = None
     """Shared W&B config. If None, falls back to the sub-config W&B settings."""
 
@@ -396,6 +397,19 @@ class RLConfig(BaseConfig):
                     "output_dir / run.name — set those instead."
                 )
             sub.output_dir = run_dir
+        return self
+
+    @model_validator(mode="after")
+    def auto_setup_resume(self):
+        """Map the top-level resume onto the sub-config checkpoint configs (their internal
+        ``resume_step`` uses -1 for "latest")."""
+        if self.resume is None:
+            return self
+        if self.trainer.ckpt is None or self.orchestrator.ckpt is None:
+            raise ValueError("resume requires checkpointing — add the [ckpt] block")
+        step = self.resume.step if self.resume.step is not None else -1
+        self.trainer.ckpt.resume_step = step
+        self.orchestrator.ckpt.resume_step = step
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -412,16 +412,15 @@ class RLConfig(BaseConfig):
 
     @model_validator(mode="after")
     def auto_setup_run_identity(self):
-        """Propagate the run identity to the orchestrator (which stamps it on rollout
-        traces) and default the W&B and Prime platform run names to ``run.name``.
+        """Default the W&B and Prime platform run names to ``run.name``.
 
         Explicit names always win: only unset names inherit. Runs after the
         orchestrator's own ``auto_setup_prime_monitor_run_name``, so an explicitly
-        set W&B name still takes precedence for the platform run name. The run id is
-        minted by the launcher (see the ``rl`` entrypoint), not here.
+        set W&B name still takes precedence for the platform run name. The run
+        identity itself is runtime-only ($PRL_RUN_ID / $PRL_RUN_NAME, set by the
+        ``rl`` entrypoint), never sub-config.
         """
         self._resolve_run_name()
-        self.orchestrator.run.name = self.run.name
         for wandb in (self.wandb, self.trainer.wandb, self.orchestrator.wandb):
             if wandb is not None and wandb.name is None:
                 wandb.name = self.run.name

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -1,3 +1,4 @@
+import uuid
 import warnings
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
@@ -238,7 +239,18 @@ class RLConfig(BaseConfig):
 
     @property
     def run_dir(self) -> Path:
-        return self.output_dir / self.run.name
+        assert self.run.dir is not None  # resolved at construction
+        return self.output_dir / self.run.dir
+
+    def _resolve_run_name(self) -> None:
+        """Fill the auto-generated run name and directory (idempotent — called by every
+        validator that reads them, so it does not depend on validator ordering)."""
+        if self.run.name is None:
+            envs = "+".join(dict.fromkeys(source.resolved_name for source in self.orchestrator.train.source))
+            model = self.trainer.model.name.split("/")[-1]
+            self.run.name = f"{envs or 'no-env'}--{model}--{uuid.uuid4().hex[:8]}"
+        if self.run.dir is None:
+            self.run.dir = self.run.name
 
     ### Shared configurations
 
@@ -374,6 +386,7 @@ class RLConfig(BaseConfig):
         The sub-configs' ``output_dir`` is fully derived here: sub-processes spawned by
         the launcher receive the resolved run directory and never re-derive it.
         """
+        self._resolve_run_name()
         run_dir = self.run_dir
         for sub in (self.trainer, self.orchestrator):
             if "output_dir" in sub.model_fields_set and sub.output_dir != run_dir:
@@ -395,6 +408,7 @@ class RLConfig(BaseConfig):
         set W&B name still takes precedence for the platform run name. The run id is
         minted by the launcher (see the ``rl`` entrypoint), not here.
         """
+        self._resolve_run_name()
         self.orchestrator.run.name = self.run.name
         for wandb in (self.wandb, self.trainer.wandb, self.orchestrator.wandb):
             if wandb is not None and wandb.name is None:

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -401,13 +401,13 @@ class RLConfig(BaseConfig):
 
     @model_validator(mode="after")
     def auto_setup_resume(self):
-        """Propagate the top-level resume onto the sub-config checkpoint configs."""
+        """Propagate the top-level resume onto the sub-configs."""
         if self.resume is None:
             return self
         if self.trainer.ckpt is None or self.orchestrator.ckpt is None:
             raise ValueError("resume requires checkpointing — add the [ckpt] block")
-        self.trainer.ckpt.resume = self.resume.model_copy()
-        self.orchestrator.ckpt.resume = self.resume.model_copy()
+        self.trainer.resume = self.resume.model_copy()
+        self.orchestrator.resume = self.resume.model_copy()
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -21,6 +21,7 @@ from prime_rl.configs.orchestrator import (
 from prime_rl.configs.shared import (
     EnvVars,
     FileMonitorConfig,
+    RunConfig,
     SlurmConfig,
     TransportConfig,
     VLMConfig,
@@ -46,7 +47,6 @@ from prime_rl.utils.validation import (
     validate_shared_ckpt_config,
     validate_shared_max_steps,
     validate_shared_model_name,
-    validate_shared_output_dir,
     validate_shared_seq_len,
     validate_shared_tokenizer,
     validate_shared_wandb_config,
@@ -227,11 +227,18 @@ class RLConfig(BaseConfig):
     env_vars: EnvVars = {}
     """Extra environment variables for every launched RL component. Component-specific env_vars override these."""
 
+    run: RunConfig = Field(default_factory=RunConfig)
+    """Run metadata. ``run.name`` names the run directory under ``output_dir``."""
+
     output_dir: Path = Path("outputs")
-    """Output directory. Should be unique per experiment."""
+    """Directory that groups related runs. Each run writes its artifacts to ``output_dir / run.name``."""
 
     clean_output_dir: bool = False
-    """Delete the output directory before starting training. Required to overwrite an output directory that contains checkpoints from a previous run when not resuming."""
+    """Delete the run directory (``output_dir / run.name``) before starting training. Required to overwrite a run directory that contains artifacts from a previous run when not resuming."""
+
+    @property
+    def run_dir(self) -> Path:
+        return self.output_dir / self.run.name
 
     ### Shared configurations
 
@@ -360,12 +367,29 @@ class RLConfig(BaseConfig):
         """
         return propagate_shared_fields(data)
 
+    @model_validator(mode="after")
+    def auto_setup_run_dir(self):
+        """Point trainer and orchestrator at the run directory (``output_dir / run.name``).
+
+        The sub-configs' ``output_dir`` is fully derived here: sub-processes spawned by
+        the launcher receive the resolved run directory and never re-derive it.
+        """
+        run_dir = self.run_dir
+        for sub in (self.trainer, self.orchestrator):
+            if "output_dir" in sub.model_fields_set and sub.output_dir != run_dir:
+                raise ValueError(
+                    f"{type(sub).__name__}.output_dir ({sub.output_dir}) conflicts with the run directory "
+                    f"({run_dir}). Under the rl entrypoint, sub-config output directories are derived from "
+                    "output_dir / run.name — set those instead."
+                )
+            sub.output_dir = run_dir
+        return self
+
     ### Validate shared configs (after sub-config construction)
 
     @model_validator(mode="after")
     def validate_shared_configs(self):
         """Validate consistency of shared configs across trainer, orchestrator, and inference."""
-        validate_shared_output_dir(self.trainer, self.orchestrator)
         validate_shared_model_name(self.trainer, self.orchestrator, self.inference)
         validate_shared_tokenizer(self.trainer, self.orchestrator, self.inference)
         validate_shared_max_steps(self.trainer, self.orchestrator)

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -401,15 +401,13 @@ class RLConfig(BaseConfig):
 
     @model_validator(mode="after")
     def auto_setup_resume(self):
-        """Map the top-level resume onto the sub-config checkpoint configs (their internal
-        ``resume_step`` uses -1 for "latest")."""
+        """Propagate the top-level resume onto the sub-config checkpoint configs."""
         if self.resume is None:
             return self
         if self.trainer.ckpt is None or self.orchestrator.ckpt is None:
             raise ValueError("resume requires checkpointing — add the [ckpt] block")
-        step = self.resume.step if self.resume.step is not None else -1
-        self.trainer.ckpt.resume_step = step
-        self.orchestrator.ckpt.resume_step = step
+        self.trainer.ckpt.resume = self.resume.model_copy()
+        self.orchestrator.ckpt.resume = self.resume.model_copy()
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -392,9 +392,10 @@ class RLConfig(BaseConfig):
 
         Explicit names always win: only unset names inherit. Runs after the
         orchestrator's own ``auto_setup_prime_monitor_run_name``, so an explicitly
-        set W&B name still takes precedence for the platform run name.
+        set W&B name still takes precedence for the platform run name. The run id is
+        minted by the launcher (see the ``rl`` entrypoint), not here.
         """
-        self.orchestrator.run = self.run
+        self.orchestrator.run.name = self.run.name
         for wandb in (self.wandb, self.trainer.wandb, self.orchestrator.wandb):
             if wandb is not None and wandb.name is None:
                 wandb.name = self.run.name

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -385,6 +385,24 @@ class RLConfig(BaseConfig):
             sub.output_dir = run_dir
         return self
 
+    @model_validator(mode="after")
+    def auto_setup_run_identity(self):
+        """Propagate the run identity to the orchestrator (which stamps it on rollout
+        traces) and default the W&B and Prime platform run names to ``run.name``.
+
+        Explicit names always win: only unset names inherit. Runs after the
+        orchestrator's own ``auto_setup_prime_monitor_run_name``, so an explicitly
+        set W&B name still takes precedence for the platform run name.
+        """
+        self.orchestrator.run = self.run
+        for wandb in (self.wandb, self.trainer.wandb, self.orchestrator.wandb):
+            if wandb is not None and wandb.name is None:
+                wandb.name = self.run.name
+        prime_monitor = self.orchestrator.prime_monitor
+        if prime_monitor is not None and prime_monitor.run_name is None:
+            prime_monitor.run_name = self.run.name
+        return self
+
     ### Validate shared configs (after sub-config construction)
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -234,7 +234,7 @@ class RLConfig(BaseConfig):
     output_dir: Path = Path("outputs")
     """Directory that groups related runs. Each run writes its artifacts to ``output_dir / run.name``."""
 
-    clean_output_dir: bool = False
+    clean: bool = False
     """Delete the run directory (``output_dir / run.name``) before starting training. Required to overwrite a run directory that contains artifacts from a previous run when not resuming."""
 
     @property
@@ -248,7 +248,7 @@ class RLConfig(BaseConfig):
         if self.run.name is None:
             envs = "+".join(dict.fromkeys(source.resolved_name for source in self.orchestrator.train.source))
             model = self.trainer.model.name.split("/")[-1]
-            self.run.name = f"{envs or 'no-env'}--{model}--{uuid.uuid4().hex[:8]}"
+            self.run.name = f"{envs or 'no-env'}--{model}--{uuid.uuid4().hex[:8]}".lower()
         if self.run.dir is None:
             self.run.dir = self.run.name
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -10,6 +10,7 @@ from prime_rl.configs.shared import (
     EnvVars,
     FileMonitorConfig,
     HeartbeatConfig,
+    RunConfig,
     SlurmConfig,
     TrainerLogConfig,
     WandbConfig,
@@ -195,11 +196,18 @@ class SFTConfig(BaseConfig):
     file_monitor: FileMonitorConfig | None = None
     """Local JSONL metric sink. If set, metrics are appended to ``<output_dir>/metrics.jsonl``."""
 
+    run: RunConfig = Field(default_factory=RunConfig)
+    """Run metadata. ``run.name`` names the run directory under ``output_dir``."""
+
     output_dir: Path = Path("outputs")
-    """Directory to write outputs to — checkpoints and logs are written as subdirectories. Should be a persistent directory with enough disk space and unique per experiment running on a single node."""
+    """Directory that groups related runs. Each run writes its artifacts (checkpoints, logs, ...) to ``output_dir / run.name``. Should be a persistent directory with enough disk space."""
 
     clean_output_dir: bool = False
-    """Delete the output directory before starting training. Required to overwrite an output directory that contains checkpoints from a previous run when not resuming."""
+    """Delete the run directory (``output_dir / run.name``) before starting training. Required to overwrite a run directory that contains artifacts from a previous run when not resuming."""
+
+    @property
+    def run_dir(self) -> Path:
+        return self.output_dir / self.run.name
 
     matmul_precision: Literal["highest", "high", "medium"] = "high"
     """Precision for float32 matrix multiplications. ``highest`` is full FP32 (required on ROCm/AMD GPUs to avoid catastrophic precision loss in softmax over large vocabularies). ``high`` enables TF32 on NVIDIA GPUs for a speedup with minor precision tradeoff. See ``torch.set_float32_matmul_precision``."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -216,13 +216,9 @@ class SFTConfig(BaseConfig):
         return self.output_dir / self.run.dir
 
     @model_validator(mode="after")
-    def auto_setup_resume(self):
-        """Propagate the top-level resume onto the checkpoint config."""
-        if self.resume is None:
-            return self
-        if self.ckpt is None:
+    def validate_resume_requires_ckpt(self):
+        if self.resume is not None and self.ckpt is None:
             raise ValueError("resume requires checkpointing — add the [ckpt] block")
-        self.ckpt.resume = self.resume.model_copy()
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -217,13 +217,12 @@ class SFTConfig(BaseConfig):
 
     @model_validator(mode="after")
     def auto_setup_resume(self):
-        """Map the top-level resume onto the checkpoint config (its internal
-        ``resume_step`` uses -1 for "latest")."""
+        """Propagate the top-level resume onto the checkpoint config."""
         if self.resume is None:
             return self
         if self.ckpt is None:
             raise ValueError("resume requires checkpointing — add the [ckpt] block")
-        self.ckpt.resume_step = self.resume.step if self.resume.step is not None else -1
+        self.ckpt.resume = self.resume.model_copy()
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -1,3 +1,4 @@
+import uuid
 import warnings
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
@@ -207,11 +208,20 @@ class SFTConfig(BaseConfig):
 
     @property
     def run_dir(self) -> Path:
-        return self.output_dir / self.run.name
+        assert self.run.dir is not None  # resolved at construction
+        return self.output_dir / self.run.dir
 
     @model_validator(mode="after")
     def auto_setup_run_identity(self):
-        """Default the W&B run name to ``run.name`` when not set explicitly."""
+        """Auto-generate the run name (``<dataset>--<model>--<short-id>``) when unset and
+        default the run directory and W&B run name to it when not set explicitly."""
+        if self.run.name is None:
+            dataset = str(getattr(self.data, "name", "")).split("/")[-1]
+            model = self.model.name.split("/")[-1]
+            parts = [part for part in (dataset, model) if part]
+            self.run.name = "--".join([*parts, uuid.uuid4().hex[:8]])
+        if self.run.dir is None:
+            self.run.dir = self.run.name
         if self.wandb is not None and self.wandb.name is None:
             self.wandb.name = self.run.name
         return self

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -203,7 +203,7 @@ class SFTConfig(BaseConfig):
     output_dir: Path = Path("outputs")
     """Directory that groups related runs. Each run writes its artifacts (checkpoints, logs, ...) to ``output_dir / run.name``. Should be a persistent directory with enough disk space."""
 
-    clean_output_dir: bool = False
+    clean: bool = False
     """Delete the run directory (``output_dir / run.name``) before starting training. Required to overwrite a run directory that contains artifacts from a previous run when not resuming."""
 
     @property
@@ -219,7 +219,7 @@ class SFTConfig(BaseConfig):
             dataset = str(getattr(self.data, "name", "")).split("/")[-1]
             model = self.model.name.split("/")[-1]
             parts = [part for part in (dataset, model) if part]
-            self.run.name = "--".join([*parts, uuid.uuid4().hex[:8]])
+            self.run.name = "--".join([*parts, uuid.uuid4().hex[:8]]).lower()
         if self.run.dir is None:
             self.run.dir = self.run.name
         if self.wandb is not None and self.wandb.name is None:

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -11,6 +11,7 @@ from prime_rl.configs.shared import (
     EnvVars,
     FileMonitorConfig,
     HeartbeatConfig,
+    ResumeConfig,
     RunConfig,
     SlurmConfig,
     TrainerLogConfig,
@@ -190,6 +191,9 @@ class SFTConfig(BaseConfig):
 
     ckpt: CheckpointConfig | None = None
 
+    resume: ResumeConfig | None = None
+    """Resume the run from a checkpoint (requires ``[ckpt]`` and the previous run's ``run.name``). If None, does not resume."""
+
     log: TrainerLogConfig = TrainerLogConfig()
 
     wandb: WandbConfig | None = None
@@ -210,6 +214,17 @@ class SFTConfig(BaseConfig):
     def run_dir(self) -> Path:
         assert self.run.dir is not None  # resolved at construction
         return self.output_dir / self.run.dir
+
+    @model_validator(mode="after")
+    def auto_setup_resume(self):
+        """Map the top-level resume onto the checkpoint config (its internal
+        ``resume_step`` uses -1 for "latest")."""
+        if self.resume is None:
+            return self
+        if self.ckpt is None:
+            raise ValueError("resume requires checkpointing — add the [ckpt] block")
+        self.ckpt.resume_step = self.resume.step if self.resume.step is not None else -1
+        return self
 
     @model_validator(mode="after")
     def auto_setup_run_identity(self):

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -209,6 +209,13 @@ class SFTConfig(BaseConfig):
     def run_dir(self) -> Path:
         return self.output_dir / self.run.name
 
+    @model_validator(mode="after")
+    def auto_setup_run_identity(self):
+        """Default the W&B run name to ``run.name`` when not set explicitly."""
+        if self.wandb is not None and self.wandb.name is None:
+            self.wandb.name = self.run.name
+        return self
+
     matmul_precision: Literal["highest", "high", "medium"] = "high"
     """Precision for float32 matrix multiplications. ``highest`` is full FP32 (required on ROCm/AMD GPUs to avoid catastrophic precision loss in softmax over large vocabularies). ``high`` enables TF32 on NVIDIA GPUs for a speedup with minor precision tradeoff. See ``torch.set_float32_matmul_precision``."""
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -192,7 +192,7 @@ class SFTConfig(BaseConfig):
     ckpt: CheckpointConfig | None = None
 
     resume: ResumeConfig | None = None
-    """Resume the run from a checkpoint (requires ``[ckpt]`` and the previous run's ``run.name``). If None, does not resume."""
+    """Resume the run from a checkpoint (point at it with the previous run's ``run.name``). Without ``[ckpt]`` the run loads the checkpoint but saves no new ones. If None, does not resume."""
 
     log: TrainerLogConfig = TrainerLogConfig()
 
@@ -214,12 +214,6 @@ class SFTConfig(BaseConfig):
     def run_dir(self) -> Path:
         assert self.run.dir is not None  # resolved at construction
         return self.output_dir / self.run.dir
-
-    @model_validator(mode="after")
-    def validate_resume_requires_ckpt(self):
-        if self.resume is not None and self.ckpt is None:
-            raise ValueError("resume requires checkpointing — add the [ckpt] block")
-        return self
 
     @model_validator(mode="after")
     def auto_setup_run_identity(self):

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -11,7 +11,7 @@ from prime_rl.utils.config import BaseConfig
 # and the single shared W&B run. The launcher always sets these last, so allowing them in
 # `env_vars` would be a silent no-op (or, on multi-node, a footgun) — reject them instead.
 PROTECTED_ENV_VARS = frozenset(
-    {"CUDA_VISIBLE_DEVICES", "PRL_RUN_ID", "WANDB_RUN_ID", "WANDB_SHARED_MODE", "WANDB_SHARED_LABEL"}
+    {"CUDA_VISIBLE_DEVICES", "PRL_RUN_ID", "PRL_RUN_NAME", "WANDB_RUN_ID", "WANDB_SHARED_MODE", "WANDB_SHARED_LABEL"}
 )
 
 
@@ -61,14 +61,6 @@ class ResumeConfig(BaseConfig):
         """The step encoded in ``dir``'s name (validated to exist)."""
         assert self.dir is not None
         return int(self.dir.name.removeprefix("step_"))
-
-
-class RunInfoConfig(BaseConfig):
-    """Launcher-resolved run info — not user config. The launcher resolves the name from
-    ``run.name``; sub-processes stamp it on traces and label sandboxes with it. The run
-    id is runtime-only and travels as ``$PRL_RUN_ID``, never through config."""
-
-    name: str | None = None
 
 
 class SlurmConfig(BaseConfig):

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -29,8 +29,12 @@ EnvVars: TypeAlias = Annotated[dict[str, str], AfterValidator(reject_protected_e
 
 
 class RunConfig(BaseConfig):
+    # TODO: fetch this identifier from the Prime SDK once runs are registered there.
+    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    """Unique run identifier, locally generated for now. Stamped on rollout traces and used as the shared W&B run id."""
+
     name: str = Field(default_factory=lambda: uuid.uuid4().hex)
-    """Run name. The run writes all its artifacts to ``output_dir / name``. Defaults to a random UUID, so every launch gets a fresh run directory; set an explicit name (e.g. an experiment name) to get a predictable run directory, which is also required to resume a previous run."""
+    """Run name. The run writes all its artifacts to ``output_dir / name``. Defaults to a random UUID, so every launch gets a fresh run directory; set an explicit name (e.g. an experiment name) to get a predictable run directory, which is also required to resume a previous run. Unless set explicitly, the W&B run name and the Prime platform run name inherit it."""
 
 
 class SlurmConfig(BaseConfig):

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -9,9 +9,7 @@ from prime_rl.utils.config import BaseConfig
 # Launcher-managed env vars that a component's `env_vars` must not set: GPU partitioning
 # and the single shared W&B run. The launcher always sets these last, so allowing them in
 # `env_vars` would be a silent no-op (or, on multi-node, a footgun) — reject them instead.
-PROTECTED_ENV_VARS = frozenset(
-    {"CUDA_VISIBLE_DEVICES", "PRL_RUN_ID", "WANDB_SHARED_MODE", "WANDB_SHARED_RUN_ID", "WANDB_SHARED_LABEL"}
-)
+PROTECTED_ENV_VARS = frozenset({"CUDA_VISIBLE_DEVICES", "PRL_RUN_ID", "WANDB_SHARED_MODE", "WANDB_SHARED_LABEL"})
 
 
 def reject_protected_env_vars(env_vars: dict[str, str]) -> dict[str, str]:

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -10,7 +10,7 @@ from prime_rl.utils.config import BaseConfig
 # and the single shared W&B run. The launcher always sets these last, so allowing them in
 # `env_vars` would be a silent no-op (or, on multi-node, a footgun) — reject them instead.
 PROTECTED_ENV_VARS = frozenset(
-    {"CUDA_VISIBLE_DEVICES", "WANDB_SHARED_MODE", "WANDB_SHARED_RUN_ID", "WANDB_SHARED_LABEL"}
+    {"CUDA_VISIBLE_DEVICES", "PRL_RUN_ID", "WANDB_SHARED_MODE", "WANDB_SHARED_RUN_ID", "WANDB_SHARED_LABEL"}
 )
 
 
@@ -36,11 +36,10 @@ class RunConfig(BaseConfig):
 
 
 class RunInfoConfig(BaseConfig):
-    """Launcher-injected run identity — not user config. The launcher mints the id
-    (TODO: fetch it from the Prime SDK once runs are registered there) and resolves the
-    name from ``run.name``; sub-processes stamp it on traces and label sandboxes with it."""
+    """Launcher-resolved run info — not user config. The launcher resolves the name from
+    ``run.name``; sub-processes stamp it on traces and label sandboxes with it. The run
+    id is runtime-only and travels as ``$PRL_RUN_ID``, never through config."""
 
-    id: str | None = None
     name: str | None = None
 
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -9,7 +9,9 @@ from prime_rl.utils.config import BaseConfig
 # Launcher-managed env vars that a component's `env_vars` must not set: GPU partitioning
 # and the single shared W&B run. The launcher always sets these last, so allowing them in
 # `env_vars` would be a silent no-op (or, on multi-node, a footgun) — reject them instead.
-PROTECTED_ENV_VARS = frozenset({"CUDA_VISIBLE_DEVICES", "PRL_RUN_ID", "WANDB_SHARED_MODE", "WANDB_SHARED_LABEL"})
+PROTECTED_ENV_VARS = frozenset(
+    {"CUDA_VISIBLE_DEVICES", "PRL_RUN_ID", "WANDB_RUN_ID", "WANDB_SHARED_MODE", "WANDB_SHARED_LABEL"}
+)
 
 
 def reject_protected_env_vars(env_vars: dict[str, str]) -> dict[str, str]:
@@ -31,6 +33,14 @@ class RunConfig(BaseConfig):
 
     dir: str | None = None
     """Run directory name — the run writes all its artifacts to ``output_dir / dir``. Defaults to ``run.name``; set it only when the directory should differ from the display name."""
+
+
+class ResumeConfig(BaseConfig):
+    """Resume the run from a checkpoint. A bare ``--resume`` (or empty ``[resume]`` block)
+    resumes from the latest checkpoint."""
+
+    step: int | None = Field(None, ge=1)
+    """Checkpoint step to resume from. None resumes from the latest checkpoint."""
 
 
 class RunInfoConfig(BaseConfig):

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -1,5 +1,4 @@
 import os
-import uuid
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
@@ -29,8 +28,11 @@ EnvVars: TypeAlias = Annotated[dict[str, str], AfterValidator(reject_protected_e
 
 
 class RunConfig(BaseConfig):
-    name: str = Field(default_factory=lambda: uuid.uuid4().hex)
-    """Run name. The run writes all its artifacts to ``output_dir / name``. Defaults to a random UUID, so every launch gets a fresh run directory; set an explicit name (e.g. an experiment name) to get a predictable run directory, which is also required to resume a previous run. Unless set explicitly, the W&B run name and the Prime platform run name inherit it."""
+    name: str | None = None
+    """Run name. Auto-generated as ``<envs>--<model>--<short-id>`` when unset, so every launch gets a fresh, readable run directory; set an explicit name (e.g. an experiment name) to get a predictable run directory, which is also required to resume a previous run. Unless set explicitly, the W&B run name and the Prime platform run name inherit it."""
+
+    dir: str | None = None
+    """Run directory name — the run writes all its artifacts to ``output_dir / dir``. Defaults to ``run.name``; set it only when the directory should differ from the display name."""
 
 
 class RunInfoConfig(BaseConfig):

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
@@ -25,6 +26,11 @@ def reject_protected_env_vars(env_vars: dict[str, str]) -> dict[str, str]:
 
 EnvVars: TypeAlias = Annotated[dict[str, str], AfterValidator(reject_protected_env_vars)]
 """A per-component `env_vars` mapping, validated to not clobber `PROTECTED_ENV_VARS`."""
+
+
+class RunConfig(BaseConfig):
+    name: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    """Run name. The run writes all its artifacts to ``output_dir / name``. Defaults to a random UUID, so every launch gets a fresh run directory; set an explicit name (e.g. an experiment name) to get a predictable run directory, which is also required to resume a previous run."""
 
 
 class SlurmConfig(BaseConfig):

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -29,12 +29,17 @@ EnvVars: TypeAlias = Annotated[dict[str, str], AfterValidator(reject_protected_e
 
 
 class RunConfig(BaseConfig):
-    # TODO: fetch this identifier from the Prime SDK once runs are registered there.
-    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
-    """Unique run identifier, locally generated for now. Stamped on rollout traces and used as the shared W&B run id."""
-
     name: str = Field(default_factory=lambda: uuid.uuid4().hex)
     """Run name. The run writes all its artifacts to ``output_dir / name``. Defaults to a random UUID, so every launch gets a fresh run directory; set an explicit name (e.g. an experiment name) to get a predictable run directory, which is also required to resume a previous run. Unless set explicitly, the W&B run name and the Prime platform run name inherit it."""
+
+
+class RunInfoConfig(BaseConfig):
+    """Launcher-injected run identity — not user config. The launcher mints the id
+    (TODO: fetch it from the Prime SDK once runs are registered there) and resolves the
+    name from ``run.name``; sub-processes stamp it on traces and label sandboxes with it."""
+
+    id: str | None = None
+    name: str | None = None
 
 
 class SlurmConfig(BaseConfig):

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
@@ -41,6 +42,25 @@ class ResumeConfig(BaseConfig):
 
     step: int | None = Field(None, ge=1)
     """Checkpoint step to resume from. None resumes from the latest checkpoint."""
+
+    dir: Path | None = None
+    """External checkpoint step directory to resume from (e.g. ``other/run/checkpoints/step_50``) — forks another run's checkpoint into this run. Mutually exclusive with ``step``."""
+
+    @model_validator(mode="after")
+    def validate_step_xor_dir(self):
+        if self.step is not None and self.dir is not None:
+            raise ValueError(
+                "resume.step and resume.dir are mutually exclusive — the step is taken from the directory name"
+            )
+        if self.dir is not None and not re.fullmatch(r"step_\d+", self.dir.name):
+            raise ValueError(f"resume.dir must point at a checkpoint step directory (`.../step_<N>`), got '{self.dir}'")
+        return self
+
+    @property
+    def dir_step(self) -> int:
+        """The step encoded in ``dir``'s name (validated to exist)."""
+        assert self.dir is not None
+        return int(self.dir.name.removeprefix("step_"))
 
 
 class RunInfoConfig(BaseConfig):

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -10,6 +10,7 @@ from prime_rl.configs.shared import (
     FileMonitorConfig,
     HeartbeatConfig,
     MetricsServerConfig,
+    ResumeConfig,
     TrainerLogConfig,
     TransportConfig,
     WandbConfig,
@@ -431,8 +432,8 @@ class CheckpointConfig(BaseConfig):
     weights_only: bool = False
     """Save only weight checkpoints (no optimizer/scheduler state). Much faster and smaller than full checkpoints, but cannot resume training."""
 
-    resume_step: int | None = Field(None, ge=-1)
-    """Step to resume training from. None starts from scratch; ``-1`` restarts from the latest checkpoint available."""
+    resume: ResumeConfig | None = None
+    """Resume training from a checkpoint. None starts from scratch; an empty block resumes from the latest checkpoint, ``resume.step`` from that step."""
 
     keep_last: int | None = Field(None, ge=1)
     """Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints based on recency."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -577,7 +577,7 @@ class TrainerConfig(BaseConfig):
     ckpt: CheckpointConfig | None = None
 
     resume: ResumeConfig | None = None
-    """Resume training from a checkpoint (requires ``ckpt``). None starts from scratch; an empty block resumes from the latest checkpoint, ``resume.step`` from that step, ``resume.dir`` from an external checkpoint step directory."""
+    """Resume training from a checkpoint. None starts from scratch; an empty block resumes from the latest checkpoint, ``resume.step`` from that step, ``resume.dir`` from an external checkpoint step directory. Without ``ckpt`` the run loads but saves no new checkpoints."""
     """Full training-state checkpoint configuration (model + optimizer + scheduler). If None, no resume-capable checkpoints are written."""
 
     weight_broadcast: WeightBroadcastConfig = FileSystemWeightBroadcastConfig()

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -432,9 +432,6 @@ class CheckpointConfig(BaseConfig):
     weights_only: bool = False
     """Save only weight checkpoints (no optimizer/scheduler state). Much faster and smaller than full checkpoints, but cannot resume training."""
 
-    resume: ResumeConfig | None = None
-    """Resume training from a checkpoint. None starts from scratch; an empty block resumes from the latest checkpoint, ``resume.step`` from that step."""
-
     keep_last: int | None = Field(None, ge=1)
     """Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints based on recency."""
 
@@ -578,6 +575,9 @@ class TrainerConfig(BaseConfig):
     scheduler: SchedulerConfig = ConstantSchedulerConfig()
 
     ckpt: CheckpointConfig | None = None
+
+    resume: ResumeConfig | None = None
+    """Resume training from a checkpoint (requires ``ckpt``). None starts from scratch; an empty block resumes from the latest checkpoint, ``resume.step`` from that step, ``resume.dir`` from an external checkpoint step directory."""
     """Full training-state checkpoint configuration (model + optimizer + scheduler). If None, no resume-capable checkpoints are written."""
 
     weight_broadcast: WeightBroadcastConfig = FileSystemWeightBroadcastConfig()

--- a/packages/prime-rl-configs/src/prime_rl/utils/config.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/config.py
@@ -6,38 +6,14 @@ from pydantic_config import BaseConfig as BaseConfig  # noqa: F401
 from pydantic_config import cli  # noqa: F401
 
 
-def to_toml_dict(config: BaseModel, exclude: set[str] | None = None) -> dict:
-    """Dump a config to a TOML-serializable dict.
+def dump_resolved_config(config: BaseModel, exclude: set[str] | None = None) -> dict:
+    """Dump a resolved config for a machine-written JSON artifact.
 
-    TOML cannot represent null, so None fields left at their default are dropped
-    (they re-resolve identically on re-parse) while explicitly-set None fields
-    are encoded as the string ``"None"``, which ``BaseConfig`` converts back to
-    ``None``. Dropping those too would silently revert explicit None overrides
-    (e.g. ``--trainer.model.compile None``) to their non-None defaults when the
-    written config is re-parsed.
+    Resolved configs are written as JSON, not TOML: JSON keeps nulls, so explicit None
+    overrides (e.g. ``--trainer.optim.max-norm None``) round-trip exactly on re-parse.
+    Hand-written configs stay TOML (sparse, commented); the format split is the marker.
     """
-    return _encode_model(config, config.model_dump(exclude=exclude, mode="json"))
-
-
-def _encode_model(model: BaseModel, dumped: dict) -> dict:
-    encoded = {}
-    for name, value in dumped.items():
-        if value is None:
-            if name in model.model_fields_set:
-                encoded[name] = "None"
-            continue
-        encoded[name] = _encode_value(getattr(model, name), value)
-    return encoded
-
-
-def _encode_value(attr: Any, value: Any) -> Any:
-    if isinstance(attr, BaseModel) and isinstance(value, dict):
-        return _encode_model(attr, value)
-    if isinstance(value, list) and isinstance(attr, (list, tuple)):
-        return [_encode_value(a, v) for a, v in zip(attr, value)]
-    if isinstance(value, dict) and isinstance(attr, dict):
-        return {k: _encode_value(a, v) for (k, v), a in zip(value.items(), attr.values())}
-    return "None" if value is None else value
+    return config.model_dump(exclude=exclude, mode="json")
 
 
 def find_package_resource(subdir: str) -> Path | None:

--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -194,9 +194,9 @@ def validate_shared_ckpt_config(
         raise ValueError(
             f"Trainer checkpoint interval ({trainer.ckpt.interval}) and orchestrator checkpoint interval ({orchestrator.ckpt.interval}) are not the same. Please specify the same checkpoint interval for both."
         )
-    if trainer.ckpt and orchestrator.ckpt and trainer.ckpt.resume_step != orchestrator.ckpt.resume_step:
+    if trainer.ckpt and orchestrator.ckpt and trainer.ckpt.resume != orchestrator.ckpt.resume:
         raise ValueError(
-            f"Trainer checkpoint resume step ({trainer.ckpt.resume_step}) and orchestrator checkpoint resume step ({orchestrator.ckpt.resume_step}) are not the same. Please specify the same checkpoint resume step for both."
+            f"Trainer checkpoint resume ({trainer.ckpt.resume}) and orchestrator checkpoint resume ({orchestrator.ckpt.resume}) are not the same. Please specify the same resume config for both."
         )
 
 

--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -194,9 +194,9 @@ def validate_shared_ckpt_config(
         raise ValueError(
             f"Trainer checkpoint interval ({trainer.ckpt.interval}) and orchestrator checkpoint interval ({orchestrator.ckpt.interval}) are not the same. Please specify the same checkpoint interval for both."
         )
-    if trainer.ckpt and orchestrator.ckpt and trainer.ckpt.resume != orchestrator.ckpt.resume:
+    if trainer.resume != orchestrator.resume:
         raise ValueError(
-            f"Trainer checkpoint resume ({trainer.ckpt.resume}) and orchestrator checkpoint resume ({orchestrator.ckpt.resume}) are not the same. Please specify the same resume config for both."
+            f"Trainer resume ({trainer.resume}) and orchestrator resume ({orchestrator.resume}) are not the same. Please specify the same resume config for both."
         )
 
 

--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -90,7 +90,6 @@ def propagate_shared_fields(data: Any) -> Any:
     # ``orchestrator.ckpt`` has no ``output_dir`` field — trainer-only.
     propagate("ckpt.output_dir", "trainer.ckpt.output_dir")
     propagate("ckpt.interval", "trainer.ckpt.interval", "orchestrator.ckpt.interval")
-    propagate("ckpt.resume_step", "trainer.ckpt.resume_step", "orchestrator.ckpt.resume_step")
     propagate("ckpt.keep_last", "trainer.ckpt.keep_last", "orchestrator.ckpt.keep_last")
     propagate("ckpt.keep_interval", "trainer.ckpt.keep_interval", "orchestrator.ckpt.keep_interval")
 

--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -138,8 +138,6 @@ def propagate_shared_fields(data: Any) -> Any:
     # pass (the per-rank inference.toml drops slurm, so each rank still runs locally).
     propagate("slurm", "inference.slurm")
 
-    propagate("output_dir", "trainer.output_dir", "orchestrator.output_dir")
-
     # Cascade trainer.tokenizer.chat_template → inference.vllm.chat_template
     # (vLLM ``--chat-template``). Read trainer's value *after* the shared
     # propagation above so we cover both:
@@ -222,17 +220,6 @@ def validate_shared_model_name(
     if trainer.model.name != orchestrator.model.name:
         raise ValueError(
             f"Trainer model name ({trainer.model.name}) and orchestrator model name ({orchestrator.model.name}) are not the same. Please specify the same model name for both."
-        )
-
-
-def validate_shared_output_dir(
-    trainer: TrainerConfig,
-    orchestrator: OrchestratorConfig,
-) -> None:
-    if trainer.output_dir != orchestrator.output_dir:
-        raise ValueError(
-            f"Trainer outputs directory ({trainer.output_dir}) and orchestrator outputs directory ({orchestrator.output_dir}) are not the same. "
-            "Please specify the same outputs directory for both (the orchestrator no longer nests under a run_default subdirectory)."
         )
 
 

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -25,7 +25,7 @@ Naming: CLI uses kebab-case (`--vllm.max-model-len`); TOML uses snake_case (`max
 
 ```bash
 uv run rl --help                                  # all fields and defaults
-uv run rl @ rl.toml --dry-run --output-dir /tmp/x --run.name check # write resolved TOML to /tmp/x/check/configs
+uv run rl @ rl.toml --dry-run --output-dir /tmp/x --run.name check # write resolved configs (JSON) to /tmp/x/check/configs
 ```
 
 ## Validators

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -25,7 +25,7 @@ Naming: CLI uses kebab-case (`--vllm.max-model-len`); TOML uses snake_case (`max
 
 ```bash
 uv run rl --help                                  # all fields and defaults
-uv run rl @ rl.toml --dry-run --output-dir /tmp/x # write resolved TOML to /tmp/x/configs
+uv run rl @ rl.toml --dry-run --output-dir /tmp/x --run.name check # write resolved TOML to /tmp/x/check/configs
 ```
 
 ## Validators
@@ -90,7 +90,7 @@ In TOML, an empty section header (`[ckpt]`) does the same.
 
 ## RL trainer token exports
 
-For rollout debugging, enable trainer-side token export with `trainer.enable_token_export = true` (or `--enable-token-export` when running the trainer entrypoint directly). It writes one JSONL record per exported sequence under `output_dir/token_exports/step_<step>/rank_<rank>.jsonl`. Each record stores aligned per-token arrays for token ids, loss mask, component weight streams (rl/ce/ref_kl), advantages, entropy, mismatch KL, inference/trainer logprobs, importance ratios, probability deltas, and masking diagnostics. It does not decode token text in the trainer.
+For rollout debugging, enable trainer-side token export with `trainer.enable_token_export = true` (or `--enable-token-export` when running the trainer entrypoint directly). It writes one JSONL record per exported sequence under `<run_dir>/token_exports/step_<step>/rank_<rank>.jsonl`. Each record stores aligned per-token arrays for token ids, loss mask, component weight streams (rl/ce/ref_kl), advantages, entropy, mismatch KL, inference/trainer logprobs, importance ratios, probability deltas, and masking diagnostics. It does not decode token text in the trainer.
 
 ```toml
 enable_token_export = true

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -9,9 +9,9 @@ description: Monitor an ongoing prime-rl training run — find the output direct
 
 ### On launch
 
-1. Find the output dir and read the resolved configs at `{output_dir}/configs/` (start with `rl.toml`).
+1. Find the run dir and read the resolved configs at `{run_dir}/configs/` (start with `rl.toml`). The run dir is `{output_dir}/{run_name}` — `run.name` defaults to a random UUID, so if you only know the output dir, pick the most recently modified subdirectory (`ls -t {output_dir} | head -1`) or read `run.name` from the launch command.
 2. Confirm all processes are alive and the run is making progress.
-3. Write the initial summary into `{output_dir}/STATUS.md`.
+3. Write the initial summary into `{run_dir}/STATUS.md`.
 
 ### Recurring check-ins
 
@@ -19,7 +19,7 @@ Default cadence: **1 hour** (researcher can override). At each check-in:
 
 1. Confirm processes are alive.
 2. Grep logs for errors/warnings; note current step and key metrics.
-3. **Append** an entry to `{output_dir}/STATUS.md` (never overwrite):
+3. **Append** an entry to `{run_dir}/STATUS.md` (never overwrite):
 
 ```markdown
 ## YYYY-MM-DD HH:MM UTC
@@ -55,15 +55,15 @@ After a restart, verify all processes are back up and progress resumed before th
 
 ### Where to find things
 
-- `scripts/tmux.sh` launches the run with a `Launcher` window in the named tmux session. The Claude window receives the output dir and session name in its appended prompt — if either is missing, **ask** rather than guess.
-- `{output_dir}/configs/` — resolved TOMLs (`rl.toml` has the full picture).
-- `{output_dir}/logs/` — see below.
-- `{output_dir}/rollouts/step_N/{train,eval}/` — saved rollout traces (see Traces below).
+- `scripts/tmux.sh` launches the run with a `Launcher` window in the named tmux session. The Claude window receives the run dir and session name in its appended prompt — if either is missing, **ask** rather than guess.
+- `{run_dir}/configs/` — resolved TOMLs (`rl.toml` has the full picture).
+- `{run_dir}/logs/` — see below.
+- `{run_dir}/rollouts/step_N/{train,eval}/` — saved rollout traces (see Traces below).
 
 ### Logs
 
 ```
-{output_dir}/logs/
+{run_dir}/logs/
 ├── trainer.log                # rank 0 stdout
 ├── orchestrator.log           # orchestrator stdout
 ├── inference.log              # vLLM stdout
@@ -81,8 +81,8 @@ Usually tailing `trainer.log`, `orchestrator.log`, and `inference.log` is enough
 Scan for problems:
 
 ```bash
-grep -E "WARNING|ERROR" {output_dir}/logs/{trainer,orchestrator,inference}.log
-grep -E "WARNING|ERROR" {output_dir}/logs/envs/{train,eval}/*.log
+grep -E "WARNING|ERROR" {run_dir}/logs/{trainer,orchestrator,inference}.log
+grep -E "WARNING|ERROR" {run_dir}/logs/envs/{train,eval}/*.log
 ```
 
 ### Metrics
@@ -141,8 +141,8 @@ curl -s http://localhost:8100/metrics | grep -E "num_requests|gpu_cache_usage"  
 ### Traces
 
 ```
-{output_dir}/rollouts/step_N/{train,eval}/all/traces.jsonl        # appended per rollout as it completes
-{output_dir}/rollouts/step_N/{train,eval}/effective/traces.jsonl  # written per finalized batch / eval epoch
+{run_dir}/rollouts/step_N/{train,eval}/all/traces.jsonl        # appended per rollout as it completes
+{run_dir}/rollouts/step_N/{train,eval}/effective/traces.jsonl  # written per finalized batch / eval epoch
 ```
 
 JSONL files of `vf.Trace` records (training tensors excluded), one line per trace — a
@@ -157,12 +157,12 @@ share the step file) — untrainable traces (a frozen judge's) appear only in `a
 `group_id`, `episode_id`, and `policy_version` under `info`.
 
 ```bash
-wc -l {output_dir}/rollouts/step_42/train/{all,effective}/traces.jsonl
-jq '.rewards' {output_dir}/rollouts/step_42/train/effective/traces.jsonl
-jq 'select(.ok | not) | {id, env: .info.env_name, runtime}' {output_dir}/rollouts/step_*/train/all/traces.jsonl
+wc -l {run_dir}/rollouts/step_42/train/{all,effective}/traces.jsonl
+jq '.rewards' {run_dir}/rollouts/step_42/train/effective/traces.jsonl
+jq 'select(.ok | not) | {id, env: .info.env_name, runtime}' {run_dir}/rollouts/step_*/train/all/traces.jsonl
 ```
 
-The batches consumed by the trainer are shipped over ZMQ by default, so nothing binary is written. With `rollout_transport.type = "filesystem"` they land at `{output_dir}/rollouts/step_N/rank_<rank>.bin` (one packed micro-batch file per trainer DP rank), next to the trace subtrees.
+The batches consumed by the trainer are shipped over ZMQ by default, so nothing binary is written. With `rollout_transport.type = "filesystem"` they land at `{run_dir}/rollouts/step_N/rank_<rank>.bin` (one packed micro-batch file per trainer DP rank), next to the trace subtrees.
 
 ### Common failure modes
 

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -9,7 +9,7 @@ description: Monitor an ongoing prime-rl training run — find the output direct
 
 ### On launch
 
-1. Find the run dir and read the resolved configs at `{run_dir}/configs/` (start with `rl.toml`). The run dir is `{output_dir}/{run_name}` — `run.name` auto-generates as `<envs>--<model>--<short-id>`, so if you only know the output dir, pick the most recently modified subdirectory (`ls -t {output_dir} | head -1`) or read `run.name` from the launch command.
+1. Find the run dir and read the resolved configs at `{run_dir}/configs/` (start with `rl.json`). The run dir is `{output_dir}/{run_name}` — `run.name` auto-generates as `<envs>--<model>--<short-id>`, so if you only know the output dir, pick the most recently modified subdirectory (`ls -t {output_dir} | head -1`) or read `run.name` from the launch command.
 2. Confirm all processes are alive and the run is making progress.
 3. Write the initial summary into `{run_dir}/STATUS.md`.
 
@@ -56,7 +56,7 @@ After a restart, verify all processes are back up and progress resumed before th
 ### Where to find things
 
 - `scripts/tmux.sh` launches the run with a `Launcher` window in the named tmux session. The Claude window receives the run dir and session name in its appended prompt — if either is missing, **ask** rather than guess.
-- `{run_dir}/configs/` — resolved TOMLs (`rl.toml` has the full picture).
+- `{run_dir}/configs/` — resolved configs, written as JSON so explicit None settings round-trip (`rl.json` has the full picture).
 - `{run_dir}/logs/` — see below.
 - `{run_dir}/rollouts/step_N/{train,eval}/` — saved rollout traces (see Traces below).
 

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -9,7 +9,7 @@ description: Monitor an ongoing prime-rl training run — find the output direct
 
 ### On launch
 
-1. Find the run dir and read the resolved configs at `{run_dir}/configs/` (start with `rl.toml`). The run dir is `{output_dir}/{run_name}` — `run.name` defaults to a random UUID, so if you only know the output dir, pick the most recently modified subdirectory (`ls -t {output_dir} | head -1`) or read `run.name` from the launch command.
+1. Find the run dir and read the resolved configs at `{run_dir}/configs/` (start with `rl.toml`). The run dir is `{output_dir}/{run_name}` — `run.name` auto-generates as `<envs>--<model>--<short-id>`, so if you only know the output dir, pick the most recently modified subdirectory (`ls -t {output_dir} | head -1`) or read `run.name` from the launch command.
 2. Confirm all processes are alive and the run is making progress.
 3. Write the initial summary into `{run_dir}/STATUS.md`.
 

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -9,7 +9,7 @@ All entrypoints run via `uv run <command>` and accept TOML configs via `@ path/t
 
 ## Run directories
 
-`output_dir` (default `outputs`) groups related runs; each run writes all its artifacts (logs, configs, checkpoints, weights, rollouts) to its own run directory `<output_dir>/<run_name>`. `run.name` auto-generates as `<envs>--<model>--<short-id>` (SFT: `<dataset>--<model>--<short-id>`), so every launch gets a fresh, readable run directory; `run.dir` overrides the directory leaf when it should differ from the name. Pass `--run.name <name>` to make the run directory predictable — required to resume the run later (`--ckpt.resume-step` reuses the named run directory). Launching into a run directory that already contains artifacts fails unless resuming or `--clean-output-dir` is set (which wipes only that run directory).
+`output_dir` (default `outputs`) groups related runs; each run writes all its artifacts (logs, configs, checkpoints, weights, rollouts) to its own run directory `<output_dir>/<run_name>`. `run.name` auto-generates as `<envs>--<model>--<short-id>` (SFT: `<dataset>--<model>--<short-id>`), so every launch gets a fresh, readable run directory; `run.dir` overrides the directory leaf when it should differ from the name. Pass `--run.name <name>` to make the run directory predictable — required to resume the run later (`--ckpt.resume-step` reuses the named run directory). Launching into a run directory that already contains artifacts fails unless resuming or `--clean` is set (which wipes only that run directory).
 
 ## Config system at a glance
 

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -9,7 +9,7 @@ All entrypoints run via `uv run <command>` and accept TOML configs via `@ path/t
 
 ## Run directories
 
-`output_dir` (default `outputs`) groups related runs; each run writes all its artifacts (logs, configs, checkpoints, weights, rollouts) to its own run directory `<output_dir>/<run_name>`. `run.name` defaults to a random UUID, so every launch gets a fresh run directory. Pass `--run.name <name>` to make the run directory predictable — required to resume the run later (`--ckpt.resume-step` reuses the named run directory). Launching into a run directory that already contains artifacts fails unless resuming or `--clean-output-dir` is set (which wipes only that run directory).
+`output_dir` (default `outputs`) groups related runs; each run writes all its artifacts (logs, configs, checkpoints, weights, rollouts) to its own run directory `<output_dir>/<run_name>`. `run.name` auto-generates as `<envs>--<model>--<short-id>` (SFT: `<dataset>--<model>--<short-id>`), so every launch gets a fresh, readable run directory; `run.dir` overrides the directory leaf when it should differ from the name. Pass `--run.name <name>` to make the run directory predictable — required to resume the run later (`--ckpt.resume-step` reuses the named run directory). Launching into a run directory that already contains artifacts fails unless resuming or `--clean-output-dir` is set (which wipes only that run directory).
 
 ## Config system at a glance
 

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -9,7 +9,7 @@ All entrypoints run via `uv run <command>` and accept TOML configs via `@ path/t
 
 ## Run directories
 
-`output_dir` (default `outputs`) groups related runs; each run writes all its artifacts (logs, configs, checkpoints, weights, rollouts) to its own run directory `<output_dir>/<run_name>`. `run.name` auto-generates as `<envs>--<model>--<short-id>` (SFT: `<dataset>--<model>--<short-id>`), so every launch gets a fresh, readable run directory; `run.dir` overrides the directory leaf when it should differ from the name. Pass `--run.name <name>` to make the run directory predictable — required to resume the run later (`--ckpt.resume-step` reuses the named run directory). Launching into a run directory that already contains artifacts fails unless resuming or `--clean` is set (which wipes only that run directory).
+`output_dir` (default `outputs`) groups related runs; each run writes all its artifacts (logs, configs, checkpoints, weights, rollouts) to its own run directory `<output_dir>/<run_name>`. `run.name` auto-generates as `<envs>--<model>--<short-id>` (SFT: `<dataset>--<model>--<short-id>`), so every launch gets a fresh, readable run directory; `run.dir` overrides the directory leaf when it should differ from the name. Pass `--run.name <name>` to make the run directory predictable — required to resume the run later (`--resume`, or `--resume.step N`, reuses the named run directory; requires `[ckpt]`). Launching into a run directory that already contains artifacts fails unless resuming or `--clean` is set (which wipes only that run directory).
 
 ## Config system at a glance
 

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -7,6 +7,10 @@ description: How to launch prime-rl training runs — the `rl`, `sft`, and `infe
 
 All entrypoints run via `uv run <command>` and accept TOML configs via `@ path/to.toml` plus CLI overrides.
 
+## Run directories
+
+`output_dir` (default `outputs`) groups related runs; each run writes all its artifacts (logs, configs, checkpoints, weights, rollouts) to its own run directory `<output_dir>/<run_name>`. `run.name` defaults to a random UUID, so every launch gets a fresh run directory. Pass `--run.name <name>` to make the run directory predictable — required to resume the run later (`--ckpt.resume-step` reuses the named run directory). Launching into a run directory that already contains artifacts fails unless resuming or `--clean-output-dir` is set (which wipes only that run directory).
+
 ## Config system at a glance
 
 [`pydantic-config`](https://github.com/PrimeIntellect-ai/pydantic-config) — Pydantic-based TOML + CLI loader. Highlights (see the `configs` skill for full mechanics):

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -9,7 +9,7 @@ All entrypoints run via `uv run <command>` and accept TOML configs via `@ path/t
 
 ## Run directories
 
-`output_dir` (default `outputs`) groups related runs; each run writes all its artifacts (logs, configs, checkpoints, weights, rollouts) to its own run directory `<output_dir>/<run_name>`. `run.name` auto-generates as `<envs>--<model>--<short-id>` (SFT: `<dataset>--<model>--<short-id>`), so every launch gets a fresh, readable run directory; `run.dir` overrides the directory leaf when it should differ from the name. Pass `--run.name <name>` to make the run directory predictable — required to resume the run later (`--resume`, or `--resume.step N`, reuses the named run directory; requires `[ckpt]`). Launching into a run directory that already contains artifacts fails unless resuming or `--clean` is set (which wipes only that run directory).
+`output_dir` (default `outputs`) groups related runs; each run writes all its artifacts (logs, configs, checkpoints, weights, rollouts) to its own run directory `<output_dir>/<run_name>`. `run.name` auto-generates as `<envs>--<model>--<short-id>` (SFT: `<dataset>--<model>--<short-id>`), so every launch gets a fresh, readable run directory; `run.dir` overrides the directory leaf when it should differ from the name. Pass `--run.name <name>` to make the run directory predictable — required to resume the run later (`--resume`, or `--resume.step N`, reuses the named run directory; without `[ckpt]` it loads but saves no new checkpoints). Launching into a run directory that already contains artifacts fails unless resuming or `--clean` is set (which wipes only that run directory).
 
 ## Config system at a glance
 

--- a/src/prime_rl/entrypoints/env_server.py
+++ b/src/prime_rl/entrypoints/env_server.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 from verifiers.v1 import pool_serve_kwargs
@@ -18,7 +19,8 @@ def setup_worker(log_level: str | None, json_logging: bool, sandbox_labels: list
 
 @clean_exit
 def run_server(config: EnvServerConfig):
-    sandbox_labels = [config.run.name] if config.run.name else []
+    run_name = os.environ.get("PRL_RUN_NAME")
+    sandbox_labels = [run_name] if run_name else []
     # ``serve.pool`` (static or elastic) sizes the server. serve_env applies the worker
     # setup in this process and in every spawned worker.
     serve_env(

--- a/src/prime_rl/entrypoints/env_server.py
+++ b/src/prime_rl/entrypoints/env_server.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from verifiers.v1 import pool_serve_kwargs
+from verifiers.v1 import pool_serve_kwargs, set_base_sandbox_labels
 from verifiers.v1.serve import env_config_data, serve_env
 
 from prime_rl.configs.env_server import EnvServerConfig
@@ -10,14 +10,19 @@ from prime_rl.utils.process import set_proc_title
 from prime_rl.utils.utils import clean_exit
 
 
+def setup_worker(log_level: str | None, json_logging: bool, sandbox_labels: list[str]) -> None:
+    setup_env_server_logging(log_level, json_logging)
+    set_base_sandbox_labels(sandbox_labels)
+
+
 @clean_exit
 def run_server(config: EnvServerConfig):
-    # ``serve.pool`` (static or elastic) sizes the server. serve_env applies the logging
+    # ``serve.pool`` (static or elastic) sizes the server. serve_env applies the worker
     # setup in this process and in every spawned worker.
     serve_env(
         **pool_serve_kwargs(config.serve.pool),
         address=config.serve.address,
-        log_setup=partial(setup_env_server_logging, config.log.level, config.log.json_logging),
+        log_setup=partial(setup_worker, config.log.level, config.log.json_logging, config.sandbox_labels),
         config_data=env_config_data(config.env),
         max_concurrent=config.serve.max_concurrent,
     )

--- a/src/prime_rl/entrypoints/env_server.py
+++ b/src/prime_rl/entrypoints/env_server.py
@@ -1,6 +1,7 @@
 from functools import partial
 
-from verifiers.v1 import pool_serve_kwargs, set_base_sandbox_labels
+from verifiers.v1 import pool_serve_kwargs
+from verifiers.v1.runtimes import set_base_sandbox_labels
 from verifiers.v1.serve import env_config_data, serve_env
 
 from prime_rl.configs.env_server import EnvServerConfig
@@ -17,12 +18,13 @@ def setup_worker(log_level: str | None, json_logging: bool, sandbox_labels: list
 
 @clean_exit
 def run_server(config: EnvServerConfig):
+    sandbox_labels = [config.run.name] if config.run.name else []
     # ``serve.pool`` (static or elastic) sizes the server. serve_env applies the worker
     # setup in this process and in every spawned worker.
     serve_env(
         **pool_serve_kwargs(config.serve.pool),
         address=config.serve.address,
-        log_setup=partial(setup_worker, config.log.level, config.log.json_logging, config.sandbox_labels),
+        log_setup=partial(setup_worker, config.log.level, config.log.json_logging, sandbox_labels),
         config_data=env_config_data(config.env),
         max_concurrent=config.serve.max_concurrent,
     )

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -7,10 +7,8 @@ from pathlib import Path
 from threading import Event, Thread
 from typing import Any
 
-import tomli_w
-
 from prime_rl.configs.inference import InferenceConfig
-from prime_rl.utils.config import cli, to_toml_dict
+from prime_rl.utils.config import cli, dump_resolved_config
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir
 from prime_rl.utils.process import (
@@ -20,7 +18,7 @@ from prime_rl.utils.process import (
     set_proc_title,
 )
 
-INFERENCE_TOML = "inference.toml"
+INFERENCE_CONFIG = "inference.json"
 INFERENCE_SBATCH = "inference.sbatch"
 
 
@@ -44,12 +42,12 @@ def write_config(
     engines — the sbatch script starts the single global router.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
-    config_path = output_dir / INFERENCE_TOML
-    toml_dict = to_toml_dict(config, exclude=exclude)
+    config_path = output_dir / INFERENCE_CONFIG
+    config_dict = dump_resolved_config(config, exclude=exclude)
     if engine_only:
-        toml_dict["router"] = "None"
-    with open(config_path, "wb") as f:
-        tomli_w.dump(toml_dict, f)
+        config_dict["router"] = None
+    with open(config_path, "w") as f:
+        json.dump(config_dict, f, indent=2)
     return config_path
 
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -116,7 +116,7 @@ def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
             "env": source_dict["env"],
             "serve": {**source_dict.get("serve", {}), "address": address},
             "log": {"level": config.orchestrator.log.vf_level, "json_logging": config.orchestrator.log.json_logging},
-            "run": {"id": config.orchestrator.run.id, "name": config.run.name},
+            "run": {"name": config.run.name},
         }
         with open(env_dir / f"{source.resolved_name}.toml", "wb") as f:
             tomli_w.dump(env_server_dict, f)
@@ -167,7 +167,7 @@ def rl_local(config: RLConfig):
     # The monitor short-circuits when WANDB_MODE=disabled/offline is also set.
     wandb_shared_env: dict[str, str] = {
         "WANDB_SHARED_MODE": "1",
-        "WANDB_SHARED_RUN_ID": os.environ.get("WANDB_SHARED_RUN_ID", config.orchestrator.run.id or uuid.uuid4().hex),
+        "WANDB_SHARED_RUN_ID": os.environ.get("WANDB_SHARED_RUN_ID", os.environ["PRL_RUN_ID"]),
     }
 
     # Validate client port matches inference server port
@@ -620,11 +620,10 @@ def rl_slurm(config: RLConfig):
 
 
 def rl(config: RLConfig):
-    # Mint the run id here, not in config: it is not user-settable and must survive the
-    # rl.toml round-trip on SLURM re-invocation. TODO: fetch it from the Prime SDK once
-    # runs are registered there.
-    if config.orchestrator.run.id is None:
-        config.orchestrator.run.id = uuid.uuid4().hex
+    # The run id is runtime-only, never config: $PRL_RUN_ID is the vehicle for runtime
+    # info between processes, and every spawned process inherits it. TODO: fetch it from
+    # the Prime SDK once runs are registered there.
+    os.environ.setdefault("PRL_RUN_ID", uuid.uuid4().hex)
 
     resuming = config.ckpt is not None and config.ckpt.resume_step is not None
     clean = config.clean and not os.environ.get("NEVER_CLEAN")

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -24,9 +24,10 @@ from prime_rl.utils.pathing import (
     clean_future_steps,
     format_log_message,
     get_ckpt_dir,
+    get_config_dir,
     get_log_dir,
     resolve_latest_ckpt_step,
-    validate_output_dir,
+    validate_run_dir,
 )
 from prime_rl.utils.process import (
     DEFAULT_COMMON_ENV_VARS,
@@ -128,7 +129,7 @@ def rl_local(config: RLConfig):
         json_logging=config.log.json_logging,
     )
 
-    config_dir = config.output_dir / "configs"
+    config_dir = get_config_dir(config.run_dir)
     write_subconfigs(config, config_dir)
     logger.info(f"Wrote subconfigs to {config_dir}")
 
@@ -181,7 +182,7 @@ def rl_local(config: RLConfig):
             )
 
     # Prepare paths to communicate with the trainer
-    log_dir = get_log_dir(config.output_dir)
+    log_dir = get_log_dir(config.run_dir)
     log_dir.mkdir(parents=True, exist_ok=True)
 
     # Start processes
@@ -470,7 +471,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
         script = template.render(
             **config.slurm.template_vars,
             config_path=config_dir / RL_TOML,
-            output_dir=config.output_dir,
+            output_dir=config.run_dir,
             gpus_per_node=config.deployment.gpus_per_node,
         )
     elif config.inference is not None and config.inference.deployment.type == "disaggregated":
@@ -480,7 +481,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             **config.slurm.template_vars,
             is_disaggregated=True,
             config_dir=config_dir,
-            output_dir=config.output_dir,
+            output_dir=config.run_dir,
             num_train_nodes=config.deployment.num_train_nodes,
             num_infer_nodes=infer_deploy.num_nodes * config.deployment.num_infer_replicas,
             nodes_per_infer_replica=infer_deploy.num_nodes,
@@ -520,7 +521,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             **config.slurm.template_vars,
             is_disaggregated=False,
             config_dir=config_dir,  # TODO: should prob have each subconfig path separately
-            output_dir=config.output_dir,
+            output_dir=config.run_dir,
             num_train_nodes=config.deployment.num_train_nodes,
             num_infer_nodes=config.deployment.total_infer_nodes,
             nodes_per_infer_replica=config.deployment.infer_nodes_per_replica,
@@ -563,8 +564,8 @@ def rl_slurm(config: RLConfig):
         config.log.level or os.environ.get("PRIME_LOG_LEVEL", "info"), json_logging=config.log.json_logging
     )
 
-    config_dir = config.output_dir / "configs"
-    log_dir = get_log_dir(config.output_dir)
+    config_dir = get_config_dir(config.run_dir)
+    log_dir = get_log_dir(config.run_dir)
 
     if config.deployment.type == "single_node":
         write_config(config, config_dir, exclude={"slurm", "dry_run", "clean_output_dir"})
@@ -600,7 +601,7 @@ def rl_slurm(config: RLConfig):
             num_infer_nodes=config.deployment.total_infer_nodes if has_infer else 0,
         )
 
-    script_path = config.output_dir / RL_SBATCH
+    script_path = config.run_dir / RL_SBATCH
     write_slurm_script(config, config_dir, script_path)
     logger.info(f"Wrote SLURM script to {script_path}")
 
@@ -621,28 +622,28 @@ def rl(config: RLConfig):
     resuming = config.ckpt is not None and config.ckpt.resume_step is not None
     clean = config.clean_output_dir and not os.environ.get("NEVER_CLEAN_OUTPUT_DIR")
     ckpt_output_dir = config.ckpt.output_dir if config.ckpt else None
-    validate_output_dir(config.output_dir, resuming=resuming, clean=clean, ckpt_output_dir=ckpt_output_dir)
-    config.output_dir.mkdir(parents=True, exist_ok=True)
+    validate_run_dir(config.run_dir, resuming=resuming, clean=clean, ckpt_output_dir=ckpt_output_dir)
+    config.run_dir.mkdir(parents=True, exist_ok=True)
     if ckpt_output_dir is not None:
         ckpt_output_dir.mkdir(parents=True, exist_ok=True)
 
     # Clean stale rollouts and broadcasts. When resuming, anything past the resume
     # step is stale. When training from scratch, every existing step directory is
-    # stale — without this, a fresh run in a dirty output_dir would pick up rollouts
+    # stale — without this, a fresh run in a dirty run dir would pick up rollouts
     # from a previous run and the orchestrator would see a negative async level.
     resume_step: int | None = None
     if resuming:
         resume_step = config.ckpt.resume_step
         if resume_step == -1:
-            ckpt_base = ckpt_output_dir if ckpt_output_dir is not None else config.output_dir
+            ckpt_base = ckpt_output_dir if ckpt_output_dir is not None else config.run_dir
             resume_step = resolve_latest_ckpt_step(get_ckpt_dir(ckpt_base))
 
     if resume_step is not None:
         get_logger().info(f"Resuming from step {resume_step}, cleaning future rollouts and broadcasts")
-        clean_future_steps(config.output_dir, resume_step)
+        clean_future_steps(config.run_dir, resume_step)
     else:
         get_logger().info("Training from scratch, cleaning any stale rollouts and broadcasts")
-        clean_future_steps(config.output_dir, -1)
+        clean_future_steps(config.run_dir, -1)
 
     if not config.dry_run:
         from prime_rl.trainer.model import pre_download_model

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -164,9 +164,11 @@ def rl_local(config: RLConfig):
 
     # Build shared W&B env vars for subprocesses. Shared mode is always on for
     # the rl entrypoint — trainer and orchestrator log to a single W&B run whose
-    # id is $PRL_RUN_ID. The monitor short-circuits when WANDB_MODE=disabled/offline is also set.
+    # id ($WANDB_RUN_ID) equals $PRL_RUN_ID. The monitor short-circuits when
+    # WANDB_MODE=disabled/offline is also set.
     wandb_shared_env: dict[str, str] = {
         "WANDB_SHARED_MODE": "1",
+        "WANDB_RUN_ID": os.environ["PRL_RUN_ID"],
     }
 
     # Validate client port matches inference server port
@@ -624,10 +626,12 @@ def rl(config: RLConfig):
     # the Prime SDK once runs are registered there.
     os.environ.setdefault("PRL_RUN_ID", uuid.uuid4().hex)
 
-    resuming = config.ckpt is not None and config.ckpt.resume_step is not None
+    resuming = config.resume is not None
     clean = config.clean and not os.environ.get("NEVER_CLEAN")
     ckpt_output_dir = config.ckpt.output_dir if config.ckpt else None
-    validate_run_dir(config.run_dir, resuming=resuming, clean=clean, ckpt_output_dir=ckpt_output_dir)
+    validate_run_dir(
+        config.run_dir, output_dir=config.output_dir, resuming=resuming, clean=clean, ckpt_output_dir=ckpt_output_dir
+    )
     config.run_dir.mkdir(parents=True, exist_ok=True)
     if ckpt_output_dir is not None:
         ckpt_output_dir.mkdir(parents=True, exist_ok=True)
@@ -638,8 +642,8 @@ def rl(config: RLConfig):
     # from a previous run and the orchestrator would see a negative async level.
     resume_step: int | None = None
     if resuming:
-        resume_step = config.ckpt.resume_step
-        if resume_step == -1:
+        resume_step = config.resume.step
+        if resume_step is None:
             ckpt_base = ckpt_output_dir if ckpt_output_dir is not None else config.run_dir
             resume_step = resolve_latest_ckpt_step(get_ckpt_dir(ckpt_base))
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -116,7 +116,7 @@ def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
             "env": source_dict["env"],
             "serve": {**source_dict.get("serve", {}), "address": address},
             "log": {"level": config.orchestrator.log.vf_level, "json_logging": config.orchestrator.log.json_logging},
-            "sandbox_labels": [config.run.name],
+            "run": {"id": config.orchestrator.run.id, "name": config.run.name},
         }
         with open(env_dir / f"{source.resolved_name}.toml", "wb") as f:
             tomli_w.dump(env_server_dict, f)
@@ -167,7 +167,7 @@ def rl_local(config: RLConfig):
     # The monitor short-circuits when WANDB_MODE=disabled/offline is also set.
     wandb_shared_env: dict[str, str] = {
         "WANDB_SHARED_MODE": "1",
-        "WANDB_SHARED_RUN_ID": os.environ.get("WANDB_SHARED_RUN_ID", config.run.id),
+        "WANDB_SHARED_RUN_ID": os.environ.get("WANDB_SHARED_RUN_ID", config.orchestrator.run.id or uuid.uuid4().hex),
     }
 
     # Validate client port matches inference server port
@@ -620,6 +620,12 @@ def rl_slurm(config: RLConfig):
 
 
 def rl(config: RLConfig):
+    # Mint the run id here, not in config: it is not user-settable and must survive the
+    # rl.toml round-trip on SLURM re-invocation. TODO: fetch it from the Prime SDK once
+    # runs are registered there.
+    if config.orchestrator.run.id is None:
+        config.orchestrator.run.id = uuid.uuid4().hex
+
     resuming = config.ckpt is not None and config.ckpt.resume_step is not None
     clean = config.clean_output_dir and not os.environ.get("NEVER_CLEAN_OUTPUT_DIR")
     ckpt_output_dir = config.ckpt.output_dir if config.ckpt else None

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -163,11 +163,10 @@ def rl_local(config: RLConfig):
     logger.debug(f"RL start command: {' '.join(start_command)}")
 
     # Build shared W&B env vars for subprocesses. Shared mode is always on for
-    # the rl entrypoint — trainer and orchestrator log to a single W&B run.
-    # The monitor short-circuits when WANDB_MODE=disabled/offline is also set.
+    # the rl entrypoint — trainer and orchestrator log to a single W&B run whose
+    # id is $PRL_RUN_ID. The monitor short-circuits when WANDB_MODE=disabled/offline is also set.
     wandb_shared_env: dict[str, str] = {
         "WANDB_SHARED_MODE": "1",
-        "WANDB_SHARED_RUN_ID": os.environ.get("WANDB_SHARED_RUN_ID", os.environ["PRL_RUN_ID"]),
     }
 
     # Validate client port matches inference server port

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -569,7 +569,7 @@ def rl_slurm(config: RLConfig):
     log_dir = get_log_dir(config.run_dir)
 
     if config.deployment.type == "single_node":
-        write_config(config, config_dir, exclude={"slurm", "dry_run", "clean_output_dir"})
+        write_config(config, config_dir, exclude={"slurm", "dry_run", "clean"})
         logger.info(f"Wrote config to {config_dir / RL_TOML}")
 
         train_env_names = env_server_names(config, "train")
@@ -627,7 +627,7 @@ def rl(config: RLConfig):
         config.orchestrator.run.id = uuid.uuid4().hex
 
     resuming = config.ckpt is not None and config.ckpt.resume_step is not None
-    clean = config.clean_output_dir and not os.environ.get("NEVER_CLEAN_OUTPUT_DIR")
+    clean = config.clean and not os.environ.get("NEVER_CLEAN")
     ckpt_output_dir = config.ckpt.output_dir if config.ckpt else None
     validate_run_dir(config.run_dir, resuming=resuming, clean=clean, ckpt_output_dir=ckpt_output_dir)
     config.run_dir.mkdir(parents=True, exist_ok=True)

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -11,14 +11,13 @@ from threading import Event, Thread
 from urllib.parse import urlparse
 
 import pynvml
-import tomli_w
 
 from prime_rl.configs.algorithm import FrozenModelConfig
 from prime_rl.configs.inference import VllmRouterConfig
 from prime_rl.configs.orchestrator import EnvConfig
 from prime_rl.configs.rl import RLConfig
 from prime_rl.entrypoints.inference import vllm_overrides_fragment
-from prime_rl.utils.config import cli, to_toml_dict
+from prime_rl.utils.config import cli, dump_resolved_config
 from prime_rl.utils.logger import get_logger, setup_logger
 from prime_rl.utils.pathing import (
     clean_future_steps,
@@ -39,12 +38,12 @@ from prime_rl.utils.process import (
     set_proc_title,
 )
 
-RL_TOML = "rl.toml"
+RL_CONFIG = "rl.json"
 RL_SBATCH = "rl.sbatch"
 
-TRAINER_TOML = "trainer.toml"
-ORCHESTRATOR_TOML = "orchestrator.toml"
-INFERENCE_TOML = "inference.toml"
+TRAINER_CONFIG = "trainer.json"
+ORCHESTRATOR_CONFIG = "orchestrator.json"
+INFERENCE_CONFIG = "inference.json"
 
 ENVS_DIR = "envs"
 
@@ -80,29 +79,29 @@ def get_physical_gpu_ids() -> list[int]:
 def write_config(config: RLConfig, output_dir: Path, exclude: set[str] | None = None) -> None:
     """Write resolved config to disk, excluding launcher-only fields."""
     output_dir.mkdir(parents=True, exist_ok=True)
-    with open(output_dir / RL_TOML, "wb") as f:
-        tomli_w.dump(to_toml_dict(config, exclude=exclude), f)
+    with open(output_dir / RL_CONFIG, "w") as f:
+        json.dump(dump_resolved_config(config, exclude=exclude), f, indent=2)
 
 
 def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
     """Write resolved subconfigs to disk as TOML files."""
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    with open(output_dir / TRAINER_TOML, "wb") as f:
-        tomli_w.dump(to_toml_dict(config.trainer), f)
+    with open(output_dir / TRAINER_CONFIG, "w") as f:
+        json.dump(dump_resolved_config(config.trainer), f, indent=2)
 
-    with open(output_dir / ORCHESTRATOR_TOML, "wb") as f:
-        tomli_w.dump(to_toml_dict(config.orchestrator), f)
+    with open(output_dir / ORCHESTRATOR_CONFIG, "w") as f:
+        json.dump(dump_resolved_config(config.orchestrator), f, indent=2)
 
     if config.inference is not None:
         # Exclude launcher-only fields that are not needed by the vLLM server
         exclude_inference = {"deployment", "slurm", "output_dir", "dry_run"}
-        inference_dict = to_toml_dict(config.inference, exclude=exclude_inference)
+        inference_dict = dump_resolved_config(config.inference, exclude=exclude_inference)
         if config.deployment.type == "multi_node":
             # Per-rank processes run bare engines; the sbatch starts the single global router.
-            inference_dict["router"] = "None"
-        with open(output_dir / INFERENCE_TOML, "wb") as f:
-            tomli_w.dump(inference_dict, f)
+            inference_dict["router"] = None
+        with open(output_dir / INFERENCE_CONFIG, "w") as f:
+            json.dump(inference_dict, f, indent=2)
 
     # One EnvServerConfig TOML per launcher-managed source: `env-server @ <path>` binds
     # at the source's deterministic address, where the orchestrator connects. The source's
@@ -111,14 +110,14 @@ def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
     for split, source, address in env_servers(config):
         env_dir = output_dir / ENVS_DIR / split
         env_dir.mkdir(parents=True, exist_ok=True)
-        source_dict = to_toml_dict(source)
+        source_dict = dump_resolved_config(source)
         env_server_dict = {
             "env": source_dict["env"],
             "serve": {**source_dict.get("serve", {}), "address": address},
             "log": {"level": config.orchestrator.log.vf_level, "json_logging": config.orchestrator.log.json_logging},
         }
-        with open(env_dir / f"{source.resolved_name}.toml", "wb") as f:
-            tomli_w.dump(env_server_dict, f)
+        with open(env_dir / f"{source.resolved_name}.json", "w") as f:
+            json.dump(env_server_dict, f, indent=2)
 
 
 def rl_local(config: RLConfig):
@@ -203,7 +202,7 @@ def rl_local(config: RLConfig):
     try:
         # Optionally, start inference process
         if config.inference:
-            inference_cmd = ["inference", "@", (config_dir / INFERENCE_TOML).as_posix()]
+            inference_cmd = ["inference", "@", (config_dir / INFERENCE_CONFIG).as_posix()]
             logger.info(f"Starting inference on GPU(s) {' '.join(map(str, infer_gpu_ids))}")
             logger.debug(f"Inference start command: {' '.join(inference_cmd)}")
             # If we don't log stdout, the server hangs
@@ -262,7 +261,7 @@ def rl_local(config: RLConfig):
         # orchestrator start in parallel.
         for split, source, address in env_servers(config):
             name = source.resolved_name
-            env_server_cmd = ["env-server", "@", (config_dir / ENVS_DIR / split / f"{name}.toml").as_posix()]
+            env_server_cmd = ["env-server", "@", (config_dir / ENVS_DIR / split / f"{name}.json").as_posix()]
             logger.info(f"Starting {split} env server {name} at {address}")
             logger.debug(f"Env server start command: {' '.join(env_server_cmd)}")
             env_server_log = log_dir / ENVS_DIR / split / f"{name}.log"
@@ -292,7 +291,7 @@ def rl_local(config: RLConfig):
             monitor_thread.start()
             monitor_threads.append(monitor_thread)
 
-        orchestrator_cmd = ["orchestrator", "@", (config_dir / ORCHESTRATOR_TOML).as_posix()]
+        orchestrator_cmd = ["orchestrator", "@", (config_dir / ORCHESTRATOR_CONFIG).as_posix()]
         logger.info("Starting orchestrator process")
         logger.debug(f"Orchestrator start command: {' '.join(orchestrator_cmd)}")
         with open(log_dir / "orchestrator.log", "w") as log_file:
@@ -342,7 +341,7 @@ def rl_local(config: RLConfig):
             "-m",
             "prime_rl.trainer.rl.train",
             "@",
-            (config_dir / TRAINER_TOML).as_posix(),
+            (config_dir / TRAINER_CONFIG).as_posix(),
         ]
         logger.info(f"Starting trainer on GPU(s) {' '.join(map(str, trainer_gpu_ids))}")
         logger.debug(f"Training start command: {' '.join(trainer_cmd)}")
@@ -471,7 +470,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
     if config.deployment.type == "single_node":
         script = template.render(
             **config.slurm.template_vars,
-            config_path=config_dir / RL_TOML,
+            config_path=config_dir / RL_CONFIG,
             output_dir=config.run_dir,
             gpus_per_node=config.deployment.gpus_per_node,
         )
@@ -572,7 +571,7 @@ def rl_slurm(config: RLConfig):
 
     if config.deployment.type == "single_node":
         write_config(config, config_dir, exclude={"slurm", "dry_run", "clean"})
-        logger.info(f"Wrote config to {config_dir / RL_TOML}")
+        logger.info(f"Wrote config to {config_dir / RL_CONFIG}")
 
         train_env_names = env_server_names(config, "train")
         eval_env_names = env_server_names(config, "eval")

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -116,7 +116,6 @@ def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
             "env": source_dict["env"],
             "serve": {**source_dict.get("serve", {}), "address": address},
             "log": {"level": config.orchestrator.log.vf_level, "json_logging": config.orchestrator.log.json_logging},
-            "run": {"name": config.run.name},
         }
         with open(env_dir / f"{source.resolved_name}.toml", "wb") as f:
             tomli_w.dump(env_server_dict, f)
@@ -482,6 +481,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
         script = template.render(
             **config.slurm.template_vars,
             is_disaggregated=True,
+            run_name=config.run.name,
             config_dir=config_dir,
             output_dir=config.run_dir,
             num_train_nodes=config.deployment.num_train_nodes,
@@ -522,6 +522,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
         script = template.render(
             **config.slurm.template_vars,
             is_disaggregated=False,
+            run_name=config.run.name,
             config_dir=config_dir,  # TODO: should prob have each subconfig path separately
             output_dir=config.run_dir,
             num_train_nodes=config.deployment.num_train_nodes,
@@ -621,10 +622,13 @@ def rl_slurm(config: RLConfig):
 
 
 def rl(config: RLConfig):
-    # The run id is runtime-only, never config: $PRL_RUN_ID is the vehicle for runtime
-    # info between processes, and every spawned process inherits it. TODO: fetch it from
+    # The run identity is runtime-only, never sub-config: $PRL_RUN_ID / $PRL_RUN_NAME are
+    # the vehicle for runtime info between processes, and every spawned process inherits
+    # them. Components launched standalone have no run identity. TODO: fetch the id from
     # the Prime SDK once runs are registered there.
     os.environ.setdefault("PRL_RUN_ID", uuid.uuid4().hex)
+    assert config.run.name is not None  # resolved at construction
+    os.environ["PRL_RUN_NAME"] = config.run.name
 
     resuming = config.resume is not None
     clean = config.clean and not os.environ.get("NEVER_CLEAN")

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -642,10 +642,13 @@ def rl(config: RLConfig):
     # from a previous run and the orchestrator would see a negative async level.
     resume_step: int | None = None
     if resuming:
-        resume_step = config.resume.step
-        if resume_step is None:
-            ckpt_base = ckpt_output_dir if ckpt_output_dir is not None else config.run_dir
-            resume_step = resolve_latest_ckpt_step(get_ckpt_dir(ckpt_base))
+        if config.resume.dir is not None:
+            resume_step = config.resume.dir_step
+        else:
+            resume_step = config.resume.step
+            if resume_step is None:
+                ckpt_base = ckpt_output_dir if ckpt_output_dir is not None else config.run_dir
+                resume_step = resolve_latest_ckpt_step(get_ckpt_dir(ckpt_base))
 
     if resume_step is not None:
         get_logger().info(f"Resuming from step {resume_step}, cleaning future rollouts and broadcasts")

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -116,6 +116,7 @@ def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
             "env": source_dict["env"],
             "serve": {**source_dict.get("serve", {}), "address": address},
             "log": {"level": config.orchestrator.log.vf_level, "json_logging": config.orchestrator.log.json_logging},
+            "sandbox_labels": [config.run.name],
         }
         with open(env_dir / f"{source.resolved_name}.toml", "wb") as f:
             tomli_w.dump(env_server_dict, f)
@@ -166,7 +167,7 @@ def rl_local(config: RLConfig):
     # The monitor short-circuits when WANDB_MODE=disabled/offline is also set.
     wandb_shared_env: dict[str, str] = {
         "WANDB_SHARED_MODE": "1",
-        "WANDB_SHARED_RUN_ID": os.environ.get("WANDB_SHARED_RUN_ID", uuid.uuid4().hex),
+        "WANDB_SHARED_RUN_ID": os.environ.get("WANDB_SHARED_RUN_ID", config.run.id),
     }
 
     # Validate client port matches inference server port

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -11,7 +11,7 @@ import tomli_w
 from prime_rl.configs.sft import SFTConfig
 from prime_rl.utils.config import cli, to_toml_dict
 from prime_rl.utils.logger import setup_logger
-from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir, validate_output_dir
+from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir, validate_run_dir
 from prime_rl.utils.process import (
     DEFAULT_COMMON_ENV_VARS,
     DEFAULT_TRAINER_ENV_VARS,
@@ -52,14 +52,14 @@ def write_slurm_script(config: SFTConfig, config_path: Path, script_path: Path) 
         script = template.render(
             **config.slurm.template_vars,
             config_path=config_path,
-            output_dir=config.output_dir,
+            output_dir=config.run_dir,
             gpus_per_node=config.deployment.gpus_per_node,
         )
     else:
         script = template.render(
             **config.slurm.template_vars,
             config_path=config_path,
-            output_dir=config.output_dir,
+            output_dir=config.run_dir,
             trainer_env_vars=trainer_env_vars,
             num_nodes=config.deployment.num_nodes,
             gpus_per_node=config.deployment.gpus_per_node,
@@ -76,7 +76,7 @@ def sft_slurm(config: SFTConfig):
 
     logger = setup_logger(config.log.level or "info", json_logging=config.log.json_logging)
 
-    config_dir = get_config_dir(config.output_dir)
+    config_dir = get_config_dir(config.run_dir)
     config_path = config_dir / SFT_TOML
     exclude = (
         {"deployment", "slurm", "dry_run", "clean_output_dir"}
@@ -86,11 +86,11 @@ def sft_slurm(config: SFTConfig):
     write_config(config, config_path, exclude=exclude)
     logger.info(f"Wrote config to {config_path}")
 
-    script_path = config.output_dir / SFT_SBATCH
+    script_path = config.run_dir / SFT_SBATCH
     write_slurm_script(config, config_path, script_path)
     logger.info(f"Wrote SLURM script to {script_path}")
 
-    log_dir = get_log_dir(config.output_dir)
+    log_dir = get_log_dir(config.run_dir)
     num_nodes = config.deployment.num_nodes if config.deployment.type == "multi_node" else 1
     log_message = format_log_message(log_dir=log_dir, trainer=True, num_train_nodes=num_nodes)
 
@@ -113,7 +113,7 @@ def sft_local(config: SFTConfig):
 
     logger = setup_logger(config.log.level or "info", json_logging=config.log.json_logging)
 
-    config_dir = get_config_dir(config.output_dir)
+    config_dir = get_config_dir(config.run_dir)
     config_path = config_dir / SFT_TOML
     write_config(config, config_path)
     logger.info(f"Wrote config to {config_path}")
@@ -122,7 +122,7 @@ def sft_local(config: SFTConfig):
         logger.success("Dry run complete. To start an SFT run locally, remove --dry-run from your command.")
         return
 
-    log_dir = config.output_dir / "logs"
+    log_dir = get_log_dir(config.run_dir)
     log_dir.mkdir(parents=True, exist_ok=True)
 
     from prime_rl.utils.utils import get_free_port
@@ -132,7 +132,7 @@ def sft_local(config: SFTConfig):
         "--role=trainer",
         f"--rdzv-endpoint=localhost:{get_free_port()}",
         f"--rdzv-id={uuid.uuid4().hex}",
-        f"--log-dir={config.output_dir / 'logs' / 'trainer' / 'torchrun'}",
+        f"--log-dir={log_dir / 'trainer' / 'torchrun'}",
         f"--local-ranks-filter={','.join(map(str, config.log.ranks_filter))}",
         "--redirect=3",
         "--tee=3",
@@ -208,8 +208,8 @@ def sft_local(config: SFTConfig):
 def sft(config: SFTConfig):
     resuming = config.ckpt is not None and config.ckpt.resume_step is not None
     clean = config.clean_output_dir and not os.environ.get("NEVER_CLEAN_OUTPUT_DIR")
-    validate_output_dir(config.output_dir, resuming=resuming, clean=clean)
-    config.output_dir.mkdir(parents=True, exist_ok=True)
+    validate_run_dir(config.run_dir, resuming=resuming, clean=clean)
+    config.run_dir.mkdir(parents=True, exist_ok=True)
 
     if not config.dry_run:
         from prime_rl.trainer.model import pre_download_model

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import sys
@@ -6,10 +7,8 @@ from pathlib import Path
 from subprocess import Popen
 from threading import Event, Thread
 
-import tomli_w
-
 from prime_rl.configs.sft import SFTConfig
-from prime_rl.utils.config import cli, to_toml_dict
+from prime_rl.utils.config import cli, dump_resolved_config
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir, validate_run_dir
 from prime_rl.utils.process import (
@@ -21,15 +20,15 @@ from prime_rl.utils.process import (
     set_proc_title,
 )
 
-SFT_TOML = "sft.toml"
+SFT_CONFIG = "sft.json"
 SFT_SBATCH = "sft.sbatch"
 
 
 def write_config(config: SFTConfig, config_path: Path, exclude: set[str] | None = None) -> None:
     """Write resolved config to disk, excluding launcher-only fields."""
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(config_path, "wb") as f:
-        tomli_w.dump(to_toml_dict(config, exclude=exclude), f)
+    with open(config_path, "w") as f:
+        json.dump(dump_resolved_config(config, exclude=exclude), f, indent=2)
 
 
 def write_slurm_script(config: SFTConfig, config_path: Path, script_path: Path) -> None:
@@ -77,7 +76,7 @@ def sft_slurm(config: SFTConfig):
     logger = setup_logger(config.log.level or "info", json_logging=config.log.json_logging)
 
     config_dir = get_config_dir(config.run_dir)
-    config_path = config_dir / SFT_TOML
+    config_path = config_dir / SFT_CONFIG
     exclude = (
         {"deployment", "slurm", "dry_run", "clean"}
         if config.deployment.type == "multi_node"
@@ -114,7 +113,7 @@ def sft_local(config: SFTConfig):
     logger = setup_logger(config.log.level or "info", json_logging=config.log.json_logging)
 
     config_dir = get_config_dir(config.run_dir)
-    config_path = config_dir / SFT_TOML
+    config_path = config_dir / SFT_CONFIG
     write_config(config, config_path)
     logger.info(f"Wrote config to {config_path}")
 
@@ -140,7 +139,7 @@ def sft_local(config: SFTConfig):
         "-m",
         "prime_rl.trainer.sft.train",
         "@",
-        (config_dir / SFT_TOML).as_posix(),
+        (config_dir / SFT_CONFIG).as_posix(),
     ]
 
     logger.info(f"Starting SFT trainer with {config.deployment.num_gpus} GPU(s)")

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -79,9 +79,9 @@ def sft_slurm(config: SFTConfig):
     config_dir = get_config_dir(config.run_dir)
     config_path = config_dir / SFT_TOML
     exclude = (
-        {"deployment", "slurm", "dry_run", "clean_output_dir"}
+        {"deployment", "slurm", "dry_run", "clean"}
         if config.deployment.type == "multi_node"
-        else {"slurm", "dry_run", "clean_output_dir"}
+        else {"slurm", "dry_run", "clean"}
     )
     write_config(config, config_path, exclude=exclude)
     logger.info(f"Wrote config to {config_path}")
@@ -207,7 +207,7 @@ def sft_local(config: SFTConfig):
 
 def sft(config: SFTConfig):
     resuming = config.ckpt is not None and config.ckpt.resume_step is not None
-    clean = config.clean_output_dir and not os.environ.get("NEVER_CLEAN_OUTPUT_DIR")
+    clean = config.clean and not os.environ.get("NEVER_CLEAN")
     validate_run_dir(config.run_dir, resuming=resuming, clean=clean)
     config.run_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -206,9 +206,9 @@ def sft_local(config: SFTConfig):
 
 
 def sft(config: SFTConfig):
-    resuming = config.ckpt is not None and config.ckpt.resume_step is not None
+    resuming = config.resume is not None
     clean = config.clean and not os.environ.get("NEVER_CLEAN")
-    validate_run_dir(config.run_dir, resuming=resuming, clean=clean)
+    validate_run_dir(config.run_dir, output_dir=config.output_dir, resuming=resuming, clean=clean)
     config.run_dir.mkdir(parents=True, exist_ok=True)
 
     if not config.dry_run:

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -78,7 +78,7 @@ class CheckpointManager:
         get_logger().debug(f"Orchestrator checkpoint loaded in {format_time(time.perf_counter() - start)}")
 
 
-def setup_ckpt_manager(output_dir: Path, config: CheckpointConfig | None) -> CheckpointManager | None:
-    if config is None:
-        return None
-    return CheckpointManager(output_dir, config)
+def setup_ckpt_manager(output_dir: Path, config: CheckpointConfig | None) -> CheckpointManager:
+    """The checkpoint manager always exists: ``resume`` decides whether it loads,
+    ``ckpt`` whether it saves (a resume without ``ckpt`` loads but saves nothing)."""
+    return CheckpointManager(output_dir, config or CheckpointConfig())

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -47,8 +47,10 @@ class CheckpointManager:
             f"Orchestrator checkpoint saved to {ckpt_path} in {format_time(time.perf_counter() - start)}"
         )
 
-    def load(self, progress: Progress, train_source: TrainSource, step: int) -> None:
-        ckpt_path = self.get_ckpt_path(step)
+    def load(self, progress: Progress, train_source: TrainSource, step: int, path: Path | None = None) -> None:
+        """``path`` overrides where the checkpoint is read from (an external run's
+        ``step_<N>/orchestrator``)."""
+        ckpt_path = path if path is not None else self.get_ckpt_path(step)
         state_file = ckpt_path / "progress.pt"
         if not state_file.exists():
             raise FileNotFoundError(f"Orchestrator checkpoint not found at {state_file}")

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -277,9 +277,12 @@ class Orchestrator:
             get_logger().success("Eval environment(s) ready")
 
         if config.ckpt is not None and config.ckpt.resume is not None and self.ckpt_manager is not None:
-            self.resume_step = config.ckpt.resume.step
-            if self.resume_step is None:
-                self.resume_step = resolve_latest_ckpt_step(self.ckpt_manager.ckpt_dir)
+            if config.ckpt.resume.dir is not None:
+                self.resume_step = config.ckpt.resume.dir_step
+            else:
+                self.resume_step = config.ckpt.resume.step
+                if self.resume_step is None:
+                    self.resume_step = resolve_latest_ckpt_step(self.ckpt_manager.ckpt_dir)
 
         # Resume below may bump ``policy.version`` and the LoRA model name
         self.policy.model_name = self.policy_inference.model_name
@@ -336,7 +339,9 @@ class Orchestrator:
         self.train_source = TrainSource(self.train_envs)
 
         if self.resume_step is not None and self.ckpt_manager is not None:
-            self.ckpt_manager.load(self.progress, self.train_source, step=self.resume_step)
+            resume = self.config.ckpt.resume if self.config.ckpt else None
+            resume_path = resume.dir / "orchestrator" if resume is not None and resume.dir is not None else None
+            self.ckpt_manager.load(self.progress, self.train_source, step=self.resume_step, path=resume_path)
             # The checkpoint finished step ``resume_step``; resume at the next step. Derive the step
             # from ``resume_step`` (not the loaded progress.step) so it stays coordinated with the
             # trainer even when ``ckpt.skip_progress`` left the counter unrestored.

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -122,7 +122,7 @@ class Orchestrator:
     last_batch_at: float | None
     consecutive_empty_batches: int
     eval_triggered_at: dict[tuple[str, int], float]
-    ckpt_manager: CheckpointManager | None
+    ckpt_manager: CheckpointManager
     component_tasks: list[asyncio.Task]
 
     # Always set by ``setup()``
@@ -277,7 +277,7 @@ class Orchestrator:
             await self.eval_envs.start()
             get_logger().success("Eval environment(s) ready")
 
-        if config.ckpt is not None and config.resume is not None and self.ckpt_manager is not None:
+        if config.resume is not None:
             if config.resume.dir is not None:
                 self.resume_step = config.resume.dir_step
             else:
@@ -339,7 +339,7 @@ class Orchestrator:
 
         self.train_source = TrainSource(self.train_envs)
 
-        if self.resume_step is not None and self.ckpt_manager is not None:
+        if self.resume_step is not None:
             resume = self.config.resume
             resume_path = resume.dir / "orchestrator" if resume is not None and resume.dir is not None else None
             self.ckpt_manager.load(self.progress, self.train_source, step=self.resume_step, path=resume_path)
@@ -513,7 +513,7 @@ class Orchestrator:
             # ``progress.step`` points at the next (unshipped) step; the last finished step is
             # ``progress.step - 1``. Checkpoint it as ``step_{progress.step - 1}`` (no-op before the
             # first ship).
-            if self.ckpt_manager is not None and self.progress.step > 1:
+            if self.config.ckpt is not None and self.progress.step > 1:
                 self.progress.step -= 1
                 get_logger().info("Writing final checkpoint")
                 self.ckpt_manager.save(self.progress, self.train_source, step=self.progress.step)
@@ -915,7 +915,7 @@ class Orchestrator:
     async def maybe_save_ckpt(self, step: int) -> float:
         """Checkpoint the step just shipped if it's an interval boundary. Returns
         elapsed time (0.0 when no save happened)."""
-        if self.ckpt_manager is None or self.config.ckpt is None or not self.config.ckpt.interval:
+        if self.config.ckpt is None or not self.config.ckpt.interval:
             return 0.0
         # The final step's checkpoint is written once in ``start()``'s teardown; skip it here so
         # we don't double-save. This mirrors the trainer (its is_last_step skips the in-loop save).

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -239,10 +239,11 @@ class Orchestrator:
         # Prefer the monitor identity (platform run id, else W&B id) so traces link
         # back to it, then the launcher-set $PRL_RUN_ID; standalone runs mint a local one.
         self.run_id = self.monitor.run_id or os.environ.get("PRL_RUN_ID") or uuid.uuid4().hex
-        # Base labels for sandboxes created in this process; env-server processes get
-        # them via their own config.
-        if config.run.name:
-            set_base_sandbox_labels([config.run.name])
+        # Base labels for sandboxes created in this process; env-server processes read
+        # the same launcher-set env var themselves.
+        self.run_name = os.environ.get("PRL_RUN_NAME")
+        if self.run_name:
+            set_base_sandbox_labels([self.run_name])
 
         if config.heartbeat is not None:
             self.heart = Heartbeat(config.heartbeat.url)
@@ -546,9 +547,9 @@ class Orchestrator:
             step = episode[0].eval_step if kind == "eval" else self.progress.step
             assert step is not None
             run: vf.RunInfo = (
-                vf.EvalRunInfo(id=self.run_id, name=self.config.run.name, step=step)
+                vf.EvalRunInfo(id=self.run_id, name=self.run_name, step=step)
                 if kind == "eval"
-                else vf.TrainRunInfo(id=self.run_id, name=self.config.run.name, step=step)
+                else vf.TrainRunInfo(id=self.run_id, name=self.run_name, step=step)
             )
             for rollout in episode:
                 rollout.record_run(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -276,11 +276,10 @@ class Orchestrator:
             await self.eval_envs.start()
             get_logger().success("Eval environment(s) ready")
 
-        if config.ckpt is not None and config.ckpt.resume_step is not None and self.ckpt_manager is not None:
-            if config.ckpt.resume_step == -1:
+        if config.ckpt is not None and config.ckpt.resume is not None and self.ckpt_manager is not None:
+            self.resume_step = config.ckpt.resume.step
+            if self.resume_step is None:
                 self.resume_step = resolve_latest_ckpt_step(self.ckpt_manager.ckpt_dir)
-            else:
-                self.resume_step = config.ckpt.resume_step
 
         # Resume below may bump ``policy.version`` and the LoRA model name
         self.policy.model_name = self.policy_inference.model_name

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -24,11 +24,13 @@ from __future__ import annotations
 import asyncio
 import os
 import time
+import uuid
 from typing import TYPE_CHECKING
 
 import verifiers.v1 as vf
 from modelexpress import p2p_pb2
 from modelexpress.client import MxClient
+from verifiers.v1.runtimes import set_base_sandbox_labels
 
 if TYPE_CHECKING:
     from renderers.base import Renderer
@@ -235,11 +237,12 @@ class Orchestrator:
             eval_env_names=[source.resolved_name for source in config.eval.source] if config.eval is not None else [],
         )
         # Prefer the monitor identity (platform run id, else W&B id) so traces link
-        # back to it; fall back to the config-generated run id.
-        self.run_id = self.monitor.run_id or config.run.id
+        # back to it, then the launcher-injected run id; standalone runs mint a local one.
+        self.run_id = self.monitor.run_id or config.run.id or uuid.uuid4().hex
         # Base labels for sandboxes created in this process; env-server processes get
         # them via their own config.
-        vf.set_base_sandbox_labels([config.run.name])
+        if config.run.name:
+            set_base_sandbox_labels([config.run.name])
 
         if config.heartbeat is not None:
             self.heart = Heartbeat(config.heartbeat.url)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -237,8 +237,8 @@ class Orchestrator:
             eval_env_names=[source.resolved_name for source in config.eval.source] if config.eval is not None else [],
         )
         # Prefer the monitor identity (platform run id, else W&B id) so traces link
-        # back to it, then the launcher-injected run id; standalone runs mint a local one.
-        self.run_id = self.monitor.run_id or config.run.id or uuid.uuid4().hex
+        # back to it, then the launcher-set $PRL_RUN_ID; standalone runs mint a local one.
+        self.run_id = self.monitor.run_id or os.environ.get("PRL_RUN_ID") or uuid.uuid4().hex
         # Base labels for sandboxes created in this process; env-server processes get
         # them via their own config.
         if config.run.name:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import asyncio
 import os
 import time
-import uuid
 from typing import TYPE_CHECKING
 
 import verifiers.v1 as vf
@@ -235,9 +234,12 @@ class Orchestrator:
             train_env_names=[env.resolved_name for env in config.train.source],
             eval_env_names=[source.resolved_name for source in config.eval.source] if config.eval is not None else [],
         )
-        # ``RunInfo.id`` is required on the trace: fall back to a run-local uuid
-        # when no external monitor identity (W&B) exists.
-        self.run_id = self.monitor.run_id or uuid.uuid4().hex
+        # Prefer the monitor identity (platform run id, else W&B id) so traces link
+        # back to it; fall back to the config-generated run id.
+        self.run_id = self.monitor.run_id or config.run.id
+        # Base labels for sandboxes created in this process; env-server processes get
+        # them via their own config.
+        vf.set_base_sandbox_labels([config.run.name])
 
         if config.heartbeat is not None:
             self.heart = Heartbeat(config.heartbeat.url)
@@ -536,9 +538,9 @@ class Orchestrator:
             step = episode[0].eval_step if kind == "eval" else self.progress.step
             assert step is not None
             run: vf.RunInfo = (
-                vf.EvalRunInfo(id=self.run_id, step=step)
+                vf.EvalRunInfo(id=self.run_id, name=self.config.run.name, step=step)
                 if kind == "eval"
-                else vf.TrainRunInfo(id=self.run_id, step=step)
+                else vf.TrainRunInfo(id=self.run_id, name=self.config.run.name, step=step)
             )
             for rollout in episode:
                 rollout.record_run(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -277,11 +277,11 @@ class Orchestrator:
             await self.eval_envs.start()
             get_logger().success("Eval environment(s) ready")
 
-        if config.ckpt is not None and config.ckpt.resume is not None and self.ckpt_manager is not None:
-            if config.ckpt.resume.dir is not None:
-                self.resume_step = config.ckpt.resume.dir_step
+        if config.ckpt is not None and config.resume is not None and self.ckpt_manager is not None:
+            if config.resume.dir is not None:
+                self.resume_step = config.resume.dir_step
             else:
-                self.resume_step = config.ckpt.resume.step
+                self.resume_step = config.resume.step
                 if self.resume_step is None:
                     self.resume_step = resolve_latest_ckpt_step(self.ckpt_manager.ckpt_dir)
 
@@ -340,7 +340,7 @@ class Orchestrator:
         self.train_source = TrainSource(self.train_envs)
 
         if self.resume_step is not None and self.ckpt_manager is not None:
-            resume = self.config.ckpt.resume if self.config.ckpt else None
+            resume = self.config.resume
             resume_path = resume.dir / "orchestrator" if resume is not None and resume.dir is not None else None
             self.ckpt_manager.load(self.progress, self.train_source, step=self.resume_step, path=resume_path)
             # The checkpoint finished step ``resume_step``; resume at the next step. Derive the step

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -63,8 +63,9 @@ rm -f $OUTPUT_DIR/logs/inference/*.log
 ln -sfn trainer/node_0.log $OUTPUT_DIR/logs/trainer.log
 ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log
 
+export PRL_RUN_ID=${PRL_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}
 export WANDB_SHARED_MODE=1
-export WANDB_SHARED_RUN_ID=${WANDB_SHARED_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}
+export WANDB_SHARED_RUN_ID=${WANDB_SHARED_RUN_ID:-$PRL_RUN_ID}
 
 # Networking
 HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -64,6 +64,7 @@ ln -sfn trainer/node_0.log $OUTPUT_DIR/logs/trainer.log
 ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log
 
 export PRL_RUN_ID=${PRL_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}
+export PRL_RUN_NAME={{ run_name }}
 export WANDB_RUN_ID=$PRL_RUN_ID
 export WANDB_SHARED_MODE=1
 

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -65,7 +65,6 @@ ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log
 
 export PRL_RUN_ID=${PRL_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}
 export WANDB_SHARED_MODE=1
-export WANDB_SHARED_RUN_ID=${WANDB_SHARED_RUN_ID:-$PRL_RUN_ID}
 
 # Networking
 HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -244,7 +244,7 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     echo "INFER_NODE_RANK=$INFER_NODE_RANK REPLICA=$REPLICA_IDX RANK_IN_REPLICA=$RANK_IN_REPLICA LOCAL_IP=$LOCAL_IP" \
         | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
 
-    CONFIG_PATH="$CONFIG_DIR/inference.toml"
+    CONFIG_PATH="$CONFIG_DIR/inference.json"
 {% include '_launch_rank.sh.j2' %}
 {% include '_launch_router.sh.j2' %}
 
@@ -408,7 +408,7 @@ else
         --redirects=3 \
         --local-ranks-filter={{ ranks_filter }} \
         -m prime_rl.trainer.rl.train \
-        @ $CONFIG_DIR/trainer.toml \
+        @ $CONFIG_DIR/trainer.json \
         {% if use_zmq_transport %}--rollout_transport.host $ORCH_ADDR \
         {% endif %}2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log &
 {% if num_infer_nodes > 0 %}    fi{% endif %}
@@ -417,7 +417,7 @@ else
 # computation above). Top-level (after the role if/else) so the wait -n teardown
 # covers it.
 if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
-    ORCHESTRATOR_ARGS="@ $CONFIG_DIR/orchestrator.toml"
+    ORCHESTRATOR_ARGS="@ $CONFIG_DIR/orchestrator.json"
     ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --model.client.base-url $INFER_URLS"
     ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --model.client.admin-base-url $ADMIN_URLS"
 {%- if orchestrator_env_vars %}
@@ -436,12 +436,12 @@ if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
     # the script fails to parse.
 {%- for name in train_env_names %}
     mkdir -p $OUTPUT_DIR/logs/envs/train
-    uv run env-server @ $CONFIG_DIR/envs/train/{{ name }}.toml \
+    uv run env-server @ $CONFIG_DIR/envs/train/{{ name }}.json \
         > $OUTPUT_DIR/logs/envs/train/{{ name }}.log 2>&1 &
 {%- endfor %}
 {%- for name in eval_env_names %}
     mkdir -p $OUTPUT_DIR/logs/envs/eval
-    uv run env-server @ $CONFIG_DIR/envs/eval/{{ name }}.toml \
+    uv run env-server @ $CONFIG_DIR/envs/eval/{{ name }}.json \
         > $OUTPUT_DIR/logs/envs/eval/{{ name }}.log 2>&1 &
 {%- endfor %}
 {%- endif %}

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -64,6 +64,7 @@ ln -sfn trainer/node_0.log $OUTPUT_DIR/logs/trainer.log
 ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log
 
 export PRL_RUN_ID=${PRL_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}
+export WANDB_RUN_ID=$PRL_RUN_ID
 export WANDB_SHARED_MODE=1
 
 # Networking

--- a/src/prime_rl/templates/single_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/single_node_rl.sbatch.j2
@@ -37,4 +37,5 @@ uv sync --all-extras --all-packages
 # Pre-run command
 {{ pre_run_command }}
 {% endif %}
+export PRL_RUN_ID=${PRL_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}
 uv run rl @ {{ config_path }}

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -530,12 +530,12 @@ def setup_ckpt_managers(
     ckpt_config: CheckpointConfig | None,
     lora_config: LoRAConfig | None = None,
     resume: ResumeConfig | None = None,
-) -> tuple[CheckpointManager | None, WeightCheckpointManager | None]:
-    if ckpt_config is None:
-        return None, None
-    ckpt_output_dir = ckpt_config.output_dir or output_dir
-    ckpt_manager = CheckpointManager(ckpt_output_dir, ckpt_config, resume)
-    if ckpt_config.weights and not ckpt_config.skip_gather_master_weights:
+) -> tuple[CheckpointManager, WeightCheckpointManager | None]:
+    """The checkpoint manager always exists: ``resume`` decides whether it loads,
+    ``ckpt`` whether it saves (a resume without ``ckpt`` loads but saves nothing)."""
+    ckpt_output_dir = (ckpt_config.output_dir if ckpt_config else None) or output_dir
+    ckpt_manager = CheckpointManager(ckpt_output_dir, ckpt_config or CheckpointConfig(), resume)
+    if ckpt_config and ckpt_config.weights and not ckpt_config.skip_gather_master_weights:
         weight_ckpt_manager = WeightCheckpointManager(
             ckpt_output_dir,
             ckpt_config.weights,

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -264,9 +264,11 @@ class CheckpointManager:
         scheduler: LRScheduler | None,
         progress: Progress | None,
         dataloader: StatefulDataLoader | None = None,
+        path: Path | None = None,
     ) -> None:
-        """Load the trainer checkpoint for a given step (in-place)."""
-        ckpt_path = self.get_ckpt_path(step)
+        """Load the trainer checkpoint for a given step (in-place). ``path`` overrides
+        where the checkpoint is read from (an external run's ``step_<N>/trainer``)."""
+        ckpt_path = path if path is not None else self.get_ckpt_path(step)
         if not ckpt_path.exists():
             raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
         self.load_from_path(ckpt_path, model, optimizers, scheduler, progress, dataloader)

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -21,6 +21,7 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers.processing_utils import ProcessorMixin
 from transformers.tokenization_utils import PreTrainedTokenizer
 
+from prime_rl.configs.shared import ResumeConfig
 from prime_rl.configs.trainer import CheckpointConfig, LoRAConfig, WeightCheckpointConfig
 from prime_rl.trainer.lora import get_lora_state, has_lora_layers, save_lora_config
 from prime_rl.trainer.models import PreTrainedModelPrimeRL
@@ -174,8 +175,8 @@ class CheckpointManager:
         self.world = get_world()
 
         all_steps = get_all_ckpt_steps(self.ckpt_dir)
-        if config.resume_step is not None and config.resume_step >= 0:
-            self.ckpt_steps = [s for s in all_steps if s <= config.resume_step]
+        if config.resume is not None and config.resume.step is not None:
+            self.ckpt_steps = [s for s in all_steps if s <= config.resume.step]
         else:
             self.ckpt_steps = all_steps
 
@@ -336,7 +337,7 @@ class WeightCheckpointManager:
         save_async: bool = False,
         keep_last: int | None = None,
         keep_interval: int | None = None,
-        resume_step: int | None = None,
+        resume: ResumeConfig | None = None,
     ):
         self.weights_dir = get_weights_dir(output_dir)
         self.config = config
@@ -345,8 +346,8 @@ class WeightCheckpointManager:
         self.world = get_world()
         if self.world.is_master:
             all_steps = get_all_ckpt_steps(self.weights_dir)
-            if resume_step is not None and resume_step >= 0:
-                self.ckpt_steps = [s for s in all_steps if s <= resume_step]
+            if resume is not None and resume.step is not None:
+                self.ckpt_steps = [s for s in all_steps if s <= resume.step]
             else:
                 self.ckpt_steps = all_steps
         else:
@@ -536,7 +537,7 @@ def setup_ckpt_managers(
             lora_config=lora_config,
             keep_last=ckpt_config.keep_last,
             keep_interval=ckpt_config.keep_interval,
-            resume_step=ckpt_config.resume_step,
+            resume=ckpt_config.resume,
         )
     else:
         weight_ckpt_manager = None

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -167,7 +167,7 @@ class AppState(Stateful):
 class CheckpointManager:
     """Utility class to save and load trainer checkpoints to resume SFT and RL training."""
 
-    def __init__(self, output_dir: Path, config: CheckpointConfig):
+    def __init__(self, output_dir: Path, config: CheckpointConfig, resume: ResumeConfig | None = None):
         self.config = config
         self.skip_optimizer = config.skip_optimizer
         self.ckpt_dir = get_ckpt_dir(output_dir)
@@ -175,8 +175,8 @@ class CheckpointManager:
         self.world = get_world()
 
         all_steps = get_all_ckpt_steps(self.ckpt_dir)
-        if config.resume is not None and config.resume.step is not None:
-            self.ckpt_steps = [s for s in all_steps if s <= config.resume.step]
+        if resume is not None and resume.step is not None:
+            self.ckpt_steps = [s for s in all_steps if s <= resume.step]
         else:
             self.ckpt_steps = all_steps
 
@@ -526,12 +526,15 @@ class WeightCheckpointManager:
 
 
 def setup_ckpt_managers(
-    output_dir: Path, ckpt_config: CheckpointConfig | None, lora_config: LoRAConfig | None = None
+    output_dir: Path,
+    ckpt_config: CheckpointConfig | None,
+    lora_config: LoRAConfig | None = None,
+    resume: ResumeConfig | None = None,
 ) -> tuple[CheckpointManager | None, WeightCheckpointManager | None]:
     if ckpt_config is None:
         return None, None
     ckpt_output_dir = ckpt_config.output_dir or output_dir
-    ckpt_manager = CheckpointManager(ckpt_output_dir, ckpt_config)
+    ckpt_manager = CheckpointManager(ckpt_output_dir, ckpt_config, resume)
     if ckpt_config.weights and not ckpt_config.skip_gather_master_weights:
         weight_ckpt_manager = WeightCheckpointManager(
             ckpt_output_dir,
@@ -539,7 +542,7 @@ def setup_ckpt_managers(
             lora_config=lora_config,
             keep_last=ckpt_config.keep_last,
             keep_interval=ckpt_config.keep_interval,
-            resume=ckpt_config.resume,
+            resume=resume,
         )
     else:
         weight_ckpt_manager = None

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -138,7 +138,7 @@ def train(config: TrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    loading_from_ckpt_later = config.ckpt and checkpoint_step is not None
+    loading_from_ckpt_later = checkpoint_step is not None
     model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -124,13 +124,15 @@ def train(config: TrainerConfig):
     # Check for checkpoint to resume from
     checkpoint_step = None
     logger.info(f"Initializing checkpoint managers ({config.ckpt})")
-    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(config.output_dir, config.ckpt, config.model.lora)
+    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(
+        config.output_dir, config.ckpt, config.model.lora, resume=config.resume
+    )
 
-    if config.ckpt and config.ckpt.resume is not None and ckpt_manager is not None:
-        if config.ckpt.resume.dir is not None:
-            checkpoint_step = config.ckpt.resume.dir_step
+    if config.ckpt and config.resume is not None and ckpt_manager is not None:
+        if config.resume.dir is not None:
+            checkpoint_step = config.resume.dir_step
         else:
-            checkpoint_step = config.ckpt.resume.step
+            checkpoint_step = config.resume.step
             if checkpoint_step is None:
                 checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
 
@@ -211,7 +213,7 @@ def train(config: TrainerConfig):
     # Optionally, resume training from a checkpoint
     progress = Progress()
     if checkpoint_step is not None:
-        resume_dir = config.ckpt.resume.dir if config.ckpt and config.ckpt.resume else None
+        resume_dir = config.resume.dir if config.resume else None
         ckpt_manager.load(
             checkpoint_step,
             model,

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -128,7 +128,7 @@ def train(config: TrainerConfig):
         config.output_dir, config.ckpt, config.model.lora, resume=config.resume
     )
 
-    if config.ckpt and config.resume is not None and ckpt_manager is not None:
+    if config.resume is not None:
         if config.resume.dir is not None:
             checkpoint_step = config.resume.dir_step
         else:
@@ -589,8 +589,7 @@ def train(config: TrainerConfig):
 
         # Checkpoint the step we just finished (model = policy v{progress.step}).
         if (
-            ckpt_manager is not None
-            and (config.ckpt and config.ckpt.interval)
+            (config.ckpt and config.ckpt.interval)
             # the last step is written once after the loop (final ckpt), so skip it here
             and not is_last_step
             and progress.step % config.ckpt.interval == 0
@@ -724,8 +723,8 @@ def train(config: TrainerConfig):
     token_exporter.close()
 
     # Write final checkpoint
-    if ckpt_manager is not None:
-        if not (config.ckpt and config.ckpt.weights_only):
+    if config.ckpt is not None:
+        if not config.ckpt.weights_only:
             logger.info("Writing final checkpoint")
             ckpt_manager.save(progress.step, model, [optimizer], scheduler, progress)
         ckpt_manager.maybe_clean()

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -126,11 +126,10 @@ def train(config: TrainerConfig):
     logger.info(f"Initializing checkpoint managers ({config.ckpt})")
     ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(config.output_dir, config.ckpt, config.model.lora)
 
-    if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:
-        if config.ckpt.resume_step == -1:
+    if config.ckpt and config.ckpt.resume is not None and ckpt_manager is not None:
+        checkpoint_step = config.ckpt.resume.step
+        if checkpoint_step is None:
             checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
-        else:
-            checkpoint_step = config.ckpt.resume_step
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -127,9 +127,12 @@ def train(config: TrainerConfig):
     ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(config.output_dir, config.ckpt, config.model.lora)
 
     if config.ckpt and config.ckpt.resume is not None and ckpt_manager is not None:
-        checkpoint_step = config.ckpt.resume.step
-        if checkpoint_step is None:
-            checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
+        if config.ckpt.resume.dir is not None:
+            checkpoint_step = config.ckpt.resume.dir_step
+        else:
+            checkpoint_step = config.ckpt.resume.step
+            if checkpoint_step is None:
+                checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
@@ -208,7 +211,15 @@ def train(config: TrainerConfig):
     # Optionally, resume training from a checkpoint
     progress = Progress()
     if checkpoint_step is not None:
-        ckpt_manager.load(checkpoint_step, model, [optimizer], scheduler, progress)
+        resume_dir = config.ckpt.resume.dir if config.ckpt and config.ckpt.resume else None
+        ckpt_manager.load(
+            checkpoint_step,
+            model,
+            [optimizer],
+            scheduler,
+            progress,
+            path=resume_dir / "trainer" if resume_dir is not None else None,
+        )
         # The checkpoint finished step ``checkpoint_step``; resume training at the next step.
         progress.step += 1
         logger.info(f"Resuming training from checkpoint step {checkpoint_step}")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -128,11 +128,10 @@ def train(config: SFTConfig):
     ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(config.run_dir, config.ckpt, config.model.lora)
 
     checkpoint_step = None
-    if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:
-        if config.ckpt.resume_step == -1:
+    if config.ckpt and config.ckpt.resume is not None and ckpt_manager is not None:
+        checkpoint_step = config.ckpt.resume.step
+        if checkpoint_step is None:
             checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
-        else:
-            checkpoint_step = config.ckpt.resume_step
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
@@ -176,10 +175,10 @@ def train(config: SFTConfig):
     )
 
     # Set up the learning rate scheduler
+    resume_from = config.ckpt.resume.step if config.ckpt and config.ckpt.resume is not None else None
     scheduler_steps = (
-        config.max_steps - config.ckpt.resume_step
-        if config.max_steps is not None
-        and (config.ckpt and config.ckpt.skip_scheduler and config.ckpt.resume_step is not None)
+        config.max_steps - resume_from
+        if config.max_steps is not None and (config.ckpt and config.ckpt.skip_scheduler and resume_from is not None)
         else config.max_steps
     )
     logger.info(f"Setting up {config.scheduler.type} scheduler with {scheduler_steps} steps ({config.scheduler})")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -125,14 +125,16 @@ def train(config: SFTConfig):
 
     # Set up checkpoint manager
     logger.info(f"Initializing checkpoint managers ({config.ckpt})")
-    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(config.run_dir, config.ckpt, config.model.lora)
+    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(
+        config.run_dir, config.ckpt, config.model.lora, resume=config.resume
+    )
 
     checkpoint_step = None
-    if config.ckpt and config.ckpt.resume is not None and ckpt_manager is not None:
-        if config.ckpt.resume.dir is not None:
-            checkpoint_step = config.ckpt.resume.dir_step
+    if config.ckpt and config.resume is not None and ckpt_manager is not None:
+        if config.resume.dir is not None:
+            checkpoint_step = config.resume.dir_step
         else:
-            checkpoint_step = config.ckpt.resume.step
+            checkpoint_step = config.resume.step
             if checkpoint_step is None:
                 checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
 
@@ -178,7 +180,7 @@ def train(config: SFTConfig):
     )
 
     # Set up the learning rate scheduler
-    resume_from = config.ckpt.resume.step if config.ckpt and config.ckpt.resume is not None else None
+    resume_from = config.resume.step if config.resume is not None else None
     scheduler_steps = (
         config.max_steps - resume_from
         if config.max_steps is not None and (config.ckpt and config.ckpt.skip_scheduler and resume_from is not None)
@@ -203,7 +205,7 @@ def train(config: SFTConfig):
     progress = Progress()
 
     if checkpoint_step is not None:
-        resume_dir = config.ckpt.resume.dir if config.ckpt.resume else None
+        resume_dir = config.resume.dir if config.resume else None
         ckpt_manager.load(
             checkpoint_step,
             model,

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -72,9 +72,7 @@ def train(config: SFTConfig):
 
     # Setup the monitor
     logger.info(f"Initializing monitor ({config.wandb})")
-    monitor = setup_monitor(
-        config.wandb, file_config=config.file_monitor, output_dir=config.output_dir, run_config=config
-    )
+    monitor = setup_monitor(config.wandb, file_config=config.file_monitor, output_dir=config.run_dir, run_config=config)
 
     # Setup heartbeat (only on rank 0)
     heart = None
@@ -127,7 +125,7 @@ def train(config: SFTConfig):
 
     # Set up checkpoint manager
     logger.info(f"Initializing checkpoint managers ({config.ckpt})")
-    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(config.output_dir, config.ckpt, config.model.lora)
+    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(config.run_dir, config.ckpt, config.model.lora)
 
     checkpoint_step = None
     if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:
@@ -599,7 +597,7 @@ def train(config: SFTConfig):
         monitor.log(time_metrics, step=progress.step)
 
         # Log disk metrics
-        disk_metrics = get_ckpt_disk_metrics(config.output_dir)
+        disk_metrics = get_ckpt_disk_metrics(config.run_dir)
         disk_metrics["step"] = progress.step
         monitor.log(disk_metrics, step=progress.step)
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -141,7 +141,7 @@ def train(config: SFTConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    loading_from_ckpt_later = config.ckpt and checkpoint_step is not None
+    loading_from_ckpt_later = checkpoint_step is not None
     model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
 
     if parallel_dims.cp_enabled:

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -129,9 +129,12 @@ def train(config: SFTConfig):
 
     checkpoint_step = None
     if config.ckpt and config.ckpt.resume is not None and ckpt_manager is not None:
-        checkpoint_step = config.ckpt.resume.step
-        if checkpoint_step is None:
-            checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
+        if config.ckpt.resume.dir is not None:
+            checkpoint_step = config.ckpt.resume.dir_step
+        else:
+            checkpoint_step = config.ckpt.resume.step
+            if checkpoint_step is None:
+                checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
@@ -200,6 +203,7 @@ def train(config: SFTConfig):
     progress = Progress()
 
     if checkpoint_step is not None:
+        resume_dir = config.ckpt.resume.dir if config.ckpt.resume else None
         ckpt_manager.load(
             checkpoint_step,
             model,
@@ -207,6 +211,7 @@ def train(config: SFTConfig):
             scheduler if not config.ckpt.skip_scheduler else None,
             progress if not config.ckpt.skip_progress else None,
             dataloader=dataloader if not config.ckpt.skip_dataloader else None,
+            path=resume_dir / "trainer" if resume_dir is not None else None,
         )
         logger.info(f"Resuming training from checkpoint step {checkpoint_step}")
         # The checkpoint finished step ``checkpoint_step``; resume training at the next step.

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -18,6 +18,7 @@ from torch.profiler import profile, ProfilerActivity, record_function
 from prime_rl.trainer.ckpt import Progress, setup_ckpt_managers
 from prime_rl.utils.pathing import resolve_latest_ckpt_step
 from prime_rl.configs.sft import SFTConfig
+from prime_rl.configs.trainer import CheckpointConfig
 from prime_rl.utils.cp import setup_cp_params, shard_for_cp
 from prime_rl.trainer.lora import get_lora_state
 from prime_rl.trainer.models.layers.lora import set_lora_num_tokens
@@ -130,7 +131,7 @@ def train(config: SFTConfig):
     )
 
     checkpoint_step = None
-    if config.ckpt and config.resume is not None and ckpt_manager is not None:
+    if config.resume is not None:
         if config.resume.dir is not None:
             checkpoint_step = config.resume.dir_step
         else:
@@ -180,10 +181,11 @@ def train(config: SFTConfig):
     )
 
     # Set up the learning rate scheduler
-    resume_from = config.resume.step if config.resume is not None else None
+    # skip_scheduler rebuilds a fresh schedule over the remaining steps: size it from the
+    # resolved checkpoint step (bare --resume and --resume.dir carry no explicit step).
     scheduler_steps = (
-        config.max_steps - resume_from
-        if config.max_steps is not None and (config.ckpt and config.ckpt.skip_scheduler and resume_from is not None)
+        config.max_steps - checkpoint_step
+        if config.max_steps is not None and (config.ckpt and config.ckpt.skip_scheduler and checkpoint_step is not None)
         else config.max_steps
     )
     logger.info(f"Setting up {config.scheduler.type} scheduler with {scheduler_steps} steps ({config.scheduler})")
@@ -206,21 +208,22 @@ def train(config: SFTConfig):
 
     if checkpoint_step is not None:
         resume_dir = config.resume.dir if config.resume else None
+        skip = config.ckpt or CheckpointConfig()
         ckpt_manager.load(
             checkpoint_step,
             model,
             [optimizer],
-            scheduler if not config.ckpt.skip_scheduler else None,
-            progress if not config.ckpt.skip_progress else None,
-            dataloader=dataloader if not config.ckpt.skip_dataloader else None,
+            scheduler if not skip.skip_scheduler else None,
+            progress if not skip.skip_progress else None,
+            dataloader=dataloader if not skip.skip_dataloader else None,
             path=resume_dir / "trainer" if resume_dir is not None else None,
         )
         logger.info(f"Resuming training from checkpoint step {checkpoint_step}")
         # The checkpoint finished step ``checkpoint_step``; resume training at the next step.
-        if not config.ckpt.skip_progress:
+        if not skip.skip_progress:
             progress.step += 1
         # This redundant setup is necessary because loading the optimizer's state has side effects on the scheduler state dict
-        if config.ckpt.skip_scheduler:
+        if skip.skip_scheduler:
             scheduler = setup_scheduler(optimizer, config.scheduler, scheduler_steps, config.optim.lr)
     logger.info(
         f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples}, dataset_state={dataloader.state_dict()['dataset_state']})"
@@ -483,12 +486,7 @@ def train(config: SFTConfig):
 
         # Checkpoint the step we just finished. The last step's checkpoint is written once after
         # the loop, so skip it here to avoid a double-save.
-        if (
-            ckpt_manager is not None
-            and (config.ckpt and config.ckpt.interval)
-            and not is_last_step
-            and progress.step % config.ckpt.interval == 0
-        ):
+        if (config.ckpt and config.ckpt.interval) and not is_last_step and progress.step % config.ckpt.interval == 0:
             save_ckpt_time = 0
 
             if not config.ckpt.weights_only:
@@ -630,8 +628,8 @@ def train(config: SFTConfig):
         logger.info(f"Saved trace to {trace_file}")
 
     # Write final checkpoint
-    if ckpt_manager is not None:
-        if not (config.ckpt and config.ckpt.weights_only):
+    if config.ckpt is not None:
+        if not config.ckpt.weights_only:
             logger.info("Writing final checkpoint")
             ckpt_manager.save(progress.step, model, [optimizer], scheduler, progress, dataloader=dataloader)
         ckpt_manager.maybe_clean()

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -79,7 +79,8 @@ class WandbMonitor(Monitor):
         _wandb_mode = os.environ.get("WANDB_MODE")
         shared_mode = os.environ.get("WANDB_SHARED_MODE") == "1" and _wandb_mode not in ("disabled", "offline")
         if shared_mode:
-            run_id = os.environ.get("WANDB_SHARED_RUN_ID")
+            # The run identity doubles as the shared W&B run id.
+            run_id = os.environ.get("PRL_RUN_ID")
             label = os.environ.get("WANDB_SHARED_LABEL")
             primary = label == "orchestrator"
             settings = wandb.Settings(

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -79,8 +79,8 @@ class WandbMonitor(Monitor):
         _wandb_mode = os.environ.get("WANDB_MODE")
         shared_mode = os.environ.get("WANDB_SHARED_MODE") == "1" and _wandb_mode not in ("disabled", "offline")
         if shared_mode:
-            # The run identity doubles as the shared W&B run id.
-            run_id = os.environ.get("PRL_RUN_ID")
+            # W&B's native run-id var, set by the launcher to $PRL_RUN_ID.
+            run_id = os.environ.get("WANDB_RUN_ID")
             label = os.environ.get("WANDB_SHARED_LABEL")
             primary = label == "orchestrator"
             settings = wandb.Settings(

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -162,7 +162,7 @@ def validate_run_dir(run_dir: Path, *, resuming: bool, clean: bool, ckpt_output_
         raise FileExistsError(
             f"{blocked} "
             f"To resume the latest step of the previous run, set ckpt.resume_step=-1 or --ckpt.resume-step -1 via CLI. "
-            f"To delete the existing directory and start fresh, set clean_output_dir=true or --clean-output-dir via CLI. "
+            f"To delete the existing directory and start fresh, set clean=true or --clean via CLI. "
             f"Otherwise use a unique run name (run.name or --run.name via CLI) or output_dir for this run."
         )
 

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -131,7 +131,9 @@ def has_run_artifacts(run_dir: Path) -> bool:
     return any(entry not in launcher_entries for entry in run_dir.iterdir())
 
 
-def validate_run_dir(run_dir: Path, *, resuming: bool, clean: bool, ckpt_output_dir: Path | None = None) -> None:
+def validate_run_dir(
+    run_dir: Path, *, output_dir: Path, resuming: bool, clean: bool, ckpt_output_dir: Path | None = None
+) -> None:
     """Validate the run directory before training starts.
 
     Raises if the run directory was already used by a previous run, unless explicitly
@@ -144,6 +146,8 @@ def validate_run_dir(run_dir: Path, *, resuming: bool, clean: bool, ckpt_output_
     if resuming:
         return
     if clean:
+        if not run_dir.resolve().is_relative_to(output_dir.resolve()):
+            raise ValueError(f"clean requires the run directory ({run_dir}) to remain under output_dir ({output_dir})")
         logger = get_logger()
         dirs_to_clean = [run_dir]
         if ckpt_output_dir is not None and ckpt_output_dir != run_dir:
@@ -161,7 +165,7 @@ def validate_run_dir(run_dir: Path, *, resuming: bool, clean: bool, ckpt_output_
     if blocked:
         raise FileExistsError(
             f"{blocked} "
-            f"To resume the latest step of the previous run, set ckpt.resume_step=-1 or --ckpt.resume-step -1 via CLI. "
+            f"To resume the latest step of the previous run, pass --resume (or --resume.step N). "
             f"To delete the existing directory and start fresh, set clean=true or --clean via CLI. "
             f"Otherwise use a unique run name (run.name or --run.name via CLI) or output_dir for this run."
         )

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -117,37 +117,54 @@ def has_checkpoints(output_dir: Path) -> bool:
     return ckpt_dir.exists() and any(ckpt_dir.iterdir())
 
 
-def validate_output_dir(output_dir: Path, *, resuming: bool, clean: bool, ckpt_output_dir: Path | None = None) -> None:
-    """Validate the output directory before training starts.
+# Launcher artifacts that may exist in a run directory before training starts: resolved
+# configs and the SLURM script/job log (a submitted job re-invokes the entrypoint inside
+# the run directory). Everything else is treated as artifacts of a previous run.
+LAUNCHER_ARTIFACTS = ("configs", "rl.sbatch", "sft.sbatch", "job_*.log")
 
-    Raises if the directory contains checkpoints from a previous run, unless
-    explicitly resuming or opting into cleaning. Other artifacts (logs,
-    rollouts, configs) are fine and don't trigger the error.
+
+def has_run_artifacts(run_dir: Path) -> bool:
+    """Check if the run directory contains artifacts beyond what the launcher pre-writes."""
+    if not run_dir.exists():
+        return False
+    launcher_entries = {entry for pattern in LAUNCHER_ARTIFACTS for entry in run_dir.glob(pattern)}
+    return any(entry not in launcher_entries for entry in run_dir.iterdir())
+
+
+def validate_run_dir(run_dir: Path, *, resuming: bool, clean: bool, ckpt_output_dir: Path | None = None) -> None:
+    """Validate the run directory before training starts.
+
+    Raises if the run directory was already used by a previous run, unless explicitly
+    resuming or opting into cleaning — a second run writing into the same run directory
+    would overwrite or interleave with the first run's artifacts.
 
     When ckpt_output_dir is set, checkpoints live there instead of under
-    output_dir, so the guard and clean logic check both locations.
+    run_dir, so the guard and clean logic check both locations.
     """
-    dirs_to_check = [output_dir]
-    if ckpt_output_dir is not None and ckpt_output_dir != output_dir:
-        dirs_to_check.append(ckpt_output_dir)
-
     if resuming:
         return
     if clean:
         logger = get_logger()
-        for d in dirs_to_check:
+        dirs_to_clean = [run_dir]
+        if ckpt_output_dir is not None and ckpt_output_dir != run_dir:
+            dirs_to_clean.append(ckpt_output_dir)
+        for d in dirs_to_clean:
             if d.exists():
                 logger.warning(f"Cleaning existing directory: {d}")
                 shutil.rmtree(d)
         return
-    for d in dirs_to_check:
-        if has_checkpoints(d):
-            raise FileExistsError(
-                f"Directory '{d}' already contains checkpoints from a previous run. "
-                f"To resume the latest step of the previous run, set ckpt.resume_step=-1 or --ckpt.resume-step -1 via CLI. "
-                f"To delete the existing directory and start fresh, set clean_output_dir=true or --clean-output-dir via CLI. "
-                f"Otherwise use a unique output_dir for this experiment."
-            )
+    blocked = None
+    if has_run_artifacts(run_dir):
+        blocked = f"Run directory '{run_dir}' already contains artifacts from a previous run."
+    elif ckpt_output_dir is not None and ckpt_output_dir != run_dir and has_checkpoints(ckpt_output_dir):
+        blocked = f"Checkpoint directory '{ckpt_output_dir}' already contains checkpoints from a previous run."
+    if blocked:
+        raise FileExistsError(
+            f"{blocked} "
+            f"To resume the latest step of the previous run, set ckpt.resume_step=-1 or --ckpt.resume-step -1 via CLI. "
+            f"To delete the existing directory and start fresh, set clean_output_dir=true or --clean-output-dir via CLI. "
+            f"Otherwise use a unique run name (run.name or --run.name via CLI) or output_dir for this run."
+        )
 
 
 def clean_future_steps(output_dir: Path, resume_step: int) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,7 @@ def branch_name() -> str:
 @pytest.fixture(scope="session")
 def output_dir(tmp_path_factory: pytest.TempPathFactory) -> Generator[Path, None, None]:
     """Fixture for the tests' output directory. Never deleted — CI uploads run logs
-    from it on failure; runs start with ``--clean-output-dir`` for a fresh workspace."""
+    from it on failure; runs start with ``--clean`` for a fresh workspace."""
     output_dir = Path(os.environ.get("PYTEST_OUTPUT_DIR", tmp_path_factory.mktemp("outputs")))
     output_dir.mkdir(parents=True, exist_ok=True)
     yield output_dir

--- a/tests/integration/test_alphabet_sort.py
+++ b/tests/integration/test_alphabet_sort.py
@@ -45,7 +45,7 @@ def rl_process(
         "rl",
         "@",
         "configs/ci/integration/alphabet_sort.toml",
-        "--clean-output-dir",
+        "--clean",
         "--wandb.project",
         wandb_project,
         "--wandb.name",

--- a/tests/integration/test_alphabet_sort.py
+++ b/tests/integration/test_alphabet_sort.py
@@ -14,6 +14,13 @@ from tests.utils import (
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
+RUN_NAME = "alphabet-sort"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
 
 TIMEOUT = 1200  # 20 minutes (was 900s — alphabet-sort steps can take 2+ min
 # each on contended CI GPU runners, and vLLM warm-up eats ~2 min)
@@ -45,32 +52,34 @@ def rl_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
     return run_process(cmd, timeout=TIMEOUT)
 
 
 @pytest.fixture(scope="module")
-def test_no_error(rl_process: ProcessResult, output_dir: Path):
+def test_no_error(rl_process: ProcessResult, run_dir: Path):
     """Tests that the RL process does not fail."""
-    check_no_error(rl_process, output_dir)
+    check_no_error(rl_process, run_dir)
 
 
-def test_reward_goes_up(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process."""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
 
 
-def test_reward_in_range(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_in_range(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward is in range in the RL process."""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=0.10)
 
 
-def test_mismatch_kl_in_range(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_mismatch_kl_in_range(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the average mismatch KL is below 0.15 across the last 5 steps."""
-    with open(output_dir / "logs" / "trainer.log", "r") as f:
+    with open(run_dir / "logs" / "trainer.log", "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()
     check_avg_mismatch_kl_in_range(trainer_stdout, last_n_steps=5, max_threshold=0.15)

--- a/tests/integration/test_reverse_text.py
+++ b/tests/integration/test_reverse_text.py
@@ -45,7 +45,7 @@ def rl_process(
         "rl",
         "@",
         "configs/ci/integration/reverse-text/start.toml",
-        "--clean-output-dir",
+        "--clean",
         "--wandb.project",
         wandb_project,
         "--wandb.name",

--- a/tests/integration/test_reverse_text.py
+++ b/tests/integration/test_reverse_text.py
@@ -14,6 +14,13 @@ from tests.utils import (
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
+RUN_NAME = "reverse-text"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
 
 TIMEOUT = 900  # 15 minutes (was 600s — can be tight on contended CI runners
 # after verifiers per-call tracing overhead was added)
@@ -45,6 +52,8 @@ def rl_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
     return run_process(cmd, timeout=TIMEOUT)
 
@@ -72,46 +81,48 @@ def rl_resume_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
 
     return run_process(cmd, timeout=TIMEOUT)
 
 
 @pytest.fixture(scope="module")
-def test_no_error(rl_process: ProcessResult, output_dir: Path):
+def test_no_error(rl_process: ProcessResult, run_dir: Path):
     """Tests that the RL process does not fail."""
-    check_no_error(rl_process, output_dir)
+    check_no_error(rl_process, run_dir)
 
 
-def test_reward_goes_up(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
 
 
-def test_reward_in_range(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_in_range(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward is in range in the RL process"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=0.6)
 
 
-def test_mismatch_kl_in_range(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_mismatch_kl_in_range(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the average mismatch KL is below 0.01 across all steps"""
-    with open(output_dir / "logs" / "trainer.log", "r") as f:
+    with open(run_dir / "logs" / "trainer.log", "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()
     check_avg_mismatch_kl_in_range(trainer_stdout, last_n_steps=3, max_threshold=0.01)
 
 
 @pytest.fixture(scope="module")
-def test_no_error_resume(rl_resume_process: ProcessResult, output_dir: Path):
+def test_no_error_resume(rl_resume_process: ProcessResult, run_dir: Path):
     """Tests that the RL resume process does not fail."""
-    check_no_error(rl_resume_process, output_dir)
+    check_no_error(rl_resume_process, run_dir)
 
 
-def test_reward_in_range_resume(rl_resume_process: ProcessResult, test_no_error_resume, output_dir: Path):
+def test_reward_in_range_resume(rl_resume_process: ProcessResult, test_no_error_resume, run_dir: Path):
     """Tests that the reward is in range in the RL resume process"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=0.6)

--- a/tests/integration/test_reverse_text_lora.py
+++ b/tests/integration/test_reverse_text_lora.py
@@ -8,6 +8,13 @@ from tests.utils import check_no_error, check_reward_goes_up, check_reward_in_ra
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
+RUN_NAME = "reverse-text-lora"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
 
 TIMEOUT = 600  # 10 minutes
 
@@ -38,6 +45,8 @@ def rl_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
     return run_process(cmd, env={"VLLM_ALLOW_RUNTIME_LORA_UPDATING": "True"}, timeout=TIMEOUT)
 
@@ -65,39 +74,41 @@ def rl_resume_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
 
     return run_process(cmd, env={"VLLM_ALLOW_RUNTIME_LORA_UPDATING": "True"}, timeout=TIMEOUT)
 
 
 @pytest.fixture(scope="module")
-def test_no_error(rl_process: ProcessResult, output_dir: Path):
+def test_no_error(rl_process: ProcessResult, run_dir: Path):
     """Tests that the RL process does not fail."""
-    check_no_error(rl_process, output_dir)
+    check_no_error(rl_process, run_dir)
 
 
-def test_reward_goes_up(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
 
 
-def test_reward_in_range(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_in_range(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward is in range in the RL process"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=0.65)
 
 
 @pytest.fixture(scope="module")
-def test_no_error_resume(rl_resume_process: ProcessResult, output_dir: Path):
+def test_no_error_resume(rl_resume_process: ProcessResult, run_dir: Path):
     """Tests that the RL resume process does not fail."""
-    check_no_error(rl_resume_process, output_dir)
+    check_no_error(rl_resume_process, run_dir)
 
 
-def test_reward_in_range_resume(rl_resume_process: ProcessResult, test_no_error_resume, output_dir: Path):
+def test_reward_in_range_resume(rl_resume_process: ProcessResult, test_no_error_resume, run_dir: Path):
     """Tests that the reward is in range in the RL resume process"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=0.65)

--- a/tests/integration/test_reverse_text_lora.py
+++ b/tests/integration/test_reverse_text_lora.py
@@ -38,7 +38,7 @@ def rl_process(
         "rl",
         "@",
         "configs/ci/integration/reverse-text-lora/start.toml",
-        "--clean-output-dir",
+        "--clean",
         "--wandb.project",
         wandb_project,
         "--wandb.name",

--- a/tests/integration/test_reverse_text_moe.py
+++ b/tests/integration/test_reverse_text_moe.py
@@ -8,6 +8,14 @@ from tests.utils import check_no_error
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
+RUN_NAME = "reverse-text-moe"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
+
 TIMEOUT = 900  # 15 minutes
 
 
@@ -38,13 +46,15 @@ def rl_process(
         f"{wandb_name}-custom",
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
     return run_process(cmd, timeout=TIMEOUT)
 
 
 @pytest.fixture(scope="module")
-def test_no_error(rl_process: ProcessResult, output_dir: Path):
-    check_no_error(rl_process, output_dir)
+def test_no_error(rl_process: ProcessResult, run_dir: Path):
+    check_no_error(rl_process, run_dir)
 
 
 def test_moe_runs(rl_process: ProcessResult, test_no_error):

--- a/tests/integration/test_reverse_text_moe.py
+++ b/tests/integration/test_reverse_text_moe.py
@@ -37,7 +37,7 @@ def rl_process(
         "rl",
         "@",
         "configs/ci/integration/reverse-text-moe/start.toml",
-        "--clean-output-dir",
+        "--clean",
         "--trainer.model.impl",
         "custom",
         "--wandb.project",

--- a/tests/integration/test_reverse_text_rl_opd.py
+++ b/tests/integration/test_reverse_text_rl_opd.py
@@ -48,7 +48,7 @@ def ref_inference(output_dir: Path) -> Generator[subprocess.Popen, None, None]:
     """Spawn a `uv run inference` frozen reference server on GPU 0 (shared with the rl-launched
     policy) at 40% gpu_memory_utilization. Tears down at module scope.
     """
-    # The rl entrypoint's --clean-output-dir wipes the rl output_dir on start,
+    # The rl entrypoint's --clean wipes the rl output_dir on start,
     # so park the reference-server log next to it instead of inside it.
     ref_log_dir = output_dir.parent / f"{output_dir.name}_ref"
     ref_log_dir.mkdir(parents=True, exist_ok=True)
@@ -100,7 +100,7 @@ def rl_opd_process(
         "rl",
         "@",
         "configs/ci/integration/reverse-text-rl-opd/start.toml",
-        "--clean-output-dir",
+        "--clean",
         "--wandb.project",
         wandb_project,
         "--wandb.name",

--- a/tests/integration/test_reverse_text_rl_opd.py
+++ b/tests/integration/test_reverse_text_rl_opd.py
@@ -14,6 +14,14 @@ from tests.utils import check_final_eval_reward_above, check_no_error, strip_esc
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
+RUN_NAME = "reverse-text-rl-opd"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
+
 TIMEOUT = 900  # 15 minutes (was 600s — the OPD orchestrator finishes in ~8m but
 # the rl entrypoint cleanup phase can push total wall-clock past the old limit)
 REF_PORT = 8001
@@ -99,16 +107,18 @@ def rl_opd_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
     return run_process(cmd, timeout=TIMEOUT)
 
 
 @pytest.fixture(scope="module")
-def test_no_error(rl_opd_process: ProcessResult, output_dir: Path):
-    check_no_error(rl_opd_process, output_dir)
+def test_no_error(rl_opd_process: ProcessResult, run_dir: Path):
+    check_no_error(rl_opd_process, run_dir)
 
 
-def test_eval_reward_converges(rl_opd_process: ProcessResult, test_no_error, output_dir: Path):
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+def test_eval_reward_converges(rl_opd_process: ProcessResult, test_no_error, run_dir: Path):
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_final_eval_reward_above(orchestrator_stdout, env_name="reverse-text", min_threshold=0.5)

--- a/tests/integration/test_reverse_text_rl_sft.py
+++ b/tests/integration/test_reverse_text_rl_sft.py
@@ -47,7 +47,7 @@ def ref_inference(output_dir: Path) -> Generator[subprocess.Popen, None, None]:
     """Spawn a `uv run inference` frozen reference server on GPU 0 (shared with the rl-launched
     policy) at 40% gpu_memory_utilization. Tears down at module scope.
     """
-    # The rl entrypoint's --clean-output-dir wipes the rl output_dir on start,
+    # The rl entrypoint's --clean wipes the rl output_dir on start,
     # so park the reference-server log next to it instead of inside it.
     ref_log_dir = output_dir.parent / f"{output_dir.name}_ref"
     ref_log_dir.mkdir(parents=True, exist_ok=True)
@@ -99,7 +99,7 @@ def rl_sft_process(
         "rl",
         "@",
         "configs/ci/integration/reverse-text-rl-sft/start.toml",
-        "--clean-output-dir",
+        "--clean",
         "--wandb.project",
         wandb_project,
         "--wandb.name",

--- a/tests/integration/test_reverse_text_rl_sft.py
+++ b/tests/integration/test_reverse_text_rl_sft.py
@@ -14,6 +14,14 @@ from tests.utils import check_final_eval_reward_above, check_no_error, strip_esc
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
+RUN_NAME = "reverse-text-rl-sft"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
+
 TIMEOUT = 900  # 15 minutes (was 600s — same overhead as reverse_text)
 REF_PORT = 8001
 REF_READY_TIMEOUT_S = 300
@@ -98,16 +106,18 @@ def rl_sft_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
     return run_process(cmd, timeout=TIMEOUT)
 
 
 @pytest.fixture(scope="module")
-def test_no_error(rl_sft_process: ProcessResult, output_dir: Path):
-    check_no_error(rl_sft_process, output_dir)
+def test_no_error(rl_sft_process: ProcessResult, run_dir: Path):
+    check_no_error(rl_sft_process, run_dir)
 
 
-def test_eval_reward_converges(rl_sft_process: ProcessResult, test_no_error, output_dir: Path):
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+def test_eval_reward_converges(rl_sft_process: ProcessResult, test_no_error, run_dir: Path):
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_final_eval_reward_above(orchestrator_stdout, env_name="reverse-text", min_threshold=0.5)

--- a/tests/integration/test_reverse_text_sft.py
+++ b/tests/integration/test_reverse_text_sft.py
@@ -8,6 +8,14 @@ from tests.utils import check_loss_goes_down, strip_escape_codes
 
 pytestmark = [pytest.mark.slow, pytest.mark.gpu]
 
+RUN_NAME = "reverse-text-sft"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
+
 TIMEOUT = 300  # 5 minutes
 
 
@@ -40,6 +48,8 @@ def sft_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
 
     return run_process(cmd, timeout=TIMEOUT)
@@ -69,6 +79,8 @@ def sft_resume_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
 
     return run_process(cmd, timeout=TIMEOUT)
@@ -79,9 +91,9 @@ def test_no_error(sft_process: ProcessResult):
     assert sft_process.returncode == 0, f"Process has non-zero return code ({sft_process})"
 
 
-def test_loss_goes_down(sft_process: ProcessResult, output_dir: Path):
+def test_loss_goes_down(sft_process: ProcessResult, run_dir: Path):
     """Tests that the loss goes down in the SFT process"""
-    trainer_log_path = output_dir / "logs" / "trainer.log"
+    trainer_log_path = run_dir / "logs" / "trainer.log"
     print(f"Checking trainer path in {trainer_log_path}")
     with open(trainer_log_path, "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()
@@ -93,9 +105,9 @@ def test_no_error_resume(sft_resume_process: ProcessResult):
     assert sft_resume_process.returncode == 0, f"Process has non-zero return code ({sft_resume_process})"
 
 
-def test_loss_goes_down_resume(sft_resume_process: ProcessResult, output_dir: Path):
+def test_loss_goes_down_resume(sft_resume_process: ProcessResult, run_dir: Path):
     """Tests that the loss goes down in the SFT resume process"""
-    trainer_log_path = output_dir / "logs" / "trainer.log"
+    trainer_log_path = run_dir / "logs" / "trainer.log"
     print(f"Checking trainer path in {trainer_log_path}")
     with open(trainer_log_path, "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()

--- a/tests/integration/test_reverse_text_sft.py
+++ b/tests/integration/test_reverse_text_sft.py
@@ -41,7 +41,7 @@ def sft_process(
         "configs/ci/integration/reverse-text-sft/start.toml",
         "--deployment.num-gpus",
         "2",
-        "--clean-output-dir",
+        "--clean",
         "--wandb.project",
         wandb_project,
         "--wandb.name",

--- a/tests/integration/test_reverse_text_sft_lora.py
+++ b/tests/integration/test_reverse_text_sft_lora.py
@@ -9,6 +9,14 @@ from tests.utils import check_loss_goes_down, strip_escape_codes
 
 pytestmark = [pytest.mark.slow, pytest.mark.gpu]
 
+RUN_NAME = "reverse-text-sft-lora"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
+
 TIMEOUT = 300  # 5 minutes
 
 
@@ -50,6 +58,8 @@ def sft_lora_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
 
     return run_process(cmd, timeout=TIMEOUT)
@@ -79,6 +89,8 @@ def sft_lora_resume_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
 
     return run_process(cmd, timeout=TIMEOUT)
@@ -89,18 +101,18 @@ def test_no_error(sft_lora_process: ProcessResult):
     assert sft_lora_process.returncode == 0, f"Process has non-zero return code ({sft_lora_process})"
 
 
-def test_loss_goes_down(sft_lora_process: ProcessResult, output_dir: Path):
+def test_loss_goes_down(sft_lora_process: ProcessResult, run_dir: Path):
     """Tests that the loss goes down in the SFT LoRA process"""
-    trainer_log_path = output_dir / "logs" / "trainer.log"
+    trainer_log_path = run_dir / "logs" / "trainer.log"
     print(f"Checking trainer path in {trainer_log_path}")
     with open(trainer_log_path, "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()
     check_loss_goes_down(trainer_stdout)
 
 
-def test_adapter_checkpoint_written(sft_lora_process: ProcessResult, output_dir: Path):
+def test_adapter_checkpoint_written(sft_lora_process: ProcessResult, run_dir: Path):
     """Tests that the adapter checkpoint is written with valid PEFT-compatible keys."""
-    adapter_dir = output_dir / "weights" / "step_5" / "lora_adapters"
+    adapter_dir = run_dir / "weights" / "step_5" / "lora_adapters"
     assert_adapter_checkpoint(adapter_dir)
 
 
@@ -109,16 +121,16 @@ def test_no_error_resume(sft_lora_resume_process: ProcessResult):
     assert sft_lora_resume_process.returncode == 0, f"Process has non-zero return code ({sft_lora_resume_process})"
 
 
-def test_loss_goes_down_resume(sft_lora_resume_process: ProcessResult, output_dir: Path):
+def test_loss_goes_down_resume(sft_lora_resume_process: ProcessResult, run_dir: Path):
     """Tests that the loss goes down in the SFT LoRA resume process"""
-    trainer_log_path = output_dir / "logs" / "trainer.log"
+    trainer_log_path = run_dir / "logs" / "trainer.log"
     print(f"Checking trainer path in {trainer_log_path}")
     with open(trainer_log_path, "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()
     check_loss_goes_down(trainer_stdout)
 
 
-def test_adapter_checkpoint_written_resume(sft_lora_resume_process: ProcessResult, output_dir: Path):
+def test_adapter_checkpoint_written_resume(sft_lora_resume_process: ProcessResult, run_dir: Path):
     """Tests that the adapter checkpoint is written after resuming with valid PEFT-compatible keys."""
-    adapter_dir = output_dir / "weights" / "step_10" / "lora_adapters"
+    adapter_dir = run_dir / "weights" / "step_10" / "lora_adapters"
     assert_adapter_checkpoint(adapter_dir)

--- a/tests/integration/test_reverse_text_sft_lora.py
+++ b/tests/integration/test_reverse_text_sft_lora.py
@@ -51,7 +51,7 @@ def sft_lora_process(
         "configs/ci/integration/reverse-text-sft-lora/start.toml",
         "--deployment.num-gpus",
         "2",
-        "--clean-output-dir",
+        "--clean",
         "--wandb.project",
         wandb_project,
         "--wandb.name",

--- a/tests/nightly/test_alphabet_sort.py
+++ b/tests/nightly/test_alphabet_sort.py
@@ -8,6 +8,13 @@ from tests.utils import check_no_error, check_reward_goes_up, strip_escape_codes
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
+RUN_NAME = "alphabet-sort"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
 
 @pytest.fixture(scope="module")
 def wandb_name(branch_name: str) -> str:
@@ -34,18 +41,20 @@ def rl_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
     return run_process(cmd)
 
 
 @pytest.fixture(scope="module")
-def test_no_error(rl_process: ProcessResult, output_dir: Path):
+def test_no_error(rl_process: ProcessResult, run_dir: Path):
     """Tests that the RL process does not fail."""
-    check_no_error(rl_process, output_dir)
+    check_no_error(rl_process, run_dir)
 
 
-def test_reward_goes_up(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)

--- a/tests/nightly/test_hendrycks_sanity.py
+++ b/tests/nightly/test_hendrycks_sanity.py
@@ -14,6 +14,13 @@ from tests.utils import (
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
+RUN_NAME = "hendrycks-sanity"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
 
 @pytest.fixture(scope="module")
 def wandb_name(branch_name: str) -> str:
@@ -40,6 +47,8 @@ def rl_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
         "--max-steps",
         "1000",  # do less steps to finish in time
     ]
@@ -52,27 +61,27 @@ MISMATCH_KL_MAX = 0.0005
 
 
 @pytest.fixture(scope="module")
-def test_no_error(rl_process: ProcessResult, output_dir: Path):
+def test_no_error(rl_process: ProcessResult, run_dir: Path):
     """Tests that the RL process does not fail."""
-    check_no_error(rl_process, output_dir)
+    check_no_error(rl_process, run_dir)
 
 
-def test_reward_goes_up(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the train reward goes up during training"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
 
 
-def test_reward_reaches_threshold(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_reaches_threshold(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the train reward reaches a minimum threshold"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=MIN_TRAIN_REWARD)
 
 
-def test_mismatch_kl_in_band(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_mismatch_kl_in_band(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that mismatch KL stays within the expected band."""
-    with open(output_dir / "logs" / "trainer.log", "r") as f:
+    with open(run_dir / "logs" / "trainer.log", "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()
     check_mismatch_kl_in_range(trainer_stdout, min_threshold=MISMATCH_KL_MIN, max_threshold=MISMATCH_KL_MAX)

--- a/tests/nightly/test_multimodal_color_codeword.py
+++ b/tests/nightly/test_multimodal_color_codeword.py
@@ -8,6 +8,14 @@ from tests.utils import check_avg_reward_in_range, check_no_error, check_reward_
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
+RUN_NAME = "multimodal-color-codeword"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
+
 REWARD_MIN_THRESHOLD = 0.85
 REWARD_AVG_LAST_N_STEPS = 7
 
@@ -37,26 +45,28 @@ def rl_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
     return run_process(cmd)
 
 
 @pytest.fixture(scope="module")
-def test_no_error(rl_process: ProcessResult, output_dir: Path):
+def test_no_error(rl_process: ProcessResult, run_dir: Path):
     """Tests that the RL process does not fail."""
-    check_no_error(rl_process, output_dir)
+    check_no_error(rl_process, run_dir)
 
 
-def test_reward_goes_up(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
 
 
-def test_reward_reaches_threshold(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_reaches_threshold(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the average reward over the last steps exceeds the threshold"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_avg_reward_in_range(
         orchestrator_stdout, last_n_steps=REWARD_AVG_LAST_N_STEPS, min_threshold=REWARD_MIN_THRESHOLD

--- a/tests/nightly/test_reverse_text.py
+++ b/tests/nightly/test_reverse_text.py
@@ -8,6 +8,13 @@ from tests.utils import check_no_error, check_reward_goes_up, check_reward_in_ra
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
+RUN_NAME = "reverse-text"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
 
 @pytest.fixture(scope="module")
 def wandb_name(branch_name: str) -> str:
@@ -34,25 +41,27 @@ def rl_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
     return run_process(cmd)
 
 
 @pytest.fixture(scope="module")
-def test_no_error(rl_process: ProcessResult, output_dir: Path):
+def test_no_error(rl_process: ProcessResult, run_dir: Path):
     """Tests that the RL process does not fail."""
-    check_no_error(rl_process, output_dir)
+    check_no_error(rl_process, run_dir)
 
 
-def test_reward_goes_up(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
 
 
-def test_reward_reaches_threshold(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_reaches_threshold(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=0.65)

--- a/tests/nightly/test_wiki_search.py
+++ b/tests/nightly/test_wiki_search.py
@@ -8,6 +8,13 @@ from tests.utils import check_no_error, check_reward_goes_up, strip_escape_codes
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
+RUN_NAME = "wiki-search"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
 
 @pytest.fixture(scope="module")
 def wandb_name(branch_name: str) -> str:
@@ -34,18 +41,20 @@ def rl_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
     return run_process(cmd)
 
 
 @pytest.fixture(scope="module")
-def test_no_error(rl_process: ProcessResult, output_dir: Path):
+def test_no_error(rl_process: ProcessResult, run_dir: Path):
     """Tests that the RL process does not fail."""
-    check_no_error(rl_process, output_dir)
+    check_no_error(rl_process, run_dir)
 
 
-def test_reward_goes_up(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)

--- a/tests/nightly/test_wordle.py
+++ b/tests/nightly/test_wordle.py
@@ -8,6 +8,13 @@ from tests.utils import check_no_error, check_reward_goes_up, strip_escape_codes
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
+RUN_NAME = "wordle"
+
+
+@pytest.fixture(scope="module")
+def run_dir(output_dir: Path) -> Path:
+    return output_dir / RUN_NAME
+
 
 @pytest.fixture(scope="module")
 def wandb_name(branch_name: str) -> str:
@@ -34,18 +41,20 @@ def rl_process(
         wandb_name,
         "--output-dir",
         output_dir.as_posix(),
+        "--run.name",
+        RUN_NAME,
     ]
     return run_process(cmd)
 
 
 @pytest.fixture(scope="module")
-def test_no_error(rl_process: ProcessResult, output_dir: Path):
+def test_no_error(rl_process: ProcessResult, run_dir: Path):
     """Tests that the RL process does not fail."""
-    check_no_error(rl_process, output_dir)
+    check_no_error(rl_process, run_dir)
 
 
-def test_reward_goes_up(rl_process: ProcessResult, test_no_error, output_dir: Path):
+def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -13,7 +13,7 @@ from prime_rl.configs.rl import RLConfig
 from prime_rl.configs.sft import SFTConfig
 from prime_rl.configs.trainer import ModelConfig as TrainerModelConfig
 from prime_rl.configs.trainer import TrainerConfig
-from prime_rl.utils.config import BaseConfig, cli, to_toml_dict
+from prime_rl.utils.config import BaseConfig, cli, dump_resolved_config
 
 # All config config classes
 CONFIG_CLASSES = [
@@ -161,20 +161,21 @@ def test_removed_fused_lm_head_chunk_size_field_is_rejected():
         TrainerModelConfig.model_validate({"fused_lm_head_chunk_size": "auto"})
 
 
-def test_to_toml_dict_roundtrips_explicit_none(tmp_path):
-    """An explicit None override survives the write/re-parse round-trip used by SLURM launches."""
+def test_resolved_json_roundtrips_explicit_none(tmp_path):
+    """An explicit None override survives the write/re-parse round-trip used by launches:
+    resolved configs are JSON, which keeps nulls (TOML cannot)."""
+    import json
+
     config = cli(TrainerConfig, args=["--model.compile", "None", "--optim.max_norm", "None"])
     assert config.model.compile is None
     assert config.optim.max_norm is None
 
-    write_toml(tmp_path / "cfg.toml", to_toml_dict(config))
-    reloaded = cli(TrainerConfig, args=["@", str(tmp_path / "cfg.toml")])
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps(dump_resolved_config(config)))
+    reloaded = cli(TrainerConfig, args=["@", str(path)])
     assert reloaded.model.compile is None
     assert reloaded.optim.max_norm is None
     assert reloaded == config
-
-    # Unset None fields stay dropped, so defaults still resolve on re-parse
-    assert "max_steps" not in to_toml_dict(cli(TrainerConfig, args=[]))
 
 
 def test_env_algo_overrides_top_level():

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -547,8 +547,8 @@ def test_shared_and_subconfig_disjoint_fields_coexist():
     assert config.trainer.model.impl == "custom"
 
 
-def test_shared_output_dir_propagates_through_cli(tmp_path):
-    """Shared output_dir from CLI reaches sub-configs even when tyro constructs sub-configs before the before-validator."""
+def test_run_dir_propagates_through_cli(tmp_path):
+    """Sub-configs receive the run directory (output_dir / run.name) resolved from the CLI."""
     toml_path = tmp_path / "cfg.toml"
     write_toml(
         toml_path,
@@ -562,9 +562,10 @@ def test_shared_output_dir_propagates_through_cli(tmp_path):
         },
     )
     shared_out = tmp_path / "shared"
-    config = cli(RLConfig, args=["@", str(toml_path), "--output-dir", str(shared_out)])
-    assert config.trainer.output_dir == shared_out
-    assert config.orchestrator.output_dir == shared_out
+    config = cli(RLConfig, args=["@", str(toml_path), "--output-dir", str(shared_out), "--run.name", "my-exp"])
+    assert config.run_dir == shared_out / "my-exp"
+    assert config.trainer.output_dir == shared_out / "my-exp"
+    assert config.orchestrator.output_dir == shared_out / "my-exp"
 
 
 def test_orchestrator_renderer_auto_rejects_unmapped_model():

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -568,7 +568,8 @@ def test_run_dir_propagates_through_cli(tmp_path):
     assert config.trainer.output_dir == shared_out / "my-exp"
     assert config.orchestrator.output_dir == shared_out / "my-exp"
     # Run identity propagates to the orchestrator; unset monitor names inherit run.name
-    assert config.orchestrator.run == config.run
+    assert config.orchestrator.run.name == "my-exp"
+    assert config.orchestrator.run.id is None  # minted by the rl entrypoint, not config
     assert config.wandb is not None and config.wandb.name == "my-exp"
     assert config.trainer.wandb is not None and config.trainer.wandb.name == "my-exp"
     assert config.orchestrator.wandb is not None and config.orchestrator.wandb.name == "my-exp"

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -567,8 +567,7 @@ def test_run_dir_propagates_through_cli(tmp_path):
     assert config.run_dir == shared_out / "my-exp"
     assert config.trainer.output_dir == shared_out / "my-exp"
     assert config.orchestrator.output_dir == shared_out / "my-exp"
-    # Run identity propagates to the orchestrator; unset monitor names inherit run.name
-    assert config.orchestrator.run.name == "my-exp"
+    # Unset monitor names inherit run.name
     assert config.wandb is not None and config.wandb.name == "my-exp"
     assert config.trainer.wandb is not None and config.trainer.wandb.name == "my-exp"
     assert config.orchestrator.wandb is not None and config.orchestrator.wandb.name == "my-exp"

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -569,7 +569,6 @@ def test_run_dir_propagates_through_cli(tmp_path):
     assert config.orchestrator.output_dir == shared_out / "my-exp"
     # Run identity propagates to the orchestrator; unset monitor names inherit run.name
     assert config.orchestrator.run.name == "my-exp"
-    assert config.orchestrator.run.id is None  # minted by the rl entrypoint, not config
     assert config.wandb is not None and config.wandb.name == "my-exp"
     assert config.trainer.wandb is not None and config.trainer.wandb.name == "my-exp"
     assert config.orchestrator.wandb is not None and config.orchestrator.wandb.name == "my-exp"

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -556,6 +556,7 @@ def test_run_dir_propagates_through_cli(tmp_path):
             "max_steps": 1,
             "seq_len": 128,
             "model": {"name": "Qwen/Qwen3-0.6B"},
+            "wandb": {},
             "trainer": {},
             "orchestrator": {"batch_size": 16, "group_size": 1},
             "inference": {},
@@ -566,6 +567,11 @@ def test_run_dir_propagates_through_cli(tmp_path):
     assert config.run_dir == shared_out / "my-exp"
     assert config.trainer.output_dir == shared_out / "my-exp"
     assert config.orchestrator.output_dir == shared_out / "my-exp"
+    # Run identity propagates to the orchestrator; unset monitor names inherit run.name
+    assert config.orchestrator.run == config.run
+    assert config.wandb is not None and config.wandb.name == "my-exp"
+    assert config.trainer.wandb is not None and config.trainer.wandb.name == "my-exp"
+    assert config.orchestrator.wandb is not None and config.orchestrator.wandb.name == "my-exp"
 
 
 def test_orchestrator_renderer_auto_rejects_unmapped_model():

--- a/tests/unit/utils/test_pathing.py
+++ b/tests/unit/utils/test_pathing.py
@@ -1,57 +1,78 @@
 import pytest
 
-from prime_rl.utils.pathing import validate_output_dir
+from prime_rl.utils.pathing import validate_run_dir
 
 
 def test_nonexistent_dir_passes(tmp_path):
-    output_dir = tmp_path / "does_not_exist"
-    validate_output_dir(output_dir, resuming=False, clean=False)
+    run_dir = tmp_path / "does_not_exist"
+    validate_run_dir(run_dir, resuming=False, clean=False)
 
 
 def test_empty_dir_passes(tmp_path):
-    output_dir = tmp_path / "empty"
-    output_dir.mkdir()
-    validate_output_dir(output_dir, resuming=False, clean=False)
+    run_dir = tmp_path / "empty"
+    run_dir.mkdir()
+    validate_run_dir(run_dir, resuming=False, clean=False)
 
 
-def test_dir_with_only_logs_passes(tmp_path):
-    output_dir = tmp_path / "has_logs"
-    output_dir.mkdir()
-    (output_dir / "logs").mkdir()
-    (output_dir / "logs" / "trainer.log").touch()
-    validate_output_dir(output_dir, resuming=False, clean=False)
+def test_dir_with_launcher_artifacts_passes(tmp_path):
+    run_dir = tmp_path / "submitted"
+    run_dir.mkdir()
+    (run_dir / "configs").mkdir()
+    (run_dir / "configs" / "trainer.toml").touch()
+    (run_dir / "rl.sbatch").touch()
+    (run_dir / "job_1234.log").touch()
+    validate_run_dir(run_dir, resuming=False, clean=False)
+
+
+def test_dir_with_logs_raises(tmp_path):
+    run_dir = tmp_path / "has_logs"
+    run_dir.mkdir()
+    (run_dir / "logs").mkdir()
+    (run_dir / "logs" / "trainer.log").touch()
+    with pytest.raises(FileExistsError, match="already contains artifacts"):
+        validate_run_dir(run_dir, resuming=False, clean=False)
 
 
 def test_dir_with_checkpoints_raises(tmp_path):
-    output_dir = tmp_path / "has_ckpt"
-    output_dir.mkdir()
-    (output_dir / "checkpoints").mkdir()
-    (output_dir / "checkpoints" / "step_0").mkdir()
-    with pytest.raises(FileExistsError, match="already contains checkpoints"):
-        validate_output_dir(output_dir, resuming=False, clean=False)
+    run_dir = tmp_path / "has_ckpt"
+    run_dir.mkdir()
+    (run_dir / "checkpoints").mkdir()
+    (run_dir / "checkpoints" / "step_0").mkdir()
+    with pytest.raises(FileExistsError, match="already contains artifacts"):
+        validate_run_dir(run_dir, resuming=False, clean=False)
 
 
 def test_dir_with_checkpoints_passes_when_resuming(tmp_path):
-    output_dir = tmp_path / "has_ckpt"
-    output_dir.mkdir()
-    (output_dir / "checkpoints").mkdir()
-    (output_dir / "checkpoints" / "step_0").mkdir()
-    validate_output_dir(output_dir, resuming=True, clean=False)
+    run_dir = tmp_path / "has_ckpt"
+    run_dir.mkdir()
+    (run_dir / "checkpoints").mkdir()
+    (run_dir / "checkpoints" / "step_0").mkdir()
+    validate_run_dir(run_dir, resuming=True, clean=False)
 
 
 def test_dir_with_checkpoints_cleaned_when_flag_set(tmp_path):
-    output_dir = tmp_path / "has_ckpt"
-    output_dir.mkdir()
-    (output_dir / "checkpoints").mkdir()
-    (output_dir / "checkpoints" / "step_0").mkdir()
-    (output_dir / "logs").mkdir()
+    run_dir = tmp_path / "has_ckpt"
+    run_dir.mkdir()
+    (run_dir / "checkpoints").mkdir()
+    (run_dir / "checkpoints" / "step_0").mkdir()
+    (run_dir / "logs").mkdir()
 
-    validate_output_dir(output_dir, resuming=False, clean=True)
+    validate_run_dir(run_dir, resuming=False, clean=True)
 
-    assert not output_dir.exists()
+    assert not run_dir.exists()
 
 
 def test_clean_on_nonexistent_dir_is_noop(tmp_path):
-    output_dir = tmp_path / "does_not_exist"
-    validate_output_dir(output_dir, resuming=False, clean=True)
-    assert not output_dir.exists()
+    run_dir = tmp_path / "does_not_exist"
+    validate_run_dir(run_dir, resuming=False, clean=True)
+    assert not run_dir.exists()
+
+
+def test_ckpt_output_dir_with_checkpoints_raises(tmp_path):
+    run_dir = tmp_path / "fresh"
+    ckpt_output_dir = tmp_path / "ckpts"
+    ckpt_output_dir.mkdir()
+    (ckpt_output_dir / "checkpoints").mkdir()
+    (ckpt_output_dir / "checkpoints" / "step_0").mkdir()
+    with pytest.raises(FileExistsError, match="already contains checkpoints"):
+        validate_run_dir(run_dir, resuming=False, clean=False, ckpt_output_dir=ckpt_output_dir)

--- a/tests/unit/utils/test_pathing.py
+++ b/tests/unit/utils/test_pathing.py
@@ -5,13 +5,13 @@ from prime_rl.utils.pathing import validate_run_dir
 
 def test_nonexistent_dir_passes(tmp_path):
     run_dir = tmp_path / "does_not_exist"
-    validate_run_dir(run_dir, resuming=False, clean=False)
+    validate_run_dir(run_dir, output_dir=tmp_path, resuming=False, clean=False)
 
 
 def test_empty_dir_passes(tmp_path):
     run_dir = tmp_path / "empty"
     run_dir.mkdir()
-    validate_run_dir(run_dir, resuming=False, clean=False)
+    validate_run_dir(run_dir, output_dir=tmp_path, resuming=False, clean=False)
 
 
 def test_dir_with_launcher_artifacts_passes(tmp_path):
@@ -21,7 +21,7 @@ def test_dir_with_launcher_artifacts_passes(tmp_path):
     (run_dir / "configs" / "trainer.toml").touch()
     (run_dir / "rl.sbatch").touch()
     (run_dir / "job_1234.log").touch()
-    validate_run_dir(run_dir, resuming=False, clean=False)
+    validate_run_dir(run_dir, output_dir=tmp_path, resuming=False, clean=False)
 
 
 def test_dir_with_logs_raises(tmp_path):
@@ -30,7 +30,7 @@ def test_dir_with_logs_raises(tmp_path):
     (run_dir / "logs").mkdir()
     (run_dir / "logs" / "trainer.log").touch()
     with pytest.raises(FileExistsError, match="already contains artifacts"):
-        validate_run_dir(run_dir, resuming=False, clean=False)
+        validate_run_dir(run_dir, output_dir=tmp_path, resuming=False, clean=False)
 
 
 def test_dir_with_checkpoints_raises(tmp_path):
@@ -39,7 +39,7 @@ def test_dir_with_checkpoints_raises(tmp_path):
     (run_dir / "checkpoints").mkdir()
     (run_dir / "checkpoints" / "step_0").mkdir()
     with pytest.raises(FileExistsError, match="already contains artifacts"):
-        validate_run_dir(run_dir, resuming=False, clean=False)
+        validate_run_dir(run_dir, output_dir=tmp_path, resuming=False, clean=False)
 
 
 def test_dir_with_checkpoints_passes_when_resuming(tmp_path):
@@ -47,7 +47,7 @@ def test_dir_with_checkpoints_passes_when_resuming(tmp_path):
     run_dir.mkdir()
     (run_dir / "checkpoints").mkdir()
     (run_dir / "checkpoints" / "step_0").mkdir()
-    validate_run_dir(run_dir, resuming=True, clean=False)
+    validate_run_dir(run_dir, output_dir=tmp_path, resuming=True, clean=False)
 
 
 def test_dir_with_checkpoints_cleaned_when_flag_set(tmp_path):
@@ -57,14 +57,14 @@ def test_dir_with_checkpoints_cleaned_when_flag_set(tmp_path):
     (run_dir / "checkpoints" / "step_0").mkdir()
     (run_dir / "logs").mkdir()
 
-    validate_run_dir(run_dir, resuming=False, clean=True)
+    validate_run_dir(run_dir, output_dir=tmp_path, resuming=False, clean=True)
 
     assert not run_dir.exists()
 
 
 def test_clean_on_nonexistent_dir_is_noop(tmp_path):
     run_dir = tmp_path / "does_not_exist"
-    validate_run_dir(run_dir, resuming=False, clean=True)
+    validate_run_dir(run_dir, output_dir=tmp_path, resuming=False, clean=True)
     assert not run_dir.exists()
 
 
@@ -75,4 +75,12 @@ def test_ckpt_output_dir_with_checkpoints_raises(tmp_path):
     (ckpt_output_dir / "checkpoints").mkdir()
     (ckpt_output_dir / "checkpoints" / "step_0").mkdir()
     with pytest.raises(FileExistsError, match="already contains checkpoints"):
-        validate_run_dir(run_dir, resuming=False, clean=False, ckpt_output_dir=ckpt_output_dir)
+        validate_run_dir(run_dir, output_dir=tmp_path, resuming=False, clean=False, ckpt_output_dir=ckpt_output_dir)
+
+
+def test_clean_outside_output_dir_raises(tmp_path):
+    escaped = tmp_path / "elsewhere"
+    escaped.mkdir()
+    with pytest.raises(ValueError, match="remain under output_dir"):
+        validate_run_dir(escaped, output_dir=tmp_path / "outputs", resuming=False, clean=True)
+    assert escaped.exists()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,14 +9,14 @@ def strip_escape_codes(text: str) -> str:
     return re.sub(r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", text)
 
 
-def check_no_error(process: ProcessResult, output_dir: Path) -> None:
+def check_no_error(process: ProcessResult, run_dir: Path) -> None:
     """Helper to assert that a process did not error"""
     if process.returncode != 0:
         print("=== Inference Outputs ===")
-        with open(output_dir / "logs" / "inference.log", "r") as f:
+        with open(run_dir / "logs" / "inference.log", "r") as f:
             print(*f.readlines()[-100:], sep="")
         print("=== Orchestrator Outputs ===")
-        with open(output_dir / "logs" / "orchestrator.log", "r") as f:
+        with open(run_dir / "logs" / "orchestrator.log", "r") as f:
             print(*f.readlines()[-1000:], sep="")
     assert process.returncode == 0, f"Process has non-zero return code ({process})"
 


### PR DESCRIPTION
## Summary

- `output_dir` now groups related runs: each run writes all artifacts (logs, configs, checkpoints, weights, rollouts) to its own `output_dir / run.dir`.
- New `[run]` block on `rl`/`sft`: `name` auto-generates as `<envs>--<model>--<short-id>` (SFT: `<dataset>--<model>--<short-id>`; lowercase, `+`-joined env names) so defaults are readable and collision-free; `dir` defaults to `name`. Unset W&B and Prime platform run names inherit `run.name`.
- The run identity is runtime-only, never sub-config: the launcher sets `$PRL_RUN_ID` (Prime SDK will issue it later) and `$PRL_RUN_NAME`, and every process reads them — traces are stamped with `RunInfo{id, name}` (companion PrimeIntellect-ai/verifiers#2358, merged — submodule pinned to the merge commit on verifiers main), the shared W&B run id *is* `$PRL_RUN_ID` (`WANDB_SHARED_RUN_ID` retired), and env servers label every Prime sandbox with the run name. Standalone components simply have no run identity.
- Resume is a top-level `[resume]` block, unified across entrypoints and sub-configs (it sits next to `ckpt`, never inside it): bare `--resume` = latest checkpoint, `--resume.step N` = specific step, `--resume.dir <other-run>/checkpoints/step_N` = fork an external checkpoint into this run (`step`/`dir` mutually exclusive). Checkpoint managers always exist: `resume` gates loading, `ckpt` gates saving — resuming without `[ckpt]` loads the checkpoint but saves no new ones.
- **Resolved configs are JSON** (`configs/{rl,trainer,orchestrator,inference}.json`, env servers too): JSON keeps nulls, so explicit None overrides (e.g. `--trainer.optim.max-norm None`) round-trip exactly and `to_toml_dict`'s `"None"`-string convention is deleted. Hand-written configs stay TOML — the format split marks intent vs artifact. Aligned with verifiers' `configs/<cli>.json`.
- A run dir that already contains artifacts refuses a fresh launch; `--clean` (renamed from `clean_output_dir`) wipes only that run dir, with a containment check.

### Example

```toml
# rl.toml
max_steps = 100
output_dir = "outputs/wordle"  # groups related runs (default: "outputs")

[run]
name = "exp1"  # optional - auto-generates as <envs>--<model>--<short-id>;
               # run.dir (defaults to name) is the directory leaf

[ckpt]

[resume]       # optional - omit to start fresh; empty block = latest checkpoint
step = 50      # or: dir = "outputs/wordle/exp0/checkpoints/step_50" (fork)
```

```bash
uv run rl @ rl.toml            # -> outputs/wordle/exp1/{configs,logs,checkpoints,weights,rollouts}
                               #    configs/ holds the resolved rl/trainer/orchestrator/inference JSON
uv run rl @ rl.toml --resume   # resume latest checkpoint, same run dir
uv run rl @ rl.toml --clean    # wipe outputs/wordle/exp1 and start fresh
```

## Breaking

- **Artifact paths** moved down one level: `output_dir/logs` etc. → `output_dir/<run_dir>/...`.
- **`ckpt.resume_step` → top-level `[resume]`** (no `-1` sentinel; trainer/orchestrator ckpt configs carry the same block). Resume needs the run name: `--run.name <name>` at launch and resume.
- **Stricter reuse guard**: any run artifact blocks a fresh launch (was checkpoints-only).
- **`clean_output_dir` → `clean`** (deletes only the run dir); `NEVER_CLEAN_OUTPUT_DIR` → `NEVER_CLEAN`.
- **`WANDB_SHARED_RUN_ID` retired** (use `$PRL_RUN_ID`); unnamed W&B runs are now named `run.name` instead of W&B auto-names.
- **`trainer.output_dir` / `orchestrator.output_dir` are derived** under the `rl` entrypoint; setting them to conflicting values errors.
- **Resolved artifacts renamed**: `configs/rl.toml` etc. → `configs/rl.json` (JSON, nulls included); `to_toml_dict` removed.

## Verification

E2E on 2 GPUs (reverse-text, 0.6B):

- Two 10-step runs share `--output-dir`: UUID-suffixed and named run dirs side by side, rewards healthy, exit 0.
- Same-name relaunch without resume → `FileExistsError`; `--resume` continues 10→12 in the same dir; `--clean` wipes only that run dir (sibling intact); same name under another `output_dir` is fresh.
- `--resume.dir`: a fresh run forked from another run's `checkpoints/step_5` trains steps 6–7 warm (step-6 reward ~0.50 vs ~0.15 cold), saving its own checkpoints.
- Identity: with `PRL_RUN_ID` preset, every trace records exactly that id + the run name (via `$PRL_RUN_NAME`); sub-config TOMLs carry no run info at all.
- JSON round-trip: a 2-step run with `--trainer.optim.max-norm None` writes `"max_norm": null` into `trainer.json`, subprocesses boot from the JSON configs, exit 0.
- `pytest tests/unit` green throughout; ruff green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking config and path changes affect every RL/SFT launch, resume, and W&B integration; incorrect migration can lose checkpoints or write into the wrong directory.
> 
> **Overview**
> Introduces **per-run artifact layout**: `output_dir` groups runs; each run writes to `output_dir / run.dir` (auto `run.name` like `<envs>--<model>--<short-id>` unless set). **`clean_output_dir` → `clean`** wipes only that run directory; reuse is blocked unless resuming or cleaning.
> 
> **Checkpoint resume** moves out of `ckpt.resume_step` into a top-level **`[resume]`** block (`--resume`, `--resume.step N`, or `--resume.dir` to fork another run’s `step_<N>`). Loading is gated by `resume`; saving stays on `[ckpt]` (resume without ckpt loads but does not save).
> 
> **Launchers** set `$PRL_RUN_ID` / `$PRL_RUN_NAME`, align shared W&B with `WANDB_RUN_ID`, derive trainer/orchestrator `output_dir` from `run_dir`, and write **resolved sub-configs as JSON** (replacing `*.toml` / `to_toml_dict`) so explicit `null` overrides round-trip.
> 
> Trainer/orchestrator checkpoint managers always exist; external resume paths load `step_<N>/trainer` and `.../orchestrator`. Env servers tag sandboxes with the run name; traces carry run id/name. Docs, examples, CI configs, and tests follow the new flags and paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03c416ed156dfc88fbd01473109556dd20c37eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->