### PR TITLE
feat: support Qwen3.8

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/utils/parsers.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/parsers.py
@@ -16,8 +16,8 @@ TOOL_CALL_PARSER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^PrimeIntellect/INTELLECT-3"), "qwen3_coder"),
     (re.compile(r"^nvidia/NVIDIA-Nemotron-3"), "qwen3_coder"),
     (re.compile(r"^stepfun-ai/Step-3\.5"), "step3p5"),
-    # Qwen3.5 and Qwen3-Coder use qwen3_coder — must be before the Qwen3 catch-all.
-    (re.compile(r"^Qwen/Qwen3\.5-"), "qwen3_coder"),
+    # Qwen3.5/3.6/3.8 and Qwen3-Coder use qwen3_coder — must be before the Qwen3 catch-all.
+    (re.compile(r"^Qwen/Qwen3\.(5|6|8)-"), "qwen3_coder"),
     (re.compile(r"^Qwen/Qwen3-Coder"), "qwen3_coder"),
     (re.compile(r"^Qwen/Qwen3-"), "hermes"),
 ]
@@ -37,7 +37,7 @@ REASONING_PARSER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^stepfun-ai/Step-3\.5"), "step3p5"),
     # Only Qwen3 Thinking models reason — Instruct/base models do not.
     (re.compile(r"^Qwen/Qwen3-.*Thinking"), "deepseek_r1"),
-    (re.compile(r"^Qwen/Qwen3\.5-"), "qwen3"),
+    (re.compile(r"^Qwen/Qwen3\.(5|6|8)-"), "qwen3"),
 ]
 
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -567,11 +567,6 @@ def get_model(
 
     is_vlm_training = config.vlm is not None
 
-    if "Qwen3.5" in config.name or "qwen3_5" in config.name.lower():
-        _patch_qwen3_5_text_position_ids()
-        _patch_qwen3_5_moe_conversion_mapping()
-        _patch_qwen3_5_linear_attn_varlen()
-
     model_config = cast(
         PretrainedConfig,
         AutoConfig.from_pretrained(
@@ -602,8 +597,8 @@ def get_model(
 
         _hub_kernels._kernels_enabled = True
 
-    # Fallback Qwen3.5 patch detection from loaded config model_type
-    if getattr(model_config, "model_type", "").startswith("qwen3_5_moe"):
+    # Qwen3.6 and Qwen3.8 reuse the Qwen3.5 architecture, so match on model_type, not repo name.
+    if getattr(model_config, "model_type", "").startswith("qwen3_5"):
         _patch_qwen3_5_text_position_ids()
         _patch_qwen3_5_moe_conversion_mapping()
         _patch_qwen3_5_linear_attn_varlen()

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -89,6 +89,13 @@ EXPECTED_PARSERS: list[tuple[str, str | None, str | None]] = [
     ("Qwen/Qwen3.5-35B-A3B", "qwen3_coder", "qwen3"),
     ("Qwen/Qwen3.5-122B-A10B", "qwen3_coder", "qwen3"),
     ("Qwen/Qwen3.5-397B-A17B", "qwen3_coder", "qwen3"),
+    # Qwen3.6
+    ("Qwen/Qwen3.6-35B-A3B", "qwen3_coder", "qwen3"),
+    # Qwen3.8
+    ("Qwen/Qwen3.8-27B", "qwen3_coder", "qwen3"),
+    ("Qwen/Qwen3.8-27B-FP8", "qwen3_coder", "qwen3"),
+    ("Qwen/Qwen3.8-2.4T-A95B", "qwen3_coder", "qwen3"),
+    ("Qwen/Qwen3.8-2.4T-A95B-FP8", "qwen3_coder", "qwen3"),
     # Unknown model
     ("some/unknown-model", None, None),
 ]


### PR DESCRIPTION
## Summary

Qwen3.8 reuses the Qwen3.5 architecture verbatim — the dense `Qwen/Qwen3.8-27B` reports `model_type: qwen3_5` / `architectures: ["Qwen3_5ForConditionalGeneration"]`, and `Qwen/Qwen3.8-2.4T-A95B` reports `qwen3_5_moe_text`. The custom trainer implementations (`trainer/models/qwen3_5/`, `trainer/models/qwen3_5_moe/`) are fully config-driven and the VLM registry already keys on `qwen3_5`, so the weights load as-is. The two places that *enable* Qwen3.5 keyed off the repo name instead of the architecture, so neither picked Qwen3.8 up.

## Trainer: gate the Qwen3.5 patches on `model_type`

`get_model` decided whether to apply the three Qwen3.5 patches from `"Qwen3.5" in config.name`, with a fallback that only matched `model_type.startswith("qwen3_5_moe")`. `Qwen/Qwen3.8-27B` matched neither, so the dense 27B would have trained with all three skipped — most importantly `_patch_qwen3_5_linear_attn_varlen`, without which GatedDeltaNet never receives `cu_seqlens`, conv/SSM state leaks across packed sequences (~0.23 mismatch KL vs vLLM per that patch's docstring), and 48 of the 27B's 64 layers are linear attention. Silent, and fatal for RL.

Keying on the loaded config's `model_type` prefix collapses the two checks into one and also covers Qwen3.6 and renamed fine-tunes, which the name check missed as well. The patches now run after `AutoConfig.from_pretrained` but still well before the model is instantiated and weights are loaded, which is all the conversion-mapping and `forward` patches require.

## Parsers: cover the dotted Qwen3.x names

`^Qwen/Qwen3\.5-` doesn't match `Qwen/Qwen3.8-27B`, and the `^Qwen/Qwen3-` catch-all only matches the hyphenated names, so `tool_call_parser` and `reasoning_parser` both auto-resolved to `None` and vLLM launched with neither flag. Qwen3.8's chat template opens `<think>\n` at the generation prompt, so reasoning would land in `content` and tool calls would go unparsed — silent reward breakage on agentic envs. vLLM's own recipe for the model asks for `--tool-call-parser qwen3_coder --reasoning-parser qwen3`, which is what these patterns now resolve to.

This fixes the identical hole for **Qwen3.6**, which has a parity-tested renderer in `renderers` but also resolved to `None` on both parsers.


## Tests

`tests/unit/test_parsers.py` gains rows for Qwen3.6 and the four Qwen3.8 checkpoints; 149 tests pass locally. The trainer change is runtime glue that needs a GPU + real checkpoint, so it's unverified beyond review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches trainer model-load patch gating for linear attention / packed sequences; a wrong `model_type` match would skip or apply those patches incorrectly. Parser auto-resolution also affects vLLM tool/reasoning parsing for these models.
> 
> **Overview**
> Enables Qwen3.6 and Qwen3.8 (which reuse the Qwen3.5 `model_type`) so trainer patches and vLLM parsers actually apply.
> 
> `get_model` now applies the Qwen3.5 position-id, MoE conversion, and linear-attn varlen patches when `model_type` starts with `qwen3_5`, instead of matching `"Qwen3.5"` in the repo name (with a MoE-only fallback). That was skipping the packed-sequence GatedDeltaNet fix on dense Qwen3.8.
> 
> Tool-call and reasoning parser regexes now match `Qwen/Qwen3.(5|6|8)-` so these models resolve to `qwen3_coder` / `qwen3` instead of `None`. Parser tests cover Qwen3.6 and the Qwen3.8 checkpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e5d092e21318e0d7ef42d59c81c6eddf9d76374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->