### PR TITLE
Mario/cpu optimization chunk size

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -63,6 +63,9 @@ class FakeDataConfig(BaseDataConfig):
     input_ids: Literal["increasing", "random"] = "increasing"
     """Token id generator: ``increasing`` for deterministic sequences, ``random`` for random ids."""
 
+    seed: int = 0
+    """Seed for the per-rank packing/token generator, combined with the data rank."""
+
 
 class LossMaskConfig(BaseConfig):
     system: bool = False

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -42,6 +42,9 @@ class BaseDataConfig(BaseConfig):
     micro_batch_size: int = Field(1, ge=1)
     """Per-step micro batch size. ``batch_size`` must be divisible by this."""
 
+    num_workers: int = Field(1, ge=0)
+    """Number of dataloader worker processes. With ``>= 1``, batches are prepared and pinned in the background so tokenization/packing overlaps with training. ``0`` loads inline on the main process."""
+
     @model_validator(mode="after")
     def validate_batch_size(self):
         if self.batch_size % self.micro_batch_size != 0:

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -255,7 +255,7 @@ class ModelConfig(BaseModelConfig):
     debug: DebugModelConfig = DebugModelConfig()
     """Debugging knobs for the model and distributed training."""
 
-    fused_lm_head_token_chunk_size: int | Literal["disabled"] = 1024
+    fused_lm_head_token_chunk_size: int | Literal["disabled"] = 8192
     """Flattened token chunk size for the fused LM head. ``int >= 1`` sets the tokens per LM-head chunk explicitly; ``disabled`` uses the vanilla LM head. SFT training silently disables this (not supported yet)."""
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -255,7 +255,7 @@ class ModelConfig(BaseModelConfig):
     debug: DebugModelConfig = DebugModelConfig()
     """Debugging knobs for the model and distributed training."""
 
-    fused_lm_head_token_chunk_size: int | Literal["disabled"] = 4096
+    fused_lm_head_token_chunk_size: int | Literal["disabled"] = 8192
     """Flattened token chunk size for the fused LM head. ``int >= 1`` sets the tokens per LM-head chunk explicitly; ``disabled`` uses the vanilla LM head. SFT training silently disables this (not supported yet)."""
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -255,7 +255,7 @@ class ModelConfig(BaseModelConfig):
     debug: DebugModelConfig = DebugModelConfig()
     """Debugging knobs for the model and distributed training."""
 
-    fused_lm_head_token_chunk_size: int | Literal["disabled"] = 8192
+    fused_lm_head_token_chunk_size: int | Literal["disabled"] = 4096
     """Flattened token chunk size for the fused LM head. ``int >= 1`` sets the tokens per LM-head chunk explicitly; ``disabled`` uses the vanilla LM head. SFT training silently disables this (not supported yet)."""
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -531,20 +531,19 @@ class CatDataset(StatefulIterableDataset):
 
 
 def cat_collate(samples: list[Sample]) -> Batch:
+    # CPU tensors only: this runs in dataloader workers then the trainer moves batches to the GPU with async copies from pinned memory
     (sample,) = samples
     mm_kwargs = sample.get("mm_kwargs")
     mm_token_type_ids = sample.get("mm_token_type_ids")
     return {
-        "input_ids": torch.tensor(sample["input_ids"], dtype=torch.long, device="cuda").unsqueeze(0),
-        "position_ids": torch.tensor(sample["position_ids"], dtype=torch.long, device="cuda").unsqueeze(0),
-        "loss_mask": torch.tensor(sample["loss_mask"], dtype=torch.bool, device="cuda").unsqueeze(0),
-        "target_ids": torch.tensor(sample["target_ids"], dtype=torch.long, device="cuda").unsqueeze(0),
-        "seq_lens": torch.tensor(sample["seq_lens"], dtype=torch.long, device="cuda"),
-        "mm_kwargs": {key: value.to("cuda") for key, value in mm_kwargs.items()} if mm_kwargs is not None else None,
+        "input_ids": torch.tensor(sample["input_ids"], dtype=torch.long).unsqueeze(0),
+        "position_ids": torch.tensor(sample["position_ids"], dtype=torch.long).unsqueeze(0),
+        "loss_mask": torch.tensor(sample["loss_mask"], dtype=torch.bool).unsqueeze(0),
+        "target_ids": torch.tensor(sample["target_ids"], dtype=torch.long).unsqueeze(0),
+        "seq_lens": torch.tensor(sample["seq_lens"], dtype=torch.long),
+        "mm_kwargs": dict(mm_kwargs) if mm_kwargs is not None else None,
         "mm_token_type_ids": (
-            torch.tensor(mm_token_type_ids, dtype=torch.long, device="cuda").unsqueeze(0)
-            if mm_token_type_ids is not None
-            else None
+            torch.tensor(mm_token_type_ids, dtype=torch.long).unsqueeze(0) if mm_token_type_ids is not None else None
         ),
     }
 
