### PR TITLE
chore: consolidate artifact ignores under outputs/

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,17 +1,11 @@
 # .git stays: docker-editable-pretend-versions.sh reads .git/modules via the bind mount.
-**/wandb
-!src/prime_rl/monitors/wandb/
+**/outputs
 **/.venv
 **/__pycache__
 **/*.py[cod]
 **/.pytest_cache
 **/.ruff_cache
 **/.mypy_cache
-**/checkpoints
-**/weights
-**/broadcasts
-**/rollouts
-**/torchrun
 .claude
 .vscode
 *.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -6,21 +6,8 @@
 configs/endpoints.py
 
 # Artifacts
-**/slurm
-!src/prime_rl/slurm
-!examples/slurm
-!docs/slurm.md
-**/torchrun
-**/weights
-**/checkpoints
-**/broadcasts
-**/rollouts
-**/logs
-**/wandb
-!src/prime_rl/monitors/wandb/
-**/evals
+outputs/
 **/run_*/
-!configs/**/evals
 final_summary.json
 .pydantic_config
 .chroma_db
@@ -201,7 +188,5 @@ cython_debug/
 # Files created while testing
 debug_I2_zero_band
 .idea
-
-outputs/
 
 third_party/


### PR DESCRIPTION
Follow-up to #3292, per review feedback: ignore `outputs/` wholesale instead of listing every artifact leaf.

## Why one pattern covers it

Every run artifact hangs off `output_dir` (`utils/pathing.py`):

```
output_dir / "logs"        ← torchrun nests here: logs/trainer/torchrun/*/*/*/*.log
output_dir / "configs"
output_dir / "checkpoints"
output_dir / "weights"
output_dir / "rollouts"
output_dir / "evals"
output_dir / "broadcasts"
```

W&B lands there too — `monitors/wandb/monitor.py` passes `dir=output_dir` to `wandb.init()`, so the local run dir is written *inside* the run dir, not at the repo root. With `output_dir` defaulting to `outputs`, one pattern replaces the whole list.

## What this retires

- **The `!src/prime_rl/monitors/wandb/` exemption from #3292.** Once `**/wandb` is gone nothing shadows the package, so the ordering constraint it depended on (bytecode patterns must follow the negation, since the last matching line wins) disappears with it.
- **Two dead exemptions**, neither matching a tracked path:
  - `!src/prime_rl/slurm`, `!examples/slurm`, `!docs/slurm.md` — all three paths were removed from the repo.
  - `!configs/**/evals` — no tracked path contains `evals` at all.
- **A duplicate `outputs/`** in `.gitignore`, which listed it twice.

## `**/outputs` vs `outputs` in .dockerignore

`.dockerignore` patterns anchor at the context root, so a bare `outputs` would only match the top-level directory. The `**/` prefix keeps the any-depth reach the old per-leaf patterns had (e.g. `deps/verifiers/outputs/`).

## Verification

Built against the real repo context with a populated `outputs/` tree:

| | result |
|---|---|
| `monitors/wandb/{__init__,monitor,overview}.py` | present |
| `monitors/**/__pycache__` | excluded |
| `outputs/myrun/{checkpoints,weights,wandb,logs/trainer/torchrun}` | excluded |
| `deps/verifiers/outputs/` | excluded |

`git ls-files \| git check-ignore --stdin` returns empty — no tracked file became ignored.

## Trade-off

The old per-leaf patterns caught artifacts under *any* output dir; `outputs/` only covers the default. The two examples that override it (`examples/advanced/glm-5.2/*.toml` → `/shared/outputs`) use absolute paths outside the repo, so they're unaffected. The remaining exposure is a relative custom `output_dir` — easy to spot, and easy to re-add a pattern for if it ever comes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only ignore-file edits with no runtime or application logic changes; the main caveat is slightly narrower coverage for non-default relative output directories.
> 
> **Overview**
> **`.gitignore`** replaces many per-artifact rules (`checkpoints`, `weights`, `wandb`, `logs`, `torchrun`, etc.) with a single **`outputs/`** entry, and drops negation exceptions that are no longer needed (`!src/prime_rl/monitors/wandb/`, removed slurm paths, `!configs/**/evals`) plus a duplicate **`outputs/`** line.
> 
> **`.dockerignore`** swaps the same leaf patterns for **`**/outputs`** so nested trees (e.g. `deps/verifiers/outputs/`) stay excluded from the image context, and removes the wandb package negation for the same reason as git.
> 
> **Trade-off:** ignores apply to the default `outputs` layout under `output_dir`; custom relative `output_dir` paths outside `outputs/` would not be covered unless another pattern is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8780f0d07dfe202e27a48921403dec68f746a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->