### PR TITLE
fix: apply concurrency bootstrap only once

### DIFF
--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -102,6 +102,7 @@ class ConcurrencyController:
         self.max_inflight = config.initial_inflight or floor
         # None until the first unfrozen on_step (or a cut initializes it early)
         self.kappa: float | None = None
+        self.bootstrapped = False
         self.completed_steps = 0
 
         self.estimates: dict[tuple[str, str], EnvEstimate] = {}
@@ -187,13 +188,16 @@ class ConcurrencyController:
 
         # First capacity observation before any step completed, without a
         # user-set start: raise the pre-capacity floor to the feedforward
-        # bootstrap
+        # bootstrap. Fires once — every later change goes through on_step
+        # (or a HARD cut), so the cap is stable between step boundaries.
         if (
-            not self.frozen
+            not self.bootstrapped
+            and not self.frozen
             and self.kappa is None
             and self.config.initial_inflight is None
             and self.capacity is not None
         ):
+            self.bootstrapped = True
             derived = self.clamp(self.capacity / self.cost_estimate())
             get_logger().info(
                 f"Derived initial max inflight {derived} - {format_num(self.capacity, precision=1)} KV cache tokens "


### PR DESCRIPTION
## Summary
- Latch the pre-step feedforward bootstrap in `ConcurrencyController.observe()` so it fires once, on the first KV-capacity observation (keeps the derived-initial-cap logging).
- After that, the cap changes only at step boundaries (`on_step`) and on emergency HARD cuts, as intended.

## Verification
Before (run `glm-air-swe`, job 724): with no `initial_inflight`, the guard `kappa is None` stayed true for the whole first step, so every ~5s metrics poll re-applied `capacity / cost_estimate()` against the moving cost EWMA — the orchestrator log shows the derived cap flapping 33 → 407 → 480 → 317 → 639 within minutes, before any step completed.

After: a single derived-initial-cap raise from the group-size floor, then the next change is the first step re-evaluation. Note this makes the pre-step-1 warmup intentionally conservative: the cap holds at the pessimistic `capacity / engine_max_len` estimate until step 1 reprices it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestrator admission control timing; wrong latching could leave the cap too low or too high during warmup, but scope is a small guard in `ConcurrencyController.observe()`.
> 
> **Overview**
> Fixes **max inflight** thrashing when `initial_inflight` is unset: `observe()` used to re-apply `capacity / cost_estimate()` on every metrics poll while `kappa` stayed unset, so the moving cost EWMA could swing the cap repeatedly before the first training step finished.
> 
> Adds a **`bootstrapped`** latch so the pre-step feedforward raise runs **once** on the first KV-capacity observation (same derived-initial-cap logging). After that, the cap only moves at **step boundaries** via `on_step` or on **HARD** overload cuts—stable between polls. Early warmup stays conservative until step 1 reprices `G`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86dcb300bd03b8741d9628b5d692e092c0b8779c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->