### PR TITLE
feat: per-attempt log directories

### DIFF
--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -69,7 +69,7 @@ uv run torchrun \
   src/prime_rl/trainer/sft/train.py @ sft.toml
 ```
 
-`--local-ranks-filter 0` keeps console output to rank 0 only; per-rank stdout/stderr is still captured in `<run_dir>/logs/trainer/torchrun/`.
+`--local-ranks-filter 0` keeps console output to rank 0 only; per-rank stdout/stderr is still captured in `<run_dir>/logs/latest/trainer/torchrun/`.
 
 ### Multi-Node
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -267,10 +267,10 @@ For LoRA runs, set `ckpt.weights.save_adapter_separately = true` to also write t
 
 ### Log Files
 
-The launcher tees every process's stdout/stderr into `<run_dir>/logs/`. The full layout (single-node runs skip the `node_*.log` and `router.log` files — there the router logs into `inference.log`):
+The launcher tees every process's stdout/stderr into `<run_dir>/logs/attempt_<n>/` — every launch (fresh or resumed) gets its own numbered attempt directory, and `logs/latest` symlinks to the current one. The full layout (single-node runs skip the `node_*.log` and `router.log` files — there the router logs into `inference.log`):
 
 ```
-<run_dir>/logs/
+<run_dir>/logs/latest/     # symlink -> attempt_<n>, one per launch
 ├── trainer.log                  # rank 0 only; symlink → trainer/node_0.log on multi-node
 ├── orchestrator.log             # single instance, single file
 ├── inference.log                # symlink → inference/node_0.log on multi-node
