### PR TITLE
chore: bump verifiers for prime vm runtime default

### DIFF
--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -104,7 +104,6 @@ summarize_at_tokens = [65536, 131072]
 
 [orchestrator.train.source.env.agent.runtime]
 type = "prime"
-vm = true
 idle_timeout = "None"
 labels = ["glm45air-search"]
 
@@ -137,7 +136,6 @@ summarize_at_tokens = [65536, 131072]
 
 [orchestrator.train.source.env.agent.runtime]
 type = "prime"
-vm = true
 idle_timeout = "None"
 labels = ["glm45air-search"]
 
@@ -176,7 +174,6 @@ summarize_at_tokens = 98304
 
 [orchestrator.eval.source.env.agent.runtime]
 type = "prime"
-vm = true
 idle_timeout = "None"
 labels = ["glm45air-search"]
 

--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -103,8 +103,6 @@ forward_env = ["SERPER_API_KEY"]
 summarize_at_tokens = [65536, 131072]
 
 [orchestrator.train.source.env.agent.runtime]
-type = "prime"
-idle_timeout = "None"
 labels = ["glm45air-search"]
 
 [orchestrator.train.source.env.taskset]
@@ -135,8 +133,6 @@ forward_env = ["SERPER_API_KEY"]
 summarize_at_tokens = [65536, 131072]
 
 [orchestrator.train.source.env.agent.runtime]
-type = "prime"
-idle_timeout = "None"
 labels = ["glm45air-search"]
 
 [orchestrator.train.source.env.taskset]
@@ -173,8 +169,6 @@ forward_env = ["SERPER_API_KEY"]
 summarize_at_tokens = 98304
 
 [orchestrator.eval.source.env.agent.runtime]
-type = "prime"
-idle_timeout = "None"
 labels = ["glm45air-search"]
 
 [orchestrator.eval.source.env.agent.timeout]

--- a/examples/advanced/glm-4.5-air/swe.toml
+++ b/examples/advanced/glm-4.5-air/swe.toml
@@ -109,7 +109,6 @@ summarize_at_tokens = [65536, 131072]
 
 [orchestrator.train.source.env.agent.runtime]
 type = "prime"
-vm = true
 idle_timeout = "None"
 labels = ["glm45air-swe"]
 
@@ -132,7 +131,6 @@ summarize_at_tokens = 98304
 
 [orchestrator.eval.source.env.agent.runtime]
 type = "prime"
-vm = true
 idle_timeout = "None"
 labels = ["glm45air-swe"]
 

--- a/examples/advanced/glm-4.5-air/swe.toml
+++ b/examples/advanced/glm-4.5-air/swe.toml
@@ -108,8 +108,6 @@ id = "rlm"
 summarize_at_tokens = [65536, 131072]
 
 [orchestrator.train.source.env.agent.runtime]
-type = "prime"
-idle_timeout = "None"
 labels = ["glm45air-swe"]
 
 [orchestrator.prime_monitor]
@@ -130,8 +128,6 @@ id = "rlm"
 summarize_at_tokens = 98304
 
 [orchestrator.eval.source.env.agent.runtime]
-type = "prime"
-idle_timeout = "None"
 labels = ["glm45air-swe"]
 
 [orchestrator.eval.source.env.agent.timeout]

--- a/examples/advanced/glm-4.5-air/terminal.toml
+++ b/examples/advanced/glm-4.5-air/terminal.toml
@@ -99,8 +99,6 @@ id = "rlm"
 summarize_at_tokens = [65536, 131072]
 
 [orchestrator.train.source.env.agent.runtime]
-type = "prime"
-idle_timeout = "None"
 labels = ["glm45air-terminal"]
 
 [orchestrator.train.source.env.taskset]
@@ -134,8 +132,6 @@ id = "rlm"
 summarize_at_tokens = 98304
 
 [orchestrator.eval.source.env.agent.runtime]
-type = "prime"
-idle_timeout = "None"
 labels = ["glm45air-terminal"]
 
 [orchestrator.eval.source.env.agent.timeout]
@@ -167,8 +163,6 @@ id = "rlm"
 summarize_at_tokens = 98304
 
 [orchestrator.eval.source.env.agent.runtime]
-type = "prime"
-idle_timeout = "None"
 labels = ["glm45air-terminal"]
 
 [orchestrator.eval.source.env.agent.timeout]

--- a/examples/advanced/glm-4.5-air/terminal.toml
+++ b/examples/advanced/glm-4.5-air/terminal.toml
@@ -100,7 +100,6 @@ summarize_at_tokens = [65536, 131072]
 
 [orchestrator.train.source.env.agent.runtime]
 type = "prime"
-vm = true
 idle_timeout = "None"
 labels = ["glm45air-terminal"]
 
@@ -136,7 +135,6 @@ summarize_at_tokens = 98304
 
 [orchestrator.eval.source.env.agent.runtime]
 type = "prime"
-vm = true
 idle_timeout = "None"
 labels = ["glm45air-terminal"]
 
