### PR TITLE
Increase chunk size to 8k

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -255,7 +255,7 @@ class ModelConfig(BaseModelConfig):
     debug: DebugModelConfig = DebugModelConfig()
     """Debugging knobs for the model and distributed training."""
 
-    fused_lm_head_token_chunk_size: int | Literal["disabled"] = 1024
+    fused_lm_head_token_chunk_size: int | Literal["disabled"] = 8192
     """Flattened token chunk size for the fused LM head. ``int >= 1`` sets the tokens per LM-head chunk explicitly; ``disabled`` uses the vanilla LM head. SFT training silently disables this (not supported yet)."""
 
     @model_validator(mode="after")


### PR DESCRIPTION
Makes the transient buffer 8x bigger but reduces loop iters and thus kernel launches.

Measured speed differences:

A truncated 12-layer debug sweep (Qwen3-30B, seq_len=65536) initially suggested a large win:

| chunk size | step time |
|---|---|
| 4096 | 3589.5ms |
| 8192 | 3193.1ms |
| **delta** | **11.0% faster (1.12x)** |

That's inflated by the truncation — the LM head's chunking loop runs once per forward pass and its cost depends only on `hidden_dim`/`vocab_size`/`seq_len`, not on the number of transformer layers, so the same fixed overhead is a much bigger fraction of a 12-layer step than a real one. Re-measured on the full, non-truncated model (Qwen3-30B-A3B, 48/48 layers, real weights config, seq_len=65536, `optim_cpu_offload=false`):

| chunk size | step time | vs 1024 |
|---|---|---|
| 1024 | 29.433s ± 0.082s | — |
| 4096 | 29.083s ± 0.041s | 1.19% faster |
| 8192 | 29.000s ± 0.000s | 1.47% faster |

So 4096 → 8192 is **0.29% faster** at real scale, not 11%. Still a real, no-downside win (same memory-safety story, just a larger transient buffer) — just recalibrating the expected impact from the debug-config sweep down to what actually shows up on a full-scale run.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single default change in trainer model config with no logic changes; risk is mainly higher peak memory or different throughput for jobs that relied on the 1024 default.
> 
> **Overview**
> **Default fused LM head chunk size** is increased from **1024** to **8192** on `ModelConfig.fused_lm_head_token_chunk_size` in trainer config.
> 
> Runs that do not override this setting will process **eight times more flattened tokens per fused LM-head chunk**, which typically **reduces kernel-launch overhead** and can **increase peak activation memory** during the LM head compared to the old default. Explicit values and `"disabled"` behave as before; only the default changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa549d27e67b6446e3b0716c74e4d705e07bbb0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->