### PR TITLE
feat: sign-SGD support for full CPU optimizer offload

### DIFF
--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -87,7 +87,7 @@ FSDP2 is the default model sharding strategy. By default the trainer fully shard
 | `trainer.model.reshard_after_forward` | If `true` (default), parameters are resharded after the forward pass to free memory; the backward pass re-gathers. Set `false` to keep params resident — faster but more memory. |
 | `trainer.model.fsdp_cpu_offload` | Offload params + grads + optimizer state to CPU. Big memory win, large throughput hit. |
 | `trainer.model.optim_cpu_offload` | Offload optimizer state to CPU between steps. Enabled by default. |
-| `trainer.model.full_offload` | Offload gradients, FP32 masters, and optimizer state and run AdamW on CPU during backward. Disabled by default. |
+| `trainer.model.full_offload` | Offload gradients, FP32 masters, and optimizer state and run the optimizer (AdamW or SignSGD) on CPU during backward. Disabled by default. |
 
 ### Expert Parallelism
 
@@ -138,7 +138,7 @@ targets = ["norm", "attn_proj"]  # see Reference for the full list per architect
 
 ### Optimizer Offloading
 
-State-only optimizer offload remains enabled by default with `model.optim_cpu_offload = true`. For full offload, set `model.optim_cpu_offload = false` and `model.full_offload = true`; this keeps BF16 compute weights on GPU and runs CPU AdamW chunks as gradients become ready during backward. Full offload only supports AdamW and disables gradient clipping.
+State-only optimizer offload remains enabled by default with `model.optim_cpu_offload = true`. For full offload, set `model.optim_cpu_offload = false` and `model.full_offload = true`; this keeps BF16 compute weights on GPU and runs CPU optimizer chunks as gradients become ready during backward. Full offload only supports AdamW and SignSGD (`optim.type = "sign_sgd"`) and disables gradient clipping. SignSGD is stateless, so it halves the host RAM footprint versus AdamW (8 instead of 16 bytes per parameter: FP32 master + FP32 accumulated gradient, no moments).
 
 ### LM Head Chunking
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -319,9 +319,9 @@ class SFTConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
-    def full_optimizer_offload_requires_adamw(self):
-        if self.model.full_offload and self.optim.type != "adamw":
-            raise ValueError("Full optimizer offload only supports AdamW")
+    def full_optimizer_offload_requires_supported_optimizer(self):
+        if self.model.full_offload and self.optim.type not in ("adamw", "sign_sgd"):
+            raise ValueError("Full optimizer offload only supports AdamW and SignSGD")
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -55,19 +55,20 @@ class ActivationOffloadingConfig(BaseConfig):
 
 
 class OptimizerInBackwardOffloadConfig(BaseConfig):
-    """Full CPU optimizer offload: FP32 masters, moments, and accumulated gradients live in
-    CPU RAM, each optimizer chunk runs on CPU as soon as its last gradient arrives, and the
-    refreshed BF16 weights stream back while backward is still executing.
+    """Full CPU optimizer offload: FP32 masters, optimizer state (AdamW moments; SignSGD is
+    stateless), and accumulated gradients live in CPU RAM, each optimizer chunk runs on CPU as
+    soon as its last gradient arrives, and the refreshed BF16 weights stream back while backward
+    is still executing.
 
     Gradient numerics: gradients are reduced across ranks in FP32 (``reduce_dtype``) but FSDP2
     materializes them in the sharded parameter's dtype, which is BF16 for the offload compute
     model — so each gradient is rounded to BF16 once before the FP32 CPU update. Masters,
