### PR TITLE
fix(tests): migrate full-offload SFT fixture to num-train-gpus

### DIFF
--- a/tests/integration/test_reverse_text_sft.py
+++ b/tests/integration/test_reverse_text_sft.py
@@ -104,7 +104,7 @@ def sft_full_offload_model_only_resume_process(
         "sft",
         "@",
         "configs/ci/integration/reverse-text-sft/full-offload-resume.toml",
-        "--deployment.num-gpus",
+        "--deployment.num-train-gpus",
         "2",
         "--monitors.wandb.project",
         wandb_project,


### PR DESCRIPTION
## Summary
- Rename `--deployment.num-gpus` to `--deployment.num-train-gpus` in the `sft_full_offload_model_only_resume_process` fixture.
- #3256 renamed SFT `deployment.num_gpus` to `num_train_gpus` and migrated the other two fixtures in this file. The full-offload fixture landed in parallel via #3234 and kept the old flag.

## Verification
On main, the `reverse_text_sft` GPU integration job fails with:

```
1 validation error for SFTConfig
--deployment.single-node.num-gpus
  Extra inputs are not permitted (got '2')
```

The renamed flag matches the two fixtures above it, which pass on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CLI flag rename with no production or runtime behavior changes.
> 
> **Overview**
> Updates the `sft_full_offload_model_only_resume_process` integration fixture so it passes **`--deployment.num-train-gpus`** instead of the removed **`--deployment.num-gpus`**, matching the other reverse-text SFT fixtures after the SFT deployment config rename.
> 
> Without this change, the GPU `reverse_text_sft` job fails config validation (`Extra inputs are not permitted` for `num-gpus`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc3916968c63b76efb1db5bec5344c3ac6a57edd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->