### PR TITLE
perf(docker): split the uv dependency layer and add registry-backed build cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# .git stays in the context: docker-editable-pretend-versions.sh resolves
+# submodule versions from .git/modules via the build-context bind mount.
+**/.venv
+**/__pycache__
+**/*.py[cod]
+**/.pytest_cache
+**/.ruff_cache
+**/.mypy_cache
+**/wandb
+**/checkpoints
+**/weights
+**/broadcasts
+**/rollouts
+**/torchrun
+.claude
+.vscode
+*.ipynb

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
-# .git stays in the context: docker-editable-pretend-versions.sh resolves
-# submodule versions from .git/modules via the build-context bind mount.
+# .git stays: docker-editable-pretend-versions.sh reads .git/modules via the bind mount.
 **/.venv
 **/__pycache__
 **/*.py[cod]

--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -198,6 +198,12 @@ jobs:
           # rather than needlessly recompressed. Pulling zstd layers needs containerd >= 1.5
           # or Docker >= 23.
           outputs: type=image,push=true,compression=zstd,compression-level=3
+          # Registry-backed BuildKit cache: setup-buildx-action creates a fresh
+          # builder per job, so without this every build is cold and re-runs the
+          # full dependency sync. mode=max caches builder-stage layers (where the
+          # sync lives); blobs already in GHCR are not re-uploaded.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.suffix }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.suffix }},mode=max,image-manifest=true,oci-mediatypes=true,compression=zstd,compression-level=3
           platforms: ${{ matrix.platform }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.tag }}-${{ matrix.suffix }}

--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -161,7 +161,14 @@ jobs:
     steps:
       - name: Remove unnecessary packages
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          # Only reclaim space when the disk is actually tight — deleting the
+          # preinstalled toolchains costs ~70s on the amd64 image-builder runner.
+          avail_gb=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+          if [ "${avail_gb:-0}" -lt 80 ]; then
+            sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          else
+            echo "Skipping cleanup: ${avail_gb}G available on /"
+          fi
 
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -161,8 +161,7 @@ jobs:
     steps:
       - name: Remove unnecessary packages
         run: |
-          # Only reclaim space when the disk is actually tight — deleting the
-          # preinstalled toolchains costs ~70s on the amd64 image-builder runner.
+          # Deleting the preinstalled toolchains costs ~70s; skip unless disk is tight.
           avail_gb=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
           if [ "${avail_gb:-0}" -lt 80 ]; then
             sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -205,10 +204,8 @@ jobs:
           # rather than needlessly recompressed. Pulling zstd layers needs containerd >= 1.5
           # or Docker >= 23.
           outputs: type=image,push=true,compression=zstd,compression-level=3
-          # Registry-backed BuildKit cache: setup-buildx-action creates a fresh
-          # builder per job, so without this every build is cold and re-runs the
-          # full dependency sync. mode=max caches builder-stage layers (where the
-          # sync lives); blobs already in GHCR are not re-uploaded.
+          # The per-job builder is ephemeral; mode=max caches builder-stage
+          # layers so warm builds skip the dependency sync.
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.suffix }}
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.suffix }},mode=max,image-manifest=true,oci-mediatypes=true,compression=zstd,compression-level=3
           platforms: ${{ matrix.platform }}

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -4,14 +4,10 @@
 
 #inspired from https://github.com/astral-sh/uv-docker-example/blob/main/multistage.Dockerfile
 
-# Skeleton stage: collect every pyproject.toml plus the lockfile, so the
-# dependency sync in the builder caches independently of source edits. COPY
-# from this stage is content-hashed, so re-running this cheap stage on every
-# build is free and the sync layer only busts when project metadata changes.
+# Every pyproject.toml + uv.lock, so the dependency sync below caches
+# independently of source edits.
 FROM nvidia/cuda:12.8.1-base-ubuntu24.04 AS manifests
-# --exclude=.git: .git holds no pyprojects but is ~735 MB and changes every
-# commit; without the exclude it lands in this stage's /ctx layer and gets
-# shipped to the registry cache (mode=max) on every build.
+# .git is ~735 MB, changes every commit, and would land in the registry cache.
 COPY --exclude=.git . /ctx
 RUN mkdir -p /manifests \
     && cd /ctx \
@@ -95,12 +91,9 @@ WORKDIR /app
 
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
-# Dependency layer: sync third-party deps against the pyproject skeleton only,
-# so source edits don't invalidate the multi-GB wheel install. The first-party
-# editables (skipped here) install in the source-layer sync below; they need
-# their source trees and git-derived pretend versions, which this layer must
-# not depend on. No build-context bind mount here either — .git changes every
-# commit and would bust this layer's cache.
+# Third-party deps only — source edits don't bust this layer. First-party
+# editables install in the source-layer sync below. No build-context bind
+# mount here: .git would bust the cache every commit.
 COPY --from=manifests /manifests /app
 RUN --mount=type=cache,target=/usr/local/share/uv/cache \
     uv sync --all-packages --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra disagg --extra gpt-oss --extra quack --group mamba-ssm --locked --no-dev \
@@ -250,9 +243,8 @@ WORKDIR /app
 # ~20 GB venv as one layer serialized the export behind a single compressor. Splitting
 # also lets nodes pull the image in parallel. Keep the excludes below in sync with the
 # per-tree copies above, or the data lands in the image twice.
-# Layer order matters: the big trees only change on dependency bumps, while the
-# excluded /app remainder changes on every source edit — it goes last so a code
-# change re-executes and re-pushes one layer instead of all of them.
+# The volatile /app remainder goes last so a source edit re-pushes one layer,
+# not all of them.
 COPY --from=builder --chown=appuser:appuser /app/.venv/lib/python3.12/site-packages/nvidia /app/.venv/lib/python3.12/site-packages/nvidia
 COPY --from=builder --chown=appuser:appuser /app/.venv/lib/python3.12/site-packages/torch /app/.venv/lib/python3.12/site-packages/torch
 COPY --from=builder --chown=appuser:appuser /app/.venv/lib/python3.12/site-packages/vllm /app/.venv/lib/python3.12/site-packages/vllm

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -9,7 +9,10 @@
 # from this stage is content-hashed, so re-running this cheap stage on every
 # build is free and the sync layer only busts when project metadata changes.
 FROM nvidia/cuda:12.8.1-base-ubuntu24.04 AS manifests
-COPY . /ctx
+# --exclude=.git: .git holds no pyprojects but is ~735 MB and changes every
+# commit; without the exclude it lands in this stage's /ctx layer and gets
+# shipped to the registry cache (mode=max) on every build.
+COPY --exclude=.git . /ctx
 RUN mkdir -p /manifests \
     && cd /ctx \
     && find . -name .git -prune -o -type f -name pyproject.toml -exec cp --parents {} /manifests/ \; \
@@ -246,14 +249,10 @@ WORKDIR /app
 # own layers. BuildKit compresses and pushes layers in parallel, so shipping the whole
 # ~20 GB venv as one layer serialized the export behind a single compressor. Splitting
 # also lets nodes pull the image in parallel. Keep the excludes below in sync with the
-# per-tree copies that follow, or the data lands in the image twice.
-COPY --from=builder --chown=appuser:appuser \
-    --exclude=.venv/lib/python3.12/site-packages/nvidia \
-    --exclude=.venv/lib/python3.12/site-packages/torch \
-    --exclude=.venv/lib/python3.12/site-packages/vllm \
-    --exclude=.venv/lib/python3.12/site-packages/flash_attn \
-    --exclude=.venv/lib/python3.12/site-packages/flash_attn_2_cuda*.so \
-    /app /app
+# per-tree copies above, or the data lands in the image twice.
+# Layer order matters: the big trees only change on dependency bumps, while the
+# excluded /app remainder changes on every source edit — it goes last so a code
+# change re-executes and re-pushes one layer instead of all of them.
 COPY --from=builder --chown=appuser:appuser /app/.venv/lib/python3.12/site-packages/nvidia /app/.venv/lib/python3.12/site-packages/nvidia
 COPY --from=builder --chown=appuser:appuser /app/.venv/lib/python3.12/site-packages/torch /app/.venv/lib/python3.12/site-packages/torch
 COPY --from=builder --chown=appuser:appuser /app/.venv/lib/python3.12/site-packages/vllm /app/.venv/lib/python3.12/site-packages/vllm
@@ -264,6 +263,14 @@ COPY --from=builder /opt/ucx /opt/ucx
 # Copy and set up entrypoint script
 COPY --chown=appuser:appuser scripts/docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh
+
+COPY --from=builder --chown=appuser:appuser \
+    --exclude=.venv/lib/python3.12/site-packages/nvidia \
+    --exclude=.venv/lib/python3.12/site-packages/torch \
+    --exclude=.venv/lib/python3.12/site-packages/vllm \
+    --exclude=.venv/lib/python3.12/site-packages/flash_attn \
+    --exclude=.venv/lib/python3.12/site-packages/flash_attn_2_cuda*.so \
+    /app /app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -4,6 +4,17 @@
 
 #inspired from https://github.com/astral-sh/uv-docker-example/blob/main/multistage.Dockerfile
 
+# Skeleton stage: collect every pyproject.toml plus the lockfile, so the
+# dependency sync in the builder caches independently of source edits. COPY
+# from this stage is content-hashed, so re-running this cheap stage on every
+# build is free and the sync layer only busts when project metadata changes.
+FROM nvidia/cuda:12.8.1-base-ubuntu24.04 AS manifests
+COPY . /ctx
+RUN mkdir -p /manifests \
+    && cd /ctx \
+    && find . -name .git -prune -o -type f -name pyproject.toml -exec cp --parents {} /manifests/ \; \
+    && cp uv.lock /manifests/
+
 # Build stage - multi-arch base (supports amd64 + arm64)
 FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04 AS builder
 LABEL maintainer="prime intellect"
@@ -76,10 +87,25 @@ ENV UV_CACHE_DIR="/usr/local/share/uv/cache"
 # the runtime stage's `COPY /app`
 ENV UV_PROJECT_ENVIRONMENT="/app/.venv"
 
-# Install Python dependencies (The gradual copies help with caching)
+# Install Python dependencies
 WORKDIR /app
 
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+
+# Dependency layer: sync third-party deps against the pyproject skeleton only,
+# so source edits don't invalidate the multi-GB wheel install. The first-party
+# editables (skipped here) install in the source-layer sync below; they need
+# their source trees and git-derived pretend versions, which this layer must
+# not depend on. No build-context bind mount here either — .git changes every
+# commit and would bust this layer's cache.
+COPY --from=manifests /manifests /app
+RUN --mount=type=cache,target=/usr/local/share/uv/cache \
+    uv sync --all-packages --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra disagg --extra gpt-oss --extra quack --group mamba-ssm --locked --no-dev \
+        --no-install-workspace \
+        --no-install-package prime-rl-configs \
+        --no-install-package verifiers \
+        --no-install-package renderers \
+        --no-install-package prime-pydantic-config
 
 COPY pyproject.toml /app/pyproject.toml
 COPY uv.lock /app/uv.lock
@@ -98,7 +124,7 @@ COPY scripts/docker-editable-pretend-versions.sh /app/scripts/docker-editable-pr
 # /app/.git/modules to the read-only context before resolving versions.
 ARG VERIFIERS_PRETEND_VERSION
 ARG RENDERERS_PRETEND_VERSION
-RUN --mount=type=cache,target=/app/.cache/uv \
+RUN --mount=type=cache,target=/usr/local/share/uv/cache \
     --mount=type=bind,source=.,target=/build-context,readonly \
     if [ -d /build-context/.git/modules ]; then mkdir -p /app/.git && ln -s /build-context/.git/modules /app/.git/modules; fi \
     && \


### PR DESCRIPTION
## Why

A one-line edit under `src/` busted the `uv sync` layer (source was COPY'd before the sync), re-downloading ~5 GB of wheels and recompiling mamba-ssm, and the CI builders are ephemeral so every build started cold: ~16 min/arch, ~18–20 min end-to-end per image.

## What

**Layer split (`f8df1effe`)**
- New `manifests` stage collects every `pyproject.toml` + `uv.lock` (113 files, <1 MB); a deps-only layer syncs against that skeleton with `--no-install-workspace` plus `--no-install-package` for the four path editables (prime-rl-configs, verifiers, renderers, prime-pydantic-config — they need source trees and git-derived pretend versions, which this layer must not depend on). Source is copied after; the original sync then only installs first-party editables (~24 s).
- Fixed the uv cache mount: `UV_CACHE_DIR` is `/usr/local/share/uv/cache` but the mount targeted `/app/.cache/uv`, so it never cached anything.
- Added `.dockerignore`. `.git` deliberately stays in the context (the pretend-version script resolves submodule versions from `.git/modules` via the bind mount), but `**/.venv` is out — local builds were baking `packages/prime-rl-configs/.venv` (439 MB) into the image via `COPY packages/`.

**Registry cache (`f7937e2dc`)**
- `cache-from`/`cache-to` on per-arch `buildcache-{amd64,arm64}` GHCR tags with `mode=max`, since `setup-buildx-action` gives every job a cold builder.

**Profiling-driven fixes (`1d8ad9eb4`)**
- The manifests stage was snapshotting the full context including the ~735 MB `.git` into a layer that `mode=max` re-exported to the cache on every build → `COPY --exclude=.git`.
- Runtime stage copied the volatile `/app` remainder before the immutable nvidia/torch/vllm/flash-attn trees, so every code change re-executed and re-compressed them → volatile layer moved last.
- "Remove unnecessary packages" cost ~70 s on the amd64 runner and the runner has 1651 GB free → gated on <80 GB available.

## Measured

| build | end-to-end |
|---|---|
| cold (main, recent runs) | ~18–20 min |
| warm, layer split + cache (run 31912669079) | 11m22s |
| warm, all fixes (run 31914223358) | **9m30s** |

Steady-state warm profile (amd64): 189 s pull cached builder layers + 82 s pull cached runtime layers + 24 s first-party sync + 21 s volatile copy + 75 s image export + 37 s cache export. The remaining floor (~6.4 min) is the GHCR round-trip inherent to ephemeral runners; the actual build work is ~45 s. Getting to 2–3 min needs a persistent builder (e.g. long-lived buildkitd via `driver: remote`, self-hosted runner, or Depot) — out of scope here.

## Validation

- Deps-only sync validated against a skeleton-only tree in a Linux container (uv 0.11.9): `--locked --dry-run` resolves all 551 packages, plans 422 installs, no first-party editables, no lockfile errors.
- Three green builds on the branch, including the cold cache-seed run and two warm runs; final image tags build identically (multi-arch manifests created).
- `docker build --check` clean; manifests stage verified to contain exactly the 113 pyprojects + lock and no `.git`.

## Note for dispatchers

Workflow-file changes only apply when the dispatch runs the branch's workflow: `gh workflow run build_image.yaml --ref chore/docker-build-caching -f ref=chore/docker-build-caching`. Dispatching without `--ref` runs main's workflow file (no cache config) against the branch's code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect Docker/CI build caching and layer ordering only; runtime image contents and install semantics are intended to stay equivalent, with no auth or application runtime logic touched.
> 
> **Overview**
> **Cuts warm CUDA image CI from ~18–20 min to ~9.5 min** by caching third-party `uv sync` separately from source and reusing builder layers from GHCR.
> 
> A new **`manifests` stage** copies only `pyproject.toml` files and `uv.lock` (excluding `.git` so ~735 MB isn’t re-exported to the registry cache). The builder runs a **deps-only** `uv sync` with `--no-install-workspace` and skips the four path editables; full source is copied afterward for a short first-party sync. The **uv cache mount** now targets `UV_CACHE_DIR` (`/usr/local/share/uv/cache`) instead of a path that never cached.
> 
> **`.dockerignore`** drops local `**/.venv` and caches while keeping `.git` for submodule pretend-version resolution via the build bind mount.
> 
> **CI** adds per-arch `cache-from` / `cache-to` on `buildcache-{amd64,arm64}` with `mode=max` and zstd. Runner cleanup of dotnet/android/ghc runs only when free disk on `/` is under 80 GB.
> 
> In the **runtime stage**, large venv trees (nvidia, torch, vllm, flash-attn) are copied **before** the volatile `/app` remainder so code edits don’t re-push those layers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cfcf58d417a32a4b96eb5533020ed1d3048d014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->