### PR TITLE
fix(monitors): allow overriding the platform base URL via $PRIME_API_BASE

### DIFF
--- a/src/prime_rl/monitors/prime.py
+++ b/src/prime_rl/monitors/prime.py
@@ -22,6 +22,7 @@ from prime_rl.utils.logger import get_logger
 from prime_rl.utils.utils import sanitize
 
 BASE_URL = "https://api.primeintellect.ai/api/v1/rft"
+BASE_URL_VAR = "PRIME_API_BASE"
 API_KEY_VAR = "PRIME_API_KEY"
 
 SAMPLE_SCHEMA = pa.schema(
@@ -129,13 +130,14 @@ class TrainRun:
         self.id: str | None = None
         self.logger = get_logger()
         self._tasks: set[asyncio.Task] = set()
+        self.base_url = (os.getenv(BASE_URL_VAR) or BASE_URL).rstrip("/")
         self.headers = {
             "Authorization": f"Bearer {api_key}",
             "x-api-key": api_key,
             "Content-Type": "application/json",
         }
         self.client = httpx.AsyncClient(
-            base_url=BASE_URL,
+            base_url=self.base_url,
             headers=self.headers,
             timeout=30,
             transport=httpx.AsyncHTTPTransport(retries=3),
@@ -246,7 +248,7 @@ class TrainRun:
         self.logger.info(f"Marking platform run {self.id} as failed")
         try:
             httpx.put(
-                f"{BASE_URL}/external-runs/{self.id}/status",
+                f"{self.base_url}/external-runs/{self.id}/status",
                 headers=self.headers,
                 json={"status": "failed"},
                 timeout=30,


### PR DESCRIPTION
## Summary

`TrainRun` hardcodes the production public API (`https://api.primeintellect.ai/api/v1/rft`). That leaves no way to point the prime monitor anywhere else:

- **Managed (platform-dispatched) runs** need to post to the platform's internal ingestion path (`{SERVICE_URL}/api/internal/rft`, run-bound token auth) — the public `/api/v1/rft` monitoring endpoints reject non-external runs, so hosted runs on the post-#3275 monitor currently produce empty dashboards.
- **Non-prod environments** post to prod: a dev run's per-run `PRIME_API_KEY` 401s against prod — silently, since uploads are fire-and-forget warnings.

This makes `$PRIME_API_BASE` an override, taken verbatim when set (trailing slash stripped). The platform already injects exactly this env var on managed orchestrator pods — it was reserved as "the monitor endpoint on the orch env" but nothing consumed it until now — so managed runs and dev environments start working on the next pin bump with **zero platform changes**. With the var unset, behavior is byte-identical to today: the prod default.

Resolved once in `__init__` and stored on the instance, since the atexit `_mark_failed` hook runs at interpreter shutdown and must agree with the client.

## Verification

#3275 removed the monitor runtime unit tests, so this was verified by importing the module directly (torch/pyarrow/verifiers stubbed) and asserting `TrainRun(...).base_url`:

1. `PRIME_API_BASE=http://pi-backend/api/internal/rft/` → taken verbatim, trailing slash stripped, non-`/api/v1` path intact
2. Unset → `https://api.primeintellect.ai/api/v1/rft`, byte-identical to current behavior
3. Sanity: `PRIME_API_BASE_URL` (the prime CLI's env var, present on managed pods as the package-registry host) has no effect — resolution deliberately never consults the CLI config

## Context

Companion to the monitors-refactor migration: PrimeIntellect-ai/fft#58 (validator enrolls `[orchestrator.monitors.prime]` for managed runs) + a follow-up fft pin bump past this commit restores hosted-run metrics end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)