### PR TITLE
feat: rank-parallel sharded save for filesystem broadcast

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -569,12 +569,6 @@ class BaseWeightBroadcastConfig(BaseConfig):
 class FileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
     type: Literal["filesystem"] = "filesystem"
 
-    save_sharded: bool = True
-    """Save the weight checkpoint in sharded format."""
-
-    save_format: Literal["safetensors", "torch"] = "safetensors"
-    """Weight checkpoint serialization format."""
-
 
 class InMemoryWeightBroadcastConfig(BaseWeightBroadcastConfig):
     host: str = "localhost"

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -1,5 +1,4 @@
 import json
-import re
 import warnings
 from pathlib import Path
 from typing import Literal, cast
@@ -141,20 +140,28 @@ def resolve_fqn(model: nn.Module, key: str) -> str:
     return next(iter(fqns))
 
 
-_LAYER_RE = re.compile(r"^(.*?\blayers\.\d+)\.")
+def _layer_prefixes(model: nn.Module) -> list[str]:
+    """FQN prefixes of the model's decoder blocks: the children of every ``layers``
+    ModuleList. state-dict keys and module names come from the same tree traversal,
+    so the prefixes match keys verbatim, wrapper components and all."""
+    prefixes: list[str] = []
+    for name, module in model.named_modules():
+        if isinstance(module, nn.ModuleList) and name.rsplit(".", 1)[-1] == "layers":
+            prefixes.extend(f"{name}.{i}." for i in range(len(module)))
+    return prefixes
 
 
-def partition_weights(state_dict: dict[str, Tensor], world_size: int, dtype: torch.dtype) -> dict[str, int]:
+def partition_weights(model: nn.Module, world_size: int, dtype: torch.dtype) -> dict[str, int]:
     """Assign each state-dict key an owner rank, balanced by byte size.
 
     All keys of one decoder layer share an owner, so per-rank prime->HF conversion
     (which stacks/unstacks tensors within a layer) always sees complete layers.
     """
+    prefixes = _layer_prefixes(model)
     key_to_unit: dict[str, str] = {}
     unit_bytes: dict[str, int] = {}
-    for key, value in state_dict.items():
-        match = _LAYER_RE.match(key)
-        unit = match.group(1) if match else ""
+    for key, value in model.state_dict().items():
+        unit = next((prefix for prefix in prefixes if key.startswith(prefix)), "")
         key_to_unit[key] = unit
         itemsize = dtype.itemsize if isinstance(value, DTensor) else value.element_size()
         unit_bytes[unit] = unit_bytes.get(unit, 0) + value.numel() * itemsize