@@ -656,4 +655,20 @@ def setup_dataset(
 
 def setup_dataloader(dataset: StatefulIterableDataset, config: DataConfig) -> StatefulDataLoader:
     packing_dataset = CatDataset(dataset, config.seq_len * config.micro_batch_size)
-    return StatefulDataLoader(packing_dataset, batch_size=1, collate_fn=cat_collate)
+    return StatefulDataLoader(
+        packing_dataset,
+        batch_size=1,
+        collate_fn=cat_collate,
+        num_workers=config.num_workers,
+        pin_memory=config.num_workers > 0,
+        prefetch_factor=2 if config.num_workers > 0 else None,
+    )
+
+
+def get_dataset_state(dataloader: StatefulDataLoader) -> dict:
+    state = dataloader.state_dict()
+    if "dataset_state" in state:
+        return state["dataset_state"]
+    worker_snapshots = (state.get("_snapshot") or {}).get("_worker_snapshots") or {}
+    (worker_state,) = worker_snapshots.values()
+    return worker_state["dataset_state"]

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -79,14 +79,28 @@ class FakeDataset(StatefulIterableDataset):
         seq_len: int,
         length: Literal["fixed", "variable"] = "fixed",
         input_ids: Literal["increasing", "random"] = "random",
+        seed: int = 0,
     ):
         super().__init__()
         self.vocab_size = vocab_size
         self.seq_len = seq_len
         self.length = length
         self.input_ids = input_ids
+        self.seed = seed
+
+    def _draws_per_sample(self) -> int:
+        return (self.length == "variable") + (self.input_ids == "random")
 
     def __iter__(self):
+        # use a rank seeded PRNG instead of torch global default PRNG because with num workers > 0
+        # the data loader reseeds the global PRNG per worker process
+        generator = torch.Generator().manual_seed(self.seed + self.data_rank)
+        if self.fast_forward:
+            already_emitted = self.step // self.data_world_size
+            for _ in range(already_emitted * self._draws_per_sample()):
+                torch.rand((), generator=generator)
+            self.fast_forward = False
+
         while True:
             self.step += 1
 
@@ -94,11 +108,15 @@ class FakeDataset(StatefulIterableDataset):
             if (self.step - 1) % self.data_world_size != self.data_rank:
                 continue
 
-            seq_len = int(torch.randint(1, self.seq_len, (1,)).item()) if self.length == "variable" else self.seq_len
+            seq_len = (
+                int(torch.randint(1, self.seq_len, (1,), generator=generator).item())
+                if self.length == "variable"
+                else self.seq_len
+            )
             input_ids = (
                 [self.step - 1] * (seq_len + 1)
                 if self.input_ids == "increasing"
-                else torch.randint(0, self.vocab_size, (self.seq_len + 1,)).long().tolist()
+                else torch.randint(0, self.vocab_size, (self.seq_len + 1,), generator=generator).long().tolist()
             )
             position_ids = list(range(seq_len))
             loss_mask = [True] * seq_len
@@ -632,6 +650,7 @@ def setup_dataset(
             seq_len=config.seq_len,
             length=config.length,
             input_ids=config.input_ids,
+            seed=config.seed,
         )
     elif config.type == "sft":
         if renderer is None:

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -39,7 +39,7 @@ from prime_rl.trainer.model import (
 )
 from prime_rl.trainer.parallel_dims import get_parallel_dims, resolve_ep
 from prime_rl.trainer.perf import get_perf_counter
-from prime_rl.trainer.sft.data import load_sft_dataset, setup_dataloader, setup_dataset
+from prime_rl.trainer.sft.data import get_dataset_state, load_sft_dataset, setup_dataloader, setup_dataset
 from prime_rl.trainer.utils import (
     GarbageCollection,
     MemoryProfiler,
@@ -246,7 +246,7 @@ def train(config: SFTConfig):
         if skip.skip_scheduler:
             scheduler = setup_scheduler(optimizer, config.scheduler, scheduler_steps, config.optim.lr)
     logger.info(
-        f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples}, dataset_state={dataloader.state_dict()['dataset_state']})"
+        f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples}, dataset_state={get_dataset_state(dataloader)})"
     )
 
     cp_enabled = parallel_dims.cp_enabled
@@ -257,13 +257,17 @@ def train(config: SFTConfig):
 
     def compute_loss(micro_batch: dict) -> tuple[torch.Tensor, torch.Tensor]:
         """Forward pass returning (loss_sum, token_count) over unmasked tokens."""
-        input_ids = micro_batch["input_ids"].to("cuda")
-        position_ids = micro_batch["position_ids"].to("cuda")
-        target_ids = micro_batch["target_ids"].to("cuda")
-        loss_mask = micro_batch["loss_mask"].to("cuda")
-        seq_lens = micro_batch["seq_lens"].to("cuda")
+        input_ids = micro_batch["input_ids"].to("cuda", non_blocking=True)
+        position_ids = micro_batch["position_ids"].to("cuda", non_blocking=True)
+        target_ids = micro_batch["target_ids"].to("cuda", non_blocking=True)
+        loss_mask = micro_batch["loss_mask"].to("cuda", non_blocking=True)
+        seq_lens = micro_batch["seq_lens"].to("cuda", non_blocking=True)
         mm_kwargs = micro_batch.get("mm_kwargs")
