### PR TITLE
Relock prime-kernels after refreshing the v0.8.0 wheels

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4789,7 +4789,7 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.8.0/prime_kernels-0.1.0+cu128torch2.11.0-cp312-cp312-linux_aarch64.whl", hash = "sha256:5de78ebe942dffc424e03555f2f11a9b82fa19a0103286fb05e799eb719e53f7" },
+    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.8.0/prime_kernels-0.1.0+cu128torch2.11.0-cp312-cp312-linux_aarch64.whl", hash = "sha256:3ad8ce3a744c9b0f3bb9c649de44b2d99f9cab88a168b2e9d7f4c1c1a29dd19f" },
 ]
 
 [package.metadata]
@@ -4806,7 +4806,7 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.8.0/prime_kernels-0.1.0+cu128torch2.11.0-cp312-cp312-linux_x86_64.whl", hash = "sha256:aab0776e9a69b79887d25e90512147b24ed9a36427c43ed023272b55bb534b41" },
+    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.8.0/prime_kernels-0.1.0+cu128torch2.11.0-cp312-cp312-linux_x86_64.whl", hash = "sha256:6ce9fc5a8561d9b7c8283d11fb0fdac8e7981897c7308e9f520a9e4540cf805c" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
The `prime-kernels` wheels attached to v0.8.0 were rebuilt from `main` ([run 32428991336](https://github.com/PrimeIntellect-ai/prime-rl/actions/runs/32428991336)) so they carry the kernel-side shape rules that landed in #3154 — `flash_moe.BLOCK_M`, `MXFP8_SCALE_BLOCK` and `unsupported_shape_reason`, which `apply_fused_moe_kernel` now calls at setup.

The `[tool.uv.sources]` URLs are unchanged: same release, same filenames, new bytes. But `uv.lock` records a sha256 per wheel, so until this lands `uv sync --extra kernels` fails hash verification on `main`.

```
aarch64  5de78ebe… → 3ad8ce3a…
x86_64   aab0776e… → 6ce9fc5a…
```

Both digests are of the artifacts now published on the v0.8.0 release; wheel name, version (`0.1.0+cu128torch2.11.0`) and `Requires-Dist: torch>=2.9.0` are identical to what the lock already records, so the digests are the only thing that moves.

Verified that the refreshed wheel contains the new API:

```
prime_kernels-0.1.0+cu128torch2.11.0-cp312-cp312-linux_x86_64.whl
  BLOCK_M: present
  MXFP8_SCALE_BLOCK: present
  unsupported_shape_reason: present
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only digest updates for existing wheel URLs; no application or security logic changes.
> 
> **Overview**
> Updates `uv.lock` SHA256 hashes for the `prime-kernels` v0.8.0 wheels (aarch64 and x86_64) after those artifacts were rebuilt and re-uploaded to the same release URLs.
> 
> URLs, wheel names, version, and torch requirement are unchanged. This unblocks `uv sync --extra kernels`, which currently fails hash verification against the published wheels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d3e6e421c0f653f33a1cba76d85d5c060bdc1a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->