@@ -170,7 +168,6 @@ summarize_at_tokens = 98304
 
 [orchestrator.eval.source.env.agent.runtime]
 type = "prime"
-vm = true
 idle_timeout = "None"
 labels = ["glm45air-terminal"]
 

--- a/examples/advanced/glm-5.2/swe-llmd.toml
+++ b/examples/advanced/glm-5.2/swe-llmd.toml
@@ -137,7 +137,6 @@ id = "r2e-gym"
 id = "rlm"
 
 [orchestrator.train.source.env.agent.runtime]
-type = "prime"
 labels = ["glm5-llmd"]
 
 [inference]

--- a/examples/advanced/glm-5.2/swe.toml
+++ b/examples/advanced/glm-5.2/swe.toml
@@ -85,7 +85,6 @@ id = "swebench-verified"
 id = "bash"
 
 [orchestrator.eval.source.env.agent.runtime]
-type = "prime"
 labels = ["glm5-pd-disag", "swe-bench-verified"]
 
 [[orchestrator.post_batch_filters]]

--- a/examples/advanced/intellect-3.1/rl.toml
+++ b/examples/advanced/intellect-3.1/rl.toml
@@ -58,7 +58,6 @@ id = "r2e-gym"
 id = "bash"
 
 [orchestrator.train.source.env.agent.runtime]
-type = "prime"
 labels = ["intellect-3.1", "swe"]
 
 [[orchestrator.train.source]]
@@ -74,7 +73,6 @@ skills = ["search"]
 forward_env = ["SERPER_API_KEY"]
 
 [orchestrator.train.source.env.agent.runtime]
-type = "prime"
 labels = ["intellect-3.1", "deepdive"]
 
 [[orchestrator.train.source]]
@@ -136,7 +134,6 @@ id = "swebench-verified"
 id = "bash"
 
 [orchestrator.eval.source.env.agent.runtime]
-type = "prime"
 labels = ["intellect-3.1", "swe-bench-verified"]
 
 [[orchestrator.eval.source]]

--- a/examples/advanced/minimax-m2.5/swe.toml
+++ b/examples/advanced/minimax-m2.5/swe.toml
@@ -58,7 +58,6 @@ id = "r2e-gym"
 id = "bash"
 
 [orchestrator.train.source.env.agent.runtime]
-type = "prime"
 labels = ["minimax-swe", "swe"]
 
 [orchestrator.eval]
@@ -74,7 +73,6 @@ id = "swebench-verified"
 id = "bash"
 
 [orchestrator.eval.source.env.agent.runtime]
-type = "prime"
 labels = ["minimax-swe", "swe-bench-verified"]
 
 [inference.vllm]

--- a/examples/advanced/nemotron-3-super/swe.toml
+++ b/examples/advanced/nemotron-3-super/swe.toml
@@ -93,7 +93,6 @@ summarize_at_tokens = [65536, 131072]
 
 [orchestrator.train.source.env.agent.runtime]
 type = "prime"
-vm = true
 idle_timeout = "None"
 labels = ["nemotron-3-super-swe"]
 
@@ -114,7 +113,6 @@ summarize_at_tokens = 98304
 
 [orchestrator.eval.source.env.agent.runtime]
 type = "prime"
-vm = true
 idle_timeout = "None"
 labels = ["nemotron-3-super-swe"]
 

--- a/examples/advanced/nemotron-3-super/swe.toml
+++ b/examples/advanced/nemotron-3-super/swe.toml
@@ -92,8 +92,6 @@ id = "rlm"
 summarize_at_tokens = [65536, 131072]
 
 [orchestrator.train.source.env.agent.runtime]
-type = "prime"
-idle_timeout = "None"
 labels = ["nemotron-3-super-swe"]
 
 [orchestrator.prime_monitor]
@@ -112,8 +110,6 @@ id = "rlm"
 summarize_at_tokens = 98304
 
 [orchestrator.eval.source.env.agent.runtime]
-type = "prime"
-idle_timeout = "None"
 labels = ["nemotron-3-super-swe"]
 
 [orchestrator.eval.source.env.agent.timeout]

--- a/examples/advanced/qwen3-30b-a3b/swe.toml
+++ b/examples/advanced/qwen3-30b-a3b/swe.toml
@@ -56,7 +56,6 @@ id = "r2e-gym"
 id = "bash"
 
 [orchestrator.train.source.env.agent.runtime]
-type = "prime"
 labels = ["qwen30b-swe", "swe"]
 
 [orchestrator.eval]
@@ -72,7 +71,6 @@ id = "swebench-verified"
 id = "bash"
 
 [orchestrator.eval.source.env.agent.runtime]
-type = "prime"
 labels = ["qwen30b-swe", "swe-bench-verified"]
 
 [inference.vllm]