-    moments, accumulation, and Adam arithmetic remain FP32. For gradient numerics bit-faithful
-    to that path, disable offloading.
+    moments, accumulation, and optimizer arithmetic remain FP32. For gradient numerics
+    bit-faithful to that path, disable offloading.
     """
 
     cpu_optimizer_backend: Literal["native", "torch"] = "native"
-    """CPU AdamW implementation used by full offload. ``native`` is the production kernel; ``torch`` is a slower debugging and parity fallback."""
+    """CPU optimizer implementation used by full offload (AdamW or SignSGD). ``native`` is the production kernel; ``torch`` is a slower debugging and parity fallback."""
 
     numa_bind: bool = True
     """Pin each rank's CPUs to its GPU's NUMA node. Disable when the launcher already manages CPU affinity or GPU sysfs topology is unavailable."""
@@ -673,9 +674,9 @@ class TrainerConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
-    def full_optimizer_offload_requires_adamw(self):
-        if self.model.full_offload and self.optim.type != "adamw":
-            raise ValueError("Full optimizer offload only supports AdamW")
+    def full_optimizer_offload_requires_supported_optimizer(self):
+        if self.model.full_offload and self.optim.type not in ("adamw", "sign_sgd"):
+            raise ValueError("Full optimizer offload only supports AdamW and SignSGD")
         return self
 
     @model_validator(mode="after")

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -27,7 +27,8 @@ All entrypoints run via `uv run <command>` and accept TOML configs via `@ path/t
 - State-only optimizer offload remains enabled by default with `model.optim_cpu_offload = true`.
 - For gradients, FP32 masters, optimizer state, and optimizer-in-backward CPU execution, set
   `model.optim_cpu_offload = false` and `model.full_offload = true`. This mode uses the native
-  CPU AdamW kernel, only supports AdamW, and disables gradient clipping. Use a
+  CPU optimizer kernel, only supports AdamW and SignSGD (SignSGD is stateless and
+  halves the host RAM footprint), and disables gradient clipping. Use a
   `[model.full_offload]` table only to select the Torch debugging backend or disable NUMA binding.
 
 ## `rl` — RL training

--- a/src/prime_rl/trainer/optim/__init__.py
+++ b/src/prime_rl/trainer/optim/__init__.py
@@ -28,8 +28,8 @@ def setup_optimizer(
 ) -> tuple[OptimizerLike, GradientOffloadManager | None]:
     if cpu_offload and full_offload_config is not None:
         raise ValueError("State-only and full optimizer CPU offload cannot both be enabled")
-    if full_offload_config is not None and config.type != "adamw":
-        raise ValueError("Full optimizer offload only supports AdamW")
+    if full_offload_config is not None and config.type not in ("adamw", "sign_sgd"):
+        raise ValueError("Full optimizer offload only supports AdamW and SignSGD")
     if full_offload_config is not None and config.max_norm is not None:
         get_logger().warning("Disabling gradient clipping because CPU optimizer offload updates during backward")
         config.max_norm = None
@@ -43,7 +43,9 @@ def setup_optimizer(
         optimizer_named_params, master_weights = _create_cpu_master_weights(
             model,
             named_params,
-            pin_memory=not (config.type == "adamw" and full_offload_config.cpu_optimizer_backend == "native"),
+            pin_memory=not (
+                config.type in ("adamw", "sign_sgd") and full_offload_config.cpu_optimizer_backend == "native"
+            ),
             dtype_policy=full_offload_dtype_policy,
         )
 

--- a/src/prime_rl/trainer/optim/cpu_adam/__init__.py
+++ b/src/prime_rl/trainer/optim/cpu_adam/__init__.py
@@ -94,3 +94,21 @@ def adamw_step(
         eps,
         gradient_scale,
     )
+
+
+@torch.no_grad()
+def sign_sgd_step(
+    params: list[torch.Tensor],
+    grads: list[torch.Tensor],
+    compute_params: list[torch.Tensor] | None = None,
+    *,
+    lr: float,
+    weight_decay: float,
+) -> None:
+    _extension().sign_sgd_step(
+        params,
+        grads,
+        compute_params or [],
+        lr,
+        weight_decay,
+    )

--- a/src/prime_rl/trainer/optim/cpu_adam/kernel.cpp
+++ b/src/prime_rl/trainer/optim/cpu_adam/kernel.cpp
@@ -23,6 +23,16 @@ struct TensorSpan {
   float bias_correction2_sqrt;
 };
 
+struct SignSgdTensorSpan {
+  float* param;
+  const void* grad;
+  void* compute_param;
+  bool grad_bfloat16;
+  bool compute_param_bfloat16;
+  int64_t begin;
+  int64_t end;
+};
+
 struct BFloat16CopySpan {
   float* destination;
   const at::BFloat16* source;
@@ -324,6 +334,154 @@ void adamw_step(
   });
 }
 
+void sign_sgd_span(
+    const SignSgdTensorSpan& span,
+    int64_t begin,
+    int64_t end,
+    float minus_lr,
+    float minus_lr_weight_decay,
+    bool apply_weight_decay) {
+  using Vec = at::vec::Vectorized<float>;
+  using BVec = at::vec::Vectorized<at::BFloat16>;
+
+  float* param = span.param + begin;
+  const float* float_grad = span.grad_bfloat16 ? nullptr : static_cast<const float*>(span.grad) + begin;
+  const at::BFloat16* bfloat16_grad =
+      span.grad_bfloat16 ? static_cast<const at::BFloat16*>(span.grad) + begin : nullptr;
+  at::BFloat16* bfloat16_compute_param =
+      span.compute_param != nullptr && span.compute_param_bfloat16
+      ? static_cast<at::BFloat16*>(span.compute_param) + begin
+      : nullptr;
+  float* float_compute_param =
+      span.compute_param != nullptr && !span.compute_param_bfloat16
+      ? static_cast<float*>(span.compute_param) + begin
+      : nullptr;
+  const int64_t size = end - begin;
+
+  const Vec zero_vec(0.0f);
+  const Vec one_vec(1.0f);
+  const Vec minus_lr_vec(minus_lr);
+  const Vec minus_lr_weight_decay_vec(minus_lr_weight_decay);
+
+  auto update = [&](int64_t offset, const Vec& grad_vec) {
+    // Comparisons yield all-ones masks; bitwise-and with 1.0f turns them into
+    // {0.0f, 1.0f} so the difference is sign(g) with sign(0) == 0.
+    const Vec sign_vec = ((zero_vec < grad_vec) & one_vec) - ((grad_vec < zero_vec) & one_vec);
+    Vec param_vec = Vec::loadu(param + offset);
+    if (apply_weight_decay) {
+      param_vec = at::vec::fmadd(param_vec, minus_lr_weight_decay_vec, param_vec);
+    }
+    param_vec = at::vec::fmadd(sign_vec, minus_lr_vec, param_vec);
+    param_vec.store(param + offset);
+    return param_vec;
+  };
+
+  int64_t i = 0;
+  constexpr int64_t block_size = 2 * Vec::size();
+  for (; i <= size - block_size; i += block_size) {
+    Vec grad0;
+    Vec grad1;
+    if (span.grad_bfloat16) {
+      const BVec grad_bvec = BVec::loadu(bfloat16_grad + i);
+      std::tie(grad0, grad1) = at::vec::convert_to_float<at::BFloat16>(grad_bvec);
+    } else {
+      grad0 = Vec::loadu(float_grad + i);
+      grad1 = Vec::loadu(float_grad + i + Vec::size());
+    }
+    const Vec param0 = update(i, grad0);
+    const Vec param1 = update(i + Vec::size(), grad1);
+    if (bfloat16_compute_param != nullptr) {
+      at::vec::convert_from_float<at::BFloat16>(param0, param1).store(bfloat16_compute_param + i);
+    } else if (float_compute_param != nullptr) {
+      param0.store(float_compute_param + i);
+      param1.store(float_compute_param + i + Vec::size());
+    }
+  }
+
+  for (; i < size; ++i) {
+    const float grad_value = span.grad_bfloat16 ? static_cast<float>(bfloat16_grad[i]) : float_grad[i];
+    const float sign_value = grad_value > 0.0f ? 1.0f : (grad_value < 0.0f ? -1.0f : 0.0f);
+    float param_value = param[i];
+    if (apply_weight_decay) {
+      param_value = std::fma(param_value, minus_lr_weight_decay, param_value);
+    }
+    param_value = std::fma(sign_value, minus_lr, param_value);
+    param[i] = param_value;
+    if (bfloat16_compute_param != nullptr) {
+      bfloat16_compute_param[i] = at::BFloat16(param_value);
+    } else if (float_compute_param != nullptr) {
+      float_compute_param[i] = param_value;
+    }
+  }
+}
+
+void sign_sgd_step(
+    const std::vector<torch::Tensor>& params,
+    const std::vector<torch::Tensor>& grads,
+    const std::vector<torch::Tensor>& compute_params,
+    double lr,
+    double weight_decay) {
+  const auto count = params.size();
+  TORCH_CHECK(grads.size() == count, "grads and params must have the same length");
+  TORCH_CHECK(
+      compute_params.empty() || compute_params.size() == count,
+      "compute_params must be empty or have the same length as params");
+  if (count == 0) {
+    return;
+  }
+
+  std::vector<SignSgdTensorSpan> spans;
+  spans.reserve(count);
+  int64_t total_numel = 0;
+  for (size_t i = 0; i < count; ++i) {
+    check_tensor(params[i], "param");
+    check_grad(grads[i]);
+    TORCH_CHECK(params[i].numel() == grads[i].numel(), "grad shape must match param shape");
+    if (!compute_params.empty()) {
+      TORCH_CHECK(compute_params[i].device().is_cpu(), "compute_param must be on CPU");
+      TORCH_CHECK(
+          compute_params[i].scalar_type() == torch::kBFloat16 ||
+              compute_params[i].scalar_type() == torch::kFloat32,
+          "compute_param must be bfloat16 or float32");
+      TORCH_CHECK(compute_params[i].is_contiguous(), "compute_param must be contiguous");
+      TORCH_CHECK(params[i].numel() == compute_params[i].numel(), "compute_param shape must match param shape");
+    }
+
+    const int64_t numel = params[i].numel();
+    spans.push_back(SignSgdTensorSpan{
+        params[i].data_ptr<float>(),
+        grads[i].const_data_ptr(),
+        compute_params.empty() ? nullptr : compute_params[i].data_ptr(),
+        grads[i].scalar_type() == torch::kBFloat16,
+        !compute_params.empty() && compute_params[i].scalar_type() == torch::kBFloat16,
+        total_numel,
+        total_numel + numel,
+    });
+    total_numel += numel;
+  }
+
+  const float minus_lr = static_cast<float>(-lr);
+  const float minus_lr_weight_decay = static_cast<float>(-lr * weight_decay);
+  const bool apply_weight_decay = weight_decay > 0.0;
+  constexpr int64_t grain_size = 32 * 1024;
+
+  at::parallel_for(0, total_numel, grain_size, [&](int64_t begin, int64_t end) {
+    auto span_it = std::upper_bound(
+        spans.begin(),
+        spans.end(),
+        begin,
+        [](int64_t offset, const SignSgdTensorSpan& span) { return offset < span.end; });
+    while (begin < end) {
+      TORCH_INTERNAL_ASSERT(span_it != spans.end());
+      const int64_t span_begin = begin - span_it->begin;
+      const int64_t span_end = std::min(end, span_it->end) - span_it->begin;
+      sign_sgd_span(*span_it, span_begin, span_end, minus_lr, minus_lr_weight_decay, apply_weight_decay);
+      begin = std::min(end, span_it->end);
+      ++span_it;
+    }
+  });
+}
+
 }  // namespace
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
@@ -346,5 +504,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
       "adamw_step",
       &adamw_step,
       "Read-only-gradient multi-tensor CPU AdamW",
+      pybind11::call_guard<pybind11::gil_scoped_release>());
+  module.def(
+      "sign_sgd_step",
+      &sign_sgd_step,
+      "Read-only-gradient multi-tensor CPU SignSGD",
       pybind11::call_guard<pybind11::gil_scoped_release>());
 }

--- a/src/prime_rl/trainer/optim/offload.py
+++ b/src/prime_rl/trainer/optim/offload.py
@@ -20,6 +20,8 @@ from prime_rl.trainer.optim.cpu_adam import adamw_step as native_cpu_adamw_step
 from prime_rl.trainer.optim.cpu_adam import add_bfloat16_ as native_add_bfloat16_
 from prime_rl.trainer.optim.cpu_adam import copy_or_add_bfloat16_multi_ as native_copy_or_add_bfloat16_multi_
 from prime_rl.trainer.optim.cpu_adam import load_cpu_adamw_kernel
+from prime_rl.trainer.optim.cpu_adam import sign_sgd_step as native_cpu_sign_sgd_step
+from prime_rl.trainer.sign_sgd import SignSGD
 from prime_rl.utils.logger import get_logger
 
 
@@ -1089,6 +1091,8 @@ class FullCPUOffloadOptimizer(OffloadOptimizer):
         self._all_param_groups = self.optimizer.param_groups
         self._chunk_groups = self._build_chunk_groups()
         self._native_cpu_adamw = isinstance(optimizer, AdamW) and offload_config.cpu_optimizer_backend == "native"
+        self._native_cpu_sign_sgd = isinstance(optimizer, SignSGD) and offload_config.cpu_optimizer_backend == "native"
+        self._native_cpu_optimizer = self._native_cpu_adamw or self._native_cpu_sign_sgd
         self._fused_cpu_adamw = (
             isinstance(optimizer, AdamW)
             and all(group["fused"] for group in optimizer.param_groups)
@@ -1096,11 +1100,12 @@ class FullCPUOffloadOptimizer(OffloadOptimizer):
         )
         self._adamw_grad_scale = torch.ones((), dtype=torch.float32) if self._fused_cpu_adamw else None
         self._adamw_found_inf = torch.zeros((), dtype=torch.float32) if self._fused_cpu_adamw else None
-        if self._native_cpu_adamw:
-            get_logger().info("Loading native read-only-gradient multi-tensor CPU AdamW kernel")
+        if self._native_cpu_optimizer:
+            kernel_name = "AdamW" if self._native_cpu_adamw else "SignSGD"
+            get_logger().info(f"Loading native read-only-gradient multi-tensor CPU {kernel_name} kernel")
             load_cpu_adamw_kernel()
         gradient_chunks = [[master_weights[id(param)].model_param for param in chunk] for chunk in self._chunks]
-        if self._native_cpu_adamw:
+        if self._native_cpu_optimizer:
             gradient_dtypes = {id(master.model_param): master.gradient_dtype for master in master_weights.values()}
             compute_dtypes = {id(master.model_param): master.compute_dtype for master in master_weights.values()}
             self._gradient_manager = BoundedGradientOffloadManager(
@@ -1231,6 +1236,49 @@ class FullCPUOffloadOptimizer(OffloadOptimizer):
                 gradient_scale=self._gradient_manager.gradient_scale,
             )
 
+    def _step_native_cpu_sign_sgd_chunk(
+        self,
+        chunk_idx: int,
+        gradients: list[torch.Tensor | None],
+        compute_params: list[torch.Tensor],
+    ) -> None:
+        assert self._gradient_manager is not None
+        assert self._master_weights is not None
+        # The kernel consumes unscaled gradients: sign(scale * g) == sign(g) for scale > 0,
+        # so the positive gradient scale can be dropped entirely.
+        assert self._gradient_manager.gradient_scale > 0
+        gradient_by_param_id = {
+            id(param): gradient for param, gradient in zip(self._chunks[chunk_idx], gradients) if gradient is not None
+        }
+        compute_by_param_id = {
+            id(param): compute_param for param, compute_param in zip(self._chunks[chunk_idx], compute_params)
+        }
+        for param, gradient, compute_param in zip(self._chunks[chunk_idx], gradients, compute_params):
+            if gradient is None:
+                compute_param.copy_(self._master_weights[id(param)].cpu_tensor)
+        for group, params in self._chunk_groups[chunk_idx]:
+            params_with_grad = [param for param in params if id(param) in gradient_by_param_id]
+            if not params_with_grad:
+                continue
+            native_cpu_sign_sgd_step(
+                params_with_grad,
+                [gradient_by_param_id[id(param)] for param in params_with_grad],
+                [compute_by_param_id[id(param)] for param in params_with_grad],
+                lr=group["lr"],
+                weight_decay=group["weight_decay"],
+            )
+
+    def _step_native_cpu_chunk(
+        self,
+        chunk_idx: int,
+        gradients: list[torch.Tensor | None],
+        compute_params: list[torch.Tensor],
+    ) -> None:
+        if self._native_cpu_adamw:
+            self._step_native_cpu_adamw_chunk(chunk_idx, gradients, compute_params)
+        else:
+            self._step_native_cpu_sign_sgd_chunk(chunk_idx, gradients, compute_params)
+
     def _step_cpu_chunk(self, chunk_idx: int) -> None:
         assert self._gradient_manager is not None
         self._prepare_fused_cpu_adamw()
@@ -1238,19 +1286,19 @@ class FullCPUOffloadOptimizer(OffloadOptimizer):
             chunk_idx,
             self._chunks[chunk_idx],
             wait=False,
-            apply_scale=not (self._native_cpu_adamw or self._fused_cpu_adamw),
-            assign_grad=not self._native_cpu_adamw,
+            apply_scale=not (self._native_cpu_optimizer or self._fused_cpu_adamw),
+            assign_grad=not self._native_cpu_optimizer,
         )
-        if self._native_cpu_adamw:
+        if self._native_cpu_optimizer:
             if not isinstance(self._gradient_manager, BoundedGradientOffloadManager):
-                raise TypeError("Native CPU AdamW requires bounded gradient offload")
+                raise TypeError("Native CPU optimizers require bounded gradient offload")
             timings = self._gradient_manager._timings
             acquire_start = time.perf_counter()
             output_slots, compute_params = self._gradient_manager.acquire_output_chunk(chunk_idx)
-            adam_start = time.perf_counter()
-            timings["output_slot_wait"] = timings.get("output_slot_wait", 0.0) + adam_start - acquire_start
-            self._step_native_cpu_adamw_chunk(chunk_idx, gradients, compute_params)
-            timings["adam_kernel"] = timings.get("adam_kernel", 0.0) + time.perf_counter() - adam_start
+            kernel_start = time.perf_counter()
+            timings["output_slot_wait"] = timings.get("output_slot_wait", 0.0) + kernel_start - acquire_start
+            self._step_native_cpu_chunk(chunk_idx, gradients, compute_params)
+            timings["optimizer_kernel"] = timings.get("optimizer_kernel", 0.0) + time.perf_counter() - kernel_start
         else:
             self._step_chunk(chunk_idx)
         self._gradient_manager.release_chunk(chunk_idx, self._chunks[chunk_idx])
@@ -1258,9 +1306,9 @@ class FullCPUOffloadOptimizer(OffloadOptimizer):
             self._update_compute_weights(
                 chunk_idx,
                 self._h2d_stream,
-                compute_params if self._native_cpu_adamw else None,
+                compute_params if self._native_cpu_optimizer else None,
             )
-            if self._native_cpu_adamw:
+            if self._native_cpu_optimizer:
                 self._gradient_manager.release_output_chunk(output_slots, self._h2d_stream)
 
     def _prepare_fused_cpu_adamw(self) -> None:
@@ -1274,7 +1322,7 @@ class FullCPUOffloadOptimizer(OffloadOptimizer):
         self.optimizer.found_inf = self._adamw_found_inf
 
     def _record_native_optimizer_step(self) -> None:
-        if self._native_cpu_adamw:
+        if self._native_cpu_optimizer:
             # LRScheduler normally sets this marker through its optimizer.step wrapper.
             self.optimizer._opt_called = True
 
@@ -1302,16 +1350,16 @@ class FullCPUOffloadOptimizer(OffloadOptimizer):
                 self._gradient_manager.load_cpu_chunk(
                     i,
                     self._chunks[i],
-                    apply_scale=not (self._native_cpu_adamw or self._fused_cpu_adamw),
-                    assign_grad=not self._native_cpu_adamw,
+                    apply_scale=not (self._native_cpu_optimizer or self._fused_cpu_adamw),
+                    assign_grad=not self._native_cpu_optimizer,
                 )
             )
-        if self._native_cpu_adamw:
+        if self._native_cpu_optimizer:
             if not isinstance(self._gradient_manager, BoundedGradientOffloadManager):
-                raise TypeError("Native CPU AdamW requires bounded gradient offload")
+                raise TypeError("Native CPU optimizers require bounded gradient offload")
             for i in range(len(self._chunks)):
                 output_slots, compute_params = self._gradient_manager.acquire_output_chunk(i)
-                self._step_native_cpu_adamw_chunk(i, gradients_by_chunk[i], compute_params)
+                self._step_native_cpu_chunk(i, gradients_by_chunk[i], compute_params)
                 self._gradient_manager.release_chunk(i, self._chunks[i])
                 self._update_compute_weights(i, self._h2d_stream, compute_params)
                 self._gradient_manager.release_output_chunk(output_slots, self._h2d_stream)
@@ -1354,6 +1402,9 @@ class FullCPUOffloadOptimizer(OffloadOptimizer):
 
     @torch.no_grad()
     def _initialize_cpu_optimizer_state(self) -> None:
+        if isinstance(self.optimizer, SignSGD):
+            # SignSGD is stateless: no moments or step counters to materialize.
+            return
         if self.optimizer.state:
             return
         if self._native_cpu_adamw:
@@ -1439,9 +1490,9 @@ class FullCPUOffloadOptimizer(OffloadOptimizer):
     @torch.no_grad()
     def finish_checkpoint_load(self) -> None:
         if self._master_weights is not None:
-            if self._native_cpu_adamw:
+            if self._native_cpu_optimizer:
                 if not isinstance(self._gradient_manager, BoundedGradientOffloadManager):
-                    raise TypeError("Native CPU AdamW requires bounded gradient offload")
+                    raise TypeError("Native CPU optimizers require bounded gradient offload")
                 for i in range(len(self._chunks)):
                     output_slots, compute_params = self._gradient_manager.acquire_output_chunk(i)
                     for param, compute_param in zip(self._chunks[i], compute_params):

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -201,15 +201,27 @@ def test_full_optimizer_offload_accepts_debug_backend(config_cls):
 
 
 @pytest.mark.parametrize("config_cls", [TrainerConfig, SFTConfig])
-@pytest.mark.parametrize("optimizer_type", ["sgd", "muon", "sign_sgd"])
-def test_full_optimizer_offload_requires_adamw(config_cls, optimizer_type):
-    with pytest.raises(ValidationError, match="Full optimizer offload only supports AdamW"):
+@pytest.mark.parametrize("optimizer_type", ["sgd", "muon"])
+def test_full_optimizer_offload_requires_supported_optimizer(config_cls, optimizer_type):
+    with pytest.raises(ValidationError, match="Full optimizer offload only supports AdamW and SignSGD"):
         config_cls.model_validate(
             {
                 "model": {"optim_cpu_offload": False, "full_offload": True},
                 "optim": {"type": optimizer_type, "max_norm": None},
             }
         )
+
+
+@pytest.mark.parametrize("config_cls", [TrainerConfig, SFTConfig])
+def test_full_optimizer_offload_accepts_sign_sgd(config_cls):
+    config = config_cls.model_validate(
+        {
+            "model": {"optim_cpu_offload": False, "full_offload": True},
+            "optim": {"type": "sign_sgd", "max_norm": None},
+        }
+    )
+    assert config.model.full_offload is not None
+    assert config.optim.type == "sign_sgd"
 
 
 def test_resolved_json_roundtrips_explicit_none(tmp_path):

--- a/tests/unit/train/test_cpu_adam.py
+++ b/tests/unit/train/test_cpu_adam.py
@@ -5,8 +5,10 @@ from prime_rl.trainer.optim.cpu_adam import (
     add_bfloat16_,
     copy_bfloat16_,
     copy_or_add_bfloat16_multi_,
+    sign_sgd_step,
 )
 from prime_rl.trainer.optim.offload import _cast_full_offload_compute_parameters
+from prime_rl.trainer.sign_sgd import SignSGD
 
 
 def test_full_offload_preserves_per_parameter_compute_dtypes():
@@ -130,3 +132,43 @@ def test_native_cpu_adamw_matches_fused_torch_and_preserves_gradients():
         torch.testing.assert_close(exp_avgs[index], state["exp_avg"], rtol=1e-6, atol=1e-8)
         torch.testing.assert_close(exp_avg_sqs[index], state["exp_avg_sq"], rtol=1e-6, atol=1e-8)
         assert state_steps[index].item() == state["step"].item() == 5
+
+
+def test_native_cpu_sign_sgd_matches_python_reference():
+    torch.manual_seed(0)
+    # Sizes deliberately off vector-width multiples to exercise the scalar tail.
+    shapes = [(17,), (33, 65), (257, 129), (1000,)]
+    gradient_dtypes = [torch.bfloat16, torch.float32, torch.bfloat16, torch.float32]
+    compute_dtypes = [torch.bfloat16, torch.float32, torch.bfloat16, torch.bfloat16]
+    for weight_decay in (0.0, 0.1):
+        initial = [torch.randn(shape) for shape in shapes]
+        native_params = [tensor.clone() for tensor in initial]
+        reference_params = [torch.nn.Parameter(tensor.clone()) for tensor in initial]
+        compute_params = [torch.empty_like(tensor, dtype=dtype) for tensor, dtype in zip(native_params, compute_dtypes)]
+        reference = SignSGD(reference_params, lr=3e-4, weight_decay=weight_decay)
+        for iteration in range(1, 6):
+            gradient_scale = 1.0 / (iteration * 7 + 3)
+            gradients = []
+            for tensor, dtype in zip(native_params, gradient_dtypes):
+                gradient = torch.randn_like(tensor).to(dtype)
+                gradient.view(-1)[::7] = 0.0  # exercise sign(0) == 0
+                gradients.append(gradient)
+            # The reference sees scaled FP32 gradients; the native kernel consumes the raw
+            # unscaled gradients because sign(scale * g) == sign(g) for scale > 0.
+            for param, gradient in zip(reference_params, gradients):
+                param.grad = gradient.float() * gradient_scale
+            reference.step()
+            native_gradients = [gradient.clone() for gradient in gradients]
+            sign_sgd_step(
+                native_params,
+                native_gradients,
+                compute_params,
+                lr=3e-4,
+                weight_decay=weight_decay,
+            )
+            for actual, expected in zip(native_gradients, gradients):
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+            for native_param, reference_param in zip(native_params, reference_params):
+                torch.testing.assert_close(native_param, reference_param, rtol=0, atol=0)
+            for compute_param, native_param in zip(compute_params, native_params):
+                torch.testing.assert_close(compute_param, native_param.to(compute_param.dtype), rtol=0, atol=0)


### PR DESCRIPTION
**TL;DR**: `optim.type = "sign_sgd"` now works with `model.full_offload`, cutting the full-offload host RAM footprint from 16 to 8 B/param — for GLM-4.5-Air that is ~1.7 TiB → ~0.85 TiB of host RAM.

## Motivation

Full CPU optimizer offload with AdamW keeps, per parameter, in host RAM:

| Buffer | Bytes/param |
|---|---|
| FP32 master | 4 |
| FP32 `exp_avg` | 4 |
| FP32 `exp_avg_sq` | 4 |
| FP32 accumulated gradient | 4 |
| **AdamW total** | **16** |

SignSGD is stateless — no moments, no step counters — so it only needs the FP32 master and the FP32 accumulated gradient: **8 B/param, half the host RAM**. For GLM-4.5-Air (~110 B params) that is ~1.7 TiB → ~0.85 TiB per node.

## What changed

- **Native kernel** (`src/prime_rl/trainer/optim/cpu_adam/kernel.cpp`): new multi-tensor `sign_sgd_step` mirroring `adamw_step`'s span structure (`at::parallel_for`, 32k grain, BF16/FP32 gradients, BF16/FP32 compute-param write-out). Vectorized `sign(g)` is built from comparison masks (`((0 < g) & 1.0f) - ((g < 0) & 1.0f)`), so `sign(0) == 0` like `torch.sign`. Weight decay is applied only when `weight_decay > 0` and in the exact operation order of the python `SignSGD` (`p += p * (-lr*wd)` via fma, then `p -= lr * sign(g)`). Python wrapper `sign_sgd_step(params, grads, compute_params, *, lr, weight_decay)` in `cpu_adam/__init__.py`.
- **Gradient scale**: the kernel takes no `gradient_scale` — `sign(scale * g) == sign(g)` for `scale > 0`, so the positive scale is dropped (asserted where it is dropped). Gradient clipping is already disabled under full offload, so the scale is always positive.
- **`FullCPUOffloadOptimizer`** (`src/prime_rl/trainer/optim/offload.py`): a `_native_cpu_sign_sgd` flag parallels `_native_cpu_adamw`, and the pipeline plumbing (BoundedGradientOffloadManager selection, `load_cpu_chunk` `apply_scale`/`assign_grad`, output-slot acquire/release, sync fallback in `step()`, `finish_checkpoint_load`, scheduler `_opt_called` marker) now branches on the combined `_native_cpu_optimizer`. `_fused_cpu_adamw` stays AdamW-only.
- **Stateless checkpointing**: `_initialize_cpu_optimizer_state` skips state materialization entirely for SignSGD (both backends); checkpoints then carry only the FP32 masters under the `prime_rl_master_weight` key and round-trip through the existing DCP save/resume path.
- **Config**: trainer and SFT validators plus the `setup_optimizer` guard accept `sign_sgd`; native-backend masters stay pageable for sign_sgd like for AdamW. Docs (`docs/scaling.md`) and the `start-run` skill updated.

## Kernel parity test

`tests/unit/train/test_cpu_adam.py::test_native_cpu_sign_sgd_matches_python_reference` checks the native kernel against the python `SignSGD` reference stepping FP32 copies: BF16 and FP32 gradients mixed in one multi-tensor call, `weight_decay` 0 and 0.1, zeroed gradient elements (`sign(0) == 0`), and sizes off vector-width multiples to exercise the scalar tail — **bit-exact** (`rtol=0, atol=0`) over 5 steps, including the BF16/FP32 compute-param write-out. Ran on an AVX-512 Xeon:

```
uv run pytest tests/unit/train/test_cpu_adam.py -q        # 3 passed
uv run pytest tests/unit/test_configs.py -q -k "not test_load_configs"  # 54 passed (1 pre-existing env-plugin failure unrelated)
```

## Not yet validated

**No GPU end-to-end smoke has been run** — the dev box has no GPU. The maintainer is currently running a 4-node GLM-Air offload test and can validate the full pipeline there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the full-offload training hot path (native C++ kernel and optimizer-in-backward scheduling) for a memory-critical mode; mitigated by parity tests but GPU end-to-end offload is noted as not yet run in the PR.
> 
> **Overview**
> **SignSGD** can now be used with **`model.full_offload`** (`optim.type = "sign_sgd"`), not only AdamW. Because SignSGD has no optimizer moments, full offload needs **8 B/param** on the host (FP32 master + accumulated gradient) instead of **16 B/param** for AdamW.
> 
> A new **native multi-tensor `sign_sgd_step`** in the CPU extension mirrors the AdamW offload path: BF16/FP32 gradients, optional BF16/FP32 compute-param write-out, vectorized `sign(g)` with `sign(0) == 0`, and the same weight-decay ordering as the Python `SignSGD`. **`FullCPUOffloadOptimizer`** selects AdamW or SignSGD for the native kernel, skips materializing optimizer state for SignSGD on init/checkpoint, and drops gradient scaling in the SignSGD kernel (`sign(scale·g) == sign(g)`).
> 
> **Trainer/SFT validators** and **`setup_optimizer`** accept `sign_sgd` with full offload; **docs** (`scaling.md`) and the **start-run** skill describe SignSGD and the RAM tradeoff. **Tests** cover config acceptance and bit-exact native-vs-Python SignSGD parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76f624b962dbb37fd2e581acff0e471178c9b730. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->