### PR TITLE
feat!: remove the benchmark mode

### DIFF
--- a/benchmarks/scripts/run_single_benchmark.py
+++ b/benchmarks/scripts/run_single_benchmark.py
@@ -2,15 +2,18 @@
 """
 Run a single benchmark configuration and output JSON results.
 
-This script wraps the prime-rl training with --bench.output-json to get
-metrics directly without parsing console output.
+This script runs a normal short training (--max-steps) with the file monitor
+enabled and aggregates throughput / MFU / step time / peak memory from the
+run's metrics.jsonl.
 """
 
 from __future__ import annotations
 
 import json
+import statistics
 import subprocess
 import sys
+import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -83,6 +86,8 @@ class BenchmarkConfig(BaseConfig):
 
     timeout: Annotated[int, Field(description="Timeout in seconds")] = 3600
 
+    max_steps: Annotated[int, Field(ge=2, description="Training steps to run. The first step is warmup.")] = 4
+
     micro_batches: Annotated[int, Field(ge=1, description="Number of micro batches")] = 2
 
     ep: Annotated[int, Field(ge=1, description="Expert parallelism size (1 = no EP)")] = 1
@@ -115,7 +120,7 @@ class BenchmarkConfig(BaseConfig):
     ] = None
 
 
-def build_command(config: BenchmarkConfig) -> list[str]:
+def build_command(config: BenchmarkConfig, output_dir: Path) -> list[str]:
     """Build the benchmark command from config."""
     # Determine training script
     if config.type == "rl":
@@ -137,12 +142,18 @@ def build_command(config: BenchmarkConfig) -> list[str]:
         str(config.seq_len),
         "--model.attn",
         config.attention,
-        "--bench.output-json",
-        str(config.output),
+        "--max-steps",
+        str(config.max_steps),
+        "--output-dir",
+        str(output_dir),
+        "--file-monitor.filename",
+        "metrics.jsonl",
         "--model.compile",
         "--dist-timeout-seconds",
         str(config.timeout),
     ]
+    if config.type == "sft":
+        cmd.extend(["--run.name", "bench"])
 
     # Add activation checkpointing if enabled
     if config.ac == "Recompute":
@@ -198,13 +209,60 @@ def dummy_metrics() -> dict:
     }
 
 
+def aggregate_metrics(metrics_path: Path) -> dict:
+    """Aggregate per-step metrics from a run's metrics.jsonl.
+
+    Each metrics.jsonl line is one monitor.log call (``{"step": N, ...}``);
+    merge the lines per step, drop the first (warmup) step, and compute
+    mean/std/min/max per metric like the old --bench JSON export did.
+    """
+    per_step: dict[int, dict] = {}
+    with open(metrics_path) as f:
+        for line in f:
+            row = json.loads(line)
+            per_step.setdefault(row["step"], {}).update(row)
+
+    steps = sorted(per_step)[1:]  # Exclude first warmup step
+    columns = {
+        "perf/mfu": "mfu",
+        "perf/throughput": "throughput",
+        "time/step": "step_time",
+        "perf/peak_memory": "peak_memory",
+    }
+    series = {name: [per_step[step][key] for step in steps] for key, name in columns.items()}
+
+    def stats(values: list[float]) -> dict:
+        return {
+            "mean": statistics.mean(values),
+            "std": statistics.stdev(values) if len(values) > 1 else 0.0,
+            "min": min(values),
+            "max": max(values),
+        }
+
+    total_memory_gib = torch.cuda.mem_get_info()[1] / 1024**3
+    peak_memory_gib = statistics.mean(series["peak_memory"])
+    return {
+        "mfu": stats(series["mfu"]),
+        "throughput": stats(series["throughput"]),
+        "step_time": stats(series["step_time"]),
+        "peak_memory": {
+            "gib": peak_memory_gib,
+            "pct": peak_memory_gib / total_memory_gib * 100,
+        },
+    }
+
+
 def run_benchmark(config: BenchmarkConfig) -> None:
     """Run a single benchmark and write results to output path."""
-    cmd = build_command(config)
+    output_dir = Path(tempfile.mkdtemp(prefix="benchmark-run-"))
+    cmd = build_command(config, output_dir)
     print(f"Running: {' '.join(cmd)}")
 
     if config.dry_run:
         return
+
+    # The SFT entrypoint writes to output_dir/<run.name>, the RL trainer to output_dir directly
+    metrics_path = output_dir / "bench" / "metrics.jsonl" if config.type == "sft" else output_dir / "metrics.jsonl"
 
     start_time = time.perf_counter()
     try:
@@ -221,14 +279,13 @@ def run_benchmark(config: BenchmarkConfig) -> None:
             config.success = False
             config.error_reason = extract_oom_error_reason(output) or f"Non-zero exit code: {result.returncode}"
             print(f"Process exited with code {result.returncode}: {output}")
-        if not config.output.exists():
+        if not metrics_path.exists():
             config.success = False
-            config.error_reason = config.error_reason or extract_oom_error_reason(output) or "No JSON output written"
+            config.error_reason = config.error_reason or extract_oom_error_reason(output) or "No metrics.jsonl written"
             print(f"Process exited with code {result.returncode}: {output}")
-            print("Benchmark completed but no JSON output was written")
+            print("Benchmark completed but no metrics.jsonl was written")
         else:
-            with open(config.output) as f:
-                metrics = json.load(f)
+            metrics = aggregate_metrics(metrics_path)
             lines = output.splitlines()
             print("\n".join(lines))
     except subprocess.TimeoutExpired:

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -245,22 +245,14 @@ The default templates live under [`src/prime_rl/templates/`](https://github.com/
 
 ## Benchmarking
 
-Every entrypoint supports a `--bench` flag that runs a few warm-up + measurement steps with fake data and prints a rich-formatted throughput / MFU table:
+To benchmark a parallelism config before committing a multi-day run, run a short training with fake data and a step cap, and read throughput / MFU / step time / peak memory from the logs:
 
 ```bash
 # SFT trainer alone
-uv run sft @ sft.toml --bench
-uv run sft ... --data.type fake --data.length variable --bench   # variable-length fake data
+uv run sft @ sft.toml --data.type fake --max-steps 4
 
 # RL trainer alone (no inference involved)
-uv run trainer @ train.toml --data.fake --bench
-
-# Inference alone — start the server normally, then bench the orchestrator
-uv run inference @ infer.toml
-uv run orchestrator @ orch.toml --bench
-
-# Full RL stack (trainer with fake data, inference with real data from orchestrator)
-uv run rl @ rl.toml --bench
+uv run trainer @ train.toml --data.fake --max-steps 4
 ```
 
-Persist results with `--bench.output-json`. Use this to compare parallelism configs before committing a multi-day run.
+Every step logs `Throughput`, `MFU`, and `Peak Mem.` to the console. For machine-readable numbers, enable the file monitor (`--file-monitor.filename metrics.jsonl`) and aggregate `perf/throughput`, `perf/mfu`, `time/step`, and `perf/peak_memory` from the run's `metrics.jsonl` — skip the first step, it is warmup. [`benchmarks/scripts/run_single_benchmark.py`](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/benchmarks/scripts/run_single_benchmark.py) does exactly this and is what the CI benchmark matrix runs.

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -501,9 +501,6 @@ class OrchestratorConfig(BaseConfig):
     max_off_policy_steps: int = Field(8, ge=0)
     """Maximum policies allowed to generate a single rollout. Rollouts generated more than ``max_off_policy_steps`` ahead of training are discarded. Higher values yield better throughput at the cost of off-policy noise."""
 
-    bench: bool = False
-    """Benchmark mode. Sets ``max_steps`` to 5 and disables W&B."""
-
     heartbeat: HeartbeatConfig | None = None
     """BetterStack heartbeat configuration for monitoring training progress."""
 
@@ -636,20 +633,6 @@ class OrchestratorConfig(BaseConfig):
         for env_cfg in self.train.source:
             if "group_size" not in env_cfg.model_fields_set:
                 env_cfg.group_size = self.group_size
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_bench(self):
-        if self.bench:
-            self.max_steps = 4  # Run for 1 warmup step + 3 evaluation steps
-
-            # Disable evaluation
-            self.eval = None
-            if self.wandb:
-                self.wandb.log_extras = None
-            if self.prime_monitor:
-                self.prime_monitor.log_extras = None
 
         return self
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -29,12 +29,6 @@ from prime_rl.configs.shared import (
     VLMConfig,
 )
 from prime_rl.configs.trainer import (
-    BenchConfig,
-    FakeDataLoaderConfig,
-    TokenizerConfig,
-    TrainerConfig,
-)
-from prime_rl.configs.trainer import (
     FileSystemWeightBroadcastConfig as TrainerFileSystemWeightBroadcastConfig,
 )
 from prime_rl.configs.trainer import (
@@ -42,6 +36,10 @@ from prime_rl.configs.trainer import (
 )
 from prime_rl.configs.trainer import (
     NIXLWeightBroadcastConfig as TrainerNIXLWeightBroadcastConfig,
+)
+from prime_rl.configs.trainer import (
+    TokenizerConfig,
+    TrainerConfig,
 )
 from prime_rl.utils.config import BaseConfig, find_package_resource
 from prime_rl.utils.validation import (
@@ -283,9 +281,6 @@ class RLConfig(BaseConfig):
 
     rollout_transport: TransportConfig | None = None
 
-    bench: bool = False
-    """Benchmark mode. Sets trainer and orchestrator to benchmark mode and, when set, suffixes the W&B project with ``-bench``."""
-
     deployment: DeploymentConfig = SingleNodeDeploymentConfig()
 
     slurm: SlurmConfig | None = None
@@ -336,9 +331,9 @@ class RLConfig(BaseConfig):
                     "Cannot configure inference with num_infer_nodes = 0. "
                     "Either set num_infer_nodes > 0 or remove the inference config."
                 )
-            if num_infer_nodes == 0 and not self.trainer.data.fake and not self.bench:
+            if num_infer_nodes == 0 and not self.trainer.data.fake:
                 raise ValueError(
-                    "Must use fake data (trainer.data.fake or bench = true) when num_infer_nodes = 0, "
+                    "Must use fake data (trainer.data.fake) when num_infer_nodes = 0, "
                     "since no orchestrator or inference server will be running."
                 )
         return self
@@ -525,24 +520,6 @@ class RLConfig(BaseConfig):
             raise ValueError(
                 "inference.vllm.enable_eplb requires weight_broadcast.type = 'nccl' and "
                 "weight_broadcast.quantize_in_weight_transfer = true."
-            )
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_bench(self):
-        if self.bench:
-            self.trainer.bench = BenchConfig()
-            self.orchestrator.bench = True
-            self.trainer.data.fake = FakeDataLoaderConfig(
-                batch_size=self.orchestrator.batch_size or 32,
-            )
-
-        trainer_bench_enabled = self.trainer.bench is not None
-        if trainer_bench_enabled != self.orchestrator.bench:
-            raise ValueError(
-                f"Trainer benchmark mode ({self.trainer.bench}) and orchestrator benchmark mode "
-                f"({self.orchestrator.bench}) must match. Use the top-level bench = true to set both."
             )
 
         return self

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -19,7 +19,6 @@ from prime_rl.configs.shared import (
 )
 from prime_rl.configs.trainer import (
     AdamWConfig,
-    BenchConfig,
     CheckpointConfig,
     ConstantSchedulerConfig,
     GCConfig,
@@ -239,9 +238,6 @@ class SFTConfig(BaseConfig):
     memory_profiler_path: Path | None = None
     """Path to write the memory profile to."""
 
-    bench: BenchConfig | None = None
-    """Benchmark-mode configuration. When set, ``max_steps`` is forced to 4 and fake data is used."""
-
     gc: GCConfig | None = GCConfig()
     """Garbage collection config. Disables automatic GC and runs deterministic collections every N steps to avoid stragglers. Set to null to use Python's default GC behavior."""
 
@@ -393,14 +389,6 @@ class SFTConfig(BaseConfig):
         return self
 
     ### Auto-setup and validate shared configs
-
-    @model_validator(mode="after")
-    def auto_setup_bench(self):
-        if self.bench is not None:
-            self.max_steps = 4  # 1 Warmup + 3 Benchmark
-            if self.ckpt:  # Do not checkpoint
-                self.ckpt = None
-        return self
 
     @model_validator(mode="after")
     def auto_setup_tokenizer(self):

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -60,11 +60,6 @@ class CompileConfig(BaseConfig):
     """Compile transformer blocks with ``fullgraph=True``."""
 
 
-class BenchConfig(BaseConfig):
-    output_json: Path | None = None
-    """Path to write benchmark results as JSON. If unset, results are only printed to the console."""
-
-
 class IndexCacheConfig(BaseConfig):
     topk_freq: int = Field(1, ge=1)
     """Recompute DSA top-k indices every N layers; intervening layers reuse the cached indices. ``1`` recomputes every layer (effectively no reuse). Mirrors vLLM's ``index_topk_freq`` HF override."""
@@ -608,9 +603,6 @@ class TrainerConfig(BaseConfig):
     memory_profiler_path: Path | None = None
     """Path to write the memory profile to."""
 
-    bench: BenchConfig | None = None
-    """Benchmark-mode configuration. When set, ``max_steps`` is forced to 4 and fake data is used."""
-
     gc: GCConfig | None = GCConfig()
     """Garbage collection config. Disables automatic GC and runs deterministic collections every N steps to avoid stragglers. Set to null to use Python's default GC behavior."""
 
@@ -660,16 +652,6 @@ class TrainerConfig(BaseConfig):
                 "freeze_vision_encoder=false is incompatible with LoRA. "
                 "LoRA freezes all non-adapter parameters including the vision encoder."
             )
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_bench(self):
-        if self.bench is not None:
-            self.max_steps = 4  # 1 Warmup + 3 Benchmark
-            if not self.data.fake:
-                self.data.fake = FakeDataLoaderConfig()
-            if self.ckpt:  # Do not checkpoint
-                self.ckpt = None
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -161,9 +161,6 @@ class Orchestrator:
         algorithms = sorted({env.algo.type for env in config.train.source if env.algo is not None})
         get_logger().info(f"Starting orchestrator (algorithm: {', '.join(algorithms)})")
 
-        if config.bench:
-            get_logger().warning(f"Running in benchmark mode (max_steps={config.max_steps})")
-
         self.progress = Progress()
         self.ckpt_manager = setup_ckpt_manager(config.output_dir, config.ckpt)
         self.policy = Policy(version=0, model_name="")
@@ -232,7 +229,6 @@ class Orchestrator:
             output_dir=config.output_dir,
             tokenizer=self.tokenizer,
             run_config=config,
-            keep_full_history=config.bench,
             train_env_names=[env.resolved_name for env in config.train.source],
             eval_env_names=[source.resolved_name for source in config.eval.source] if config.eval is not None else [],
         )
@@ -352,50 +348,44 @@ class Orchestrator:
             get_logger().info("Training from scratch")
 
         self.packer = BatchPacker(config)
-        if config.bench:
-            # Bench runs have no trainer: nothing consumes shipped batches, and the
-            # ZMQ sender's READY barrier would block forever.
-            self.sender = None
-        else:
-            get_logger().info(f"Initializing micro batch sender ({config.rollout_transport})")
-            self.sender = setup_micro_batch_sender(
-                config.output_dir, config.num_train_workers, self.progress.step, config.rollout_transport
-            )
+        get_logger().info(f"Initializing micro batch sender ({config.rollout_transport})")
+        self.sender = setup_micro_batch_sender(
+            config.output_dir, config.num_train_workers, self.progress.step, config.rollout_transport
+        )
 
         # Sync inference to the incoming policy before the first step, rendezvousing
         # with the trainer's startup broadcast (v{resume_step} on resume, v0 from
-        # scratch). Bench runs have no trainer, so there is no broadcast to wait for.
-        if not config.bench:
-            sync_version = self.resume_step if self.resume_step is not None else 0
-            if config.weight_broadcast.type == "nixl":
-                weights_path = None
-            else:
-                check_exists = config.weight_broadcast.type == "filesystem"
-                # The trainer's startup broadcast is always coming, so wait for it
-                # rather than failing immediately when the directory is not there yet.
-                wait_timeout = (config.ckpt.wait_for_weights_timeout if config.ckpt else None) or (
-                    STARTUP_WEIGHT_WAIT_TIMEOUT_S
-                )
-                weights_path = get_weight_dir(
-                    config.output_dir, sync_version, check_exists=check_exists, wait_timeout=wait_timeout
-                )
-            if self.model_express is not None:
-                await asyncio.to_thread(self.model_express.set_status, p2p_pb2.SOURCE_STATUS_READY)
-            await self.policy_inference.update_weights(weights_path, lora_name=self.lora_name, step=sync_version)
-            if self.model_express is not None:
-                await asyncio.to_thread(self.model_express.set_status, p2p_pb2.SOURCE_STATUS_INITIALIZING)
-                # Complete the startup rendezvous before the watcher begins its next cycle.
-                await asyncio.to_thread(
-                    self.model_express.wait_for,
-                    "trainer",
-                    count=1,
-                    status=p2p_pb2.SOURCE_STATUS_INITIALIZING,
-                    timeout=config.weight_broadcast.timeout,
-                )
-            if self.lora_name is not None:
-                self.policy_inference.update_model_name(self.lora_name)
-                self.policy.model_name = self.lora_name
-            self.policy.version = sync_version
+        # scratch).
+        sync_version = self.resume_step if self.resume_step is not None else 0
+        if config.weight_broadcast.type == "nixl":
+            weights_path = None
+        else:
+            check_exists = config.weight_broadcast.type == "filesystem"
+            # The trainer's startup broadcast is always coming, so wait for it
+            # rather than failing immediately when the directory is not there yet.
+            wait_timeout = (config.ckpt.wait_for_weights_timeout if config.ckpt else None) or (
+                STARTUP_WEIGHT_WAIT_TIMEOUT_S
+            )
+            weights_path = get_weight_dir(
+                config.output_dir, sync_version, check_exists=check_exists, wait_timeout=wait_timeout
+            )
+        if self.model_express is not None:
+            await asyncio.to_thread(self.model_express.set_status, p2p_pb2.SOURCE_STATUS_READY)
+        await self.policy_inference.update_weights(weights_path, lora_name=self.lora_name, step=sync_version)
+        if self.model_express is not None:
+            await asyncio.to_thread(self.model_express.set_status, p2p_pb2.SOURCE_STATUS_INITIALIZING)
+            # Complete the startup rendezvous before the watcher begins its next cycle.
+            await asyncio.to_thread(
+                self.model_express.wait_for,
+                "trainer",
+                count=1,
+                status=p2p_pb2.SOURCE_STATUS_INITIALIZING,
+                timeout=config.weight_broadcast.timeout,
+            )
+        if self.lora_name is not None:
+            self.policy_inference.update_model_name(self.lora_name)
+            self.policy.model_name = self.lora_name
+        self.policy.version = sync_version
 
         self.eval_source: EvalSource | None = (
             EvalSource(
@@ -630,9 +620,9 @@ class Orchestrator:
         # orchestrator finishes early, and its teardown strands the trainer inside
         # an in-memory broadcast handshake that needs the live weight watcher.
         # Always satisfiable: the trainer skips only the final TARGET_LAG+1
-        # in-memory broadcasts. Bench runs have no trainer, so they ship freely.
+        # in-memory broadcasts.
         required_version = step - 1 - TARGET_LAG
-        if not config.bench and self.policy.version < required_version:
+        if self.policy.version < required_version:
             get_logger().info(
                 f"Holding batch {step} until the trainer publishes policy v{required_version} "
                 f"(currently v{self.policy.version})"
@@ -664,8 +654,7 @@ class Orchestrator:
         pack_start_time = time.perf_counter()
         micro_batch_grid = await asyncio.to_thread(self.packer.pack, batch.samples)
         pack_time = time.perf_counter() - pack_start_time
-        if self.sender is not None:
-            await self.sender.send(micro_batch_grid)
+        await self.sender.send(micro_batch_grid)
         self.progress.step += 1
         self.update_dispatch_gate()
         # Checkpoint the step we just shipped (resume point: continue at step + 1).
@@ -982,8 +971,7 @@ class Orchestrator:
         training artifacts are already persisted before this is reached."""
 
         async def teardown() -> None:
-            if self.sender is not None:
-                self.sender.close()
+            self.sender.close()
             if self.dispatcher is not None:
                 await self.dispatcher.stop()
             if self.watcher is not None:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -48,11 +48,9 @@ from prime_rl.trainer.utils import (
     GarbageCollection,
     MemoryProfiler,
     Tensors,
-    export_benchmark_json,
     filter_rl_trainer_tensor_stats_for_wandb,
     get_ckpt_disk_metrics,
     setup_torch_distributed,
-    print_benchmark,
 )
 from prime_rl.trainer.world import get_world
 from prime_rl.trainer.lora import get_lora_state
@@ -62,7 +60,7 @@ from prime_rl.utils.metrics_server import HealthServer, MetricsServer
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.config import cli
 from prime_rl.utils.process import set_proc_title
-from prime_rl.utils.utils import clean_exit, resolve_latest_ckpt_step, to_col_format
+from prime_rl.utils.utils import clean_exit, resolve_latest_ckpt_step
 from ring_flash_attn import substitute_hf_flash_attn
 from torchtitan.distributed.utils import clip_grad_norm_
 
@@ -76,10 +74,6 @@ def train(config: TrainerConfig):
         json_logging=config.log.json_logging,
     )
     logger.info(f"Starting RL trainer in {world} in {config.output_dir}")
-
-    # Print warning if running in benchmark mode
-    if config.bench is not None:
-        logger.warning(f"Running in benchmark mode (max_steps={config.max_steps})")
 
     # Setup the monitor
     logger.info(f"Initializing monitor ({config.wandb})")
@@ -253,6 +247,7 @@ def train(config: TrainerConfig):
         prof = profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True).__enter__()
         maybe_record_function = record_function
     start_step = progress.step
+    max_peak_memory = 0.0
     while True:
         # Reset peak memory stats
         torch.cuda.reset_peak_memory_stats()
@@ -630,6 +625,7 @@ def train(config: TrainerConfig):
         throughput = perf_counter.get_step_tokens_per_second(num_tokens, forward_backward_time)
         mfu = perf_counter.get_step_mfu(num_tokens, forward_backward_time)
         peak_memory = torch.cuda.max_memory_reserved() / 1024**3  # GiB
+        max_peak_memory = max(max_peak_memory, peak_memory)
 
         # Log step metrics
         step_time = time.perf_counter() - step_start_time
@@ -734,7 +730,7 @@ def train(config: TrainerConfig):
         weight_ckpt_manager.save(progress.step, model, tokenizer)
         weight_ckpt_manager.maybe_clean()
 
-    logger.info(f"Peak memory: {max(to_col_format(monitor.history)['perf/peak_memory']):.1f} GiB")
+    logger.info(f"Peak memory: {max_peak_memory:.1f} GiB")
     logger.success("RL trainer finished!")
 
     # Stop metrics/health server if configured
@@ -742,14 +738,6 @@ def train(config: TrainerConfig):
         metrics_server.stop()
     if health_server is not None:
         health_server.stop()
-
-    # Optionally, print benchmark table and export JSON
-    if config.bench is not None and world.is_master:
-        history = to_col_format(monitor.history)
-        print_benchmark(history)
-        if config.bench.output_json:
-            export_benchmark_json(history, config.bench.output_json)
-            logger.info(f"Benchmark results written to {config.bench.output_json}")
 
 
 def main():

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -40,18 +40,16 @@ from prime_rl.trainer.sft.data import load_sft_dataset, setup_dataloader, setup_
 from prime_rl.trainer.utils import (
     GarbageCollection,
     MemoryProfiler,
-    export_benchmark_json,
     get_ckpt_disk_metrics,
     print_sample,
     setup_torch_distributed,
-    print_benchmark,
 )
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.config import cli
 from prime_rl.utils.process import set_proc_title
-from prime_rl.utils.utils import clean_exit, to_col_format
+from prime_rl.utils.utils import clean_exit
 import torch.distributed as dist
 
 from torchtitan.distributed.utils import clip_grad_norm_
@@ -66,10 +64,6 @@ def train(config: SFTConfig):
         json_logging=config.log.json_logging,
     )
     logger.info(f"Starting SFT trainer in {world}")
-
-    # Print warning if running in benchmark mode
-    if config.bench is not None:
-        logger.warning(f"Running in benchmark mode (max_steps={config.max_steps})")
 
     # Setup the monitor
     logger.info(f"Initializing monitor ({config.wandb})")
@@ -375,6 +369,7 @@ def train(config: SFTConfig):
         logger.info(f"Tracing to {config.trace_path}")
         prof = profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True).__enter__()
         maybe_record_function = record_function  # noqa: F841 – captured by run_forward_loop closure
+    max_peak_memory = 0.0
     while True:
         # Reset peak memory stats
         torch.cuda.reset_peak_memory_stats()
@@ -527,6 +522,7 @@ def train(config: SFTConfig):
         throughput = perf_counter.get_tokens_per_second() or 0
         mfu = perf_counter.get_mfu() or 0
         peak_memory = torch.cuda.max_memory_reserved() / 1024**3  # GiB
+        max_peak_memory = max(max_peak_memory, peak_memory)
 
         # Log step metrics
         step_time = time.perf_counter() - step_start_time
@@ -640,16 +636,8 @@ def train(config: SFTConfig):
         weight_ckpt_manager.save(progress.step, model, tokenizer, processor)
         weight_ckpt_manager.maybe_clean()
 
-    logger.info(f"Peak memory: {max(to_col_format(monitor.history)['perf/peak_memory']):.1f} GiB")
+    logger.info(f"Peak memory: {max_peak_memory:.1f} GiB")
     logger.success("SFT trainer finished!")
-
-    # Optionally, print benchmark table and export JSON
-    if config.bench is not None and world.is_master:
-        history = to_col_format(monitor.history)
-        print_benchmark(history)
-        if config.bench.output_json:
-            export_benchmark_json(history, config.bench.output_json)
-            logger.info(f"Benchmark results written to {config.bench.output_json}")
 
 
 def main():

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -1,19 +1,14 @@
 import gc
-import json
 import pickle
 import shutil
 import time
 from collections import defaultdict
 from datetime import timedelta
 from pathlib import Path
-from typing import Any
 
-import pandas as pd
 import torch
 import torch.distributed as dist
 from rich import print as rich_print
-from rich.console import Console
-from rich.table import Table
 from rich.text import Text
 from torch import Tensor
 from transformers.tokenization_utils import PreTrainedTokenizer
@@ -21,7 +16,7 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.pathing import get_ckpt_dir
-from prime_rl.utils.utils import format_num, format_time, get_step_path
+from prime_rl.utils.utils import get_step_path
 
 DEFAULT_TIMEOUT = timedelta(seconds=600)
 
@@ -94,125 +89,6 @@ def print_sample(input_ids: list[int], loss_mask: list[bool], tokenizer: PreTrai
     for token, mask in zip(tokenizer.convert_ids_to_tokens(input_ids), loss_mask):
         text.append(token.replace("Ġ", " ").replace("Ċ", "\n"), style="cyan" if mask else "white")
     rich_print(text)
-
-
-def print_benchmark(history: dict[str, list[Any]]) -> None:
-    """
-    Print benchmark results as rich table. Shows formatted values for the
-    training throughput and overall step time. First first N rows show the
-    per-step values, and the last row shows the mean, std, min, and max values.
-    """
-    history.pop("step")
-    assert all(len(v) for v in history.values()), "All metrics must have logged the same number of steps"
-
-    # Turn metric history into pd.DataFrame
-    df = pd.DataFrame(dict(history.items()))
-    columns = {
-        "perf/mfu": "MFU",
-        "perf/throughput": "Throughput",
-        "time/step": "Step Time",
-        "perf/peak_memory": "Peak Memory",
-    }
-    df = df[columns.keys()].rename(columns=columns)
-    df = df.iloc[1:]  # Exclude first row
-
-    # Setup console
-    console = Console()
-    table = Table(title="Benchmark")
-
-    # Add columns
-    table.add_column("Step", justify="right")
-    for col in df.columns:
-        table.add_column(col, justify="center", style="magenta")
-
-    # Add formatted rows
-    formatted_df = pd.DataFrame(columns=df.columns)
-    formatted_df["MFU"] = df["MFU"].apply(lambda x: f"{format_num(x, precision=2)}%")
-    formatted_df["Throughput"] = df["Throughput"].apply(lambda x: format_num(x, precision=2))
-    formatted_df["Step Time"] = df["Step Time"].apply(format_time)
-    formatted_df["Peak Memory"] = df["Peak Memory"].apply(lambda x: f"{format_num(x, precision=1)} GiB")
-    for step, row in formatted_df.iterrows():
-        table.add_row(*([str(step)] + [str(x) for x in row]))
-
-    # Separator
-    table.add_row(*([""] * len(formatted_df.columns)))
-
-    # Add row for formatted, aggregated statistics
-    mean_df = df.describe().loc[["mean", "std", "min", "max"], :]
-    formatted_mean_df = pd.DataFrame()
-    formatted_mean_df["MFU"] = mean_df["MFU"].apply(lambda x: f"{format_num(x, precision=2)}%")
-    formatted_mean_df["Throughput"] = mean_df["Throughput"].apply(format_num, precision=2)
-    formatted_mean_df["Step Time"] = mean_df["Step Time"].apply(format_time)
-    mean_row = (
-        ["Overall"]
-        + formatted_mean_df.T.apply(
-            lambda row: f"{row['mean']} ± {row['std']} [{row['min']}, {row['max']}]", axis=1
-        ).tolist()
-        + [
-            f"{format_num(mean_df['Peak Memory']['mean'], precision=1)} GiB ({mean_df['Peak Memory']['mean'] / (torch.cuda.mem_get_info()[1] / 1024**3) * 100:.1f}%)"
-        ]
-    )
-    table.add_row(*mean_row)
-
-    # Display table
-    console.print(table)
-
-
-def export_benchmark_json(history: dict[str, list[Any]], output_path: Path) -> None:
-    """
-    Export benchmark results to a JSON file.
-
-    The JSON contains aggregated statistics (mean, std, min, max) for each metric.
-    """
-    history = history.copy()
-    history.pop("step", None)
-
-    # Turn metric history into pd.DataFrame
-    df = pd.DataFrame(dict(history.items()))
-    columns = {
-        "perf/mfu": "mfu",
-        "perf/throughput": "throughput",
-        "time/step": "step_time",
-        "perf/peak_memory": "peak_memory",
-    }
-    df = df[columns.keys()].rename(columns=columns)
-    df = df.iloc[1:]  # Exclude first warmup row
-
-    # Calculate statistics
-    stats = df.describe().loc[["mean", "std", "min", "max"], :]
-
-    # Get peak memory percentage
-    total_memory_gib = torch.cuda.mem_get_info()[1] / 1024**3
-    peak_memory_pct = stats["peak_memory"]["mean"] / total_memory_gib * 100
-
-    result = {
-        "mfu": {
-            "mean": float(stats["mfu"]["mean"]),
-            "std": float(stats["mfu"]["std"]),
-            "min": float(stats["mfu"]["min"]),
-            "max": float(stats["mfu"]["max"]),
-        },
-        "throughput": {
-            "mean": float(stats["throughput"]["mean"]),
-            "std": float(stats["throughput"]["std"]),
-            "min": float(stats["throughput"]["min"]),
-            "max": float(stats["throughput"]["max"]),
-        },
-        "step_time": {
-            "mean": float(stats["step_time"]["mean"]),
-            "std": float(stats["step_time"]["std"]),
-            "min": float(stats["step_time"]["min"]),
-            "max": float(stats["step_time"]["max"]),
-        },
-        "peak_memory": {
-            "gib": float(stats["peak_memory"]["mean"]),
-            "pct": float(peak_memory_pct),
-        },
-    }
-
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as f:
-        json.dump(result, f, indent=2)
 
 
 def flexible_all_gather(tensor: Tensor) -> Tensor:

--- a/src/prime_rl/utils/monitor/__init__.py
+++ b/src/prime_rl/utils/monitor/__init__.py
@@ -40,19 +40,12 @@ def setup_monitor(
     *,
     prime_config: PrimeMonitorConfig | None = None,
     file_config: FileMonitorConfig | None = None,
-    keep_full_history: bool = True,
     train_env_names: list[str] = [],
     eval_env_names: list[str] = [],
     # Backward compatibility: support old 'config' keyword argument
     config: WandbWithExtrasConfig | None = None,
 ) -> Monitor:
-    """
-    Sets up monitors to log metrics.
-
-    `keep_full_history`: when False, monitors retain only the most recent
-    metrics dict. The orchestrator passes False outside `--bench` mode to
-    avoid an unbounded list growing for the lifetime of the run.
-    """
+    """Sets up monitors to log metrics."""
     global _MONITOR
     if _MONITOR is not None:
         raise RuntimeError("Monitor already initialized. Please call `setup_monitor` only once.")
@@ -69,7 +62,6 @@ def setup_monitor(
                 output_dir=output_dir,
                 tokenizer=tokenizer,
                 run_config=run_config,
-                keep_full_history=keep_full_history,
                 train_env_names=train_env_names,
                 eval_env_names=eval_env_names,
             )
@@ -82,7 +74,6 @@ def setup_monitor(
                 output_dir=output_dir,
                 tokenizer=tokenizer,
                 run_config=run_config,
-                keep_full_history=keep_full_history,
             )
         )
 
@@ -92,12 +83,11 @@ def setup_monitor(
                 config=file_config,
                 output_dir=output_dir,
                 run_config=run_config,
-                keep_full_history=keep_full_history,
             )
         )
 
     if len(monitors) == 0:
-        _MONITOR = NoOpMonitor(keep_full_history=keep_full_history)
+        _MONITOR = NoOpMonitor()
     elif len(monitors) == 1:
         _MONITOR = monitors[0]
     else:

--- a/src/prime_rl/utils/monitor/base.py
+++ b/src/prime_rl/utils/monitor/base.py
@@ -71,11 +71,7 @@ def sample_items_for_logging(items: list[Any], sample_ratio: float | None) -> li
 
 
 class Monitor(ABC):
-    """Base class for all monitoring implementations.
-
-    Subclasses should initialize a `history` attribute as a list of dictionaries
-    to store logged metrics.
-    """
+    """Base class for all monitoring implementations."""
 
     run_id: str | None = None
     """External identifier of the run this monitor reports to (platform / W&B), when it has one."""
@@ -108,15 +104,8 @@ class Monitor(ABC):
 class NoOpMonitor(Monitor):
     """Monitor that does nothing. Used when no monitors are configured."""
 
-    def __init__(self, keep_full_history: bool = True):
-        self.history: list[dict[str, Any]] = []
-        self._keep_full_history = keep_full_history
-
     def log(self, metrics: dict[str, Any], step: int) -> None:
-        if self._keep_full_history:
-            self.history.append(metrics)
-        else:
-            self.history = [metrics]
+        pass
 
     def log_samples(self, rollouts: list[Rollout], step: int) -> None:
         pass

--- a/src/prime_rl/utils/monitor/file.py
+++ b/src/prime_rl/utils/monitor/file.py
@@ -30,12 +30,10 @@ class FileMonitor(Monitor):
         config: FileMonitorConfig | None,
         output_dir: Path | None = None,
         run_config: BaseConfig | None = None,
-        keep_full_history: bool = True,
     ):
         self.config = config
         self.logger = get_logger()
-        self.history: list[dict[str, Any]] = []
-        self._keep_full_history = keep_full_history
+        self._last_metrics: dict[str, Any] = {}
         self.output_dir = output_dir
         self._file = None
 
@@ -59,10 +57,7 @@ class FileMonitor(Monitor):
         self.logger.info(f"Logging metrics to {self._path}")
 
     def log(self, metrics: dict[str, Any], step: int) -> None:
-        if self._keep_full_history:
-            self.history.append(metrics)
-        else:
-            self.history = [metrics]
+        self._last_metrics = metrics
         if not self.is_master or not self.enabled or self._file is None:
             return
 
@@ -91,7 +86,7 @@ class FileMonitor(Monitor):
     def save_final_summary(self, filename: str = "final_summary.json") -> None:
         if not self.is_master or not self.enabled or self.output_dir is None:
             return
-        summary = self.history[-1] if self.history else {}
+        summary = self._last_metrics
         dropped_paths: list[str] = []
         sanitized = drop_non_finite_json_values(summary, dropped_paths)
         with open(self.output_dir / filename, "w") as f:

--- a/src/prime_rl/utils/monitor/multi.py
+++ b/src/prime_rl/utils/monitor/multi.py
@@ -20,12 +20,6 @@ class MultiMonitor(Monitor):
         prime = next((m for m in monitors if isinstance(m, PrimeMonitor)), None)
         self.run_id = (prime.run_id if prime else None) or next((m.run_id for m in monitors if m.run_id), None)
 
-    @property
-    def history(self) -> list[dict[str, Any]]:
-        if not self.monitors:
-            return []
-        return self.monitors[0].history
-
     def log(self, metrics: dict[str, Any], step: int) -> None:
         for monitor in self.monitors:
             try:

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -75,12 +75,10 @@ class PrimeMonitor(Monitor):
         output_dir: Path | None = None,
         tokenizer: PreTrainedTokenizer | None = None,
         run_config: OrchestratorConfig | None = None,
-        keep_full_history: bool = True,
     ):
         self.config = config
         self.logger = get_logger()
-        self.history: list[dict[str, Any]] = []
-        self._keep_full_history = keep_full_history
+        self._last_metrics: dict[str, Any] = {}
         self.output_dir = output_dir
         self._registered = False
         self._finalized = False
@@ -232,10 +230,7 @@ class PrimeMonitor(Monitor):
         self.logger.info(f"Platform run {self.run_id} marked as {status_label}")
 
     def log(self, metrics: dict[str, Any], step: int) -> None:
-        if self._keep_full_history:
-            self.history.append(metrics)
-        else:
-            self.history = [metrics]
+        self._last_metrics = metrics
         if not self.is_master:
             return
         if not self.enabled:
@@ -518,7 +513,7 @@ class PrimeMonitor(Monitor):
             return
 
         self.logger.info("Saving final summary to Prime Intellect API")
-        summary = self.history[-1] if self.history else {}
+        summary = self._last_metrics
         finalized_via_summary = self._submit_final_summary(summary)
 
         if os.getpid() != self._owner_pid:

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -52,14 +52,11 @@ class WandbMonitor(Monitor):
         output_dir: Path | None = None,
         tokenizer: PreTrainedTokenizer | None = None,
         run_config: BaseConfig | None = None,
-        keep_full_history: bool = True,
         train_env_names: list[str] = [],
         eval_env_names: list[str] = [],
     ):
         self.config = config
         self.logger = get_logger()
-        self.history: list[dict[str, Any]] = []
-        self._keep_full_history = keep_full_history
         self.output_dir = output_dir
 
         rank = int(os.environ.get("RANK", os.environ.get("DP_RANK", "0")))
@@ -180,10 +177,6 @@ class WandbMonitor(Monitor):
             sys.argv = json.loads(wandb_args)
 
     def log(self, metrics: dict[str, Any], step: int) -> None:
-        if self._keep_full_history:
-            self.history.append(metrics)
-        else:
-            self.history = [metrics]
         if not self.is_master:
             return
         if not self.enabled:

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -83,30 +83,6 @@ def clean_exit(func: Callable) -> Callable:
         return sync_wrapper
 
 
-def to_col_format(list_of_dicts: list[dict[str, Any]]) -> dict[str, list[Any]]:
-    """
-    Turns a list of dicts to a dict of lists.
-
-    Example:
-
-    ```python
-    list_of_dicts = [{"a": 1, "b": 2}, {"a": 3, "b": 4}] # Row format
-    to_col_format(list_of_dicts)
-    ```
-
-    Returns:
-
-    ```python
-    {"a": [1, 3], "b": [2, 4]} # Column format
-    ```
-    """
-    dict_of_lists = defaultdict(list)
-    for row in list_of_dicts:
-        for key, value in row.items():
-            dict_of_lists[key].append(value)
-    return dict(dict_of_lists)
-
-
 def format_time(time_s: float) -> str:
     """
     Format a time in seconds to a human-readable format:


### PR DESCRIPTION
## Summary

- Remove the `--bench` mode from all entrypoints: the `bench` fields on `RLConfig`, `SFTConfig`, `TrainerConfig`, and `OrchestratorConfig`, the `BenchConfig` class, the `auto_setup_bench` validators, the bench branches in both trainers and the orchestrator (bench warning, trainer-less sender/startup-sync/ship-gate paths), and the rich benchmark table + JSON export helpers (`print_benchmark`, `export_benchmark_json`, `to_col_format`).
- Rework the benchmark CI to run training normally: `benchmarks/scripts/run_single_benchmark.py` now launches a short run with `--max-steps` (default 4, first step is warmup) and fake data, enables the file monitor, and aggregates throughput / MFU / step time / peak memory from the run's `metrics.jsonl`. The output JSON schema is unchanged, so `benchmarks.yaml`, `aggregate_results.py`, `test_benchmark_regression.py`, and the stored baselines all keep working without changes.
- Monitors no longer retain metric history: `keep_full_history` and the per-monitor `history` list are gone. The file and prime monitors keep only the last metrics dict for `save_final_summary`; W&B uses `wandb.summary` as before. The trainers track the peak-memory maximum in a local variable for the end-of-run log.
- Docs: rewrite the Benchmarking section in `docs/scaling.md` around `--max-steps` + `metrics.jsonl`.

## Breaking

- `bench` / `--bench` is removed from `RLConfig`, `SFTConfig`, `TrainerConfig`, and `OrchestratorConfig`; `trainer.bench` (`BenchConfig`, `--bench.output-json`) is gone. Migration: run with `--max-steps N` and fake data (`--data.fake` for the RL trainer, `--data.type fake` for SFT) and read throughput / MFU / step time / peak memory from the step logs, or enable `--file-monitor.filename metrics.jsonl` and aggregate from the JSONL (what `benchmarks/scripts/run_single_benchmark.py` does).

## Verification

- `ruff check` / `ruff format` clean; full non-GPU unit suite passes against this branch (463 passed; the one failure, `test_qwen3_vl_e2e`, fails identically on `main`).
- Parsed the exact trainer / SFT commands the benchmark script now builds through `cli(TrainerConfig)` / `cli(SFTConfig)`; verified `aggregate_metrics` against a synthetic `metrics.jsonl` (warmup-step exclusion, mean/std/min/max, peak-memory pct).
- `run_single_benchmark.py --dry-run` produces: `torchrun ... --max-steps 4 --output-dir <tmp> --file-monitor.filename metrics.jsonl ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking config/API removal affects anyone using `--bench`, and orchestrator no longer has a trainer-less shortcut (always syncs weights and ships batches). Benchmark CI behavior changes in implementation but keeps the same JSON contract.
> 
> **Overview**
> **Breaking:** `bench` / `--bench` and `BenchConfig` (including `--bench.output-json`) are removed from RL, SFT, trainer, and orchestrator configs, along with `auto_setup_bench` validators and trainer/orchestrator bench-only paths (no trainer, no rollout sender, skipped weight sync / ship gates).
> 
> Benchmarking is now **short normal training**: cap steps with `--max-steps`, use fake data where needed, and read throughput / MFU / step time / peak memory from step logs or **`--file-monitor.filename metrics.jsonl`**. `benchmarks/scripts/run_single_benchmark.py` runs that flow (default 4 steps, first warmup) and **`aggregate_metrics`** on JSONL so the **output JSON schema stays the same** for CI.
> 
> Trainers drop the rich benchmark table and JSON export (`print_benchmark`, `export_benchmark_json`); end-of-run peak memory uses a **local max** instead of monitor history. Monitors drop **`keep_full_history`** and in-memory **`history`**; file/prime monitors keep only the last metrics for `save_final_summary`.
> 
> `docs/scaling.md` documents the new workflow; orchestrator always wires rollout sender and startup weight sync like a full RL run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53afa7885719649020787dce97969c9d4a2b8189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->