--- a/uv.lock
+++ b/uv.lock
@@ -7500,17 +7500,21 @@ dev = [
 ]
 examples = [
     { name = "alphabet-sort", editable = "deps/verifiers/environments/alphabet_sort" },
+    { name = "bash-interception", editable = "deps/verifiers/environments/bash_interception" },
     { name = "code-golf", editable = "deps/verifiers/environments/code_golf" },
     { name = "color-codeword", editable = "deps/verifiers/environments/color_codeword" },
     { name = "compact", editable = "deps/verifiers/environments/compact" },
     { name = "deepwiki", editable = "deps/verifiers/environments/deepwiki" },
     { name = "glossary", editable = "deps/verifiers/environments/glossary" },
+    { name = "grayscale-interception", editable = "deps/verifiers/environments/grayscale_interception" },
     { name = "gsm8k", editable = "deps/verifiers/environments/gsm8k" },
+    { name = "interception", editable = "deps/verifiers/environments/interception" },
     { name = "kuhn-poker", editable = "deps/verifiers/environments/kuhn_poker" },
     { name = "openenv-wordle", editable = "deps/verifiers/environments/openenv_wordle" },
     { name = "proposer-solver", editable = "deps/verifiers/environments/proposer_solver" },
     { name = "reverse-text", editable = "deps/verifiers/environments/reverse_text" },
     { name = "scratchpad", editable = "deps/verifiers/environments/scratchpad" },
+    { name = "web-search-interception", editable = "deps/verifiers/environments/web_search_interception" },
     { name = "wiki-search", editable = "deps/verifiers/environments/wiki_search" },
     { name = "wordle", editable = "deps/verifiers/environments/wordle" },
 ]


### PR DESCRIPTION
## Summary
- Repoint the `deps/verifiers` submodule to merged main (`950bba095`) and update `uv.lock` (new verifiers example envs in the `examples` extra).
- Clean the now-redundant prime runtime keys from every example config (`glm-4.5-air/{swe,search,terminal}`, `glm-5.2/{swe,swe-llmd}`, `intellect-3.1/rl`, `minimax-m2.5/swe`, `nemotron-3-super/swe`, `qwen3-30b-a3b/swe`):
  - `type = "prime"` — the default agent runtime is now the prime VM sandbox, and pydantic_config falls back to the default union variant when the tag is omitted.
  - `vm = true` — `PrimeConfig` now defaults to `vm=true`.
  - `idle_timeout = "None"` — `PrimeRuntime` always drops `idle_minutes` for VM sandboxes (the API 422s on it), so the key is a no-op there.

## Verifiers changes pulled in (`7251c6093..950bba095`)
- **PrimeIntellect-ai/verifiers#2356 — prime VM sandbox as the default runtime.** `AgentConfig.runtime` defaults to `PrimeConfig()`, `PrimeConfig.vm` defaults to `true`, and prime auth is checked when a `PrimeRuntime`/`PrimeTunnel` is instantiated (unauthenticated local subprocess/docker runs keep working). This is the behavior change the config cleanup rides on.
- **PrimeIntellect-ai/verifiers#2178 — harness tool interception.** Typed model interception with an interception transport, replay, stop-at-typed-model-boundaries, harness hooks, and example interception environments.
- **PrimeIntellect-ai/verifiers#2291 — persistent live sessions for all ACP harnesses.** Aligns the ACP harness lifecycle, native ACP model routing, and canonicalized streamed/replayed reasoning state.
- **PrimeIntellect-ai/verifiers#2299 — block provider network escapes in restricted runtimes.**
- **PrimeIntellect-ai/verifiers#2357 — stable task keys for tasksets.**
- **PrimeIntellect-ai/verifiers#2346 — fix runtime script and IPC paths.**
- **PrimeIntellect-ai/verifiers#2251 — isolate Bash commands from the harness venv.**
- **PrimeIntellect-ai/verifiers#2336 — pin the mini-swe-agent LiteLLM dependency.**

## Verification
- `pytest tests/unit/test_configs.py::test_load_configs` — 64 passed against the bumped verifiers (all `configs/`, `examples/`, `k8s/` TOMLs parse; omitted `type` narrows to `PrimeConfig`, so `labels`-only runtime sections validate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example and lockfile-only changes; runtime semantics are intended to stay equivalent via verifiers defaults, with config load tests covering parse validation.
> 
> **Overview**
> Updates example orchestrator configs to match **verifiers** defaults where the **prime VM sandbox** is now the implicit agent runtime, and refreshes **`uv.lock`** for new verifiers example packages.
> 
> Across GLM-4.5-Air, GLM-5.2, Intellect-3.1, MiniMax, Nemotron-3-Super, and Qwen3 SWE/search/terminal examples, **`[orchestrator.*.env.agent.runtime]`** sections no longer set **`type = "prime"`**, **`vm = true`**, or **`idle_timeout = "None"`**—only **`labels`** (and other non-default fields) remain. Parsing still resolves to the same prime VM behavior via library defaults.
> 
> **`uv.lock`** adds editable **`examples`** extras for interception-related verifiers environments (`bash-interception`, `grayscale-interception`, `interception`, `web-search-interception`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92456a865ebae4ef28c918e639a966c1f661d15c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->