### PR TITLE
chore: add test for parallelism (#1432)

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -84,6 +84,9 @@ jobs:
           - test: reverse_text_moe
             runner: vm
             pytest_args: "tests/integration/test_reverse_text_moe.py"
+          - test: parallelism
+            runner: vm
+            pytest_args: "tests/integration/test_parallelism.py"
           - test: benchmark_regression
             runner: 4xa6000
             pytest_args: "tests/integration/test_benchmark_regression.py"

--- a/configs/ci/integration/parallelism/sft.toml
+++ b/configs/ci/integration/parallelism/sft.toml
@@ -1,0 +1,20 @@
+max_steps = 5
+
+[model]
+name = "samsja/mini-glm-moe"
+impl = "custom"
+compile = "None"
+# Pinned so that variants that don't test EP are not silently given it by `ep = "auto"`.
+ep = 1
+
+[optim]
+# Large enough that the loss moves per step, so a broken gradient reduction shows up.
+lr = 1e-4
+
+[data]
+type = "fake"
+input_ids = "random"
+batch_size = 4
+seq_len = 512
+
+[file_monitor]

--- a/docs/development.md
+++ b/docs/development.md
@@ -23,7 +23,7 @@ The test suite is split into three tiers, each with its own CI workflow.
 ### Layout
 
 - **`tests/unit/`** — fast-running, hermetic tests for isolated logic: config parsing and validation, advantage / loss / scheduler / packer math, individual dataset paths, model-conversion roundtrips, etc. Tests that need a GPU are tagged with the `gpu` marker.
-- **`tests/integration/`** — full-stack RL/SFT runs on a tiny model end-to-end through inference + orchestrator + trainer.
+- **`tests/integration/`** — full-stack RL/SFT runs on a tiny model end-to-end through inference + orchestrator + trainer, plus `test_parallelism.py`, which trains the same fixed data under FSDP, HSDP, CP (ring and ulysses) and EP (both the `torch` and `deepep` all-to-all backends) and asserts every layout reproduces the single-GPU loss.
 - **`tests/nightly/`** — runs the configs in [`examples/`](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples) every night to catch regressions in the shipped examples.
 
 ### Running Tests Locally
@@ -42,7 +42,7 @@ uv run pytest tests/integration/test_reverse_text.py -vvs  # one specific scenar
 | Workflow | Trigger | What runs | Where |
 |---|---|---|---|
 | [`cpu_tests.yaml`](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/.github/workflows/cpu_tests.yaml) | every PR + push to `main` | `pytest tests/unit -m "not gpu"`, plus a slim-wheel install check that `prime-rl-configs` imports cleanly without heavy deps (no torch / vllm / transformers / wandb / verifiers / datasets / liger / loguru in `sys.modules`) | `ubuntu-latest` |
-| [`gpu_tests.yaml`](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/.github/workflows/gpu_tests.yaml) | every non-draft PR + push to `main` | `pytest tests/unit -m gpu`, plus a matrix of named integration scenarios (`reverse_text`, `reverse_text_sft`, `reverse_text_lora`, `reverse_text_moe`, `reverse_text_rl_opd`, `reverse_text_rl_sft`, `reverse_text_sft_lora`, `alphabet_sort`, `benchmark_regression`) | self-hosted GPU runners (`vm`, `4xa6000`) |
+| [`gpu_tests.yaml`](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/.github/workflows/gpu_tests.yaml) | every non-draft PR + push to `main` | `pytest tests/unit -m gpu`, plus a matrix of named integration scenarios (`reverse_text`, `reverse_text_sft`, `reverse_text_lora`, `reverse_text_moe`, `reverse_text_rl_opd`, `reverse_text_rl_sft`, `reverse_text_sft_lora`, `alphabet_sort`, `parallelism`, `benchmark_regression`) | self-hosted GPU runners (`vm`, `4xa6000`) |
 | [`nightly_tests.yaml`](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/.github/workflows/nightly_tests.yaml) | 03:00 PST daily + manual `workflow_dispatch` (single-file filter optional) | every file in `tests/nightly/`, one matrix job per file | `research-cluster` |
 
 The GPU + Nightly workflows skip drafts — open the PR as **Draft** until you're ready to consume CI compute, then mark it ready for review to trigger the GPU matrix.

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -43,12 +43,12 @@ class Batch(TypedDict):
 class StatefulIterableDataset(Stateful, IterableDataset):
     """SFT dataset are iterable (infinite) and stateful (can be checkpointed)."""
 
-    def __init__(self):
+    def __init__(self, non_dp_size: int = 1):
         self.step, self.epoch = 0, 0
         self.num_samples = defaultdict(int)
         self.num_tokens = defaultdict(int)
         self.fast_forward = False
-        self._setup_world_info()
+        self._setup_world_info(non_dp_size)
 
     def state_dict(self) -> dict:
         return {"step": self.step, "epoch": self.epoch}
@@ -59,19 +59,26 @@ class StatefulIterableDataset(Stateful, IterableDataset):
         self.step = state_dict["step"]
         self.epoch = state_dict["epoch"]
 
-    def _setup_world_info(self):
+    def _setup_world_info(self, non_dp_size: int = 1):
+        """Shard samples over the data parallel ranks. Ranks of a non-DP group (e.g. CP)
+        share a data rank: they consume the same sample and split it along another dim."""
         worker_info = get_worker_info()
         if worker_info is not None:
             worker_id = worker_info.id
             num_workers = worker_info.num_workers
         else:
             worker_id, num_workers = 0, 1
-        self.data_rank = get_world().rank * num_workers + worker_id
-        self.data_world_size = get_world().world_size * num_workers
+        assert get_world().world_size % non_dp_size == 0, "world_size must be divisible by non_dp_size"
+        self.data_rank = get_world().rank // non_dp_size * num_workers + worker_id
+        self.data_world_size = get_world().world_size // non_dp_size * num_workers
 
 
 class FakeDataset(StatefulIterableDataset):
-    """A dataset of fake tokens"""
+    """A dataset of fake tokens.
+
+    Every sample is a pure function of its global index, so the same (vocab_size, seq_len)
+    yields the same data under any parallelism layout.
+    """
 
     def __init__(
         self,
@@ -79,8 +86,9 @@ class FakeDataset(StatefulIterableDataset):
         seq_len: int,
         length: Literal["fixed", "variable"] = "fixed",
         input_ids: Literal["increasing", "random"] = "random",
+        non_dp_size: int = 1,
     ):
-        super().__init__()
+        super().__init__(non_dp_size)
         self.vocab_size = vocab_size
         self.seq_len = seq_len
         self.length = length
@@ -94,11 +102,16 @@ class FakeDataset(StatefulIterableDataset):
             if (self.step - 1) % self.data_world_size != self.data_rank:
                 continue
 
-            seq_len = int(torch.randint(1, self.seq_len, (1,)).item()) if self.length == "variable" else self.seq_len
+            generator = torch.Generator().manual_seed(self.step)
+            seq_len = (
+                int(torch.randint(1, self.seq_len, (1,), generator=generator).item())
+                if self.length == "variable"
+                else self.seq_len
+            )
             input_ids = (
                 [self.step - 1] * (seq_len + 1)
                 if self.input_ids == "increasing"
-                else torch.randint(0, self.vocab_size, (self.seq_len + 1,)).long().tolist()
+                else torch.randint(0, self.vocab_size, (seq_len + 1,), generator=generator).tolist()
             )
             position_ids = list(range(seq_len))
             loss_mask = [True] * seq_len
@@ -193,7 +206,7 @@ class SFTDataset(StatefulIterableDataset):
         max_epochs: int | None = None,
         multimodal: bool = False,
     ):
