### PR TITLE
fix: report trainable rate over the shipped batch

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -49,6 +49,7 @@ from prime_rl.orchestrator.eval_sink import EvalSink
 from prime_rl.orchestrator.eval_source import EvalSource
 from prime_rl.orchestrator.filters import setup_filters
 from prime_rl.orchestrator.inference_metrics import InferenceMetricsCollector
+from prime_rl.orchestrator.metrics import TrainRollouts
 from prime_rl.orchestrator.packing import BatchPacker
 from prime_rl.orchestrator.patches import (
     monkey_patch_chat_completion_logprobs,
@@ -594,9 +595,12 @@ class Orchestrator:
                 )
             return
         self.consecutive_empty_batches = 0
-        effective = batch.rollouts.effective
-        n_shipped = sum(1 for r in batch.cohort if not r.is_filtered)
-        n_trainable = sum(1 for r in batch.cohort if not r.is_filtered and r.is_trainable)
+        # The effective (trained-on) subset is the shipped batch: the cohort's non-filtered
+        # members. It is not a subset of ``batch.rollouts`` — cohort overflow ships from an
+        # earlier window.
+        effective = TrainRollouts(batch.cohort).effective
+        n_shipped = len(effective)
+        n_trainable = sum(1 for r in effective if r.is_trainable)
         if n_shipped and n_trainable / n_shipped <= 0.1:
             get_logger().warning(
                 f"Only {n_trainable}/{n_shipped} shipped rollouts are trainable "
@@ -628,11 +632,13 @@ class Orchestrator:
         # off-policy — queue time included, unlike the dispatcher's in-flight
         # counter, which only sees weight updates during generation. Frozen-
         # sourced rollouts stay 0 (their sampler doesn't follow the policy).
-        for r in batch.rollouts:
+        # The cohort needs its own pass: overflow members left the window at an
+        # earlier ship and their stamp is stale by the steps spent queued.
+        for r in [*batch.rollouts, *batch.cohort]:
             if self.train_envs.get(r.env_name).sampler.samples_from_live_policy:
                 r.off_policy_steps = (step - 1) - r.policy_version
 
-        # The effective (clean, trained-on) subset is logged at ship time; the full arrival
+        # The effective (shipped, trained-on) subset is logged at ship time; the full arrival
         # window already streamed into the ``all`` cohort on arrival.
         await monitors.log(group_episodes(effective.rollouts), step, "train", "effective")
 
@@ -646,8 +652,8 @@ class Orchestrator:
         save_ckpt_time = await self.maybe_save_ckpt(step)
         trim_process_memory()
 
-        # Rollout metrics over the {agg,<env>} × {all,effective} matrix. ``batch.rollouts`` is the
-        # full arrival window (errored + filtered included); ``.effective`` is the clean subset.
+        # Rollout metrics over the {agg,<env>} × {all,effective} matrix. ``all`` is the full
+        # arrival window (errored + filtered included); ``effective`` is the shipped batch.
         metrics: dict[str, float] = {}
         for subset, pool in (("all", batch.rollouts), ("effective", effective)):
             metrics |= pool.metrics.to_wandb(prefix="train/agg", subset=subset)
@@ -787,16 +793,15 @@ class Orchestrator:
 
     def log_train_batch(self, batch: TrainBatch, *, step: int, step_time: float) -> None:
         """Per-step ``Step …`` success line. Multi-env runs append an indented ``╰─`` line per env.
-        ``Error`` is the sink-level rate (errored arrivals / total arrivals, over the full window);
-        the quality metrics are over the effective (clean, trained-on) subset. ``Trainable`` is over
-        the shipped batch: gradient-carrying rollouts / the cohort's non-filtered members (a
-        zero-advantage rollout ships without contributing gradient)."""
+        Every metric describes the shipped batch (the cohort's non-filtered members) except
+        ``Error``, which is over the full arrival window — errored rollouts never reach a batch.
+        ``Trainable`` = gradient-carrying shipped rollouts (a zero-advantage rollout ships without
+        contributing gradient); ``Ratio`` = the env's share of the shipped batch."""
         rollouts = batch.rollouts
-        effective = rollouts.effective
+        effective = TrainRollouts(batch.cohort).effective
         eff = effective.metrics
-        n_generated = len(rollouts)
-        n_shipped = sum(1 for r in batch.cohort if not r.is_filtered)
-        n_trainable = sum(1 for r in batch.cohort if not r.is_filtered and r.is_trainable)
+        n_shipped = len(effective)
+        n_trainable = sum(1 for r in effective if r.is_trainable)
         trainable_rate = (n_trainable / n_shipped) if n_shipped else 0.0
         max_off_policy = max((r.off_policy_steps for r in effective), default=0)
 
@@ -811,19 +816,21 @@ class Orchestrator:
             get_logger().success(head)
             return
 
-        by_env = rollouts.by_env()
-        name_width = max((len(n) for n in by_env), default=0)
+        window_by_env = rollouts.by_env()
+        shipped_by_env = effective.by_env()
+        env_names = sorted(set(window_by_env) | set(shipped_by_env))
+        name_width = max((len(n) for n in env_names), default=0)
         lines = [head]
-        for env_name in sorted(by_env):
-            pool = by_env[env_name]
-            env_eff_pool = pool.effective
+        for env_name in env_names:
+            window_pool = window_by_env.get(env_name, TrainRollouts())
+            env_eff_pool = shipped_by_env.get(env_name, TrainRollouts())
             env_eff = env_eff_pool.metrics
-            ratio = (len(pool) / n_generated) if n_generated else 0.0
+            ratio = (len(env_eff_pool) / n_shipped) if n_shipped else 0.0
             lines.append(
                 f"╰─ {env_name:<{name_width}} | Ratio {ratio:.1%} | Reward {env_eff.reward.mean():.4f} | "
                 f"Turns {env_eff.num_turns.mean():.1f} | Branches {env_eff.num_branches.mean():.1f} | "
                 f"Max Off-Policy {max((r.off_policy_steps for r in env_eff_pool), default=0)} | "
-                f"Error {pool.metrics.has_error.mean():.1%} | Truncation {env_eff.is_truncated.mean():.1%}"
+                f"Error {window_pool.metrics.has_error.mean():.1%} | Truncation {env_eff.is_truncated.mean():.1%}"
             )
         get_logger().success("\n\t\t ".join(lines))
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -595,11 +595,12 @@ class Orchestrator:
             return
         self.consecutive_empty_batches = 0
         effective = batch.rollouts.effective
-        n_trainable = sum(1 for r in effective if r.is_trainable)
-        if effective and n_trainable / len(effective) <= 0.1:
+        n_shipped = sum(1 for r in batch.cohort if not r.is_filtered)
+        n_trainable = sum(1 for r in batch.cohort if not r.is_filtered and r.is_trainable)
+        if n_shipped and n_trainable / n_shipped <= 0.1:
             get_logger().warning(
-                f"Only {n_trainable}/{len(effective)} effective rollouts are trainable "
-                f"({n_trainable / len(effective):.1%}) — consider reviewing task difficulty / filter config"
+                f"Only {n_trainable}/{n_shipped} shipped rollouts are trainable "
+                f"({n_trainable / n_shipped:.1%}) — consider reviewing task difficulty / filter config"
             )
 
         # Ship batch ``step`` only once the trainer has published v{step-1-TARGET_LAG}.
@@ -787,19 +788,21 @@ class Orchestrator:
     def log_train_batch(self, batch: TrainBatch, *, step: int, step_time: float) -> None:
         """Per-step ``Step …`` success line. Multi-env runs append an indented ``╰─`` line per env.
         ``Error`` is the sink-level rate (errored arrivals / total arrivals, over the full window);
-        the quality metrics are over the effective (clean, trained-on) subset, as is ``Trainable``."""
+        the quality metrics are over the effective (clean, trained-on) subset. ``Trainable`` is over
+        the shipped batch: gradient-carrying rollouts / the cohort's non-filtered members (a
+        zero-advantage rollout ships without contributing gradient)."""
         rollouts = batch.rollouts
         effective = rollouts.effective
         eff = effective.metrics
         n_generated = len(rollouts)
-        n_effective = len(effective)
-        n_trainable = sum(1 for r in effective if r.is_trainable)
-        trainable_rate = (n_trainable / n_effective) if n_effective else 0.0
+        n_shipped = sum(1 for r in batch.cohort if not r.is_filtered)
+        n_trainable = sum(1 for r in batch.cohort if not r.is_filtered and r.is_trainable)
+        trainable_rate = (n_trainable / n_shipped) if n_shipped else 0.0
         max_off_policy = max((r.off_policy_steps for r in effective), default=0)
 
         head = (
             f"Step {step} | {format_time(step_time):>7} | Reward {eff.reward.mean():.4f} | "
-            f"Trainable {n_trainable}/{n_effective} ({trainable_rate:.1%}) | "
+            f"Trainable {n_trainable}/{n_shipped} ({trainable_rate:.1%}) | "
             f"Turns {eff.num_turns.mean():.1f} | Branches {eff.num_branches.mean():.1f} | "
             f"Max Off-Policy {max_off_policy} | "
             f"Error {rollouts.metrics.has_error.mean():.1%} | Truncation {eff.is_truncated.mean():.1%}"

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -275,7 +275,7 @@ class TrainSink:
         rollouts = self.pending_rollouts
         if samples:
             self.pending_rollouts = TrainRollouts()
-        return TrainBatch(rollouts=rollouts, samples=samples)
+        return TrainBatch(rollouts=rollouts, cohort=cohort, samples=samples)
 
     def reset_pre_filter_stats(self) -> None:
         self.pre_filter_seen = 0

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -141,12 +141,14 @@ class Rollout(vf.Trace[DataT], Generic[DataT]):
 class TrainBatch:
     """``rollouts`` is the observation window since the last ship — every rollout of every group
     finalized in that span (errored + filtered included; rollouts of still-incomplete groups wait
-    for a later window). Its ``.effective`` / ``.metrics`` views drive logging. ``samples`` is the
-    trainer-bound payload (the shipped cohort's post-filter survivors) — an empty list means nothing
-    ships, which would stall the trainer. Trainable counts derive from ``rollouts.effective``
-    (``r.is_trainable``) and token totals from ``samples``, so neither is carried as a field."""
+    for a later window). Its ``.effective`` / ``.metrics`` views drive logging. ``cohort`` is the
+    batch-sized slice popped for the trainer (post-batch filter annotations applied) — its
+    non-filtered members are the shipped rollouts, so trainable counts are over exactly what fills
+    the batch. ``samples`` is the trainer-bound payload (the cohort's post-filter survivors) — an
+    empty list means nothing ships, which would stall the trainer."""
 
     rollouts: TrainRollouts
+    cohort: list[Rollout]
     samples: list[TrainingSample]
 
 

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -141,11 +141,13 @@ class Rollout(vf.Trace[DataT], Generic[DataT]):
 class TrainBatch:
     """``rollouts`` is the observation window since the last ship — every rollout of every group
     finalized in that span (errored + filtered included; rollouts of still-incomplete groups wait
-    for a later window). Its ``.effective`` / ``.metrics`` views drive logging. ``cohort`` is the
+    for a later window). It drives the ``all``-subset metrics and error rates. ``cohort`` is the
     batch-sized slice popped for the trainer (post-batch filter annotations applied) — its
-    non-filtered members are the shipped rollouts, so trainable counts are over exactly what fills
-    the batch. ``samples`` is the trainer-bound payload (the cohort's post-filter survivors) — an
-    empty list means nothing ships, which would stall the trainer."""
+    non-filtered members are the shipped batch, the ``effective`` (trained-on) subset all quality
+    metrics describe. Neither contains the other: the window holds errored/filtered rollouts that
+    never ship, the cohort holds overflow that finalized in an earlier window. ``samples`` is the
+    trainer-bound payload (the cohort's post-filter survivors) — an empty list means nothing
+    ships, which would stall the trainer."""
 
     rollouts: TrainRollouts
     cohort: list[Rollout]


### PR DESCRIPTION
## Summary

- The `Step …` line, the wandb `*/effective` metrics, and the ship-time `effective` trace log all derived from the observation window (`batch.rollouts` — every group finalized since the last ship), not the batch the trainer received. The window and the shipped batch diverge: overflow rollouts finalize in one window but ship in a later batch, and the window holds errored/filtered rollouts that never ship. The `Trainable` denominator drifted away from the batch size as a result.
- `TrainBatch` now carries `cohort` — the batch-sized slice `process_batch` pops for the trainer, with post-batch filter annotations applied.
- The `effective` (trained-on) subset is redefined as the shipped batch: the cohort's non-filtered members. This holds everywhere it appears — the Step line (`Reward`, `Trainable`, `Turns`, `Branches`, `Max Off-Policy`, `Truncation`, per-env `╰─` lines), the wandb `train/*/effective` matrix, the input/output token breakdown, and the ship-time `effective` trace log. The docstrings already claimed effective = "clean, trained-on subset"; the code now matches.
- `Trainable k/n` = gradient-carrying shipped rollouts / shipped rollouts (n = batch size in the common no-post-filter case). The low-trainable (≤10%) warning uses the same counts.
- `Error` and the wandb `all` subset stay window-framed — errored rollouts never reach a batch, so the window is the only frame that can report them.
- Staleness stamping (`off_policy_steps`) gets a second pass over the cohort: overflow members left the window at an earlier ship, and their old stamp misses the steps spent queued.
- Per-env `Ratio` now reads as the env's share of the shipped batch instead of the arrival mix (the wandb `batch/{env}` arrival-mix metric is unchanged).

## Repro

Observed before the fix (batch_size=128):

```
18:16:00 SUCCESS Step 1 | 2m 20s | Reward 0.3750 | Trainable 8/8 (100.0%) | ...
```

With the fix, `Trainable`'s denominator (and every quality metric's population) is the shipped batch: `n` = 128 with `batch_size=128` and no post-batch filters.

Supersedes #3289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging and metric framing only; training payload (`samples`) was already cohort-based via `TrainSink`; no auth or trainer wire changes.
> 
> **Overview**
> **Fixes misleading `Trainable k/n` on the step log** when overflow rollouts finalized in the observation window but shipped in a later batch made the denominator much smaller than `batch_size` (e.g. `8/8` with `batch_size=128`).
> 
> `TrainBatch` now carries **`cohort`** — the batch-sized slice popped for the trainer (post-batch filter annotations). The **shipped / trained-on** subset is `TrainRollouts(batch.cohort).effective`, not `batch.rollouts.effective` (the full arrival window since the last ship). That shipped subset drives the low-trainable warning, the main step line (`Trainable`, reward, truncation, off-policy), and the W&B **`effective`** rollout metrics; **`all`** and error rates still use the observation window.
> 
> **Off-policy staleness** is stamped on both `batch.rollouts` and `batch.cohort` so overflow members queued from an earlier window get correct `off_policy_steps`. Multi-env step logs use **Ratio** over the shipped batch per env while **Error** stays window-based.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe17b1146d45882ab8e7477c538d60baf43536ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->