### PR TITLE
feat(inference): Dynamo integration

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -463,8 +463,9 @@ class RLConfig(BaseConfig):
         filesystem when LoRA is enabled (not yet supported by in-memory transfer) or when no
         inference server is configured.
         """
+        client = self.orchestrator.model.client
         if self.weight_broadcast is None:
-            if self.trainer.model.lora is not None or self.inference is None:
+            if self.trainer.model.lora is not None or (self.inference is None and not client.is_dynamo()):
                 self.weight_broadcast = SharedFileSystemWeightBroadcastConfig()
             else:
                 self.weight_broadcast = SharedNCCLWeightBroadcastConfig()
@@ -475,11 +476,12 @@ class RLConfig(BaseConfig):
                 "have no disk artifact to load from."
             )
         if self.weight_broadcast.type in ("nccl", "nixl"):
-            inference_world_size = (
-                self.inference.vllm.data_parallel_size * self.inference.vllm.tensor_parallel_size
-                if self.inference
-                else 1
-            )
+            if self.inference is not None:
+                inference_world_size = self.inference.vllm.data_parallel_size * self.inference.vllm.tensor_parallel_size
+            elif client.is_dynamo() and self.deployment.type == "single_node":
+                inference_world_size = self.deployment.num_infer_gpus
+            else:
+                inference_world_size = 1
             common_config = dict(
                 host=self.weight_broadcast.host,
                 port=self.weight_broadcast.port,
@@ -490,6 +492,18 @@ class RLConfig(BaseConfig):
                 transport_config = dict(
                     quantize_in_weight_transfer=self.weight_broadcast.quantize_in_weight_transfer,
                 )
+                trainer_config = common_config
+                if client.dynamo is not None:
+                    trainer_config = {
+                        **common_config,
+                        "dynamo": {
+                            "discovery_url": client.dynamo.discovery_url,
+                            "model_name": self.trainer.model.name,
+                            "headers": client.headers,
+                            "headers_from_env": client.headers_from_env,
+                            "api_key_var": client.api_key_var,
+                        },
+                    }
                 trainer_config_type = TrainerNCCLWeightBroadcastConfig
                 orchestrator_config_type = OrchestratorNCCLWeightBroadcastConfig
             else:
@@ -497,9 +511,10 @@ class RLConfig(BaseConfig):
                     session_id=self.weight_broadcast.session_id,
                     overlap_transfer_and_replay=self.weight_broadcast.overlap_transfer_and_replay,
                 )
+                trainer_config = common_config
                 trainer_config_type = TrainerNIXLWeightBroadcastConfig
                 orchestrator_config_type = OrchestratorNIXLWeightBroadcastConfig
-            self.trainer.weight_broadcast = trainer_config_type(**common_config, **transport_config)
+            self.trainer.weight_broadcast = trainer_config_type(**trainer_config, **transport_config)
             self.orchestrator.weight_broadcast = orchestrator_config_type(**common_config, **transport_config)
         elif self.weight_broadcast.type == "filesystem":
             self.trainer.weight_broadcast = TrainerFileSystemWeightBroadcastConfig(

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -162,6 +162,11 @@ class BaseModelConfig(BaseConfig):
     """VLM configuration. Setting this enables vision-language model support."""
 
 
+class DynamoConfig(BaseConfig):
+    discovery_url: str
+    """Dynamo frontend URL used to discover the inference workers pinned for RL control."""
+
+
 class ClientConfig(BaseConfig):
     wait_for_ready_timeout: int = 1800
     """Seconds to wait at startup for the inference pool to become ready."""
@@ -183,6 +188,12 @@ class ClientConfig(BaseConfig):
 
     admin_base_url: list[str] | None = None
     """Separate base URLs for admin operations (weight updates, health checks). When set, admin clients bypass routers and hit each server directly — used in multi-replica or disaggregated P/D deployments where the router must not handle admin traffic."""
+
+    dynamo: DynamoConfig | None = None
+    """Dynamo RL worker-discovery configuration."""
+
+    def is_dynamo(self) -> bool:
+        return self.dynamo is not None
 
 
 class LogConfig(BaseConfig):

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -8,6 +8,7 @@ from prime_rl.configs.monitors import MonitorsConfig
 from prime_rl.configs.shared import (
     BaseModelConfig,
     BaseWeightBroadcastConfig,
+    DynamoConfig,
     EnvVars,
     HeartbeatConfig,
     MetricsServerConfig,
@@ -591,6 +592,13 @@ class InMemoryWeightBroadcastConfig(BaseWeightBroadcastConfig):
     """Number of inference workers."""
 
 
+class DynamoWeightBroadcastConfig(DynamoConfig):
+    model_name: str
+    headers: dict[str, str] = Field(default_factory=dict)
+    headers_from_env: dict[str, str] = Field(default_factory=dict)
+    api_key_var: str = "VLLM_API_KEY"
+
+
 class NCCLWeightBroadcastConfig(InMemoryWeightBroadcastConfig):
     type: Literal["nccl"] = "nccl"
 
@@ -599,6 +607,9 @@ class NCCLWeightBroadcastConfig(InMemoryWeightBroadcastConfig):
 
     quantize_in_weight_transfer: bool = False
     """Use kernel-format FP8 quantized NCCL transfer for weight updates. When disabled, uses default HF checkpoint-format transfer."""
+
+    dynamo: DynamoWeightBroadcastConfig | None = None
+    """Dynamo worker discovery used by the native vLLM weight-transfer sender."""
 
 
 class NIXLWeightBroadcastConfig(InMemoryWeightBroadcastConfig):

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -76,6 +76,8 @@ uv run sft @ examples/basic/reverse-text/sft.toml --dry-run
 
 OpenAI-compatible API plus prime-rl custom endpoints (`/update_weights`, `/load_lora_adapter`, `/init_broadcaster`). Always use this entrypoint — never `vllm serve` directly. It starts a `vllm-router` on `server.port` (default 8000, the client-facing URL) fronting the engine on `backend_port` (default 8100); admin endpoints must target the engine port directly.
 
+Before debugging dependency import or version errors from a reused checkout, run `uv sync --all-extras --all-packages --locked`. Stale packages left in `.venv` can be imported even when they are absent from the lockfile; for example, a mismatched `flashinfer-cubin` can prevent vLLM from starting.
+
 ```bash
 uv run inference --vllm.model Qwen/Qwen3-0.6B
 uv run inference --vllm.model Qwen/Qwen3-0.6B --vllm.enforce-eager

--- a/src/prime_rl/entrypoints/env_server.py
+++ b/src/prime_rl/entrypoints/env_server.py
@@ -6,6 +6,7 @@ from verifiers.v1.runtimes import set_base_sandbox_labels
 from verifiers.v1.serve import env_config_data, serve_env
 
 from prime_rl.configs.env_server import EnvServerConfig
+from prime_rl.inference.vllm.routed_experts import install_native_routed_experts_normalizer
 from prime_rl.orchestrator.utils import setup_env_server_logging
 from prime_rl.utils.config import cli
 from prime_rl.utils.process import set_proc_title
@@ -15,6 +16,7 @@ from prime_rl.utils.utils import clean_exit
 def setup_worker(log_level: str | None, json_logging: bool, sandbox_labels: list[str]) -> None:
     setup_env_server_logging(log_level, json_logging)
     set_base_sandbox_labels(sandbox_labels)
+    install_native_routed_experts_normalizer()
 
 
 @clean_exit

--- a/src/prime_rl/inference/dynamo.py
+++ b/src/prime_rl/inference/dynamo.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+DYNAMO_RL_DISCOVERY_PROTOCOL_VERSION = 1
+REQUIRED_ROUTES = frozenset(
+    {
+        "control/pause_generation",
+        "control/resume_generation",
+        "control/is_paused",
+        "control/get_weight_version",
+        "update/update_weight_version",
+    }
+)
+NATIVE_NCCL_ROUTES = frozenset(
+    {
+        "update/init_weight_transfer_engine",
+        "update/start_weight_update",
+        "update/update_weights",
+        "update/finish_weight_update",
+    }
+)
+
+
+class DynamoWorker(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    namespace: str = Field(min_length=1)
+    component: str = Field(min_length=1)
+    endpoint: str = Field(min_length=1)
+    instance_id: int = Field(ge=0, strict=True)
+    model: str = Field(min_length=1)
+    request_plane_url: str = Field(min_length=1)
+    system_url: str = Field(min_length=1)
+    admin_base_url: str | None = Field(default=None, min_length=1)
+    world_size: int | None = Field(default=None, gt=0, strict=True)
+    routes: tuple[str, ...]
+    error: str | None = None
+
+
+class DynamoSnapshot(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    protocol_version: int = Field(
+        strict=True,
+        ge=DYNAMO_RL_DISCOVERY_PROTOCOL_VERSION,
+        le=DYNAMO_RL_DISCOVERY_PROTOCOL_VERSION,
+    )
+    workers: list[dict[str, Any]]
+
+
+class DynamoDiscoveryPending(RuntimeError):
+    pass
+
+
+def client_headers(
+    headers: dict[str, str],
+    headers_from_env: dict[str, str],
+    api_key_var: str,
+) -> dict[str, str]:
+    resolved = {name: value for name, env in headers_from_env.items() if (value := os.getenv(env)) is not None}
+    resolved = {**headers, **resolved}
+    if api_key := os.getenv(api_key_var):
+        resolved["Authorization"] = f"Bearer {api_key}"
+    return resolved
+
+
+def parse_dynamo_workers(
+    payload: object,
+    model_name: str,
+    *,
+    require_world_size: bool = True,
+) -> tuple[DynamoWorker, ...]:
+    snapshot = DynamoSnapshot.model_validate(payload)
+    workers: list[DynamoWorker] = []
+    for raw_worker in snapshot.workers:
+        if raw_worker.get("model") != model_name:
+            continue
+        if error := raw_worker.get("error"):
+            raise DynamoDiscoveryPending(f"Dynamo worker is not ready: {error}")
+        worker = DynamoWorker.model_validate(raw_worker)
+        missing = REQUIRED_ROUTES.difference(worker.routes)
+        if missing:
+            raise DynamoDiscoveryPending(f"Dynamo worker is missing required routes: {sorted(missing)}")
+        if require_world_size and worker.world_size is None:
+            raise DynamoDiscoveryPending("Dynamo worker has not published world_size")
+        workers.append(worker)
+    if not workers:
+        raise DynamoDiscoveryPending(f"Dynamo returned no bound workers for model {model_name!r}")
+
+    identities = [(worker.namespace, worker.component, worker.endpoint, worker.instance_id) for worker in workers]
+    urls = [worker.system_url.rstrip("/") for worker in workers]
+    if len(set(identities)) != len(identities):
+        raise ValueError("Dynamo returned duplicate worker identities")
+    if len(set(urls)) != len(urls):
+        raise ValueError("Dynamo returned duplicate worker control endpoints")
+    return tuple(
+        sorted(workers, key=lambda worker: (worker.namespace, worker.component, worker.endpoint, worker.instance_id))
+    )
+
+
+def topology_fingerprint(
+    workers: tuple[DynamoWorker, ...],
+) -> tuple[tuple[str, str, str, int, str, str | None, int | None], ...]:
+    return tuple(
+        (
+            worker.namespace,
+            worker.component,
+            worker.endpoint,
+            worker.instance_id,
+            worker.system_url.rstrip("/"),
+            worker.admin_base_url.rstrip("/") if worker.admin_base_url else None,
+            worker.world_size,
+        )
+        for worker in workers
+    )
+
+
+def discover_dynamo_workers(
+    discovery_url: str,
+    model_name: str,
+    *,
+    headers: dict[str, str],
+    timeout: float,
+    require_world_size: bool = True,
+) -> tuple[DynamoWorker, ...]:
+    url = discovery_url.rstrip("/").removesuffix("/v1") + "/v1/rl/workers"
+    response = httpx.get(url, headers=headers, timeout=timeout)
+    response.raise_for_status()
+    return parse_dynamo_workers(response.json(), model_name, require_world_size=require_world_size)
+
+
+class DynamoAdminClients:
+    """Prime's Dynamo-specific admin plane, bound to one stable worker snapshot."""
+
+    def __init__(self, client_config, model_name: str, *, require_world_size: bool) -> None:
+        from prime_rl.orchestrator.clients import setup_admin_clients
+
+        self.client_config = client_config
+        self.model_name = model_name
+        self.require_world_size = require_world_size
+        self.timeout = client_config.wait_for_ready_timeout
+        self.headers = client_headers(
+            client_config.headers,
+            client_config.headers_from_env,
+            client_config.api_key_var,
+        )
+        self.frontend_clients = setup_admin_clients(client_config.model_copy(update={"admin_base_url": None}))
+        self.clients: list[httpx.AsyncClient] = []
+        self.system_clients: list[httpx.AsyncClient] = []
+        self.collective_clients: list[httpx.AsyncClient] = []
+        self.workers: tuple[DynamoWorker, ...] = ()
+
+    async def wait_for_ready(self, model_name: str) -> None:
+        from prime_rl.orchestrator.clients import check_health, maybe_check_has_model
+
+        if self.client_config.dynamo is None:
+            raise ValueError("Dynamo discovery configuration is required")
+        await check_health(self.frontend_clients, timeout=self.timeout)
+        await maybe_check_has_model(
+            self.frontend_clients,
+            model_name,
+            skip_model_check=self.client_config.skip_model_check,
+        )
+
+        deadline = time.monotonic() + self.timeout
+        previous_fingerprint = None
+        last_error: Exception | None = None
+        while time.monotonic() < deadline:
+            try:
+                workers = await asyncio.to_thread(
+                    discover_dynamo_workers,
+                    self.client_config.dynamo.discovery_url,
+                    model_name,
+                    headers=self.headers,
+                    timeout=min(30.0, max(1.0, deadline - time.monotonic())),
+                    require_world_size=self.require_world_size,
+                )
+                fingerprint = topology_fingerprint(workers)
+                if fingerprint == previous_fingerprint:
+                    self._bind(workers)
+                    return
+                previous_fingerprint = fingerprint
+            except httpx.HTTPStatusError as error:
+                if error.response.status_code < 500:
+                    raise
+                previous_fingerprint = None
+                last_error = error
+            except (DynamoDiscoveryPending, httpx.TransportError) as error:
+                previous_fingerprint = None
+                last_error = error
+            await asyncio.sleep(1)
+        raise TimeoutError("Dynamo workers did not become ready before the discovery timeout") from last_error
+
+    def _bind(self, workers: tuple[DynamoWorker, ...]) -> None:
+        self.workers = workers
+        self.system_clients = [self._client(worker.system_url) for worker in workers]
+        admin_urls = [worker.admin_base_url for worker in workers]
+        if all(admin_urls):
+            self.collective_clients = [self._client(url) for url in admin_urls if url is not None]
+            self.clients = self.collective_clients
+        else:
+            self.clients = self.frontend_clients
+
+    def _client(self, base_url: str) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=base_url.rstrip("/"),
+            headers=self.headers,
+            limits=httpx.Limits(max_connections=4, max_keepalive_connections=1),
+            timeout=httpx.Timeout(None),
+        )
+
+    async def _fanout(
+        self,
+        clients: list[httpx.AsyncClient],
+        path: str,
+        bodies: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        async def request(client: httpx.AsyncClient, body: dict[str, Any]) -> dict[str, Any]:
+            response = await client.post(path, json=body)
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict):
+                raise RuntimeError(f"Dynamo route {path} returned a non-object response")
+            if payload.get("status") == "error":
+                raise RuntimeError(payload.get("message", f"Dynamo route {path} failed"))
+            return payload
+
+        if len(clients) != len(bodies):
+            raise ValueError(f"Dynamo route {path} received {len(bodies)} bodies for {len(clients)} clients")
+        return await asyncio.wait_for(
+            asyncio.gather(*(request(client, body) for client, body in zip(clients, bodies))),
+            timeout=self.timeout,
+        )
+
+    async def fanout_system(self, path: str, bodies: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return await self._fanout(self.system_clients, path, bodies)
+
+    async def fanout_collective(self, bodies: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if len(self.collective_clients) != len(self.workers):
+            raise ValueError("Dynamo operation requires every worker to publish admin_base_url")
+        return await self._fanout(self.collective_clients, "/collective_rpc", bodies)
+
+    async def pause(self) -> None:
+        await self.fanout_system(
+            "/engine/control/pause_generation",
+            [{"mode": "keep", "clear_cache": False} for _ in self.system_clients],
+        )
+
+    async def is_paused(self) -> bool:
+        results = await self.fanout_system("/engine/control/is_paused", [{} for _ in self.system_clients])
+        return all(result.get("is_paused") is True for result in results)
+
+    async def resume(self) -> None:
+        await self.fanout_system("/engine/control/resume_generation", [{} for _ in self.system_clients])
+
+    async def update_weight_version(self, version: str) -> None:
+        await self.fanout_system(
+            "/engine/update/update_weight_version",
+            [{"new_version": version} for _ in self.system_clients],
+        )
+
+    async def weight_versions(self) -> list[str | None]:
+        results = await self.fanout_system("/engine/control/get_weight_version", [{} for _ in self.system_clients])
+        return [result.get("weight_version") for result in results]
+
+    async def aclose(self) -> None:
+        unique = {id(client): client for client in [*self.frontend_clients, *self.system_clients, *self.collective_clients]}
+        await asyncio.gather(*(client.aclose() for client in unique.values()))

--- a/src/prime_rl/inference/vllm/routed_experts.py
+++ b/src/prime_rl/inference/vllm/routed_experts.py
@@ -1,11 +1,54 @@
 from __future__ import annotations
 
+import base64
+import io
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pybase64
-from vllm.outputs import RequestOutput
+
+if TYPE_CHECKING:
+    from vllm.outputs import RequestOutput
+
+
+def normalize_native_routed_experts(result: dict[str, Any], start: int = 0) -> None:
+    """Convert vLLM's native base64 ``.npy`` value at Prime's client boundary."""
+    encoded = result.get("routed_experts")
+    if encoded is None or isinstance(encoded, dict):
+        return
+    if not isinstance(encoded, str):
+        raise TypeError(f"unsupported routed_experts payload: {type(encoded).__name__}")
+    raw = base64.b64decode(encoded, validate=True)
+    array = np.load(io.BytesIO(raw), allow_pickle=False)
+    if array.ndim != 3 or not np.issubdtype(array.dtype, np.integer):
+        raise ValueError("native routed_experts must be a rank-3 integer array")
+    array = np.ascontiguousarray(array)
+    result["routed_experts"] = {
+        "data": base64.b64encode(memoryview(array)).decode("ascii"),
+        "shape": list(array.shape),
+        "start": start,
+        "dtype": array.dtype.name,
+    }
+
+
+def install_native_routed_experts_normalizer() -> None:
+    """Teach Prime's renderer boundary to accept native vLLM opaque ``.npy`` data."""
+    import renderers.client as renderer_client
+
+    original = renderer_client.generate
+    if getattr(original, "_prime_rl_normalizes_native_routed_experts", False):
+        return
+
+    async def generate(**kwargs):
+        result = await original(**kwargs)
+        sampling_params = kwargs.get("sampling_params") or {}
+        start = int(sampling_params.get("routed_experts_prompt_start", 0) or 0)
+        normalize_native_routed_experts(result, start=start)
+        return result
+
+    generate._prime_rl_normalizes_native_routed_experts = True  # type: ignore[attr-defined]
+    renderer_client.generate = generate
 
 
 def serialize_routed_experts(routed_experts: Any, start: int = 0) -> dict[str, Any] | None:

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -5,6 +5,10 @@ import uvloop
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from starlette.datastructures import State
+from vllm.distributed.weight_transfer.base import (
+    WeightTransferInitRequest,
+    WeightTransferUpdateRequest,
+)
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.openai.api_server import init_app_state
 from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
@@ -79,7 +83,23 @@ async def resume(request: Request):
 @router.post("/update_weights")
 async def update_weights(request: Request):
     data = await request.json()
-    await engine_client(request).collective_rpc("update_weights_from_path", args=(data.get("weight_dir"),))
+    update_info = data.get("update_info")
+    if update_info is not None:
+        await engine_client(request).update_weights(WeightTransferUpdateRequest(update_info=update_info))
+    else:
+        await engine_client(request).collective_rpc("update_weights_from_path", args=(data.get("weight_dir"),))
+    return {"status": "ok"}
+
+
+@router.post("/start_weight_update")
+async def start_weight_update(request: Request):
+    await engine_client(request).start_weight_update()
+    return {"status": "ok"}
+
+
+@router.post("/finish_weight_update")
+async def finish_weight_update(request: Request):
+    await engine_client(request).finish_weight_update()
     return {"status": "ok"}
 
 
@@ -140,10 +160,22 @@ async def init_broadcaster(request: Request):
     inference_world_size = data.get("inference_world_size")
     quantize_in_weight_transfer = data.get("quantize_in_weight_transfer", False)
     session_id = data.get("session_id", "default")
-    await engine_client(request).collective_rpc(
-        "init_broadcaster",
-        args=(host, port, rank_offset, inference_world_size, timeout, quantize_in_weight_transfer, session_id),
-    )
+    if quantize_in_weight_transfer:
+        await engine_client(request).collective_rpc(
+            "init_broadcaster",
+            args=(host, port, rank_offset, inference_world_size, timeout, True, session_id),
+        )
+    else:
+        await engine_client(request).init_weight_transfer_engine(
+            WeightTransferInitRequest(
+                init_info={
+                    "master_address": host,
+                    "master_port": port,
+                    "rank_offset": rank_offset + 1,
+                    "world_size": inference_world_size + 1,
+                }
+            )
+        )
     return {"status": "ok"}
 
 
@@ -229,8 +261,11 @@ def server(config: InferenceConfig):
     assert args is not None
     validate_parsed_serve_args(args)
 
-    # Set the worker extension class based on the broadcast backend
+    # Default NCCL uses vLLM's native worker lifecycle; the extension remains
+    # available for liveness and the custom quantized transfer path.
     args.worker_extension_cls = WORKER_EXTENSION_CLS[config.weight_broadcast.type]
+    if config.weight_broadcast.type == "nccl":
+        args.weight_transfer_config = {"backend": "nccl"}
 
     if args.headless or args.api_server_count < 1:
         run_headless(args)

--- a/src/prime_rl/inference/vllm/worker/filesystem.py
+++ b/src/prime_rl/inference/vllm/worker/filesystem.py
@@ -1,10 +1,5 @@
 from typing import TYPE_CHECKING
 
-from torch.nn import Module
-from vllm.model_executor.model_loader import DefaultModelLoader, get_model_loader
-
-from prime_rl.inference.vllm.worker.weight_transfer import load_weights_checkpoint_layerwise
-
 # This is to get type hints for the Worker class but not actually extend it at runtime as this is required by vLLM worker extension
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
@@ -26,30 +21,5 @@ class FileSystemWeightUpdateWorker(Worker):
         return None
 
     def update_weights_from_path(self, weight_path: str) -> None:
-        """Update weights from a specified path in shared filesystem containing a HF-compatible checkpoint."""
-        # Get vLLM model runner and model
-        # When enforce_eager=True, model isn't wrapped by torch.compile so no .runnable attr
-        model_runner = self.model_runner
-        if hasattr(model_runner.model, "runnable"):
-            model = model_runner.model.runnable
-        else:
-            model = model_runner.model
-        assert isinstance(model, Module)
-
-        # Get vLLM model loader
-        model_loader = get_model_loader(self.load_config)
-        assert isinstance(model_loader, DefaultModelLoader)
-        local_source = DefaultModelLoader.Source(
-            weight_path,
-            revision=None,  # TODO: Check that this is correct or if we should use the default (model_config.revision)
-            prefix="",
-            fall_back_to_pt=getattr(model, "fall_back_to_pt_during_load", True),
-            allow_patterns_overrides=getattr(model, "allow_patterns_overrides", None),
-        )
-        weights_iterator = model_loader._get_weights_iterator(local_source)
-        load_weights_checkpoint_layerwise(
-            model,
-            weights_iterator,
-            self.model_runner.model_config,
-            self.vllm_config,
-        )
+        """Update weights from a specified path containing an HF-compatible checkpoint."""
+        self.reload_weights(weights_path=weight_path)

--- a/src/prime_rl/orchestrator/clients.py
+++ b/src/prime_rl/orchestrator/clients.py
@@ -114,6 +114,19 @@ class AdminClients:
             await client.aclose()
 
 
+def setup_policy_admin_clients(
+    client_config: ClientConfig,
+    model_name: str,
+    *,
+    require_world_size: bool,
+):
+    if client_config.is_dynamo():
+        from prime_rl.inference.dynamo import DynamoAdminClients
+
+        return DynamoAdminClients(client_config, model_name, require_world_size=require_world_size)
+    return AdminClients(client_config)
+
+
 async def check_inference_ready(client_config: ClientConfig, model_name: str) -> None:
     """One-shot readiness check of an inference endpoint (health + model
     listing) with transient clients — for frozen endpoints that never need a

--- a/src/prime_rl/orchestrator/clients.py
+++ b/src/prime_rl/orchestrator/clients.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from collections.abc import Callable
 from pathlib import Path
@@ -15,6 +16,7 @@ from verifiers.v1.configs.client import EvalClientConfig, TrainClientConfig
 
 from prime_rl.configs.shared import ClientConfig
 from prime_rl.utils.logger import get_logger
+from prime_rl.utils.pathing import wait_for_path
 
 
 class PrefillScorer:
@@ -258,6 +260,12 @@ ADMIN_TIMEOUT_S = 300.0
 # can take longer than the other admin ops.
 UPDATE_WEIGHTS_TIMEOUT_S = 720.0
 
+NCCL_MANIFEST = "NCCL_MANIFEST.json"
+
+
+def get_nccl_chunk_manifest(weight_dir: Path, chunk_id: int) -> Path:
+    return weight_dir / f"NCCL_CHUNK_{chunk_id}.json"
+
 
 async def _admin_post(client: AsyncClient, path: str, *, timeout_s: float = ADMIN_TIMEOUT_S, **kwargs) -> None:
     """POST an admin op with a bounded per-attempt timeout, retrying transient errors.
@@ -277,6 +285,16 @@ async def _admin_post(client: AsyncClient, path: str, *, timeout_s: float = ADMI
                 **kwargs,
             )
             response.raise_for_status()
+
+
+async def _admin_post_once(client: AsyncClient, path: str, *, timeout_s: float = ADMIN_TIMEOUT_S, **kwargs) -> None:
+    """POST a non-idempotent admin operation exactly once."""
+    response = await client.post(
+        path,
+        timeout=httpx.Timeout(connect=10.0, read=timeout_s, write=60.0, pool=10.0),
+        **kwargs,
+    )
+    response.raise_for_status()
 
 
 async def _pause_engines(admin_clients: list[AsyncClient], *, step: int) -> None:
@@ -300,11 +318,40 @@ async def _resume_engines(admin_clients: list[AsyncClient]) -> None:
     logger.debug("All inference engines resumed")
 
 
+async def _receive_native_nccl_weights(admin_clients: list[AsyncClient], weight_dir: Path) -> None:
+    """Drive vLLM's native worker update lifecycle while the trainer sends chunks."""
+    manifest_path = weight_dir / NCCL_MANIFEST
+    manifest_path.unlink(missing_ok=True)
+    for chunk_manifest in weight_dir.glob("NCCL_CHUNK_*.json"):
+        chunk_manifest.unlink()
+
+    await asyncio.gather(*[_admin_post_once(client, "/start_weight_update") for client in admin_clients])
+    await wait_for_path(manifest_path, interval=0.1, log_interval=10)
+    num_chunks = int(json.loads(manifest_path.read_text())["num_chunks"])
+    for chunk_id in range(num_chunks):
+        chunk_path = get_nccl_chunk_manifest(weight_dir, chunk_id)
+        await wait_for_path(chunk_path, interval=0.1, log_interval=10)
+        update_info = json.loads(chunk_path.read_text())
+        await asyncio.gather(
+            *[
+                _admin_post_once(
+                    client,
+                    "/update_weights",
+                    json={"update_info": update_info},
+                    timeout_s=UPDATE_WEIGHTS_TIMEOUT_S,
+                )
+                for client in admin_clients
+            ]
+        )
+    await asyncio.gather(*[_admin_post_once(client, "/finish_weight_update") for client in admin_clients])
+
+
 async def update_weights(
     admin_clients: list[AsyncClient],
     weight_dir: Path | None,
     step: int = 0,
     on_paused: Callable[[], None] | None = None,
+    native_nccl: bool = False,
 ) -> None:
     """Update weights on static inference servers.
 
@@ -320,22 +367,30 @@ async def update_weights(
     weight_dir_posix = weight_dir.as_posix() if weight_dir is not None else None
 
     await _pause_engines(admin_clients, step=step)
+    update_succeeded = False
     try:
         if on_paused is not None:
             on_paused()
-        await asyncio.gather(
-            *[
-                _admin_post(
-                    admin_client,
-                    "/update_weights",
-                    json={"weight_dir": weight_dir_posix},
-                    timeout_s=UPDATE_WEIGHTS_TIMEOUT_S,
-                )
-                for admin_client in admin_clients
-            ]
-        )
+        if native_nccl:
+            if weight_dir is None:
+                raise ValueError("Native NCCL updates require a weight directory")
+            await _receive_native_nccl_weights(admin_clients, weight_dir)
+        else:
+            await asyncio.gather(
+                *[
+                    _admin_post(
+                        admin_client,
+                        "/update_weights",
+                        json={"weight_dir": weight_dir_posix},
+                        timeout_s=UPDATE_WEIGHTS_TIMEOUT_S,
+                    )
+                    for admin_client in admin_clients
+                ]
+            )
+        update_succeeded = True
     finally:
-        await _resume_engines(admin_clients)
+        if update_succeeded or not native_nccl:
+            await _resume_engines(admin_clients)
 
 
 def _is_retryable_lora_error(exception: BaseException) -> bool:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -32,13 +32,15 @@ if TYPE_CHECKING:
     from transformers.tokenization_utils import PreTrainedTokenizer
 
     from prime_rl.orchestrator.ckpt import CheckpointManager
+    from prime_rl.orchestrator.clients import AdminClients
     from prime_rl.transports.batch.base import BatchSender
 import prime_rl._compat  # noqa: F401 — patch ring_flash_attn compat before transitive imports
 from prime_rl import monitors
 from prime_rl.configs.orchestrator import OrchestratorConfig
+from prime_rl.inference.vllm.routed_experts import install_native_routed_experts_normalizer
 from prime_rl.orchestrator.algo.routing import is_trainable
 from prime_rl.orchestrator.ckpt import setup_ckpt_manager
-from prime_rl.orchestrator.clients import AdminClients, InferenceClient
+from prime_rl.orchestrator.clients import InferenceClient, setup_policy_admin_clients
 from prime_rl.orchestrator.concurrency import ConcurrencyController
 from prime_rl.orchestrator.dispatcher import Dispatcher, DispatcherMetrics, DispatcherMode
 from prime_rl.orchestrator.envs import EvalEnvs, TrainEnvs
@@ -82,6 +84,7 @@ from prime_rl.utils.utils import clean_exit, resolve_latest_ckpt_step
 
 monkey_patch_oai_iterable_types()
 monkey_patch_chat_completion_logprobs()
+install_native_routed_experts_normalizer()
 
 
 # Wall-clock budget for post-training cleanup; force-exit if graceful
@@ -207,7 +210,11 @@ class Orchestrator:
             eval_client_type="openai_chat_completions",
             renderer_config=config.renderer,
         )
-        self.admin_clients = AdminClients(config.model.client)
+        self.admin_clients = setup_policy_admin_clients(
+            config.model.client,
+            config.model.name,
+            require_world_size=config.weight_broadcast.type in ("nccl", "nixl"),
+        )
 
         await monitors.setup(
             producer="orch",
@@ -308,6 +315,7 @@ class Orchestrator:
             config.weight_broadcast,
             admin_clients=self.admin_clients.clients,
             model_name=config.model.name,
+            admin_plane=self.admin_clients,
         )
         await self.receiver.initialize()
         get_logger().debug(f"Initialized weight broadcast in {format_time(time.perf_counter() - t0)}")

--- a/src/prime_rl/transports/weights/__init__.py
+++ b/src/prime_rl/transports/weights/__init__.py
@@ -26,6 +26,10 @@ def setup_weight_sender(
     lora_config: LoRAConfig | None = None,
 ) -> WeightSender:
     if config.type == "nccl":
+        if config.dynamo is not None:
+            from prime_rl.transports.weights.dynamo import DynamoNCCLWeightSender
+
+            return DynamoNCCLWeightSender(output_dir, config)
         return NCCLWeightSender(output_dir, config, torch.cuda.current_device())
     elif config.type == "filesystem":
         return FileSystemWeightSender(output_dir, config, lora_config)
@@ -40,7 +44,14 @@ def setup_weight_receiver(
     config: WeightBroadcastConfig,
     admin_clients: list[AsyncClient],
     model_name: str,
+    admin_plane=None,
 ) -> WeightReceiver:
+    from prime_rl.inference.dynamo import DynamoAdminClients
+
+    if isinstance(admin_plane, DynamoAdminClients):
+        from prime_rl.transports.weights.dynamo import DynamoWeightReceiver
+
+        return DynamoWeightReceiver(broadcast_dir, config, admin_clients, model_name, admin_plane)
     if config.type == "nccl":
         return NCCLWeightReceiver(broadcast_dir, config, admin_clients, model_name)
     elif config.type == "filesystem":

--- a/src/prime_rl/transports/weights/dynamo.py
+++ b/src/prime_rl/transports/weights/dynamo.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Iterator, cast
+
+import httpx
+import torch
+import torch.nn as nn
+from torch import Tensor
+from torch.distributed.tensor import DTensor
+
+from prime_rl.configs.trainer import NCCLWeightBroadcastConfig
+from prime_rl.inference.dynamo import (
+    NATIVE_NCCL_ROUTES,
+    DynamoAdminClients,
+    DynamoDiscoveryPending,
+    DynamoWorker,
+    client_headers,
+    discover_dynamo_workers,
+    topology_fingerprint,
+)
+from prime_rl.trainer.conversion_utils import get_max_layer_num
+from prime_rl.trainer.utils import get_world
+from prime_rl.transports.weights.base import FINISHED_MARKER, WeightReceiver, WeightSender
+from prime_rl.transports.weights.nccl import filter_state_dict_by_layers, preprocess_layer_checkpoint
+from prime_rl.utils.pathing import wait_for_path
+from prime_rl.utils.vlm import get_layer_prefix
+
+
+class DynamoVLLMWeightSyncClient:
+    """Synchronous client required by vLLM's trainer-side transfer engine."""
+
+    def __init__(self, workers: tuple[DynamoWorker, ...], headers: dict[str, str], timeout: float) -> None:
+        self.workers = workers
+        self.clients = [
+            httpx.Client(base_url=worker.system_url.rstrip("/"), headers=headers, timeout=timeout) for worker in workers
+        ]
+
+    @staticmethod
+    def _validate(response: httpx.Response, path: str) -> None:
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"Dynamo route {path} returned a non-object response")
+        if payload.get("status") == "error":
+            raise RuntimeError(payload.get("message", f"Dynamo route {path} failed"))
+
+    def _fanout(self, path: str, bodies: list[dict[str, Any]]) -> None:
+        def request(client: httpx.Client, body: dict[str, Any]) -> None:
+            self._validate(client.post(path, json=body), path)
+
+        with ThreadPoolExecutor(max_workers=len(self.clients)) as executor:
+            futures = [executor.submit(request, client, body) for client, body in zip(self.clients, bodies)]
+            for future in futures:
+                future.result()
+
+    def init_weight_transfer_engine(self, init_info: dict[str, Any]) -> None:
+        rank_offset = 1
+        bodies = []
+        for worker in self.workers:
+            if worker.world_size is None:
+                raise ValueError("Dynamo native NCCL requires each worker's world_size")
+            bodies.append({"init_info": {**init_info, "rank_offset": rank_offset}})
+            rank_offset += worker.world_size
+        self._fanout("/engine/update/init_weight_transfer_engine", bodies)
+
+    def start_weight_update(self) -> None:
+        self._fanout("/engine/update/start_weight_update", [{} for _ in self.clients])
+
+    def update_weights(self, update_info: dict[str, Any]) -> None:
+        self._fanout("/engine/update/update_weights", [{"update_info": update_info} for _ in self.clients])
+
+    def finish_weight_update(self, weight_version: str | None = None) -> None:
+        self._fanout(
+            "/engine/update/finish_weight_update",
+            [{"weight_version": weight_version} for _ in self.clients],
+        )
+
+    def update_weight_version(self, weight_version: str) -> None:
+        self._fanout(
+            "/engine/update/update_weight_version",
+            [{"new_version": weight_version} for _ in self.clients],
+        )
+
+
+class PrimeWeightSource:
+    """Expose Prime checkpoint-format tensors through vLLM's WeightSource protocol."""
+
+    def __init__(self, dtype: torch.dtype) -> None:
+        self.model: nn.Module | None = None
+        self.dtype = dtype
+        self._metadata = None
+
+    def set_model(self, model: nn.Module) -> None:
+        if model is not self.model:
+            self._metadata = None
+        self.model = model
+
+    def _items(self) -> Iterator[tuple[str, Tensor]]:
+        if self.model is None:
+            raise RuntimeError("Prime weight source has no model")
+        state_dict = self.model.state_dict()
+        layer_prefix = get_layer_prefix(self.model.config)
+        num_layers = get_max_layer_num(state_dict, layer_prefix)
+        for layer_idx, layer_state_dict in filter_state_dict_by_layers(state_dict, num_layers, layer_prefix):
+            resolved = {}
+            for name, tensor in layer_state_dict.items():
+                if isinstance(tensor, DTensor):
+                    tensor = cast(DTensor, tensor.to(self.dtype)).full_tensor()
+                resolved[name] = tensor
+            yield from preprocess_layer_checkpoint(self.model, resolved, layer_idx).items()
+
+    def metadata(self):
+        from vllm.distributed.weight_transfer import ParamMeta
+
+        if self._metadata is None:
+            if self.model is None:
+                raise RuntimeError("Prime weight source has no model")
+            state_dict = {
+                name: torch.empty(
+                    tuple(tensor.shape),
+                    dtype=self.dtype if isinstance(tensor, DTensor) else tensor.dtype,
+                    device="meta",
+                )
+                for name, tensor in self.model.state_dict().items()
+            }
+            layer_prefix = get_layer_prefix(self.model.config)
+            num_layers = get_max_layer_num(state_dict, layer_prefix)
+            metadata = []
+            for layer_idx, layer_state_dict in filter_state_dict_by_layers(state_dict, num_layers, layer_prefix):
+                converted = preprocess_layer_checkpoint(self.model, layer_state_dict, layer_idx)
+                metadata.extend(ParamMeta(name, tensor.dtype, tuple(tensor.shape)) for name, tensor in converted.items())
+            self._metadata = metadata
+        return list(self._metadata)
+
+    def __iter__(self) -> Iterator[tuple[str, Tensor]]:
+        yield from self._items()
+
+
+def _discover(config: NCCLWeightBroadcastConfig) -> tuple[DynamoWorker, ...]:
+    if config.dynamo is None:
+        raise ValueError("Dynamo native NCCL requires Dynamo discovery configuration")
+    headers = client_headers(config.dynamo.headers, config.dynamo.headers_from_env, config.dynamo.api_key_var)
+    deadline = time.monotonic() + config.timeout
+    previous_fingerprint = None
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            workers = discover_dynamo_workers(
+                config.dynamo.discovery_url,
+                config.dynamo.model_name,
+                headers=headers,
+                timeout=min(30.0, max(1.0, deadline - time.monotonic())),
+            )
+            discovered_world_size = sum(worker.world_size or 0 for worker in workers)
+            if discovered_world_size != config.inference_world_size:
+                raise DynamoDiscoveryPending(
+                    f"Dynamo world size {discovered_world_size} does not match Prime inference capacity "
+                    f"{config.inference_world_size}"
+                )
+            for worker in workers:
+                missing = NATIVE_NCCL_ROUTES.difference(worker.routes)
+                if missing:
+                    raise DynamoDiscoveryPending(
+                        f"Dynamo worker {worker.component}/{worker.instance_id} is missing native NCCL routes: "
+                        f"{sorted(missing)}"
+                    )
+            fingerprint = topology_fingerprint(workers)
+            if fingerprint == previous_fingerprint:
+                return workers
+            previous_fingerprint = fingerprint
+        except (DynamoDiscoveryPending, httpx.TransportError) as error:
+            previous_fingerprint = None
+            last_error = error
+        time.sleep(1)
+    raise TimeoutError("Dynamo workers did not become ready before trainer initialization") from last_error
+
+
+class DynamoNCCLWeightSender(WeightSender):
+    def __init__(
+        self,
+        output_dir: Path,
+        config: NCCLWeightBroadcastConfig,
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> None:
+        super().__init__(output_dir, config.timeout)
+        if config.quantize_in_weight_transfer:
+            raise ValueError("Dynamo native NCCL does not support Prime's custom quantized transfer")
+
+        from vllm.distributed.weight_transfer import WeightTransferTrainerFactory
+        from vllm.distributed.weight_transfer.nccl_engine import NCCLTrainerInitInfo
+
+        from prime_rl.utils.nccl import disable_nccl_p2p_if_unavailable
+
+        self.world = get_world()
+        workers = _discover(config)
+        assert config.dynamo is not None
+        headers = client_headers(config.dynamo.headers, config.dynamo.headers_from_env, config.dynamo.api_key_var)
+        self.client = DynamoVLLMWeightSyncClient(workers, headers, config.timeout)
+        self.source = PrimeWeightSource(dtype)
+        disable_nccl_p2p_if_unavailable()
+        self.engine = WeightTransferTrainerFactory.trainer_init(
+            NCCLTrainerInitInfo(
+                master_address=config.host,
+                master_port=config.port,
+                world_size=1 + sum(worker.world_size or 0 for worker in workers),
+                rank=self.world.rank,
+            ),
+            client=self.client,
+            source=self.source,
+        )
+
+    @torch.no_grad()
+    def _broadcast(self, model: nn.Module, step: int, step_dir: Path) -> None:
+        del step_dir
+        self.source.set_model(model)
+        self.engine.send_weights()
+        if self.world.is_master:
+            self.client.update_weight_version(str(step))
+
+
+class DynamoWeightReceiver(WeightReceiver):
+    def __init__(self, broadcast_dir, config, admin_clients, model_name, admin_plane: DynamoAdminClients) -> None:
+        super().__init__(broadcast_dir, config, admin_clients, model_name)
+        self.admin_plane = admin_plane
+
+    def _world_size(self) -> int:
+        sizes = [worker.world_size for worker in self.admin_plane.workers]
+        if any(size is None for size in sizes):
+            raise ValueError("Dynamo in-memory weight transfer requires every worker's world_size")
+        return sum(cast(int, size) for size in sizes)
+
+    async def initialize(self) -> None:
+        if self.config.type == "nccl":
+            discovered = self._world_size()
+            if discovered != self.config.inference_world_size:
+                raise ValueError(
+                    f"Configured inference_world_size={self.config.inference_world_size} does not match Dynamo "
+                    f"world size {discovered}"
+                )
+            for worker in self.admin_plane.workers:
+                missing = NATIVE_NCCL_ROUTES.difference(worker.routes)
+                if missing:
+                    raise ValueError(
+                        f"Dynamo worker {worker.component}/{worker.instance_id} is missing native NCCL routes: "
+                        f"{sorted(missing)}"
+                    )
+        elif self.config.type == "nixl":
+            discovered = self._world_size()
+            if discovered != self.config.inference_world_size:
+                raise ValueError(
+                    f"Configured inference_world_size={self.config.inference_world_size} does not match Dynamo "
+                    f"world size {discovered}"
+                )
+            rank_offset = 0
+            bodies = []
+            for worker in self.admin_plane.workers:
+                assert worker.world_size is not None
+                bodies.append(
+                    {
+                        "method": "init_broadcaster",
+                        "timeout": self.config.timeout,
+                        "args": [
+                            self.config.host,
+                            self.config.port,
+                            rank_offset,
+                            discovered,
+                            self.config.timeout,
+                            False,
+                            self.config.session_id,
+                        ],
+                        "kwargs": {},
+                    }
+                )
+                rank_offset += worker.world_size
+            await self.admin_plane.fanout_collective(bodies)
+
+    async def _wait_for_version(self, step: int) -> None:
+        expected = str(step)
+        deadline = time.monotonic() + self.config.timeout
+        while time.monotonic() < deadline:
+            if all(version == expected for version in await self.admin_plane.weight_versions()):
+                return
+            await asyncio.sleep(0.1)
+        raise TimeoutError(f"Dynamo workers did not commit weight version {expected}; engines remain paused")
+
+    async def receive(self, step: int) -> None:
+        await self.admin_plane.pause()
+        if not await self.admin_plane.is_paused():
+            raise RuntimeError("Dynamo did not confirm every pinned worker was paused")
+
+        if self.config.type == "nccl":
+            self._ack(step)
+        elif self.config.type == "filesystem":
+            self._ack(step)
+            weights_path = self.step_dir(step)
+            await wait_for_path(weights_path / FINISHED_MARKER)
+            await self.admin_plane.fanout_collective(
+                [
+                    {
+                        "method": "reload_weights",
+                        "timeout": self.config.timeout,
+                        "args": [],
+                        "kwargs": {"weights_path": weights_path.as_posix()},
+                    }
+                    for _ in self.admin_plane.workers
+                ]
+            )
+            await self.admin_plane.update_weight_version(str(step))
+        elif self.config.type == "nixl":
+            self._ack(step)
+            await self.admin_plane.fanout_collective(
+                [
+                    {
+                        "method": "update_weights_from_path",
+                        "timeout": self.config.timeout,
+                        "args": [None],
+                        "kwargs": {},
+                    }
+                    for _ in self.admin_plane.workers
+                ]
+            )
+            await self.admin_plane.update_weight_version(str(step))
+        else:
+            raise ValueError(f"Unsupported Dynamo weight transfer type: {self.config.type}")
+
+        await self._wait_for_version(step)
+        await self.admin_plane.resume()

--- a/src/prime_rl/transports/weights/dynamo.py
+++ b/src/prime_rl/transports/weights/dynamo.py
@@ -9,6 +9,7 @@ from typing import Any, Iterator, cast
 import httpx
 import torch
 import torch.nn as nn
+from modelexpress.client import MxClient
 from torch import Tensor
 from torch.distributed.tensor import DTensor
 
@@ -26,6 +27,15 @@ from prime_rl.trainer.conversion_utils import get_max_layer_num
 from prime_rl.trainer.utils import get_world
 from prime_rl.transports.weights.base import FINISHED_MARKER, WeightReceiver, WeightSender
 from prime_rl.transports.weights.nccl import filter_state_dict_by_layers, preprocess_layer_checkpoint
+from prime_rl.transports.weights.nixl.agent import (
+    NixlAgent,
+    NixlPeer,
+    make_agent_name,
+    policy_notification,
+    set_ucx_env_defaults,
+)
+from prime_rl.transports.weights.nixl.model_express import ModelExpressSession
+from prime_rl.transports.weights.nixl.trainer_tensor_table import TrainerTensorTable
 from prime_rl.utils.pathing import wait_for_path
 from prime_rl.utils.vlm import get_layer_prefix
 
@@ -132,7 +142,9 @@ class PrimeWeightSource:
             metadata = []
             for layer_idx, layer_state_dict in filter_state_dict_by_layers(state_dict, num_layers, layer_prefix):
                 converted = preprocess_layer_checkpoint(self.model, layer_state_dict, layer_idx)
-                metadata.extend(ParamMeta(name, tensor.dtype, tuple(tensor.shape)) for name, tensor in converted.items())
+                metadata.extend(
+                    ParamMeta(name, tensor.dtype, tuple(tensor.shape)) for name, tensor in converted.items()
+                )
             self._metadata = metadata
         return list(self._metadata)
 
@@ -226,6 +238,9 @@ class DynamoWeightReceiver(WeightReceiver):
     def __init__(self, broadcast_dir, config, admin_clients, model_name, admin_plane: DynamoAdminClients) -> None:
         super().__init__(broadcast_dir, config, admin_clients, model_name)
         self.admin_plane = admin_plane
+        self.nixl_agent: NixlAgent | None = None
+        self.nixl_session: ModelExpressSession | None = None
+        self.nixl_trainer_peer: NixlPeer | None = None
 
     def _world_size(self) -> int:
         sizes = [worker.world_size for worker in self.admin_plane.workers]
@@ -277,6 +292,45 @@ class DynamoWeightReceiver(WeightReceiver):
                 )
                 rank_offset += worker.world_size
             await self.admin_plane.fanout_collective(bodies)
+            set_ucx_env_defaults(0)
+            self.nixl_agent = NixlAgent(make_agent_name("orchestrator", 0))
+            self.nixl_session = ModelExpressSession(
+                client=MxClient(server_url=f"{self.config.host}:{self.config.port}"),
+                role="orchestrator",
+                rank=0,
+                session_id=self.config.session_id,
+                worker_id="orchestrator",
+            )
+            self.nixl_session.publish(nixl_metadata=self.nixl_agent.get_metadata())
+
+    async def _wait_for_nixl_ready(self, step: int) -> None:
+        if self.nixl_agent is None or self.nixl_session is None:
+            raise RuntimeError("Dynamo NIXL receiver was not initialized")
+        if self.nixl_trainer_peer is None:
+            trainer_refs = await asyncio.to_thread(
+                self.nixl_session.wait_for,
+                "trainer",
+                count=1,
+                timeout=self.config.timeout,
+            )
+            trainer_worker = await asyncio.to_thread(self.nixl_session.fetch, trainer_refs[0])
+            trainer_table = TrainerTensorTable.decode(trainer_worker.nixl_metadata)
+            self.nixl_trainer_peer = self.nixl_agent.add_remote_agent(trainer_table.agents[0].metadata)
+            self.nixl_agent.make_connection(self.nixl_trainer_peer)
+        await asyncio.to_thread(
+            self.nixl_agent.wait_for_notification,
+            [self.nixl_trainer_peer],
+            policy_notification(step, "ready"),
+            timeout=self.config.timeout,
+        )
+
+    def _complete_nixl_receive(self, step: int) -> None:
+        if self.nixl_agent is None or self.nixl_trainer_peer is None:
+            raise RuntimeError("Dynamo NIXL receiver has no trainer peer")
+        self.nixl_agent.send_notification(
+            self.nixl_trainer_peer,
+            policy_notification(step, "complete"),
+        )
 
     async def _wait_for_version(self, step: int) -> None:
         expected = str(step)
@@ -312,6 +366,7 @@ class DynamoWeightReceiver(WeightReceiver):
             await self.admin_plane.update_weight_version(str(step))
         elif self.config.type == "nixl":
             self._ack(step)
+            await self._wait_for_nixl_ready(step)
             await self.admin_plane.fanout_collective(
                 [
                     {
@@ -323,6 +378,7 @@ class DynamoWeightReceiver(WeightReceiver):
                     for _ in self.admin_plane.workers
                 ]
             )
+            self._complete_nixl_receive(step)
             await self.admin_plane.update_weight_version(str(step))
         else:
             raise ValueError(f"Unsupported Dynamo weight transfer type: {self.config.type}")

--- a/src/prime_rl/transports/weights/nccl.py
+++ b/src/prime_rl/transports/weights/nccl.py
@@ -1,3 +1,4 @@
+import json
 import pickle
 from pathlib import Path
 from typing import Callable, Generator, cast
@@ -9,9 +10,11 @@ from torch import Tensor
 from torch.distributed.tensor import DTensor
 from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
 from vllm.distributed.utils import StatelessProcessGroup
+from vllm.distributed.weight_transfer.nccl_common import trainer_init
+from vllm.distributed.weight_transfer.nccl_engine import NCCLTrainerInitInfo
 
 from prime_rl.configs.trainer import NCCLWeightBroadcastConfig
-from prime_rl.orchestrator.clients import init_nccl_broadcast, update_weights
+from prime_rl.orchestrator.clients import NCCL_MANIFEST, get_nccl_chunk_manifest, init_nccl_broadcast, update_weights
 from prime_rl.trainer.conversion_utils import get_max_layer_num
 from prime_rl.trainer.models import PreTrainedModelPrimeRL
 from prime_rl.trainer.utils import get_world
@@ -123,25 +126,38 @@ class NCCLBroadcaster:
 
         if self.world.is_master:
             disable_nccl_p2p_if_unavailable()
-            # Trainer is on rank 0 in process group with all inference GPUs
-            pg = StatelessProcessGroup.create(
-                host=host, port=port, rank=rank, world_size=world_size, store_timeout=timeout
-            )
-            self.communicator = PyNcclCommunicator(pg, device=device)
+            if quantize_in_weight_transfer:
+                pg = StatelessProcessGroup.create(
+                    host=host, port=port, rank=rank, world_size=world_size, store_timeout=timeout
+                )
+                self.communicator = PyNcclCommunicator(pg, device=device)
+            else:
+                self.communicator = trainer_init(
+                    NCCLTrainerInitInfo(
+                        master_address=host,
+                        master_port=port,
+                        world_size=world_size,
+                        packed=False,
+                        rank=rank,
+                    )
+                )
             self.logger.debug("Initialized NCCL broadcast on master rank")
         else:
             self.logger.debug("Initialized NCCL broadcast on non-master rank (no communicator)")
 
     @torch.no_grad()
-    def send(self, model: nn.Module) -> None:
+    def send(self, model: nn.Module, step_dir: Path) -> None:
         """Broadcast the state dict of a model into the inference pool using NCCL."""
         state_dict = model.state_dict()
         layer_prefix = get_layer_prefix(model.config)
         num_layers = get_max_layer_num(state_dict, layer_prefix)
         num_state_dict_to_send = num_layers + 1  # we send all layer plus the remaining weights
 
-        if self.world.is_master:
+        if self.world.is_master and self.quantize_in_weight_transfer:
             broadcast_integer(num_state_dict_to_send, self.communicator)
+
+        if self.world.is_master and not self.quantize_in_weight_transfer:
+            self._write_manifest(step_dir / NCCL_MANIFEST, {"num_chunks": num_state_dict_to_send})
 
         self.logger.debug(f"Broadcasting {num_state_dict_to_send} layer state dicts")
         preprocess_fn: Callable[[nn.Module, dict[str, Tensor], int], dict[str, Tensor]]
@@ -154,7 +170,29 @@ class NCCLBroadcaster:
             layer_state_dict = self._resolve_dtensors(layer_state_dict)
             layer_state_dict = preprocess_fn(model, layer_state_dict, layer_id)
             if self.world.is_master:
-                broadcast_state_dict(layer_state_dict, self.communicator)
+                if self.quantize_in_weight_transfer:
+                    broadcast_state_dict(layer_state_dict, self.communicator)
+                else:
+                    update_info = {
+                        "names": list(layer_state_dict),
+                        "dtype_names": [
+                            str(tensor.dtype).removeprefix("torch.") for tensor in layer_state_dict.values()
+                        ],
+                        "shapes": [list(tensor.shape) for tensor in layer_state_dict.values()],
+                    }
+                    self._write_manifest(
+                        get_nccl_chunk_manifest(step_dir, layer_id + 1),
+                        update_info,
+                    )
+                    for tensor in layer_state_dict.values():
+                        send = tensor if tensor.is_contiguous() else tensor.contiguous()
+                        self.communicator.broadcast(send, src=0)
+
+    @staticmethod
+    def _write_manifest(path: Path, payload: dict) -> None:
+        temporary_path = path.with_suffix(f"{path.suffix}.tmp")
+        temporary_path.write_text(json.dumps(payload))
+        temporary_path.replace(path)
 
     def _resolve_dtensors(self, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
         for key, value in list(state_dict.items()):
@@ -192,7 +230,7 @@ class NCCLWeightSender(WeightSender):
         # the collectives sit unmatched until NCCL's watchdog kills the process.
         if self.world.world_size > 1:
             dist.barrier()
-        self.nccl_broadcast_sender.send(model)
+        self.nccl_broadcast_sender.send(model, step_dir)
 
 
 class NCCLWeightReceiver(WeightReceiver):
@@ -217,4 +255,5 @@ class NCCLWeightReceiver(WeightReceiver):
             self.step_dir(step),
             step=step,
             on_paused=lambda: self._ack(step),
+            native_nccl=not self.config.quantize_in_weight_transfer,
         )

--- a/tests/unit/inference/test_dynamo.py
+++ b/tests/unit/inference/test_dynamo.py
@@ -1,0 +1,153 @@
+import base64
+import io
+import json
+
+import httpx
+import numpy as np
+import pytest
+
+from prime_rl.inference.dynamo import (
+    REQUIRED_ROUTES,
+    DynamoAdminClients,
+    DynamoDiscoveryPending,
+    parse_dynamo_workers,
+)
+from prime_rl.inference.vllm.routed_experts import (
+    install_native_routed_experts_normalizer,
+    normalize_native_routed_experts,
+)
+
+
+def _worker(component: str, instance_id: int, world_size: int = 1) -> dict:
+    return {
+        "namespace": "dynamo",
+        "component": component,
+        "endpoint": "rl",
+        "instance_id": instance_id,
+        "model": "Qwen/Qwen3-0.6B",
+        "request_plane_url": f"dyn://dynamo.{component}.rl",
+        "system_url": f"http://{component}-{instance_id}:8080",
+        "admin_base_url": f"http://{component}-{instance_id}:8120",
+        "world_size": world_size,
+        "routes": sorted(REQUIRED_ROUTES),
+    }
+
+
+def test_parse_dynamo_workers_preserves_topology_without_backend_metadata():
+    workers = parse_dynamo_workers(
+        {
+            "protocol_version": 1,
+            "workers": [_worker("prefill", 3, 2), _worker("decode", 9, 4)],
+        },
+        "Qwen/Qwen3-0.6B",
+    )
+
+    assert [(item.component, item.world_size) for item in workers] == [("decode", 4), ("prefill", 2)]
+    assert not hasattr(workers[0], "weight_transfer_backend")
+
+
+def test_parse_dynamo_workers_waits_for_required_routes():
+    incomplete = _worker("backend", 1)
+    incomplete["routes"] = []
+
+    with pytest.raises(DynamoDiscoveryPending, match="missing required routes"):
+        parse_dynamo_workers(
+            {"protocol_version": 1, "workers": [incomplete]},
+            "Qwen/Qwen3-0.6B",
+        )
+
+
+def test_parse_dynamo_workers_requires_world_size_only_for_in_memory_transfer():
+    worker = _worker("backend", 1)
+    worker.pop("world_size")
+
+    parsed = parse_dynamo_workers(
+        {"protocol_version": 1, "workers": [worker]},
+        "Qwen/Qwen3-0.6B",
+        require_world_size=False,
+    )
+    assert parsed[0].world_size is None
+
+    with pytest.raises(DynamoDiscoveryPending, match="world_size"):
+        parse_dynamo_workers(
+            {"protocol_version": 1, "workers": [worker]},
+            "Qwen/Qwen3-0.6B",
+            require_world_size=True,
+        )
+
+
+def test_native_npy_routed_experts_are_normalized_at_prime_boundary():
+    routed = np.arange(12, dtype=np.int32).reshape(3, 2, 2)
+    encoded = io.BytesIO()
+    np.save(encoded, routed, allow_pickle=False)
+    result = {"routed_experts": base64.b64encode(encoded.getvalue()).decode("ascii")}
+
+    normalize_native_routed_experts(result, start=7)
+
+    payload = result["routed_experts"]
+    assert payload["shape"] == [3, 2, 2]
+    assert payload["dtype"] == "int32"
+    assert payload["start"] == 7
+    assert base64.b64decode(payload["data"]) == routed.tobytes()
+
+
+def test_prime_routed_experts_envelope_is_left_unchanged():
+    payload = {"data": "AQID", "shape": [1, 1, 3], "dtype": "uint8", "start": 0}
+    result = {"routed_experts": payload}
+
+    normalize_native_routed_experts(result, start=9)
+
+    assert result["routed_experts"] is payload
+
+
+@pytest.mark.asyncio
+async def test_dynamo_admin_uses_system_routes_for_pause_and_version():
+    requests: list[tuple[str, dict]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content or b"{}")
+        requests.append((request.url.path, body))
+        if request.url.path.endswith("is_paused"):
+            return httpx.Response(200, json={"is_paused": True})
+        if request.url.path.endswith("get_weight_version"):
+            return httpx.Response(200, json={"weight_version": "3"})
+        return httpx.Response(200, json={"status": "ok"})
+
+    admin = object.__new__(DynamoAdminClients)
+    admin.system_clients = [httpx.AsyncClient(base_url="http://worker:8080", transport=httpx.MockTransport(handler))]
+    admin.timeout = 10
+    try:
+        await admin.pause()
+        assert await admin.is_paused()
+        await admin.update_weight_version("3")
+        assert await admin.weight_versions() == ["3"]
+        await admin.resume()
+    finally:
+        await admin.system_clients[0].aclose()
+
+    assert [path for path, _ in requests] == [
+        "/engine/control/pause_generation",
+        "/engine/control/is_paused",
+        "/engine/update/update_weight_version",
+        "/engine/control/get_weight_version",
+        "/engine/control/resume_generation",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_renderer_boundary_supplies_prime_prompt_start(monkeypatch):
+    import renderers.client as renderer_client
+
+    routed = np.arange(4, dtype=np.int16).reshape(1, 2, 2)
+    encoded = io.BytesIO()
+    np.save(encoded, routed, allow_pickle=False)
+
+    async def generate(**kwargs):
+        return {"routed_experts": base64.b64encode(encoded.getvalue()).decode("ascii")}
+
+    monkeypatch.setattr(renderer_client, "generate", generate)
+    install_native_routed_experts_normalizer()
+
+    result = await renderer_client.generate(sampling_params={"routed_experts_prompt_start": 11})
+
+    assert result["routed_experts"]["start"] == 11

--- a/tests/unit/inference/test_dynamo.py
+++ b/tests/unit/inference/test_dynamo.py
@@ -1,6 +1,9 @@
 import base64
+import importlib
 import io
 import json
+import sys
+from types import ModuleType
 
 import httpx
 import numpy as np
@@ -151,3 +154,25 @@ async def test_renderer_boundary_supplies_prime_prompt_start(monkeypatch):
     result = await renderer_client.generate(sampling_params={"routed_experts_prompt_start": 11})
 
     assert result["routed_experts"]["start"] == 11
+
+
+def test_env_server_workers_install_native_routed_experts_normalizer(monkeypatch):
+    utils_module = ModuleType("prime_rl.utils.utils")
+    utils_module.clean_exit = lambda function: function
+    monkeypatch.setitem(sys.modules, "prime_rl.utils.utils", utils_module)
+    sys.modules.pop("prime_rl.entrypoints.env_server", None)
+    env_server = importlib.import_module("prime_rl.entrypoints.env_server")
+
+    installed: list[bool] = []
+    monkeypatch.setattr(env_server, "setup_env_server_logging", lambda *_args: None)
+    monkeypatch.setattr(env_server, "set_base_sandbox_labels", lambda _labels: None)
+    monkeypatch.setattr(
+        env_server,
+        "install_native_routed_experts_normalizer",
+        lambda: installed.append(True),
+        raising=False,
+    )
+
+    env_server.setup_worker(None, False, [])
+
+    assert installed == [True]

--- a/tests/unit/orchestrator/test_clients.py
+++ b/tests/unit/orchestrator/test_clients.py
@@ -6,7 +6,13 @@ import httpx
 from verifiers.v1.configs.client import EvalClientConfig
 
 from prime_rl.configs.shared import ClientConfig
-from prime_rl.orchestrator.clients import _is_retryable_lora_error, check_health, load_lora_adapter, setup_client
+from prime_rl.orchestrator.clients import (
+    _is_retryable_lora_error,
+    check_health,
+    load_lora_adapter,
+    setup_client,
+    update_weights,
+)
 
 
 def test_is_retryable_lora_error_returns_true_for_404():
@@ -117,3 +123,32 @@ def test_setup_client_preserves_chat_client_defaults():
         base_url="http://worker-a:8000/v1",
         headers={},
     )
+
+
+def test_update_weights_uses_native_nccl_lifecycle(tmp_path: Path):
+    client = AsyncMock()
+    on_paused = MagicMock()
+
+    with (
+        patch("prime_rl.orchestrator.clients._pause_engines", new=AsyncMock()) as pause,
+        patch("prime_rl.orchestrator.clients._resume_engines", new=AsyncMock()) as resume,
+        patch(
+            "prime_rl.orchestrator.clients._receive_native_nccl_weights",
+            new=AsyncMock(),
+            create=True,
+        ) as receive,
+    ):
+        asyncio.run(
+            update_weights(
+                [client],
+                tmp_path,
+                step=7,
+                on_paused=on_paused,
+                native_nccl=True,
+            )
+        )
+
+    pause.assert_awaited_once_with([client], step=7)
+    on_paused.assert_called_once_with()
+    receive.assert_awaited_once_with([client], tmp_path)
+    resume.assert_awaited_once_with([client])

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -12,6 +12,7 @@ from prime_rl.configs.inference import InferenceConfig
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.configs.rl import RLConfig
 from prime_rl.configs.sft import SFTConfig
+from prime_rl.configs.shared import ClientConfig
 from prime_rl.configs.trainer import ModelConfig as TrainerModelConfig
 from prime_rl.configs.trainer import TrainerConfig
 from prime_rl.utils.config import BaseConfig, cli, dump_resolved_config
@@ -84,6 +85,39 @@ def write_toml(path: Path, data: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "wb") as f:
         tomli_w.dump(data, f)
+
+
+def test_client_config_identifies_dynamo():
+    config = ClientConfig(dynamo={"discovery_url": "http://frontend:8001"})
+
+    assert config.is_dynamo()
+    assert config.dynamo is not None
+    assert config.dynamo.discovery_url == "http://frontend:8001"
+    assert not ClientConfig().is_dynamo()
+
+
+def test_external_dynamo_uses_declared_inference_capacity():
+    config = RLConfig.model_validate(
+        {
+            "trainer": {},
+            "orchestrator": {
+                "model": {"client": {"dynamo": {"discovery_url": "http://dynamo-frontend:8001"}}}
+            },
+            "weight_broadcast": {"type": "nccl"},
+            "deployment": {
+                "type": "single_node",
+                "gpus_per_node": 8,
+                "num_train_gpus": 1,
+                "num_infer_gpus": 4,
+            },
+        }
+    )
+
+    assert config.trainer.weight_broadcast.type == "nccl"
+    assert config.trainer.weight_broadcast.inference_world_size == 4
+    assert config.orchestrator.weight_broadcast.inference_world_size == 4
+    assert config.trainer.weight_broadcast.dynamo is not None
+    assert config.trainer.weight_broadcast.dynamo.discovery_url == "http://dynamo-frontend:8001"
 
 
 def test_defaults():

--- a/tests/unit/transports/test_dynamo_weights.py
+++ b/tests/unit/transports/test_dynamo_weights.py
@@ -3,8 +3,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from prime_rl.transports.weights.base import RECEIVER_READY_MARKER
 import prime_rl.transports.weights.dynamo as dynamo_weights
+from prime_rl.transports.weights.base import RECEIVER_READY_MARKER
 from prime_rl.transports.weights.dynamo import DynamoWeightReceiver
 
 
@@ -97,6 +97,27 @@ async def test_dynamo_filesystem_receiver_uses_admin_collective_rpc(tmp_path):
 def test_dynamo_nixl_receiver_participates_in_orchestrator_handshake(tmp_path, monkeypatch):
     events: list[object] = []
 
+    class OrderedAdminPlane(FakeAdminPlane):
+        def __init__(self) -> None:
+            super().__init__()
+            self.version = "0"
+
+        async def resume(self) -> None:
+            events.append("resume")
+            await super().resume()
+
+        async def update_weight_version(self, version: str) -> None:
+            events.append(("update_weight_version", version))
+            self.version = version
+            await super().update_weight_version(version)
+
+        async def weight_versions(self) -> list[str]:
+            return [self.version]
+
+        async def fanout_collective(self, bodies: list[dict]) -> list[dict]:
+            events.append(("collective", bodies[0]["method"]))
+            return await super().fanout_collective(bodies)
+
     class FakeNixlAgent:
         def __init__(self, name: str) -> None:
             events.append(("agent", name))
@@ -138,15 +159,19 @@ def test_dynamo_nixl_receiver_participates_in_orchestrator_handshake(tmp_path, m
             events.append(("decode", payload))
             return SimpleNamespace(agents=[SimpleNamespace(metadata=b"trainer-metadata")])
 
-    monkeypatch.setattr(dynamo_weights, "set_ucx_env_defaults", lambda device: events.append(("ucx", device)), raising=False)
+    monkeypatch.setattr(
+        dynamo_weights, "set_ucx_env_defaults", lambda device: events.append(("ucx", device)), raising=False
+    )
     monkeypatch.setattr(dynamo_weights, "NixlAgent", FakeNixlAgent, raising=False)
     monkeypatch.setattr(dynamo_weights, "make_agent_name", lambda role, rank: f"{role}-{rank}", raising=False)
     monkeypatch.setattr(dynamo_weights, "ModelExpressSession", FakeModelExpressSession, raising=False)
     monkeypatch.setattr(dynamo_weights, "MxClient", lambda server_url: ("client", server_url), raising=False)
     monkeypatch.setattr(dynamo_weights, "TrainerTensorTable", FakeTrainerTensorTable, raising=False)
-    monkeypatch.setattr(dynamo_weights, "policy_notification", lambda step, state: f"policy-{step}-{state}", raising=False)
+    monkeypatch.setattr(
+        dynamo_weights, "policy_notification", lambda step, state: f"policy-{step}-{state}", raising=False
+    )
 
-    admin = FakeAdminPlane()
+    admin = OrderedAdminPlane()
     config = SimpleNamespace(
         type="nixl",
         timeout=10,
@@ -157,10 +182,35 @@ def test_dynamo_nixl_receiver_participates_in_orchestrator_handshake(tmp_path, m
     )
     receiver = DynamoWeightReceiver(tmp_path, config, [], "model", admin)
     receiver.step_dir(3).mkdir(parents=True)
+    receiver.step_dir(4).mkdir(parents=True)
 
     asyncio.run(receiver.initialize())
     asyncio.run(receiver.receive(3))
+    asyncio.run(receiver.receive(4))
 
-    assert ("publish", b"orchestrator-metadata") in events
-    assert ("wait_for_notification", ["trainer-peer"], "policy-3-ready", 10) in events
-    assert ("send_notification", "trainer-peer", "policy-3-complete") in events
+    critical_events = [
+        event
+        for event in events
+        if event == "resume"
+        or (
+            isinstance(event, tuple)
+            and event[0]
+            in {"publish", "wait_for_notification", "collective", "send_notification", "update_weight_version"}
+        )
+    ]
+    assert critical_events == [
+        ("collective", "init_broadcaster"),
+        ("publish", b"orchestrator-metadata"),
+        ("wait_for_notification", ["trainer-peer"], "policy-3-ready", 10),
+        ("collective", "update_weights_from_path"),
+        ("send_notification", "trainer-peer", "policy-3-complete"),
+        ("update_weight_version", "3"),
+        "resume",
+        ("wait_for_notification", ["trainer-peer"], "policy-4-ready", 10),
+        ("collective", "update_weights_from_path"),
+        ("send_notification", "trainer-peer", "policy-4-complete"),
+        ("update_weight_version", "4"),
+        "resume",
+    ]
+    assert events.count(("wait_for", "trainer", 1, 10)) == 1
+    assert events.count(("add_remote_agent", b"trainer-metadata")) == 1

--- a/tests/unit/transports/test_dynamo_weights.py
+++ b/tests/unit/transports/test_dynamo_weights.py
@@ -1,8 +1,10 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
 
 from prime_rl.transports.weights.base import RECEIVER_READY_MARKER
+import prime_rl.transports.weights.dynamo as dynamo_weights
 from prime_rl.transports.weights.dynamo import DynamoWeightReceiver
 
 
@@ -90,3 +92,75 @@ async def test_dynamo_filesystem_receiver_uses_admin_collective_rpc(tmp_path):
     )
     assert ("update_weight_version", "4") in admin.calls
     assert admin.calls[-1] == "resume"
+
+
+def test_dynamo_nixl_receiver_participates_in_orchestrator_handshake(tmp_path, monkeypatch):
+    events: list[object] = []
+
+    class FakeNixlAgent:
+        def __init__(self, name: str) -> None:
+            events.append(("agent", name))
+
+        def get_metadata(self) -> bytes:
+            return b"orchestrator-metadata"
+
+        def add_remote_agent(self, metadata: bytes) -> str:
+            events.append(("add_remote_agent", metadata))
+            return "trainer-peer"
+
+        def make_connection(self, peer: str) -> None:
+            events.append(("make_connection", peer))
+
+        def wait_for_notification(self, peers: list[str], notification: str, timeout: int) -> None:
+            events.append(("wait_for_notification", peers, notification, timeout))
+
+        def send_notification(self, peer: str, notification: str) -> None:
+            events.append(("send_notification", peer, notification))
+
+    class FakeModelExpressSession:
+        def __init__(self, **kwargs) -> None:
+            events.append(("session", kwargs))
+
+        def publish(self, *, nixl_metadata: bytes) -> None:
+            events.append(("publish", nixl_metadata))
+
+        def wait_for(self, role: str, *, count: int, timeout: int):
+            events.append(("wait_for", role, count, timeout))
+            return ["trainer-ref"]
+
+        def fetch(self, ref: str):
+            events.append(("fetch", ref))
+            return SimpleNamespace(nixl_metadata=b"trainer-table")
+
+    class FakeTrainerTensorTable:
+        @classmethod
+        def decode(cls, payload: bytes):
+            events.append(("decode", payload))
+            return SimpleNamespace(agents=[SimpleNamespace(metadata=b"trainer-metadata")])
+
+    monkeypatch.setattr(dynamo_weights, "set_ucx_env_defaults", lambda device: events.append(("ucx", device)), raising=False)
+    monkeypatch.setattr(dynamo_weights, "NixlAgent", FakeNixlAgent, raising=False)
+    monkeypatch.setattr(dynamo_weights, "make_agent_name", lambda role, rank: f"{role}-{rank}", raising=False)
+    monkeypatch.setattr(dynamo_weights, "ModelExpressSession", FakeModelExpressSession, raising=False)
+    monkeypatch.setattr(dynamo_weights, "MxClient", lambda server_url: ("client", server_url), raising=False)
+    monkeypatch.setattr(dynamo_weights, "TrainerTensorTable", FakeTrainerTensorTable, raising=False)
+    monkeypatch.setattr(dynamo_weights, "policy_notification", lambda step, state: f"policy-{step}-{state}", raising=False)
+
+    admin = FakeAdminPlane()
+    config = SimpleNamespace(
+        type="nixl",
+        timeout=10,
+        inference_world_size=2,
+        host="modelexpress",
+        port=8001,
+        session_id="test-session",
+    )
+    receiver = DynamoWeightReceiver(tmp_path, config, [], "model", admin)
+    receiver.step_dir(3).mkdir(parents=True)
+
+    asyncio.run(receiver.initialize())
+    asyncio.run(receiver.receive(3))
+
+    assert ("publish", b"orchestrator-metadata") in events
+    assert ("wait_for_notification", ["trainer-peer"], "policy-3-ready", 10) in events
+    assert ("send_notification", "trainer-peer", "policy-3-complete") in events

--- a/tests/unit/transports/test_dynamo_weights.py
+++ b/tests/unit/transports/test_dynamo_weights.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+
+import pytest
+
+from prime_rl.transports.weights.base import RECEIVER_READY_MARKER
+from prime_rl.transports.weights.dynamo import DynamoWeightReceiver
+
+
+class FakeAdminPlane:
+    def __init__(self) -> None:
+        self.workers = (
+            SimpleNamespace(
+                component="backend",
+                instance_id=1,
+                world_size=2,
+                routes=(
+                    "control/pause_generation",
+                    "control/resume_generation",
+                    "control/is_paused",
+                    "control/get_weight_version",
+                    "update/update_weight_version",
+                    "update/init_weight_transfer_engine",
+                    "update/start_weight_update",
+                    "update/update_weights",
+                    "update/finish_weight_update",
+                ),
+            ),
+        )
+        self.collective_clients = [object()]
+        self.calls: list[object] = []
+
+    async def pause(self) -> None:
+        self.calls.append("pause")
+
+    async def is_paused(self) -> bool:
+        self.calls.append("is_paused")
+        return True
+
+    async def resume(self) -> None:
+        self.calls.append("resume")
+
+    async def update_weight_version(self, version: str) -> None:
+        self.calls.append(("update_weight_version", version))
+
+    async def weight_versions(self) -> list[str]:
+        self.calls.append("weight_versions")
+        return ["3"]
+
+    async def fanout_collective(self, bodies: list[dict]) -> list[dict]:
+        self.calls.append(("collective", bodies))
+        return [{"results": [None]}]
+
+
+@pytest.mark.asyncio
+async def test_dynamo_native_nccl_receiver_acknowledges_only_after_pause(tmp_path):
+    admin = FakeAdminPlane()
+    config = SimpleNamespace(type="nccl", timeout=10, inference_world_size=2)
+    receiver = DynamoWeightReceiver(tmp_path, config, [], "model", admin)
+    receiver.step_dir(3).mkdir(parents=True)
+
+    await receiver.initialize()
+    await receiver.receive(3)
+
+    assert (receiver.step_dir(3) / RECEIVER_READY_MARKER).exists()
+    assert admin.calls == ["pause", "is_paused", "weight_versions", "resume"]
+
+
+@pytest.mark.asyncio
+async def test_dynamo_filesystem_receiver_uses_admin_collective_rpc(tmp_path):
+    admin = FakeAdminPlane()
+    config = SimpleNamespace(type="filesystem", timeout=10)
+    receiver = DynamoWeightReceiver(tmp_path, config, [], "model", admin)
+    step_dir = receiver.step_dir(4)
+    step_dir.mkdir(parents=True)
+    (step_dir / ".finished").touch()
+
+    await receiver.receive(4)
+
+    assert admin.calls[0:2] == ["pause", "is_paused"]
+    assert admin.calls[2] == (
+        "collective",
+        [
+            {
+                "method": "reload_weights",
+                "timeout": 10,
+                "args": [],
+                "kwargs": {"weights_path": step_dir.as_posix()},
+            }
+        ],
+    )
+    assert ("update_weight_version", "4") in admin.calls
+    assert admin.calls[-1] == "resume"


### PR DESCRIPTION
## Summary

- add a Dynamo inference-pool adapter for worker discovery, health, pause/resume, version fencing, and filesystem, NIXL, and native NCCL updates
- add a Dynamo-native trainer adapter for vLLM stateful weight transfer
- keep Dynamo and the vLLM sidecar agnostic to routed-expert serialization
- normalize native vLLM routed-expert data at the Prime-RL renderer boundary and install that behavior in every env-server worker
- retain Prime-RL existing inference and broadcast implementations for non-Dynamo configurations

## Stack

This branch is the Dynamo integration layer on top of #3443, the current-main rebase of #3260. It contains #3443 at `576ed1e4f`; the Dynamo layer begins at `6004a5660` and currently ends at `bf42c4c35`.

GitHub does not allow an upstream PR to use a branch in a fork as its base, so this PR temporarily targets `main` and includes the #3443 commits in its displayed diff. Once #3443 merges, this PR automatically reduces to the Dynamo-only layer.

## Scope

Dynamo behavior remains concentrated in the Dynamo adapter and weight-transfer implementation. Dynamo forwards routed data as opaque bytes without validating the framework-specific payload. Prime-RL performs any native-vLLM-to-Prime normalization at its own boundary.

## Validation

- Ruff passed for every Python file changed by the Dynamo layer
- `tests/unit/inference/test_dynamo.py`, the new Dynamo configuration tests, and `tests/unit/orchestrator/test_clients.py`: 20 passed
- recent Kubernetes Qwen3.5 multimodal smoke test exercised this restacked Prime-RL branch with Dynamo and the vLLM-Rust sidecar on the vLLM 0.28.0 runtime
- prior Qwen3-MoE two-step math GRPO test completed successfully and exercised opaque routed-expert transport and the Prime-RL routed-expert consumption path
- prior NIXL test initialized the Prime transfer group, published the model tensors, and applied the updated policy in vLLM

The local lightweight environment does not include Torch or optional taskset plugins, so the Torch transport module and repository-wide config sweep were not rerun locally during this restack.