### PR TITLE
feat: warn when inference queue exceeds inflight-episode budget

### DIFF
--- a/src/prime_rl/orchestrator/inference_metrics.py
+++ b/src/prime_rl/orchestrator/inference_metrics.py
@@ -14,6 +14,8 @@ from prime_rl.utils.logger import get_logger
 POLL_INTERVAL = 5.0
 WINDOW_SIZE = 20
 PD_ROLES = {"prefill", "decode"}
+OVERLOAD_WAITING_FRACTION = 0.2
+OVERLOAD_WARN_INTERVAL = 60.0
 
 COUNTER_KEYS = {
     "vllm:prompt_tokens": "prompt_tokens_total",
@@ -390,12 +392,19 @@ class InferenceMetricsCollector:
     disaggregated P/D deployment.
     """
 
-    def __init__(self, admin_clients: list[AsyncClient], roles: list[str | None] | None = None):
+    def __init__(
+        self,
+        admin_clients: list[AsyncClient],
+        roles: list[str | None] | None = None,
+        max_inflight_episodes: int | None = None,
+    ):
         self.endpoints = build_metrics_endpoints(admin_clients, roles=roles)
         self.metric_history: dict[str, deque[float]] = {}
         self.previous: dict[str, TimedRollup] = {}
         self.task: asyncio.Task | None = None
         self.has_pd_roles = {endpoint.role for endpoint in self.endpoints if endpoint.role is not None} == PD_ROLES
+        self.max_inflight_episodes = max_inflight_episodes
+        self.last_overload_warning = float("-inf")
 
     async def start(self):
         wandb.define_metric("inference/*", step_metric="_timestamp")
@@ -440,6 +449,20 @@ class InferenceMetricsCollector:
 
         for sample in samples:
             self.previous[sample.endpoint.key] = TimedRollup(timestamp=sample.timestamp, rollup=sample.rollup)
+
+        waiting_requests = metrics["inference/agg/waiting_requests"]
+        if (
+            self.max_inflight_episodes is not None
+            and waiting_requests > OVERLOAD_WAITING_FRACTION * self.max_inflight_episodes
+            and now - self.last_overload_warning >= OVERLOAD_WARN_INTERVAL
+        ):
+            self.last_overload_warning = now
+            get_logger().warning(
+                f"Inference is overloaded: {waiting_requests:.0f} waiting request(s), more than "
+                f"{OVERLOAD_WAITING_FRACTION:.0%} of max_inflight_episodes={self.max_inflight_episodes} - "
+                "training is slowed by queued requests. If intermittent, wait it out - if persistent, "
+                "lower concurrency by decreasing max_inflight_episodes"
+            )
 
         smoothed_metrics = self.smooth_metrics(metrics)
         if smoothed_metrics:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -294,6 +294,7 @@ class Orchestrator:
             self.inference_metrics = InferenceMetricsCollector(
                 self.policy_inference.admin_clients,
                 roles=config.inference_metrics_roles,
+                max_inflight_episodes=config.max_inflight_episodes,
             )
             await self.inference_metrics.start()
 


### PR DESCRIPTION
## Summary

- Warn when inference is overloaded: if the aggregate number of waiting requests across all vLLM engines exceeds 20% of `max_inflight_episodes`, log a warning that inference is saturated and training is slowed by queued requests.
- The warning advises to wait if the spike is intermittent, and to lower concurrency (decrease `max_inflight_episodes`) if it persists.
- The check runs in `InferenceMetricsCollector` on its existing 5s `/metrics` poll and is throttled to at most one warning per 60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only logging on the metrics poll path; no changes to rollout scheduling, weight broadcast, or inference serving.
> 
> **Overview**
> Adds **overload detection** on the existing inference metrics poll: when aggregate `num_requests_waiting` across vLLM engines exceeds **20%** of `max_inflight_episodes`, the orchestrator logs a throttled warning (at most once per **60s**) that inference is saturated and training may be slowed by queued requests, with guidance to wait or lower `max_inflight_episodes`.
> 
> `InferenceMetricsCollector` now takes optional `max_inflight_episodes`; the orchestrator passes `config.max_inflight_episodes` when W&B inference metrics collection is enabled. No change to dispatch or concurrency behavior—logging only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f9a6d46b2f517cb4c647dec965e4314960379a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->