+        if mm_kwargs is not None:
+            mm_kwargs = {key: value.to("cuda", non_blocking=True) for key, value in mm_kwargs.items()}
         mm_type_ids = micro_batch.get("mm_token_type_ids")
+        if mm_type_ids is not None:
+            mm_type_ids = mm_type_ids.to("cuda", non_blocking=True)
 
         seq_lens_are_pre_shard = False
 

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -5,7 +5,7 @@ import torch
 from transformers import AutoTokenizer
 
 from prime_rl.configs.sft import FakeDataConfig
-from prime_rl.trainer.sft.data import setup_dataloader, setup_dataset
+from prime_rl.trainer.sft.data import get_dataset_state, setup_dataloader, setup_dataset
 from prime_rl.trainer.world import reset_world
 
 pytestmark = [pytest.mark.gpu]
@@ -20,22 +20,22 @@ def test_fake_dataset_single_rank_state():
     dataiter = iter(dataloader)
 
     # Initial state
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 0, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"dataset": {"step": 0, "epoch": 0}}
 
     # Iterate over samples
     micro_batch = next(dataiter)
     print(micro_batch)
     assert micro_batch["input_ids"].unique().item() == 0
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 1, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"dataset": {"step": 1, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 1
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 2, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"dataset": {"step": 2, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 2
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 3, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"dataset": {"step": 3, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 3
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 4, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"dataset": {"step": 4, "epoch": 0}}
 
 
 @pytest.mark.parametrize("rank", [0, 1], ids=["rank0", "rank1"])
@@ -55,26 +55,26 @@ def test_fake_dataset_multi_rank_state(rank: int):
     dataiter = iter(dataloader)
 
     # Initial state
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 0, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"dataset": {"step": 0, "epoch": 0}}
 
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 0 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 1 + rank, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"dataset": {"step": 1 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 2 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 3 + rank, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"dataset": {"step": 3 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 4 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 5 + rank, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"dataset": {"step": 5 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 6 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 7 + rank, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"dataset": {"step": 7 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 8 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 9 + rank, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"dataset": {"step": 9 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 10 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 11 + rank, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"dataset": {"step": 11 + rank, "epoch": 0}}
 
 
 def test_fake_dataset_single_rank_resume():
@@ -89,7 +89,7 @@ def test_fake_dataset_single_rank_resume():
         micro_batch = next(dataiter)
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["input_ids"].unique().item() == step
-        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step + 1, "epoch": 0}}
+        assert get_dataset_state(dataloader) == {"dataset": {"step": step + 1, "epoch": 0}}
 
     # Reload dataloader
     state_dict = dataloader.state_dict()
@@ -102,7 +102,7 @@ def test_fake_dataset_single_rank_resume():
         micro_batch = next(dataiter)
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["input_ids"].unique().item() == step
-        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step + 1, "epoch": 0}}
+        assert get_dataset_state(dataloader) == {"dataset": {"step": step + 1, "epoch": 0}}
 
 
 def test_fake_dataset_single_rank_state_with_packing():
@@ -119,7 +119,7 @@ def test_fake_dataset_single_rank_state_with_packing():
         step += num_packed_examples
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["seq_lens"].sum() == micro_batch["input_ids"].shape[1]
-        dataset_state = dataloader.state_dict()["dataset_state"]
+        dataset_state = get_dataset_state(dataloader)
         pending_sample = dataset_state.get("pending_sample")
         expected_dataset_step = step + (pending_sample is not None)
         assert dataset_state["dataset"] == {"step": expected_dataset_step, "epoch": 0}


### PR DESCRIPTION
This doubles the chunk size of the fused LM head from 4k to 8k which incrased speed a little bit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the SFT data path (worker processes, pinned memory, checkpoint state layout) and changes default LM-head chunking, which can affect memory and numerics slightly; resume behavior with workers deserves validation.
> 
> **Overview**
> Improves SFT **CPU-side throughput** by overlapping batch packing with training, and bumps the default **fused LM head** token chunk size for a modest forward speedup.
> 
> **Data loading:** Adds configurable `num_workers` (default `1`) on SFT data config. Collate now builds **CPU** tensors in workers; the trainer moves batches to GPU with **`non_blocking`** copies from pinned memory when workers are enabled (`pin_memory`, `prefetch_factor=2`).
> 
> **Fake data / resume:** `FakeDataConfig.seed` and per-rank `torch.Generator` keep random/variable fake sequences stable when workers reseed the global RNG. `get_dataset_state()` reads dataset state from either the main loader snapshot or worker snapshots so logging and checkpointing stay correct with `num_workers > 0`.
> 
> **LM head:** Default `fused_lm_head_token_chunk_size` changes from **1024** to **8192** (RL trainer model config default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daa2a8e062c5fd095706bfb896b35ea71e798ba4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->