### PR TITLE
fix: report trainable rate over the shipped batch

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -595,11 +595,12 @@ class Orchestrator:
             return
         self.consecutive_empty_batches = 0
         effective = batch.rollouts.effective
-        n_trainable = sum(1 for r in effective if r.is_trainable)
-        if effective and n_trainable / len(effective) <= 0.1:
+        n_shipped = len(batch.cohort)
+        n_trainable = sum(1 for r in batch.cohort if not r.is_filtered and r.is_trainable)
+        if n_shipped and n_trainable / n_shipped <= 0.1:
             get_logger().warning(
-                f"Only {n_trainable}/{len(effective)} effective rollouts are trainable "
-                f"({n_trainable / len(effective):.1%}) — consider reviewing task difficulty / filter config"
+                f"Only {n_trainable}/{n_shipped} shipped rollouts are trainable "
+                f"({n_trainable / n_shipped:.1%}) — consider reviewing task difficulty / filter config"
             )
 
         # Ship batch ``step`` only once the trainer has published v{step-1-TARGET_LAG}.
@@ -787,19 +788,21 @@ class Orchestrator:
     def log_train_batch(self, batch: TrainBatch, *, step: int, step_time: float) -> None:
         """Per-step ``Step …`` success line. Multi-env runs append an indented ``╰─`` line per env.
         ``Error`` is the sink-level rate (errored arrivals / total arrivals, over the full window);
-        the quality metrics are over the effective (clean, trained-on) subset, as is ``Trainable``."""
+        the quality metrics are over the effective (clean, trained-on) subset. ``Trainable`` is over
+        the shipped cohort: gradient-carrying rollouts / batch size (a filtered or zero-advantage
+        rollout fills a batch slot without contributing gradient)."""
         rollouts = batch.rollouts
         effective = rollouts.effective
         eff = effective.metrics
         n_generated = len(rollouts)
-        n_effective = len(effective)
-        n_trainable = sum(1 for r in effective if r.is_trainable)
-        trainable_rate = (n_trainable / n_effective) if n_effective else 0.0
+        n_shipped = len(batch.cohort)
+        n_trainable = sum(1 for r in batch.cohort if not r.is_filtered and r.is_trainable)
+        trainable_rate = (n_trainable / n_shipped) if n_shipped else 0.0
         max_off_policy = max((r.off_policy_steps for r in effective), default=0)
 
         head = (
             f"Step {step} | {format_time(step_time):>7} | Reward {eff.reward.mean():.4f} | "
-            f"Trainable {n_trainable}/{n_effective} ({trainable_rate:.1%}) | "
+            f"Trainable {n_trainable}/{n_shipped} ({trainable_rate:.1%}) | "
             f"Turns {eff.num_turns.mean():.1f} | Branches {eff.num_branches.mean():.1f} | "
             f"Max Off-Policy {max_off_policy} | "
             f"Error {rollouts.metrics.has_error.mean():.1%} | Truncation {eff.is_truncated.mean():.1%}"

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -275,7 +275,7 @@ class TrainSink:
         rollouts = self.pending_rollouts
         if samples:
             self.pending_rollouts = TrainRollouts()
-        return TrainBatch(rollouts=rollouts, samples=samples)
+        return TrainBatch(rollouts=rollouts, cohort=cohort, samples=samples)
 
     def reset_pre_filter_stats(self) -> None:
         self.pre_filter_seen = 0

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -141,12 +141,14 @@ class Rollout(vf.Trace[DataT], Generic[DataT]):
 class TrainBatch:
     """``rollouts`` is the observation window since the last ship — every rollout of every group
     finalized in that span (errored + filtered included; rollouts of still-incomplete groups wait
-    for a later window). Its ``.effective`` / ``.metrics`` views drive logging. ``samples`` is the
-    trainer-bound payload (the shipped cohort's post-filter survivors) — an empty list means nothing
-    ships, which would stall the trainer. Trainable counts derive from ``rollouts.effective``
-    (``r.is_trainable``) and token totals from ``samples``, so neither is carried as a field."""
+    for a later window). Its ``.effective`` / ``.metrics`` views drive logging. ``cohort`` is the
+    batch-sized slice popped for the trainer (post-batch filter annotations applied; filtered
+    members ship no samples), so trainable counts are over exactly what fills the batch.
+    ``samples`` is the trainer-bound payload (the cohort's post-filter survivors) — an empty list
+    means nothing ships, which would stall the trainer."""
 
     rollouts: TrainRollouts
+    cohort: list[Rollout]
     samples: list[TrainingSample]
 
 


### PR DESCRIPTION
## Summary

- The `Step` line's `Trainable k/n` was computed over the observation window (every group finalized since the last shipped batch). `n` therefore drifted around the configured batch size: overflow rollouts counted in the window their group finalized in, then never in the batch they actually shipped with.
- `TrainBatch` now carries `cohort` — the batch-sized slice `process_batch` pops for the trainer (post-batch filter annotations applied).
- `Trainable k/n` is now over the shipped cohort: `n` is the batch size (the shipped rollout count in token-batched runs) and `k` is the cohort rollouts that carry gradient — not post-filtered and nonzero advantage. It directly reads as "how many batch slots contribute no gradient" (zero-advantage GRPO group or post-batch filter).
- The low-trainable warning (≤10%) uses the same counts, so it cannot disagree with the step line.
- The rest of the `Step` line (Reward, Turns, Error, Truncation) and the wandb metric matrix stay on the window frame; the `log_train_batch` docstring states `Trainable`'s frame explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
