### PR TITLE
fix(tests): seed qwen3_moe parity test RNG and widen grad tolerance

### DIFF
--- a/tests/unit/train/models/test_qwen3_moe.py
+++ b/tests/unit/train/models/test_qwen3_moe.py
@@ -11,6 +11,14 @@ from prime_rl.utils.utils import default_dtype
 pytestmark = [pytest.mark.gpu]
 
 
+@pytest.fixture(autouse=True)
+def _seed_rng():
+    """Pin the RNG: the HF-vs-prime bf16 gradient parity check is sensitive to
+    the random input/init draw and flakes with "Max grad diff: 1024.0".
+    """
+    torch.manual_seed(0)
+
+
 def get_model_pairs():
     hf_config = Qwen3MoeConfig(
         head_dim=128,
@@ -72,7 +80,7 @@ def test_qwen3_moe_attn_only():
         f"Max logits diff: {logits_diff.abs().max()}"
     )
     grad_diff = hf_model.model.embed_tokens.weight.grad - prime_model.model.embed_tokens.weight.grad
-    assert torch.allclose(grad_diff, torch.zeros_like(grad_diff), atol=1000), f"Max grad diff: {grad_diff.abs().max()}"
+    assert torch.allclose(grad_diff, torch.zeros_like(grad_diff), atol=2048), f"Max grad diff: {grad_diff.abs().max()}"
 
 
 def test_qwen3_moe_mlp_only():
@@ -100,7 +108,7 @@ def test_qwen3_moe_mlp_only():
         f"Max logits diff: {logits_diff.abs().max()}"
     )
     grad_diff = hf_model.model.embed_tokens.weight.grad - prime_model.model.embed_tokens.weight.grad
-    assert torch.allclose(grad_diff, torch.zeros_like(grad_diff), atol=1000), f"Max grad diff: {grad_diff.abs().max()}"
+    assert torch.allclose(grad_diff, torch.zeros_like(grad_diff), atol=2048), f"Max grad diff: {grad_diff.abs().max()}"
 
 
 def test_qwen3_moe():
@@ -120,7 +128,7 @@ def test_qwen3_moe():
         f"Max logits diff: {logits_diff.abs().max()}"
     )
     grad_diff = hf_model.model.embed_tokens.weight.grad - prime_model.model.embed_tokens.weight.grad
-    assert torch.allclose(grad_diff, torch.zeros_like(grad_diff), atol=1000), f"Max grad diff: {grad_diff.abs().max()}"
+    assert torch.allclose(grad_diff, torch.zeros_like(grad_diff), atol=2048), f"Max grad diff: {grad_diff.abs().max()}"
 
 
 def test_qwen3_moe_router_replay():


### PR DESCRIPTION
## Summary

`tests/unit/train/models/test_qwen3_moe.py::test_qwen3_moe` fails intermittently on `main` and unrelated PRs with `AssertionError: Max grad diff: 1024.0` (also observed at 1024-1344 in CI).

### Root cause

The test compares HF vs prime-rl gradients in **bf16** with an **unseeded** random input/init draw, and **FlashAttention-2 backward is not bit-deterministic** (reduction-order/atomics). Seeding alone cannot remove the kernel noise, so the embedding-grad diff (measured 512-1344 across 60 random seeds, +~256 run-to-run noise) occasionally crosses the `atol=1000` threshold by a hair.

### Changes

- **Autouse fixture pins `torch.manual_seed(0)`** — the random draw is now deterministic (seed 0 keeps grad diff in the 512-768 band locally).
- **Grad tolerance `atol` 1000 → 2048** — absorbs FA2 backward reduction-order noise that seeding cannot fix. Verified locally: 60/60 random seeds pass at 2048 (worst observed 1344); the logits check (`atol=1.0`, observed max 0.29) is unchanged and still catches gross parity breaks.

### Validation

Ran the full test file 15× locally on an RTX PRO 6000 (Blackwell): 60/60 passed. Ruff check/format pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to RNG seeding and assertion tolerances; no trainer or model code paths are modified.
> 
> **Overview**
> Stabilizes **GPU Qwen3 MoE HF vs prime-rl parity tests** that compare embedding gradients in **bf16** with FlashAttention-2.
> 
> An **autouse fixture** sets **`torch.manual_seed(0)`** so random inputs and init are fixed across runs. The embedding **gradient `allclose` tolerance** is raised from **`atol=1000` to `2048`** in `test_qwen3_moe_attn_only`, `test_qwen3_moe_mlp_only`, and `test_qwen3_moe`, to absorb FA2 backward non-determinism that seeding alone cannot remove. **Logits parity checks** stay at **`atol=1.0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d84191805f19f91fe568a18bcb2f4bce8592a69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->