@@ -288,9 +288,9 @@ Env logs are the first place to look for env-side errors (most user code lives t
 Live tailing from a single point (works on the head node for multi-node runs over a shared filesystem):
 
 ```bash
-tail -F <run_dir>/logs/{trainer,orchestrator,inference}.log
-tail -F <run_dir>/logs/trainer/node_*.log       # multi-node only
-tail -F <run_dir>/logs/inference/router.log     # multi-node only
+tail -F <run_dir>/logs/latest/{trainer,orchestrator,inference}.log
+tail -F <run_dir>/logs/latest/trainer/node_*.log   # multi-node only
+tail -F <run_dir>/logs/latest/inference/router.log # multi-node only
 ```
 
 ### Console Output

--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -60,7 +60,7 @@ if [[ ${#POSITIONAL[@]} -ge 2 ]]; then
   OUTPUT_DIR="${POSITIONAL[1]}"
 fi
 
-LOG_DIR="${OUTPUT_DIR}/logs"
+LOG_DIR="${OUTPUT_DIR}/logs/latest"
 
 if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
   echo "Attaching to tmux session: $SESSION_NAME"

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -57,13 +57,13 @@ After a restart, verify all processes are back up and progress resumed before th
 
 - `scripts/tmux.sh` launches the run with a `Launcher` window in the named tmux session. The Claude window receives the run dir and session name in its appended prompt — if either is missing, **ask** rather than guess.
 - `{run_dir}/configs/` — resolved configs, written as JSON so explicit None settings round-trip (`rl.json` has the full picture).
-- `{run_dir}/logs/` — see below.
+- `{run_dir}/logs/latest/` — the current attempt's logs (each launch gets `logs/attempt_<n>/`; resumes never overwrite earlier attempts). See below.
 - `{run_dir}/rollouts/step_N/{train,eval}/` — saved rollout traces (see Traces below).
 
 ### Logs
 
 ```
-{run_dir}/logs/
+{run_dir}/logs/latest/
 ├── trainer.log                # rank 0 stdout
 ├── orchestrator.log           # orchestrator stdout
 ├── inference.log              # vLLM stdout
@@ -81,8 +81,8 @@ Usually tailing `trainer.log`, `orchestrator.log`, and `inference.log` is enough
 Scan for problems:
 
 ```bash
-grep -E "WARNING|ERROR" {run_dir}/logs/{trainer,orchestrator,inference}.log
-grep -E "WARNING|ERROR" {run_dir}/logs/envs/{train,eval}/*.log
+grep -E "WARNING|ERROR" {run_dir}/logs/latest/{trainer,orchestrator,inference}.log
+grep -E "WARNING|ERROR" {run_dir}/logs/latest/envs/{train,eval}/*.log
 ```
 
 ### Metrics

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -10,7 +10,7 @@ from typing import Any
 from prime_rl.configs.inference import InferenceConfig
 from prime_rl.utils.config import cli, dump_resolved_config
 from prime_rl.utils.logger import setup_logger
-from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir
+from prime_rl.utils.pathing import format_log_message, get_config_dir, latest_log_dir
 from prime_rl.utils.process import (
     DEFAULT_COMMON_ENV_VARS,
     DEFAULT_INFERENCE_ENV_VARS,
@@ -135,7 +135,7 @@ def inference_slurm(config: InferenceConfig):
     write_slurm_script(config, config_path, script_path)
     logger.info(f"Wrote SLURM script to {script_path}")
 
-    log_dir = get_log_dir(config.output_dir)
+    log_dir = latest_log_dir(config.output_dir)
     num_nodes = getattr(config.deployment, "num_nodes", 1)
     log_message = format_log_message(log_dir=log_dir, inference=True, job_log=True, num_infer_nodes=num_nodes)
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -21,10 +21,11 @@ from prime_rl.utils.config import cli, dump_resolved_config
 from prime_rl.utils.logger import get_logger, setup_logger
 from prime_rl.utils.pathing import (
     clean_future_steps,
+    create_attempt_log_dir,
     format_log_message,
     get_ckpt_dir,
     get_config_dir,
-    get_log_dir,
+    latest_log_dir,
     resolve_latest_ckpt_step,
     validate_run_dir,
 )
@@ -181,9 +182,8 @@ def rl_local(config: RLConfig):
                 f"Update the base_url to use port {expected_port} to match the inference server."
             )
 
-    # Prepare paths to communicate with the trainer
-    log_dir = get_log_dir(config.run_dir)
-    log_dir.mkdir(parents=True, exist_ok=True)
+    # Per-attempt log dir: a resume never overwrites an earlier attempt's logs
+    log_dir = create_attempt_log_dir(config.run_dir)
 
     # Start processes
     processes: list[Popen] = []
@@ -567,7 +567,7 @@ def rl_slurm(config: RLConfig):
     )
 
     config_dir = get_config_dir(config.run_dir)
-    log_dir = get_log_dir(config.run_dir)
+    log_dir = latest_log_dir(config.run_dir)
 
     if config.deployment.type == "single_node":
         write_config(config, config_dir, exclude={"slurm", "dry_run", "clean"})

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -10,7 +10,13 @@ from threading import Event, Thread
 from prime_rl.configs.sft import SFTConfig
 from prime_rl.utils.config import cli, dump_resolved_config
 from prime_rl.utils.logger import setup_logger
-from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir, validate_run_dir
+from prime_rl.utils.pathing import (
+    create_attempt_log_dir,
+    format_log_message,
+    get_config_dir,
+    latest_log_dir,
+    validate_run_dir,
+)
 from prime_rl.utils.process import (
     DEFAULT_COMMON_ENV_VARS,
     DEFAULT_TRAINER_ENV_VARS,
@@ -89,7 +95,7 @@ def sft_slurm(config: SFTConfig):
     write_slurm_script(config, config_path, script_path)
     logger.info(f"Wrote SLURM script to {script_path}")
 
-    log_dir = get_log_dir(config.run_dir)
+    log_dir = latest_log_dir(config.run_dir)
     num_nodes = config.deployment.num_nodes if config.deployment.type == "multi_node" else 1
     log_message = format_log_message(log_dir=log_dir, trainer=True, num_train_nodes=num_nodes)
 
@@ -121,8 +127,7 @@ def sft_local(config: SFTConfig):
         logger.success("Dry run complete. To start an SFT run locally, remove --dry-run from your command.")
         return
 
-    log_dir = get_log_dir(config.run_dir)
-    log_dir.mkdir(parents=True, exist_ok=True)
+    log_dir = create_attempt_log_dir(config.run_dir)
 
     from prime_rl.utils.utils import get_free_port
 

--- a/src/prime_rl/templates/_launch_rank.sh.j2
+++ b/src/prime_rl/templates/_launch_rank.sh.j2
@@ -6,9 +6,9 @@
 # ranks 1+ get their own node_<rank>_rank<k>.log.
 rank_log() {
     if [ "$2" -eq 0 ]; then
-        echo "$OUTPUT_DIR/logs/inference/node_$1.log"
+        echo "$LOG_DIR/inference/node_$1.log"
     else
-        echo "$OUTPUT_DIR/logs/inference/node_$1_rank$2.log"
+        echo "$LOG_DIR/inference/node_$1_rank$2.log"
     fi
 }
 

--- a/src/prime_rl/templates/_launch_router.sh.j2
+++ b/src/prime_rl/templates/_launch_router.sh.j2
@@ -11,7 +11,7 @@ launch_router() {
 {%- if router.type == "llm-d" %}
     echo "Starting llm-d router (EPP+Envoy) on $LOCAL_IP:$port" | tee "$log"
     export PATH="$PROJECT_DIR/third_party/llmd/bin:$PATH"
-    local LLMD_DIR="$OUTPUT_DIR/logs/inference/llmd"
+    local LLMD_DIR="$LOG_DIR/inference/llmd"
     mkdir -p "$LLMD_DIR"
     read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
 {%- if is_disaggregated %}

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -53,9 +53,13 @@ export RPC_PORT={{ data_parallel_rpc_port }}
 export PROJECT_DIR={{ project_dir }}
 export CONFIG_PATH={{ config_path }}
 export OUTPUT_DIR={{ output_dir }}
-mkdir -p $OUTPUT_DIR/logs/inference
-rm -f $OUTPUT_DIR/logs/inference/*.log
-ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log
+# Per-attempt log dir: a relaunch never overwrites an earlier attempt's logs.
+ATTEMPT=1
+while [ -e $OUTPUT_DIR/logs/attempt_$ATTEMPT ]; do ATTEMPT=$((ATTEMPT+1)); done
+export LOG_DIR=$OUTPUT_DIR/logs/attempt_$ATTEMPT
+mkdir -p $LOG_DIR/inference
+ln -sfn attempt_$ATTEMPT $OUTPUT_DIR/logs/latest
+ln -sfn inference/node_0.log $LOG_DIR/inference.log
 
 # Setup environment
 cd $PROJECT_DIR
@@ -271,11 +275,11 @@ srun --kill-on-bad-exit=1 bash -s <<'LAUNCH_SH'
     fi
 
     echo "NODE_RANK=$INFER_NODE_RANK ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK DP=$DP PORT=$PORT LOCAL_IP=$LOCAL_IP" \
-        | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
+        | tee $LOG_DIR/inference/node_${INFER_NODE_RANK}.log
 
     # Start the single global router on node 0 (external LB across all per-rank endpoints)
     if [ "$INFER_NODE_RANK" -eq 0 ]; then
-        launch_router pd "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$OUTPUT_DIR/logs/inference/router.log"
+        launch_router pd "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$LOG_DIR/inference/router.log"
     fi
 {%- if router.type == "llm-d" %}
     # pd-sidecar on each decode node: EPP routes decode -> sidecar (DECODE_SIDECAR_PORT
@@ -283,7 +287,7 @@ srun --kill-on-bad-exit=1 bash -s <<'LAUNCH_SH'
     # Every decode node fronts its own local ranks, so launch on each (not just the
     # replica head), or decode nodes beyond the head get advertised but unserved endpoints.
     if [ "$ROLE" = "decode" ]; then
-        SIDECAR_LOG="$OUTPUT_DIR/logs/inference/sidecar_${INFER_NODE_RANK}.log"
+        SIDECAR_LOG="$LOG_DIR/inference/sidecar_${INFER_NODE_RANK}.log"
         echo "Starting pd-sidecar on $LOCAL_IP:$DECODE_SIDECAR_PORT(+rank) -> vLLM $DECODE_PORT(+rank)" | tee $SIDECAR_LOG
         export PATH="$PROJECT_DIR/third_party/llmd/bin:$PATH"
         pd-sidecar \
@@ -311,7 +315,7 @@ srun --kill-on-bad-exit=1 bash -s <<'LAUNCH_SH'
     done
 {%- elif num_nodes > 1 %}
     echo "INFER_NODE_RANK=${INFER_NODE_RANK}, LOCAL_IP=${LOCAL_IP}" \
-        | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
+        | tee $LOG_DIR/inference/node_${INFER_NODE_RANK}.log
 
     DP_PER_NODE={{ dp_per_node }}
     TP=$((GPUS_PER_NODE / DP_PER_NODE))
@@ -319,7 +323,7 @@ srun --kill-on-bad-exit=1 bash -s <<'LAUNCH_SH'
 
     # Start the single global router on node 0 (balances across per-rank endpoints — no intra-node DP header)
     if [ "$INFER_NODE_RANK" -eq 0 ]; then
-        launch_router regular "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$OUTPUT_DIR/logs/inference/router.log"
+        launch_router regular "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$LOG_DIR/inference/router.log"
     fi
 
     # External-LB: one vLLM API server per DP rank on this node (BACKEND_PORT + dp_local),
@@ -340,11 +344,11 @@ srun --kill-on-bad-exit=1 bash -s <<'LAUNCH_SH'
         fi
     done
 {%- else %}
-    echo "INFER_NODE_RANK=${INFER_NODE_RANK}, LOCAL_IP=${LOCAL_IP}" | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
+    echo "INFER_NODE_RANK=${INFER_NODE_RANK}, LOCAL_IP=${LOCAL_IP}" | tee $LOG_DIR/inference/node_${INFER_NODE_RANK}.log
 
     uv run inference \
         @ $CONFIG_PATH \
-        2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log &
+        2>&1 | tee -a $LOG_DIR/inference/node_${INFER_NODE_RANK}.log &
 {%- endif %}
 
 # Wait for the first background job to exit and propagate its exit code. This

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -58,10 +58,14 @@ export INFERENCE_ENABLE_EXPERT_PARALLEL={{ "1" if inference_enable_expert_parall
 export PROJECT_DIR={{ project_dir }}
 export CONFIG_DIR={{ config_dir }}
 export OUTPUT_DIR={{ output_dir }}
-mkdir -p $OUTPUT_DIR/logs/trainer $OUTPUT_DIR/logs/inference
-rm -f $OUTPUT_DIR/logs/inference/*.log
-ln -sfn trainer/node_0.log $OUTPUT_DIR/logs/trainer.log
-ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log
+# Per-attempt log dir: a resume or relaunch never overwrites an earlier attempt's logs.
+ATTEMPT=1
+while [ -e $OUTPUT_DIR/logs/attempt_$ATTEMPT ]; do ATTEMPT=$((ATTEMPT+1)); done
+export LOG_DIR=$OUTPUT_DIR/logs/attempt_$ATTEMPT
+mkdir -p $LOG_DIR/trainer $LOG_DIR/inference
+ln -sfn attempt_$ATTEMPT $OUTPUT_DIR/logs/latest
+ln -sfn trainer/node_0.log $LOG_DIR/trainer.log
+ln -sfn inference/node_0.log $LOG_DIR/inference.log
 
 export PRL_RUN_ID=${PRL_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}
 export PRL_RUN_NAME={{ run_name }}
@@ -242,7 +246,7 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     RANK_IN_REPLICA=$((INFER_NODE_RANK % NODES_PER_INFER_REPLICA))
 
     echo "INFER_NODE_RANK=$INFER_NODE_RANK REPLICA=$REPLICA_IDX RANK_IN_REPLICA=$RANK_IN_REPLICA LOCAL_IP=$LOCAL_IP" \
-        | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
+        | tee $LOG_DIR/inference/node_${INFER_NODE_RANK}.log
 
     CONFIG_PATH="$CONFIG_DIR/inference.json"
 {% include '_launch_rank.sh.j2' %}
@@ -312,11 +316,11 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     fi
 
     echo "ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK DP=$DP PORT=$PORT" \
-        | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
+        | tee -a $LOG_DIR/inference/node_${INFER_NODE_RANK}.log
 
     # Start the single global router on inference node 0 (PD mode, external LB across all per-rank endpoints)
     if [ "$INFER_NODE_RANK" -eq 0 ]; then
-        launch_router pd "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$OUTPUT_DIR/logs/inference/router.log"
+        launch_router pd "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$LOG_DIR/inference/router.log"
     fi
 {%- if router.type == "llm-d" %}
     # pd-sidecar on each decode node: EPP routes decode -> sidecar (DECODE_SIDECAR_PORT
@@ -324,7 +328,7 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     # Every decode node fronts its own local ranks, so launch on each (not just the
     # replica head), or decode nodes beyond the head get advertised but unserved endpoints.
     if [ "$ROLE" = "decode" ]; then
-        SIDECAR_LOG="$OUTPUT_DIR/logs/inference/sidecar_${INFER_NODE_RANK}.log"
+        SIDECAR_LOG="$LOG_DIR/inference/sidecar_${INFER_NODE_RANK}.log"
         echo "Starting pd-sidecar on $LOCAL_IP:$DECODE_SIDECAR_PORT(+rank) -> vLLM $DECODE_PORT(+rank)" | tee $SIDECAR_LOG
         export PATH="$PROJECT_DIR/third_party/llmd/bin:$PATH"
         pd-sidecar \
@@ -353,7 +357,7 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
 {%- else -%}
     # Start the single global router on inference node 0 (external LB across all per-rank endpoints)
     if [ "$INFER_NODE_RANK" -eq 0 ]; then
-        launch_router regular "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$OUTPUT_DIR/logs/inference/router.log"
+        launch_router regular "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$LOG_DIR/inference/router.log"
     fi
 
     # External-LB: one vLLM API server per DP rank on this node (BACKEND_PORT + d),
@@ -394,7 +398,7 @@ else
     export {{ key }}="{{ value }}"
 {%- endfor %}
 
-    echo $HOSTNAMES_STR | tee $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log
+    echo $HOSTNAMES_STR | tee $LOG_DIR/trainer/node_${TRAIN_NODE_RANK}.log
 
     WANDB_SHARED_LABEL=trainer uv run torchrun \
         --role=trainer \
@@ -403,14 +407,14 @@ else
         --node-rank=$TRAIN_NODE_RANK \
         --rdzv-endpoint=$MASTER_ADDR:$MASTER_PORT \
         --rdzv-id=job_$SLURM_JOB_ID \
-        --log-dir=$OUTPUT_DIR/logs/trainer/torchrun \
+        --log-dir=$LOG_DIR/trainer/torchrun \
         --tee=3 \
         --redirects=3 \
         --local-ranks-filter={{ ranks_filter }} \
         -m prime_rl.trainer.rl.train \
         @ $CONFIG_DIR/trainer.json \
         {% if use_zmq_transport %}--rollout_transport.host $ORCH_ADDR \
-        {% endif %}2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log &
+        {% endif %}2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $LOG_DIR/trainer/node_${TRAIN_NODE_RANK}.log &
 {% if num_infer_nodes > 0 %}    fi{% endif %}
 {% if num_infer_nodes > 0 %}
 # Launch the orchestrator on the node ORCH_ADDR points at (see the ORCH_PROCID
@@ -435,21 +439,21 @@ if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
     # single-quoted bash -c string, so a stray quote closes it early and the rest of
     # the script fails to parse.
 {%- for name in train_env_names %}
-    mkdir -p $OUTPUT_DIR/logs/envs/train
+    mkdir -p $LOG_DIR/envs/train
     uv run env-server @ $CONFIG_DIR/envs/train/{{ name }}.json \
-        > $OUTPUT_DIR/logs/envs/train/{{ name }}.log 2>&1 &
+        > $LOG_DIR/envs/train/{{ name }}.log 2>&1 &
 {%- endfor %}
 {%- for name in eval_env_names %}
-    mkdir -p $OUTPUT_DIR/logs/envs/eval
+    mkdir -p $LOG_DIR/envs/eval
     uv run env-server @ $CONFIG_DIR/envs/eval/{{ name }}.json \
-        > $OUTPUT_DIR/logs/envs/eval/{{ name }}.log 2>&1 &
+        > $LOG_DIR/envs/eval/{{ name }}.log 2>&1 &
 {%- endfor %}
 {%- endif %}
 
     {% if use_nccl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $MASTER_ADDR"
     {% endif %}{% if use_zmq_transport %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --rollout_transport.host $ORCH_ADDR"
     {% endif %}WANDB_SHARED_LABEL=orchestrator uv run orchestrator $ORCHESTRATOR_ARGS \
-        2>&1 | tee $OUTPUT_DIR/logs/orchestrator.log &
+        2>&1 | tee $LOG_DIR/orchestrator.log &
 fi
 {% endif %}
 

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -33,8 +33,13 @@ export GPUS_PER_NODE={{ gpus_per_node }}
 export PROJECT_DIR={{ project_dir }}
 export CONFIG_PATH={{ config_path }}
 export OUTPUT_DIR={{ output_dir }}
-mkdir -p $OUTPUT_DIR/logs/trainer
-ln -sfn trainer/node_0.log $OUTPUT_DIR/logs/trainer.log
+# Per-attempt log dir: a resume or relaunch never overwrites an earlier attempt's logs.
+ATTEMPT=1
+while [ -e $OUTPUT_DIR/logs/attempt_$ATTEMPT ]; do ATTEMPT=$((ATTEMPT+1)); done
+export LOG_DIR=$OUTPUT_DIR/logs/attempt_$ATTEMPT
+mkdir -p $LOG_DIR/trainer
+ln -sfn attempt_$ATTEMPT $OUTPUT_DIR/logs/latest
+ln -sfn trainer/node_0.log $LOG_DIR/trainer.log
 
 # Networking
 export HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
@@ -123,7 +128,7 @@ srun --kill-on-bad-exit=1 bash -s <<'LAUNCH_SH'
     export {{ key }}="{{ value }}"
 {%- endfor %}
 
-    echo $HOSTNAMES | tee $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log
+    echo $HOSTNAMES | tee $LOG_DIR/trainer/node_${TRAIN_NODE_RANK}.log
     uv run torchrun \
         --role=trainer \
         --nnodes=$NUM_NODES \
@@ -131,11 +136,11 @@ srun --kill-on-bad-exit=1 bash -s <<'LAUNCH_SH'
         --node-rank=$TRAIN_NODE_RANK \
         --rdzv-endpoint=$MASTER_ADDR:$MASTER_PORT \
         --rdzv-id=job_$SLURM_JOB_ID \
-        --log-dir=$OUTPUT_DIR/logs/trainer/torchrun \
+        --log-dir=$LOG_DIR/trainer/torchrun \
         --tee=3 \
         --redirects=3 \
         --local-ranks-filter={{ ranks_filter }} \
         -m prime_rl.trainer.sft.train \
         @ $CONFIG_PATH \
-        2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log
+        2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $LOG_DIR/trainer/node_${TRAIN_NODE_RANK}.log
 LAUNCH_SH

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import shutil
 import time
 from pathlib import Path
@@ -8,6 +9,34 @@ from prime_rl.utils.logger import get_logger
 
 def get_log_dir(output_dir: Path) -> Path:
     return output_dir / "logs"
+
+
+def create_attempt_log_dir(run_dir: Path) -> Path:
+    """Create ``logs/attempt_<n>`` for this launch attempt and repoint ``logs/latest`` to it.
+
+    Every launch — fresh or resumed — gets its own numbered log directory, so a resume
+    never overwrites an earlier attempt's logs. Returns the attempt directory."""
+    logs_dir = get_log_dir(run_dir)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    attempts = (
+        int(p.name.removeprefix("attempt_"))
+        for p in logs_dir.glob("attempt_*")
+        if p.name.removeprefix("attempt_").isdigit()
+    )
+    attempt_dir = logs_dir / f"attempt_{1 + max(attempts, default=0)}"
+    attempt_dir.mkdir()
+    # Atomically repoint the relative ``latest`` symlink: create a temp link, then rename.
+    tmp_link = logs_dir / f".{attempt_dir.name}"
+    if tmp_link.is_symlink() or tmp_link.exists():
+        tmp_link.unlink()
+    os.symlink(attempt_dir.name, tmp_link)
+    os.replace(tmp_link, logs_dir / "latest")
+    return attempt_dir
+
+
+def latest_log_dir(run_dir: Path) -> Path:
+    """The current attempt's log directory, via the ``logs/latest`` symlink."""
+    return get_log_dir(run_dir) / "latest"
 
 
 def format_log_message(
@@ -30,7 +59,7 @@ def format_log_message(
 
     log_lines: list[str] = []
     if job_log:
-        log_lines.append(f"{i1}{'Job:':<{col}}tail -F {log_dir.parent}/job_*.log")
+        log_lines.append(f"{i1}{'Job:':<{col}}tail -F {log_dir.parent.parent}/job_*.log")
     if trainer:
         log_lines.append(f"{i1}{'Trainer:':<{col}}tail -F {log_dir}/trainer.log")
         if num_train_nodes > 1:

--- a/tests/integration/test_alphabet_sort.py
+++ b/tests/integration/test_alphabet_sort.py
@@ -66,20 +66,20 @@ def test_no_error(rl_process: ProcessResult, run_dir: Path):
 
 def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process."""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
 
 
 def test_reward_in_range(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward is in range in the RL process."""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=0.10)
 
 
 def test_mismatch_kl_in_range(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the average mismatch KL is below 0.15 across the last 5 steps."""
-    with open(run_dir / "logs" / "trainer.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "trainer.log", "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()
     check_avg_mismatch_kl_in_range(trainer_stdout, last_n_steps=5, max_threshold=0.15)

--- a/tests/integration/test_reverse_text.py
+++ b/tests/integration/test_reverse_text.py
@@ -96,21 +96,21 @@ def test_no_error(rl_process: ProcessResult, run_dir: Path):
 
 def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
 
 
 def test_reward_in_range(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward is in range in the RL process"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=0.6)
 
 
 def test_mismatch_kl_in_range(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the average mismatch KL is below 0.01 across all steps"""
-    with open(run_dir / "logs" / "trainer.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "trainer.log", "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()
     check_avg_mismatch_kl_in_range(trainer_stdout, last_n_steps=3, max_threshold=0.01)
 
@@ -123,6 +123,6 @@ def test_no_error_resume(rl_resume_process: ProcessResult, run_dir: Path):
 
 def test_reward_in_range_resume(rl_resume_process: ProcessResult, test_no_error_resume, run_dir: Path):
     """Tests that the reward is in range in the RL resume process"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=0.6)

--- a/tests/integration/test_reverse_text_lora.py
+++ b/tests/integration/test_reverse_text_lora.py
@@ -89,14 +89,14 @@ def test_no_error(rl_process: ProcessResult, run_dir: Path):
 
 def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
 
 
 def test_reward_in_range(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward is in range in the RL process"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=0.65)
 
@@ -109,6 +109,6 @@ def test_no_error_resume(rl_resume_process: ProcessResult, run_dir: Path):
 
 def test_reward_in_range_resume(rl_resume_process: ProcessResult, test_no_error_resume, run_dir: Path):
     """Tests that the reward is in range in the RL resume process"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=0.65)

--- a/tests/integration/test_reverse_text_rl_opd.py
+++ b/tests/integration/test_reverse_text_rl_opd.py
@@ -119,6 +119,6 @@ def test_no_error(rl_opd_process: ProcessResult, run_dir: Path):
 
 
 def test_eval_reward_converges(rl_opd_process: ProcessResult, test_no_error, run_dir: Path):
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_final_eval_reward_above(orchestrator_stdout, env_name="reverse-text", min_threshold=0.5)

--- a/tests/integration/test_reverse_text_rl_sft.py
+++ b/tests/integration/test_reverse_text_rl_sft.py
@@ -118,6 +118,6 @@ def test_no_error(rl_sft_process: ProcessResult, run_dir: Path):
 
 
 def test_eval_reward_converges(rl_sft_process: ProcessResult, test_no_error, run_dir: Path):
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_final_eval_reward_above(orchestrator_stdout, env_name="reverse-text", min_threshold=0.5)

--- a/tests/integration/test_reverse_text_sft.py
+++ b/tests/integration/test_reverse_text_sft.py
@@ -93,7 +93,7 @@ def test_no_error(sft_process: ProcessResult):
 
 def test_loss_goes_down(sft_process: ProcessResult, run_dir: Path):
     """Tests that the loss goes down in the SFT process"""
-    trainer_log_path = run_dir / "logs" / "trainer.log"
+    trainer_log_path = run_dir / "logs" / "latest" / "trainer.log"
     print(f"Checking trainer path in {trainer_log_path}")
     with open(trainer_log_path, "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()
@@ -107,7 +107,7 @@ def test_no_error_resume(sft_resume_process: ProcessResult):
 
 def test_loss_goes_down_resume(sft_resume_process: ProcessResult, run_dir: Path):
     """Tests that the loss goes down in the SFT resume process"""
-    trainer_log_path = run_dir / "logs" / "trainer.log"
+    trainer_log_path = run_dir / "logs" / "latest" / "trainer.log"
     print(f"Checking trainer path in {trainer_log_path}")
     with open(trainer_log_path, "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()

--- a/tests/integration/test_reverse_text_sft_lora.py
+++ b/tests/integration/test_reverse_text_sft_lora.py
@@ -103,7 +103,7 @@ def test_no_error(sft_lora_process: ProcessResult):
 
 def test_loss_goes_down(sft_lora_process: ProcessResult, run_dir: Path):
     """Tests that the loss goes down in the SFT LoRA process"""
-    trainer_log_path = run_dir / "logs" / "trainer.log"
+    trainer_log_path = run_dir / "logs" / "latest" / "trainer.log"
     print(f"Checking trainer path in {trainer_log_path}")
     with open(trainer_log_path, "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()
@@ -123,7 +123,7 @@ def test_no_error_resume(sft_lora_resume_process: ProcessResult):
 
 def test_loss_goes_down_resume(sft_lora_resume_process: ProcessResult, run_dir: Path):
     """Tests that the loss goes down in the SFT LoRA resume process"""
-    trainer_log_path = run_dir / "logs" / "trainer.log"
+    trainer_log_path = run_dir / "logs" / "latest" / "trainer.log"
     print(f"Checking trainer path in {trainer_log_path}")
     with open(trainer_log_path, "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()

--- a/tests/nightly/test_alphabet_sort.py
+++ b/tests/nightly/test_alphabet_sort.py
@@ -55,6 +55,6 @@ def test_no_error(rl_process: ProcessResult, run_dir: Path):
 
 def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)

--- a/tests/nightly/test_hendrycks_sanity.py
+++ b/tests/nightly/test_hendrycks_sanity.py
@@ -68,20 +68,20 @@ def test_no_error(rl_process: ProcessResult, run_dir: Path):
 
 def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the train reward goes up during training"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
 
 
 def test_reward_reaches_threshold(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the train reward reaches a minimum threshold"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=MIN_TRAIN_REWARD)
 
 
 def test_mismatch_kl_in_band(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that mismatch KL stays within the expected band."""
-    with open(run_dir / "logs" / "trainer.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "trainer.log", "r") as f:
         trainer_stdout = strip_escape_codes(f.read()).splitlines()
     check_mismatch_kl_in_range(trainer_stdout, min_threshold=MISMATCH_KL_MIN, max_threshold=MISMATCH_KL_MAX)

--- a/tests/nightly/test_multimodal_color_codeword.py
+++ b/tests/nightly/test_multimodal_color_codeword.py
@@ -59,14 +59,14 @@ def test_no_error(rl_process: ProcessResult, run_dir: Path):
 
 def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
 
 
 def test_reward_reaches_threshold(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the average reward over the last steps exceeds the threshold"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_avg_reward_in_range(
         orchestrator_stdout, last_n_steps=REWARD_AVG_LAST_N_STEPS, min_threshold=REWARD_MIN_THRESHOLD

--- a/tests/nightly/test_reverse_text.py
+++ b/tests/nightly/test_reverse_text.py
@@ -55,13 +55,13 @@ def test_no_error(rl_process: ProcessResult, run_dir: Path):
 
 def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
 
 
 def test_reward_reaches_threshold(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_in_range(orchestrator_stdout, min_threshold=0.65)

--- a/tests/nightly/test_wiki_search.py
+++ b/tests/nightly/test_wiki_search.py
@@ -55,6 +55,6 @@ def test_no_error(rl_process: ProcessResult, run_dir: Path):
 
 def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)

--- a/tests/nightly/test_wordle.py
+++ b/tests/nightly/test_wordle.py
@@ -55,6 +55,6 @@ def test_no_error(rl_process: ProcessResult, run_dir: Path):
 
 def test_reward_goes_up(rl_process: ProcessResult, test_no_error, run_dir: Path):
     """Tests that the reward goes up in the RL process"""
-    with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+    with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,10 +13,10 @@ def check_no_error(process: ProcessResult, run_dir: Path) -> None:
     """Helper to assert that a process did not error"""
     if process.returncode != 0:
         print("=== Inference Outputs ===")
-        with open(run_dir / "logs" / "inference.log", "r") as f:
+        with open(run_dir / "logs" / "latest" / "inference.log", "r") as f:
             print(*f.readlines()[-100:], sep="")
         print("=== Orchestrator Outputs ===")
-        with open(run_dir / "logs" / "orchestrator.log", "r") as f:
+        with open(run_dir / "logs" / "latest" / "orchestrator.log", "r") as f:
             print(*f.readlines()[-1000:], sep="")
     assert process.returncode == 0, f"Process has non-zero return code ({process})"
 


### PR DESCRIPTION
## Summary

- Every launch of a run — fresh or resumed — writes its logs to its own `logs/attempt_<n>/` directory; `logs/latest` symlinks to the current attempt. Previously a resume reopened the same log files with mode `"w"` and destroyed the previous attempt's logs.
- The attempt is computed at launch (max existing `attempt_<n>` + 1): locally in `create_attempt_log_dir` (atomic `latest` repoint via temp-link + rename), and in bash inside the multi-node RL and inference SLURM templates (the single-node templates defer to the inner launcher).
- Readers go through `logs/latest`: `scripts/tmux.sh`, the post-launch log hints, docs/skills, and the integration/nightly tests.
- Logs are the only artifact a resume clobbers, so nothing else changes: the step-keyed dirs (`checkpoints/`, `weights/`, `rollouts/`, `broadcasts/`) are pruned deliberately by resume, and `configs/` holds the current attempt's resolved configs by design.

```
<run_dir>/logs/
├── latest -> attempt_2
├── attempt_1/{trainer,orchestrator,inference}.log ...
└── attempt_2/{trainer,orchestrator,inference}.log ...
```

## Verification

- `pytest tests/unit` green; ruff green.
- Template audit: rendered all four SLURM scripts (multi-node RL, multi-node SFT, multi-node inference, single-node RL) via `--dry-run` — every log write goes through `$LOG_DIR` (the shared `_launch_rank`/`_launch_router` snippets and the multi-node SFT template included); the only `$OUTPUT_DIR/logs` references are the attempt-computation block itself.
- E2E (5 + 5 steps reverse-text, one resume): the fresh run logs into `logs/attempt_1/` with `latest -> attempt_1`; the resume (`--resume --max-steps 10`, "Resuming from step 5") logs steps 6–10 into `logs/attempt_2/` with `latest` repointed, and `attempt_1`'s logs are byte-for-byte intact (its `orchestrator.log` still ends at step 5). Exit 0 on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and launch-script path changes only; training checkpoints and weights layout are unchanged.
> 
> **Overview**
> Each launch (fresh or resumed) now writes logs under **`logs/attempt_<n>/`** instead of reusing **`logs/`** directly, so a resume no longer truncates the previous attempt’s trainer/orchestrator/inference output. **`logs/latest`** symlinks to the current attempt; local launches use **`create_attempt_log_dir`** (numbered dir + atomic symlink update), while SLURM templates allocate **`$LOG_DIR`** the same way in bash and route all tee/torchrun paths through it.
> 
> **RL/SFT** local entrypoints call **`create_attempt_log_dir`** at start; SLURM submit paths use **`latest_log_dir`** for post-submit tail hints. **`scripts/tmux.sh`**, docs, monitor skill, and integration/nightly tests read **`logs/latest/...`** instead of flat **`logs/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2caa8cae35f2997d35083f1c8d52b7bc7c973fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