@@ -177,7 +184,7 @@ def gather_weights_parallel(model: nn.Module, dtype: torch.dtype = torch.bfloat1
     plain blocking transfers; no stream-ordering assumptions.
     """
     world = get_world()
-    owners = partition_weights(model.state_dict(), world.world_size, dtype)
+    owners = partition_weights(model, world.world_size, dtype)
     partial: dict[str, Tensor] = {}
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=FutureWarning, module="torch.distributed")

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -212,6 +212,12 @@ def save_state_dict_parallel(state_dict: dict[str, Tensor], save_dir: Path) -> N
     logger = get_logger()
     world = get_world()
 
+    # Master-only mkdir + barrier: concurrent mkdir from every rank can re-raise
+    # FileExistsError on a parallel FS (EEXIST + stale is_dir()).
+    if world.is_master:
+        save_dir.mkdir(parents=True, exist_ok=True)
+    dist.barrier()
+
     tmp_pattern = f"tmp-rank{world.rank}{{suffix}}.safetensors"
     split = split_torch_state_dict_into_shards(state_dict, filename_pattern=tmp_pattern)
     local_shards: list[tuple[str, dict[str, int]]] = []

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -117,13 +117,25 @@ def convert_state_dict_to_hf(model: nn.Module, state_dict: dict[str, Tensor]) ->
     """
     full_keys = dict.fromkeys(resolve_fqn(model, key) for key in model.state_dict().keys())
     if isinstance(model, PreTrainedModelPrimeRL) and model.is_prime_state_dict(full_keys):
+        # PrimeRL custom model holding weights in prime format: apply the model's
+        # declarative prime->HF conversion chain (renames, expert stack/unstack).
         return model.convert_to_hf(state_dict)
-    from transformers.core_model_loading import revert_weight_conversion
+    else:
+        # Plain transformers model: undo the key renames transformers applied when
+        # it loaded the HF checkpoint.
+        from transformers.core_model_loading import revert_weight_conversion
 
-    return revert_weight_conversion(model, state_dict)
+        return revert_weight_conversion(model, state_dict)
 
 
 def resolve_fqn(model: nn.Module, key: str) -> str:
+    """Resolve a state-dict key to the parameter's canonical fully-qualified name.
+
+    Strips wrapper prefixes that training composes onto module paths, e.g. with
+    ``torch.compile`` the key ``model._orig_mod.layers.0.self_attn.q_proj.weight``
+    resolves to ``model.layers.0.self_attn.q_proj.weight`` — the name the tensor
+    has in the HF checkpoint.
+    """
     fqns = get_fqns(model, key)
     assert len(fqns) == 1
     return next(iter(fqns))

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -1,9 +1,11 @@
 import json
+import re
 import warnings
 from pathlib import Path
 from typing import Literal, cast
 
 import torch
+import torch.distributed as dist
 from huggingface_hub import split_torch_state_dict_into_shards
 from safetensors import safe_open
 from safetensors.torch import save_file
@@ -22,6 +24,8 @@ from transformers.utils import (
 from prime_rl.trainer.lora import (
     clean_lora_state_dict,
 )
+from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
 
 
@@ -103,6 +107,144 @@ def save_state_dict(
             save_file(state_dict, save_dir / weights_name, metadata={"format": "pt"})
         else:
             torch.save(state_dict, save_dir / weights_name)
+
+
+def convert_state_dict_to_hf(model: nn.Module, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+    """Convert a (possibly rank-partial) training-format state dict to HF hub format.
+
+    Format detection uses the model's full key set, so a partial dict (one rank's
+    slice) converts the same way as the full state dict would.
+    """
+    full_keys = dict.fromkeys(resolve_fqn(model, key) for key in model.state_dict().keys())
+    if isinstance(model, PreTrainedModelPrimeRL) and model.is_prime_state_dict(full_keys):
+        return model.convert_to_hf(state_dict)
+    from transformers.core_model_loading import revert_weight_conversion
+
+    return revert_weight_conversion(model, state_dict)
+
+
+def resolve_fqn(model: nn.Module, key: str) -> str:
+    fqns = get_fqns(model, key)
+    assert len(fqns) == 1
+    return next(iter(fqns))
+
+
+_LAYER_RE = re.compile(r"^(.*?\blayers\.\d+)\.")
+
+# Pinned staging buffers for gather_weights_parallel, keyed by FQN. They persist
+# across saves so the D2H copies never re-pin memory (pinning is slow); each rank
+# holds roughly model_size / world_size bytes.
+_staging_buffers: dict[str, Tensor] = {}
+
+
+def partition_weights(state_dict: dict[str, Tensor], world_size: int, dtype: torch.dtype) -> dict[str, int]:
+    """Assign each state-dict key an owner rank, balanced by byte size.
+
+    All keys of one decoder layer share an owner, so per-rank prime->HF conversion
+    (which stacks/unstacks tensors within a layer) always sees complete layers.
+    """
+    key_to_unit: dict[str, str] = {}
+    unit_bytes: dict[str, int] = {}
+    for key, value in state_dict.items():
+        match = _LAYER_RE.match(key)
+        unit = match.group(1) if match else ""
+        key_to_unit[key] = unit
+        itemsize = dtype.itemsize if isinstance(value, DTensor) else value.element_size()
+        unit_bytes[unit] = unit_bytes.get(unit, 0) + value.numel() * itemsize
+    loads = [0] * world_size
+    unit_owner: dict[str, int] = {}
+    for unit in sorted(unit_bytes, key=lambda unit: (-unit_bytes[unit], unit)):
+        owner = min(range(world_size), key=lambda rank: loads[rank])
+        unit_owner[unit] = owner
+        loads[owner] += unit_bytes[unit]
+    return {key: unit_owner[unit] for key, unit in key_to_unit.items()}
+
+
+def gather_weights_parallel(model: nn.Module, dtype: torch.dtype = torch.bfloat16) -> dict[str, Tensor]:
+    """Gather distributed weights cooperatively, each rank keeping a slice on CPU.
+
+    Every rank participates in the per-tensor all-gathers (a ``full_tensor`` call is
+    collective and materializes the full tensor on all ranks anyway), but instead of
+    only the master keeping everything, each rank copies its owned slice into pinned
+    CPU buffers with non-blocking copies that overlap subsequent gathers.
+    """
+    world = get_world()
+    owners = partition_weights(model.state_dict(), world.world_size, dtype)
+    partial: dict[str, Tensor] = {}
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning, module="torch.distributed")
+        warnings.filterwarnings("ignore", category=UserWarning, module="torch.distributed.*")
+
+        for key, value in model.state_dict().items():
+            if isinstance(value, DTensor):
+                # only gather after the downcast to dtype as it will be faster
+                value = cast(DTensor, value.to(dtype)).full_tensor()
+            if owners[key] != world.rank:
+                continue
+            fqn = resolve_fqn(model, key)
+            if value.is_cuda:
+                buffer = _staging_buffers.get(fqn)
+                if buffer is None or buffer.shape != value.shape or buffer.dtype != value.dtype:
+                    buffer = torch.empty_like(value, device="cpu", pin_memory=True)
+                    _staging_buffers[fqn] = buffer
+                buffer.copy_(value, non_blocking=True)
+                partial[fqn] = buffer
+            else:
+                partial[fqn] = value
+        torch.cuda.synchronize()
+        dist.barrier()
+
+    if any(".base_layer." in key or "lora_A" in key or "lora_B" in key for key in partial.keys()):
+        raise ValueError("gather_weights_parallel does not support LoRA state dicts")
+
+    return partial
+
+
+def save_state_dict_parallel(state_dict: dict[str, Tensor], save_dir: Path) -> None:
+    """Cooperatively save a rank-partitioned state dict as sharded safetensors.
+
+    Each rank splits its slice into <=5GB shards and writes them under temporary
+    names, shard maps are exchanged, and every rank renames its own files into the
+    global numbering (non-POSIX shared filesystems cannot reliably rename another
+    rank's unpublished writes). Master writes the index last, after the barrier, so
+    a complete index implies complete shards.
+    """
+    logger = get_logger()
+    world = get_world()
+
+    tmp_pattern = f"tmp-rank{world.rank}{{suffix}}.safetensors"
+    split = split_torch_state_dict_into_shards(state_dict, filename_pattern=tmp_pattern)
+    local_shards: list[tuple[str, dict[str, int]]] = []
+    for tmp_name, tensor_names in split.filename_to_tensors.items():
+        if not tensor_names:
+            continue
+        shard = {name: state_dict[name].contiguous() for name in tensor_names}
+        save_file(shard, save_dir / tmp_name, metadata={"format": "pt"})
+        local_shards.append((tmp_name, {name: shard[name].nbytes for name in tensor_names}))
+
+    all_shards: list[list[tuple[str, dict[str, int]]] | None] = [None] * world.world_size
+    dist.all_gather_object(all_shards, local_shards)
+    flat = [(rank, tmp_name, sizes) for rank, shards in enumerate(all_shards) for tmp_name, sizes in shards]
+
+    num_shards = len(flat)
+    weight_map: dict[str, str] = {}
+    for index, (rank, tmp_name, sizes) in enumerate(flat, start=1):
+        if num_shards == 1:
+            final_name = SAFE_WEIGHTS_NAME
+        else:
+            final_name = SAFE_WEIGHTS_NAME.replace(".safetensors", f"-{index:05d}-of-{num_shards:05d}.safetensors")
+        for name in sizes:
+            weight_map[name] = final_name
+        if rank == world.rank:
+            (save_dir / tmp_name).rename(save_dir / final_name)
+    logger.debug(f"Saved {num_shards} weight shards across {world.world_size} ranks")
+
+    dist.barrier()
+    if world.is_master and num_shards > 1:
+        total_size = sum(size for _, _, sizes in flat for size in sizes.values())
+        index_json = {"metadata": {"total_size": total_size}, "weight_map": weight_map}
+        with open(save_dir / SAFE_WEIGHTS_INDEX_NAME, "w", encoding="utf-8") as f:
+            f.write(json.dumps(index_json, indent=2, sort_keys=True) + "\n")
 
 
 def gather_weights_on_master(

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -187,6 +187,12 @@ def gather_weights_parallel(model: nn.Module, dtype: torch.dtype = torch.bfloat1
                 if buffer is None or buffer.shape != value.shape or buffer.dtype != value.dtype:
                     buffer = torch.empty_like(value, device="cpu", pin_memory=True)
                     _staging_buffers[fqn] = buffer
+                # Dropping the GPU temp before this copy completes is safe only
+                # because everything stays on the current stream: the caching
+                # allocator reuses freed blocks per-stream, so later gathers
+                # writing into recycled storage are ordered after this read. If
+                # these copies ever move to a side stream, hold the refs until
+                # the synchronize (or use Tensor.record_stream).
                 buffer.copy_(value, non_blocking=True)
                 partial[fqn] = buffer
             else:

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -143,11 +143,6 @@ def resolve_fqn(model: nn.Module, key: str) -> str:
 
 _LAYER_RE = re.compile(r"^(.*?\blayers\.\d+)\.")
 
-# Pinned staging buffers for gather_weights_parallel, keyed by FQN. They persist
-# across saves so the D2H copies never re-pin memory (pinning is slow); each rank
-# holds roughly model_size / world_size bytes.
-_staging_buffers: dict[str, Tensor] = {}
-
 
 def partition_weights(state_dict: dict[str, Tensor], world_size: int, dtype: torch.dtype) -> dict[str, int]:
     """Assign each state-dict key an owner rank, balanced by byte size.
@@ -177,8 +172,9 @@ def gather_weights_parallel(model: nn.Module, dtype: torch.dtype = torch.bfloat1
 
     Every rank participates in the per-tensor all-gathers (a ``full_tensor`` call is
     collective and materializes the full tensor on all ranks anyway), but instead of
-    only the master keeping everything, each rank copies its owned slice into pinned
-    CPU buffers with non-blocking copies that overlap subsequent gathers.
+    only the master keeping everything, each rank copies its owned slice to CPU —
+    so the D2H traffic and the shard writes are split across ranks. The copies are
+    plain blocking transfers; no stream-ordering assumptions.
     """
     world = get_world()
     owners = partition_weights(model.state_dict(), world.world_size, dtype)
@@ -193,23 +189,7 @@ def gather_weights_parallel(model: nn.Module, dtype: torch.dtype = torch.bfloat1
                 value = cast(DTensor, value.to(dtype)).full_tensor()
             if owners[key] != world.rank:
                 continue
-            fqn = resolve_fqn(model, key)
-            if value.is_cuda:
-                buffer = _staging_buffers.get(fqn)
-                if buffer is None or buffer.shape != value.shape or buffer.dtype != value.dtype:
-                    buffer = torch.empty_like(value, device="cpu", pin_memory=True)
-                    _staging_buffers[fqn] = buffer
-                # Dropping the GPU temp before this copy completes is safe only
-                # because everything stays on the current stream: the caching
-                # allocator reuses freed blocks per-stream, so later gathers
-                # writing into recycled storage are ordered after this read. If
-                # these copies ever move to a side stream, hold the refs until
-                # the synchronize (or use Tensor.record_stream).
-                buffer.copy_(value, non_blocking=True)
-                partial[fqn] = buffer
-            else:
-                partial[fqn] = value
-        torch.cuda.synchronize()
+            partial[resolve_fqn(model, key)] = value.to("cpu")
         dist.barrier()
 
     if any(".base_layer." in key or "lora_A" in key or "lora_B" in key for key in partial.keys()):

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -1,4 +1,5 @@
 import json
+import re
 import warnings
 from pathlib import Path
 from typing import Literal, cast
@@ -140,28 +141,20 @@ def resolve_fqn(model: nn.Module, key: str) -> str:
     return next(iter(fqns))
 
 
-def _layer_prefixes(model: nn.Module) -> list[str]:
-    """FQN prefixes of the model's decoder blocks: the children of every ``layers``
-    ModuleList. state-dict keys and module names come from the same tree traversal,
-    so the prefixes match keys verbatim, wrapper components and all."""
-    prefixes: list[str] = []
-    for name, module in model.named_modules():
-        if isinstance(module, nn.ModuleList) and name.rsplit(".", 1)[-1] == "layers":
-            prefixes.extend(f"{name}.{i}." for i in range(len(module)))
-    return prefixes
+_LAYER_RE = re.compile(r"^(.*?\blayers\.\d+)\.")
 
 
-def partition_weights(model: nn.Module, world_size: int, dtype: torch.dtype) -> dict[str, int]:
+def partition_weights(state_dict: dict[str, Tensor], world_size: int, dtype: torch.dtype) -> dict[str, int]:
     """Assign each state-dict key an owner rank, balanced by byte size.
 
     All keys of one decoder layer share an owner, so per-rank prime->HF conversion
     (which stacks/unstacks tensors within a layer) always sees complete layers.
     """
-    prefixes = _layer_prefixes(model)
     key_to_unit: dict[str, str] = {}
     unit_bytes: dict[str, int] = {}
-    for key, value in model.state_dict().items():
-        unit = next((prefix for prefix in prefixes if key.startswith(prefix)), "")
+    for key, value in state_dict.items():
+        match = _LAYER_RE.match(key)
+        unit = match.group(1) if match else ""
         key_to_unit[key] = unit
         itemsize = dtype.itemsize if isinstance(value, DTensor) else value.element_size()
         unit_bytes[unit] = unit_bytes.get(unit, 0) + value.numel() * itemsize
@@ -184,7 +177,7 @@ def gather_weights_parallel(model: nn.Module, dtype: torch.dtype = torch.bfloat1
     plain blocking transfers; no stream-ordering assumptions.
     """
     world = get_world()
-    owners = partition_weights(model, world.world_size, dtype)
+    owners = partition_weights(model.state_dict(), world.world_size, dtype)
     partial: dict[str, Tensor] = {}
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=FutureWarning, module="torch.distributed")

--- a/src/prime_rl/transports/weights/filesystem.py
+++ b/src/prime_rl/transports/weights/filesystem.py
@@ -1,17 +1,18 @@
 import time
 from pathlib import Path
-from typing import Literal
 
+import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.tensor import DTensor
 
 from prime_rl.configs.trainer import FileSystemWeightBroadcastConfig, LoRAConfig
 from prime_rl.trainer.lora import get_lora_state, save_lora_config
-from prime_rl.trainer.models import PreTrainedModelPrimeRL
 from prime_rl.trainer.utils import maybe_clean
 from prime_rl.trainer.weights import (
-    gather_weights_on_master,
+    convert_state_dict_to_hf,
+    gather_weights_parallel,
     save_state_dict,
+    save_state_dict_parallel,
 )
 from prime_rl.trainer.world import get_world
 from prime_rl.transports.weights.base import WeightBroadcast
@@ -25,18 +26,18 @@ class FileSystemWeightBroadcast(WeightBroadcast):
         self, output_dir: Path, config: FileSystemWeightBroadcastConfig, lora_config: LoRAConfig | None = None
     ):
         super().__init__(output_dir, lora_config)
-        self.save_format: Literal["safetensors", "torch"] = config.save_format
-        self.save_sharded = config.save_sharded if lora_config is None else False
         self.world = get_world()
-        self.logger.debug(
-            f"Filesystem broadcast initialized (save_format={config.save_format}, save_sharded={self.save_sharded})"
-        )
+        self.logger.debug("Filesystem broadcast initialized")
 
     def broadcast_weights(self, model: nn.Module, step: int) -> None:
         """Broadcast weights by saving a HF-compatible checkpoint to shared filesystem and notifies the orchestrator."""
         self.logger.debug("Starting broadcasting weights to inference engine via shared filesystem")
         start_time = time.perf_counter()
         adapter_only = self.lora_config is not None
+
+        save_dir = get_step_path(get_broadcast_dir(self.output_dir), step)
+        if self.world.is_master:
+            save_dir.mkdir(parents=True, exist_ok=True)
 
         if adapter_only:
             # All ranks must participate in DTensor gathering, but only master saves
@@ -46,22 +47,9 @@ class FileSystemWeightBroadcast(WeightBroadcast):
                     value = value.full_tensor()
                 if self.world.is_master:
                     state_dict[key] = value.to("cpu", non_blocking=False)
-        else:
-            state_dict = gather_weights_on_master(model, is_master=self.world.is_master)
-            if isinstance(model, PreTrainedModelPrimeRL) and model.is_prime_state_dict(state_dict):
-                model.convert_to_hf(state_dict)
-            else:
-                from transformers.core_model_loading import revert_weight_conversion
-
-                state_dict = revert_weight_conversion(model, state_dict)
-
-        if self.world.is_master:
-            save_dir = get_step_path(get_broadcast_dir(self.output_dir), step)
-            save_dir.mkdir(parents=True, exist_ok=True)
-
-            self.logger.debug(f"Saving weights to {save_dir}")
-            save_state_dict(state_dict, save_dir, self.save_format, self.save_sharded, adapter=adapter_only)
-            if adapter_only:
+            if self.world.is_master:
+                self.logger.debug(f"Saving weights to {save_dir}")
+                save_state_dict(state_dict, save_dir, save_sharded=False, adapter=True)
                 save_lora_config(
                     model,
                     save_dir,
@@ -69,7 +57,14 @@ class FileSystemWeightBroadcast(WeightBroadcast):
                     alpha=self.lora_config.alpha,
                     dropout=self.lora_config.dropout,
                 )
+        else:
+            dist.barrier()
+            state_dict = gather_weights_parallel(model)
+            state_dict = convert_state_dict_to_hf(model, state_dict)
+            self.logger.debug(f"Saving weights to {save_dir}")
+            save_state_dict_parallel(state_dict, save_dir)
 
+        if self.world.is_master:
             self._notify_orchestrator(save_dir)
             self.logger.debug(f"Weights broadcasted in {time.perf_counter() - start_time:.2f}s")
 


### PR DESCRIPTION
## Summary

- Replace the master-only save in the filesystem weight broadcast (gather everything to rank 0, rank 0 writes all safetensors shards) with a rank-parallel save.
- `gather_weights_parallel`: all ranks still participate in the per-tensor `full_tensor()` all-gathers (they are collective and materialize the full tensor on every rank anyway), but each rank now keeps a layer-aligned slice on CPU instead of throwing it away. The copies are plain blocking D2H transfers — no pinned staging, no stream-ordering assumptions; the speedup comes from splitting the D2H traffic and, above all, the shard writes across ranks.
- Slices are layer-aligned so each rank can run the prime→HF conversion on its own slice (conversion ops only stack/unstack tensors within one layer, and all ops tolerate missing keys). `convert_state_dict_to_hf` detects the format from the model's full key set so partial dicts convert like full ones.
- `save_state_dict_parallel`: each rank splits its slice into ≤5GB shards, writes them under temporary names, shard maps are exchanged via `all_gather_object`, every rank renames its own files into the global `model-XXXXX-of-XXXXX.safetensors` numbering (non-POSIX shared filesystems can't reliably rename another rank's unpublished writes), and master writes the index after the barrier — so a complete index still implies complete shards, and `STABLE` semantics are unchanged.
- The broadcast is always sharded safetensors: the `save_sharded` / `save_format` fields on `FileSystemWeightBroadcastConfig` are removed. The adapter-only LoRA broadcast is unchanged.
- Weight checkpoints (`WeightCheckpointManager`) are untouched here; a stacked PR removes them entirely.

## Breaking

- `weight_broadcast.save_sharded` and `weight_broadcast.save_format` (`FileSystemWeightBroadcastConfig`) are removed. The filesystem broadcast always writes sharded safetensors. Migration: delete the fields from TOMLs.

## Benchmark

Laguna-XS.2 (33.4B, 68.1GB bf16), random init, 2x RTX PRO 6000 Blackwell, single local NVMe:

| impl | gather | convert | write | fsync | total |
|---|---|---|---|---|---|
| master (main) | 20.5–21.5s | 0.1s | 46.7–48.8s | 6.9–9.3s | ~75–79s |
| parallel | 20.8–21.2s | 0.1s | 20.7s | 8.1–8.7s | ~50s |

With blocking copies the gather is a wash on 2 GPUs (each rank copies half the bytes, serialized with the all-gathers); the win is the parallel write. An earlier revision staged the copies through pinned buffers with non-blocking transfers (gather 25s → 2.7s), but its safety rested on same-stream allocator-reuse ordering — dropped in favor of the obviously-correct blocking copies.

The same benchmark with `--nproc-per-node 8` on an H200 node, Laguna-S-2.1 (117.6B, 235.1GB bf16) — one save, 2 timed reps, `--fsync`. Measured on the earlier pinned-staging revision; the write path (the dominant term) is unchanged, the gather column will now sit between 5.4s and the master's 139s (each rank copies 1/8th of the bytes, blocking):

| target FS | master (main path) | parallel (this PR) | speedup |
|---|---|---|---|
| NFS | 660.6s (gather 139s, write 522s @ 0.45 GB/s) | 89.4s (gather 5.4s, write 84s @ 2.80 GB/s) | 7.4× |
| beegfs | 462.1s (gather 139s, write 323s @ 0.73 GB/s) | 75.4s (gather 5.4s, write 70s @ 3.4 GB/s) | 6.1× |

At this scale the parallel writers turn the shared-FS write from the dominant cost into ~70–85s; peak GPU memory is identical between impls (56.5 GiB). With 8 same-node writers the beegfs edge over NFS is modest — multi-node saves should widen it since writers scale with per-node bandwidth.

The benchmark script is not part of this diff — it lives at 929e43c37 (on the reference branch of #3312) for anyone reproducing the numbers: run it with `--nproc-per-node <n> --fsync`.

## Verification

- The benchmark's `--check` mode passes on a tiny 4-layer laguna config with EP=2 (exercises stacked-expert unstacking and expert DTensors), on `Qwen/Qwen3-0.6B` (exercises the `revert_weight_conversion` path and tied embeddings), and on `Qwen/Qwen3-8B` (16.4GB, 399 tensors): the parallel path produces bitwise-identical tensors to the master-gather path, and the index covers every tensor with all referenced shards present.
- `tests/integration/test_reverse_text.py` and `test_reverse_text_lora.py` pass on the equivalent change (vLLM consumes every per-step broadcast, including the LoRA adapter path).

Supersedes #3312 (re-derived from its first commits as the base of a 2-PR stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a distributed gather/write path on shared filesystems (barriers, tmp-rename, index completeness) and drops broadcast config fields. Weight checkpoints and LoRA adapter-only saves are unchanged.
> 
> **Overview**
> Filesystem weight broadcast no longer gathers the full HF checkpoint on rank 0 and writes all shards there. Each rank keeps a **layer-aligned** CPU slice, converts it to HF format, and writes its own safetensors shards.
> 
> `gather_weights_parallel` still runs collective `full_tensor()` all-gathers, then copies only owned tensors to CPU. `save_state_dict_parallel` writes temp shards, `all_gather`s the map, and each rank renames **its own** files into global `model-XXXXX-of-XXXXX.safetensors` numbering so non-POSIX shared FS stays reliable. Master writes the index after a barrier; `STABLE` semantics are unchanged.
> 
> **Breaking:** `FileSystemWeightBroadcastConfig.save_sharded` / `save_format` are removed — broadcast is always sharded safetensors. Adapter-only LoRA broadcast still uses the master-only path. Weight checkpoints are not changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db4ba53a943f4d77483851f5abb357d5133444a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

