### PR TITLE
chore: bump workflow actions to latest versions

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -146,7 +146,7 @@ jobs:
         id: artifact
         run: echo "name=benchmark-${{ matrix.runner }}-$(echo '${{ matrix.model }}' | sed 's/\//--/')-${{ matrix.type }}-${{ matrix.lora_rank || 'full' }}-${{ matrix.num_gpus }}gpu-${{ matrix.ac }}-${{ matrix.attention }}-${{ matrix.seq_len }}-cp${{ matrix.cp }}-ep${{ matrix.ep }}" >> "$GITHUB_OUTPUT"
       - name: Upload benchmark result
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ${{ steps.artifact.outputs.name }}
@@ -163,16 +163,16 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository # We can't use the image because then no git
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Install dependencies
         run: uv sync
       - name: Download all benchmark artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/benchmark_artifacts
           pattern: benchmark-*

--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -103,7 +103,7 @@ jobs:
           esac
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ env.BUILD_REF }}
           fetch-depth: 0
@@ -170,7 +170,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.ref }}
           fetch-depth: 0

--- a/.github/workflows/cpu_tests.yaml
+++ b/.github/workflows/cpu_tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: false
       - name: Init public submodules
@@ -20,7 +20,7 @@ jobs:
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           git submodule update --init --recursive -- deps/verifiers deps/renderers deps/prime-envs deps/pydantic-config
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/devx_tag.yaml
+++ b/.github/workflows/devx_tag.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create next .dev tag from latest release
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -26,7 +26,7 @@ jobs:
           apt-get install -y git
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: false
       - name: Init public submodules
@@ -34,7 +34,7 @@ jobs:
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           git submodule update --init --recursive -- deps/verifiers deps/renderers deps/prime-envs deps/pydantic-config
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
       - name: Install dependencies
         run: uv sync --all-extras --all-packages --locked
       - name: Run unit tests
@@ -94,7 +94,7 @@ jobs:
           apt-get install -y git
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: false
       - name: Init public submodules
@@ -102,7 +102,7 @@ jobs:
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           git submodule update --init --recursive -- deps/verifiers deps/renderers deps/prime-envs deps/pydantic-config
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
       - name: Install dependencies
         run: uv sync --all-extras --all-packages --locked
       - name: Run integration tests
@@ -120,7 +120,7 @@ jobs:
         run: uv run pytest -vvs ${{ matrix.pytest_args }}
       - name: Upload run logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.test }}-logs
           path: /tmp/outputs/**/*.log

--- a/.github/workflows/nightly-fft.yaml
+++ b/.github/workflows/nightly-fft.yaml
@@ -31,7 +31,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
               with:
                   submodules: false
 
@@ -70,7 +70,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
               with:
                   submodules: false
 
@@ -159,7 +159,7 @@ jobs:
                   echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: astral-sh/setup-uv@v10.0.1
 
             - name: Install prime CLI (latest)
               run: uv tool install prime

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -23,7 +23,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
               with:
                   submodules: false
 
@@ -73,7 +73,7 @@ jobs:
                   apt-get install -y git
                   git config --global --add safe.directory "$GITHUB_WORKSPACE"
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
               with:
                   submodules: false
             - name: Init public submodules
@@ -81,7 +81,7 @@ jobs:
                   git config --global url."https://github.com/".insteadOf "git@github.com:"
                   git submodule update --init --recursive -- deps/verifiers deps/renderers deps/prime-envs deps/pydantic-config
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: astral-sh/setup-uv@v10.0.1
               with:
                   enable-cache: true
                   cache-dependency-glob: "uv.lock"

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         # Submodules are excluded from ruff via pyproject.toml; no need to fetch them.
         with:
           submodules: false
       - name: Run ruff
         uses: astral-sh/ruff-action@v4.1.0
         with:
-          version: "0.13.0"
+          version: "0.15.14"
           args: "check --config=pyproject.toml"
       - name: Run ruff format (check)
         uses: astral-sh/ruff-action@v4.1.0
         with:
-          version: "0.13.0"
+          version: "0.15.14"
           args: "format --check --config=pyproject.toml"

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -10,7 +10,7 @@ jobs:
   trigger-docs-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Validate mint.json pages exist
         run: |

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -29,7 +29,7 @@ jobs:
       version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -148,14 +148,14 @@ jobs:
     steps:
       - name: Checkout tagged release (dispatch)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: refs/tags/${{ inputs.tag }}
 
       - name: Checkout tagged release (push)
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

- Bump all workflow actions to their latest majors: `actions/checkout` v5 → v7, `astral-sh/setup-uv` v7 → v10.0.1, `actions/upload-artifact` v4/v5 → v7, `actions/download-artifact` v6 → v8, `actions/github-script` v8 → v9.
- Sync the CI ruff pin with `uv.lock`: 0.13.0 → 0.15.14, so CI lints with the same ruff as `uv run ruff` locally.
- `docker/login-action@v4`, `docker/setup-buildx-action@v4`, `docker/build-push-action@v7`, `peter-evans/repository-dispatch@v4`, and `astral-sh/ruff-action@v4.1.0` are already on their latest majors and stay as-is.

Notes on compatibility, checked against each major's release notes:

- The new majors run on node24 and need runner ≥ 2.327.1. All our self-hosted runners (GPU fleet, `research-cluster`, build dispatchers) are on 2.336.0.
- `setup-uv` stopped publishing floating major tags with v8 (supply-chain hardening), so it is pinned to the exact release `v10.0.1`. Its other breaking changes (cache pruning default, cache disabled on `pull_request_target`/`workflow_run`/`release`) don't apply to our triggers.
- `github-script` v9 only breaks scripts that `require('@actions/github')`; the devx-tag script doesn't.
- `checkout` v7 blocks fork-PR checkout for `pull_request_target`/`workflow_run` events, which we don't use.

## Verification

- `uv run ruff check` and `uv run ruff format --check` pass locally under the locked ruff 0.15.14.
- `actionlint` is clean on the edited workflows (only pre-existing warnings about custom self-hosted runner labels).
- Style, CPU Tests, and GPU Tests (incl. `upload-artifact@v7` on the self-hosted fleet) run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 235074a373c237fc72b31c9cf6ca09c6ac4e7f2f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->