### PR TITLE
fix(docker): re-include the wandb monitor package in the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,12 @@
 # .git stays: docker-editable-pretend-versions.sh reads .git/modules via the bind mount.
+**/wandb
+!src/prime_rl/monitors/wandb/
 **/.venv
 **/__pycache__
 **/*.py[cod]
 **/.pytest_cache
 **/.ruff_cache
 **/.mypy_cache
-**/wandb
 **/checkpoints
 **/weights
 **/broadcasts


### PR DESCRIPTION
## Summary

Images built from `main` are missing `src/prime_rl/monitors/wandb/`, and every entrypoint dies at import:

```
File "/app/src/prime_rl/entrypoints/orchestrator.py", line 22, in main
  from prime_rl.orchestrator.orchestrator import run_orchestrator
File "/app/src/prime_rl/monitors/__init__.py", line 19, in <module>
  from prime_rl.monitors.wandb import WandbMonitor
ModuleNotFoundError: No module named 'prime_rl.monitors.wandb'
```

Two changes collided:

- #3275 turned `monitors/wandb` from a module into a **package directory** (it was `utils/monitor/wandb.py` before — a `.py` file, which `**/wandb` does not match).
- #3279 added `**/wandb` to `.dockerignore` to keep W&B's local run-output dirs out of the build context, without the exemption `.gitignore` already carries.

`Dockerfile.cuda` does `COPY src/ /app/src/`, which reads the *filtered* context, so the package is silently dropped. `monitors/__init__.py` is imported unconditionally, so this takes down the orchestrator and the trainer whether or not W&B is configured.

The three tracked files affected:

```
src/prime_rl/monitors/wandb/__init__.py
src/prime_rl/monitors/wandb/monitor.py
src/prime_rl/monitors/wandb/overview.py
```

`wandb/` is the only pattern in `.dockerignore` that shadows tracked source — `checkpoints`, `weights`, `broadcasts`, `rollouts` and `torchrun` all match 0 tracked files.

## Why the reorder

The exemption has to sit **above** `**/__pycache__` / `**/*.py[cod]`. Docker uses the last matching line, so with the pair at the bottom the re-included directory drags its host `__pycache__/*.pyc` into the context. Placing it first lets the bytecode patterns strip those back out.

## Verification

Built against the real repo context (`COPY . /c/`), before and after:

| | `monitors/wandb/*.py` | `monitors/wandb/__pycache__` | top-level `wandb/` junk |
|---|---|---|---|
| `main` today | ❌ absent | — | excluded |
| exemption appended at the bottom | ✅ present | ❌ leaks in | excluded |
| **this PR** | ✅ present | ✅ excluded | ✅ excluded |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `.dockerignore` changes; no runtime code paths. Restores expected files in `COPY src/` without widening the context beyond the monitored package.
> 
> **Overview**
> Fixes Docker images that fail at import with `ModuleNotFoundError: no module named 'prime_rl.monitors.wandb'` because `**/wandb` in `.dockerignore` excluded the tracked package at `src/prime_rl/monitors/wandb/` after that path became a directory.
> 
> Adds `!src/prime_rl/monitors/wandb/` and places the `**/wandb` / exemption pair **above** `**/__pycache__` and `**/*.py[cod]` so Docker’s last-match rules still drop host bytecode from the re-included tree while keeping local W&B run output dirs out of the context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20ea9da42af9fbcf70ba063814799e53483180a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->