### PR TITLE
fix: guard None raw tokens in logprobs detokenization

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -17,6 +17,7 @@ def apply_shared_vllm_patches():
     monkey_patch_return_routed_experts_with_nixl_connector()
     monkey_patch_kv_xfer_finished_tolerate_freed()
     monkey_patch_online_fp8_parameter_cast()
+    monkey_patch_detokenizer_none_raw_token()
 
 
 def monkey_patch_online_fp8_parameter_cast():
@@ -787,3 +788,29 @@ def monkey_patch_dp_coordinator_startup_timeout():
             zmq_addr_pipe.close()
 
     DPCoordinator._wait_for_zmq_addrs = _patched_wait_for_zmq_addrs
+
+
+def monkey_patch_detokenizer_none_raw_token():
+    """Tolerate ``None`` raw tokens in logprobs detokenization.
+
+    ``tokenizer.convert_ids_to_tokens`` returns ``None`` for ids outside the
+    tokenizer vocabulary. Models whose embedding matrix is padded past the
+    tokenizer (e.g. R1-Distill-Qwen) can sample such ids, and
+    ``convert_ids_list_to_tokens`` guards the decoded string (``or ""``) but
+    not the raw piece — ``_restore_leading_spaces`` then iterates ``None`` and
+    the ``TypeError`` kills the AsyncLLM output loop, taking the whole API
+    server down with it.
+    """
+    from vllm.tokenizers import detokenizer_utils
+
+    original = detokenizer_utils._restore_leading_spaces
+    if getattr(original, "_prime_rl_none_guard", False):
+        return
+
+    def _restore_leading_spaces(raw_token, token_str, marker):
+        if raw_token is None:
+            return token_str
+        return original(raw_token, token_str, marker)
+
+    _restore_leading_spaces._prime_rl_none_guard = True
+    detokenizer_utils._restore_leading_spaces = _restore_leading_spaces


### PR DESCRIPTION
## Summary
- `tokenizer.convert_ids_to_tokens` returns `None` for token ids outside the tokenizer vocabulary. Models whose embedding matrix is padded past the tokenizer (e.g. `R1-Distill-Qwen`) can sample such ids.
- `convert_ids_list_to_tokens` guards the decoded string (`or ""`) but not the raw piece: `_restore_leading_spaces` iterates `None`, and the `TypeError` kills the AsyncLLM output loop — the API server shuts down and every in-flight request on it fails.
- Add a `None` guard via `apply_shared_vllm_patches` (the `vllm.general_plugins` entry point), returning the decoded string unchanged.

## Verification
Observed as recurring `Process ApiServer_N died with exit code None` crashes on three different nodes during sustained R1-Distill-Qwen-1.5B sampling (adaptive-concurrency e2e runs), each preceded by this traceback in `inference.log`. The same workload is running under the patch; no recurrence so far (crashes previously recurred within tens of minutes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
