### PR TITLE
fix: validate scheduler steps at config time

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -28,6 +28,7 @@ from prime_rl.configs.trainer import (
     OptimizerConfig,
     SchedulerConfig,
     TokenizerConfig,
+    validate_scheduler,
 )
 from prime_rl.utils.config import BaseConfig, find_package_resource
 
@@ -542,6 +543,11 @@ class SFTConfig(BaseConfig):
                 raise ValueError(
                     "Tracing more than 10 steps is not recommended as your trace will be massive. Remove this line if you really want to trace more steps."
                 )
+        return self
+
+    @model_validator(mode="after")
+    def validate_scheduler_steps(self):
+        validate_scheduler(self.scheduler, self.max_steps)
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -387,6 +387,28 @@ SchedulerConfig: TypeAlias = Annotated[
 ]
 
 
+def validate_scheduler(scheduler: SchedulerConfig, max_steps: int | None) -> None:
+    """Check scheduler phases against max_steps so misconfigurations fail at config time."""
+    if isinstance(scheduler, LinearSchedulerConfig):
+        if scheduler.warmup_steps == 0 and scheduler.decay_steps == 0:
+            raise ValueError(
+                "Linear scheduler requires warmup_steps > 0 or decay_steps > 0 (use the constant scheduler instead)"
+            )
+        if scheduler.decay_steps > 0:
+            if max_steps is None:
+                raise ValueError("Must specify max_steps when using a linear scheduler with decay_steps > 0")
+            if scheduler.warmup_steps + scheduler.decay_steps > max_steps:
+                raise ValueError(
+                    f"warmup_steps ({scheduler.warmup_steps}) + decay_steps ({scheduler.decay_steps}) "
+                    f"must not exceed max_steps ({max_steps})"
+                )
+    if isinstance(scheduler, CosineSchedulerConfig):
+        if max_steps is None:
+            raise ValueError("Must specify max_steps when using a cosine scheduler")
+        if scheduler.warmup_steps >= max_steps:
+            raise ValueError(f"warmup_steps ({scheduler.warmup_steps}) must be less than max_steps ({max_steps})")
+
+
 class BaseOptimizerConfig(BaseConfig):
     lr: float = Field(1e-6, ge=0)
     """Peak learning rate."""
@@ -718,6 +740,11 @@ class TrainerConfig(BaseConfig):
                 raise ValueError(
                     "Tracing more than 10 steps is not recommended as your trace will be massive. Remove this line if you really want to trace more steps."
                 )
+        return self
+
+    @model_validator(mode="after")
+    def validate_scheduler_steps(self):
+        validate_scheduler(self.scheduler, self.max_steps)
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -41,9 +41,10 @@ def setup_linear_scheduler(
     if decay_steps > 0:
         assert max_steps is not None, "max_steps must be specified when specifying decay_steps"
         decay_start_step = max_steps - decay_steps
-        assert decay_start_step >= warmup_steps
+        assert decay_start_step >= warmup_steps, (
+            f"warmup_steps ({warmup_steps}) + decay_steps ({decay_steps}) must not exceed max_steps ({max_steps})"
+        )
         constant_steps = decay_start_step - warmup_steps
-        assert constant_steps >= 0
         constant_scheduler = LinearLR(optimizer, start_factor=1.0, end_factor=1.0, total_iters=constant_steps)
         decay_scheduler = LinearLR(optimizer, start_factor=1.0, end_factor=min_lr_factor, total_iters=decay_steps - 1)
         schedulers.append(constant_scheduler)


### PR DESCRIPTION
## Summary

- Add `validate_scheduler` to the configs package and call it from `TrainerConfig` and `SFTConfig` model validators.
- A linear scheduler with `warmup_steps + decay_steps > max_steps` now fails at config validation, not deep into trainer setup via a bare `assert` in `setup_linear_scheduler`.
- Also validated at config time: linear with `decay_steps > 0` requires `max_steps`; linear needs `warmup_steps > 0` or `decay_steps > 0`; cosine requires `max_steps` and `warmup_steps < max_steps` (previously `T_max <= 0` reached `CosineAnnealingLR` unchecked).
- Keep the runtime assert as a backstop (SFT resume with `skip_scheduler` shrinks the step budget at runtime) and give it an error message.

## Verification

Before: `TrainerConfig(scheduler={"type": "linear", "warmup_steps": 50, "decay_steps": 100}, max_steps=100)` loads fine and the trainer dies at runtime with a bare `assert decay_start_step >= warmup_steps`.

After: config validation rejects it with `warmup_steps (50) + decay_steps (100) must not exceed max_steps (100)`. Checked the same for `SFTConfig`, the `max_steps`-missing cases, and that valid linear/cosine/constant configs (including exact fit `warmup + decay == max_steps`) still load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-time validation only; training behavior is unchanged except invalid schedules fail earlier with clearer errors.
> 
> **Overview**
> Rejects invalid linear/cosine LR schedules when configs load, instead of failing later on a bare assert in `setup_linear_scheduler`.
> 
> Adds `validate_scheduler` and wires it into `TrainerConfig` and `SFTConfig`. Linear schedules must have warmup or decay, decay requires `max_steps`, and warmup+decay cannot exceed `max_steps`. Cosine requires `max_steps` and `warmup_steps < max_steps`. The runtime assert remains as a backstop (e.g. SFT resume shrinking the step budget) and now includes a clear error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9fe7ae56edae579d4562c329be1ad723f401ea6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->