-        super().__init__()
+        super().__init__(non_dp_size)
         self.logger = get_logger()
         self.dataset = dataset
         self.num_examples = len(self.dataset)
@@ -210,16 +223,6 @@ class SFTDataset(StatefulIterableDataset):
         if self.max_examples is not None:
             self.num_examples = min(self.num_examples, self.max_examples)
             self.dataset = self.dataset.take(self.max_examples)
-
-        # Get the data rank and world size
-        worker_info = get_worker_info()
-        worker_id, num_workers = 0, 1
-        if worker_info is not None:
-            worker_id = worker_info.id
-            num_workers = worker_info.num_workers
-        assert get_world().world_size % non_dp_size == 0, "world_size must be divisible by non_dp_size"
-        self.data_rank = get_world().rank // non_dp_size * num_workers + worker_id
-        self.data_world_size = get_world().world_size // non_dp_size * num_workers
 
     def _process(self, example: dict) -> dict | None:
         def resolve_messages(example: dict) -> list[dict]:
@@ -633,6 +636,7 @@ def setup_dataset(
             seq_len=config.seq_len,
             length=config.length,
             input_ids=config.input_ids,
+            non_dp_size=non_dp_size,
         )
     elif config.type == "sft":
         if renderer is None:

--- a/tests/integration/test_parallelism.py
+++ b/tests/integration/test_parallelism.py
@@ -1,0 +1,130 @@
+import importlib.util
+import json
+from pathlib import Path
+from typing import Callable
+
+import pytest
+import torch
+
+from tests.conftest import ProcessResult
+
+pytestmark = [pytest.mark.slow, pytest.mark.gpu]
+
+RUN_NAME = "parallelism"
+CONFIG = "configs/ci/integration/parallelism/sft.toml"
+TIMEOUT = 600  # 10 minutes
+
+# Every layout trains the same global batch of fake data (a pure function of the sample
+# index), so the per-step loss must match the single-GPU baseline. Parallelism only
+# reorders bf16 reductions, which drifts the loss far less than this; a bad shard, a
+# wrong reduction group or a wrong gradient scale moves it by orders of magnitude more.
+LOSS_RTOL = 5e-3
+
+# (name, number of GPUs, config overrides)
+PARALLELISMS: list[tuple[str, int, list[str]]] = [
+    ("fsdp", 2, []),
+    ("hsdp", 2, ["--model.dp-replicate", "2"]),
+    ("cp-ring", 2, ["--model.cp", "2", "--model.cp-style", "ring"]),
+    ("cp-ulysses", 2, ["--model.cp", "2", "--model.cp-style", "ulysses"]),
+    ("ep", 2, ["--model.ep", "2"]),
+]
+
+# DeepEP forces gradient clipping off, so it is compared against its own baseline.
+NO_GRAD_CLIPPING = ["--optim.max-norm", "None"]
+
+
+def has_deepep() -> bool:
+    """Whether the DeepEP backend can run here. It is an optional extra, pre-built for Hopper onwards."""
+    if importlib.util.find_spec("deep_ep") is None:
+        return False
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9
+
+
+def read_losses(run_dir: Path) -> list[float]:
+    """Read the per-step training loss from a run's JSONL metric sink."""
+    metrics_path = run_dir / "metrics.jsonl"
+    with open(metrics_path, "r") as f:
+        metrics = [json.loads(line) for line in f]
+    losses = {metric["step"]: metric["loss/mean"] for metric in metrics if "loss/mean" in metric}
+    assert losses, f"No loss metrics found in {metrics_path}"
+    return [losses[step] for step in sorted(losses)]
+
+
+def check_losses_match(name: str, losses: list[float], baseline_losses: list[float]) -> None:
+    """Helper to assert that a run reproduces the baseline loss at every step"""
+    assert len(losses) == len(baseline_losses), (
+        f"{name} logged {len(losses)} steps, baseline logged {len(baseline_losses)}"
+    )
+    for step, (loss, baseline_loss) in enumerate(zip(losses, baseline_losses), start=1):
+        assert loss == pytest.approx(baseline_loss, rel=LOSS_RTOL), (
+            f"{name} loss at step {step} ({loss}) differs from baseline ({baseline_loss}) "
+            f"by more than {LOSS_RTOL:.1%} ({name}: {losses}, baseline: {baseline_losses})"
+        )
+
+
+@pytest.fixture(scope="module")
+def run_sft(
+    run_process: Callable[..., ProcessResult], output_dir: Path
+) -> Callable[[str, int, list[str]], list[float]]:
+    """Factory fixture running SFT for one parallelism layout, returning its per-step losses."""
+
+    def _run_sft(name: str, num_gpus: int, args: list[str]) -> list[float]:
+        run_name = f"{RUN_NAME}-{name}"
+        cmd = [
+            "uv",
+            "run",
+            "sft",
+            "@",
+            CONFIG,
+            "--deployment.num-gpus",
+            str(num_gpus),
+            "--clean",
+            "--output-dir",
+            output_dir.as_posix(),
+            "--run.name",
+            run_name,
+            *args,
+        ]
+        process = run_process(cmd, timeout=TIMEOUT)
+        assert process.returncode == 0, f"SFT process for {name} has non-zero return code ({process})"
+        return read_losses(output_dir / run_name)
+
+    return _run_sft
+
+
+@pytest.fixture(scope="module")
+def baseline_losses(run_sft: Callable[[str, int, list[str]], list[float]]) -> list[float]:
+    """Fixture for the losses of a single GPU run without any parallelism."""
+    return run_sft("baseline", 1, [])
+
+
+@pytest.fixture(scope="module")
+def unclipped_baseline_losses(run_sft: Callable[[str, int, list[str]], list[float]]) -> list[float]:
+    """Fixture for the single GPU losses without gradient clipping, to compare DeepEP against."""
+    return run_sft("baseline-unclipped", 1, NO_GRAD_CLIPPING)
+
+
+def test_baseline_loss_changes(baseline_losses: list[float]):
+    """Tests that the baseline trains, else comparing losses would not test the backward pass."""
+    assert len(set(baseline_losses)) > 1, f"Baseline loss is constant across steps ({baseline_losses})"
+
+
+@pytest.mark.parametrize(("name", "num_gpus", "args"), PARALLELISMS, ids=[name for name, _, _ in PARALLELISMS])
+def test_loss_matches_baseline(
+    name: str,
+    num_gpus: int,
+    args: list[str],
+    run_sft: Callable[[str, int, list[str]], list[float]],
+    baseline_losses: list[float],
+):
+    """Tests that a parallelism technique yields the baseline loss on the same fixed data."""
+    check_losses_match(name, run_sft(name, num_gpus, args), baseline_losses)
+
+
+@pytest.mark.skipif(not has_deepep(), reason="DeepEP is not installed or unsupported on this GPU")
+def test_deepep_loss_matches_baseline(
+    run_sft: Callable[[str, int, list[str]], list[float]], unclipped_baseline_losses: list[float]
+):
+    """Tests that expert parallelism with the DeepEP all-to-all kernels yields the baseline loss."""
+    args = ["--model.ep", "2", "--model.ep-comm-backend", "deepep", *NO_GRAD_CLIPPING]
+    check_losses_match("ep-deepep", run_sft("ep-deepep", 2, args), unclipped_baseline_losses)

--- a/tests/unit/train/sft/test_fake_dataset.py
+++ b/tests/unit/train/sft/test_fake_dataset.py
@@ -1,4 +1,17 @@
+import os
+
 from prime_rl.trainer.sft.data import FakeDataset
+from prime_rl.trainer.world import reset_world
+
+
+def get_samples(rank: int, world_size: int, non_dp_size: int, num_samples: int = 2) -> list[list[int]]:
+    """Helper to collect the first samples a rank of the given topology is handed."""
+    os.environ.update(
+        RANK=str(rank), WORLD_SIZE=str(world_size), LOCAL_RANK=str(rank), LOCAL_WORLD_SIZE=str(world_size)
+    )
+    reset_world()
+    dataiter = iter(FakeDataset(vocab_size=10000, seq_len=128, non_dp_size=non_dp_size))
+    return [next(dataiter)["input_ids"] for _ in range(num_samples)]
 
 
 def test_init_fake_dataset():
@@ -22,3 +35,23 @@ def test_fake_dataset_state():
     assert dataset.state_dict() == {"step": 3, "epoch": 0}
     next(dataiter)
     assert dataset.state_dict() == {"step": 4, "epoch": 0}
+
+
+def test_fake_dataset_is_deterministic():
+    """Samples are a pure function of their index, so every parallelism layout trains on the same data."""
+    first, second = iter(FakeDataset(vocab_size=10000, seq_len=128)), iter(FakeDataset(vocab_size=10000, seq_len=128))
+
+    assert [next(first) for _ in range(3)] == [next(second) for _ in range(3)]
+
+
+def test_fake_dataset_shares_samples_within_non_dp_group():
+    """Context parallel ranks split one sample along the sequence dim, so they get the same samples."""
+    assert get_samples(rank=0, world_size=2, non_dp_size=2) == get_samples(rank=1, world_size=2, non_dp_size=2)
+
+
+def test_fake_dataset_splits_samples_across_data_ranks():
+    """Data parallel ranks get disjoint samples."""
+    rank_0_samples = get_samples(rank=0, world_size=2, non_dp_size=1)
+    rank_1_samples = get_samples(rank=1, world_size=2, non_dp_size=1)
+
+    assert all(sample not in rank_1_samples for sample in rank_0_samples)


### PR DESCRIPTION
Adds an integration test (`test_parallelism.py`) that trains the same fixed fake data under
each parallelism technique and asserts the per-step loss matches the single-GPU baseline.

- FakeDataset samples are now a pure function of the global index (seeded by step),
  so every parallelism layout sees identical data.
- Adds `non_dp_size` support so non-DP ranks (e.g. context-parallel ranks) shard
  correctly and share samples within their group.
- Tests FSDP, HSDP, CP (ring & ulysses), EP (torch & deepep) against the baseline.

Closes #1432