### PR TITLE
fix: guard kernel wheels on published releases

### DIFF
--- a/.github/workflows/build_kernels.yaml
+++ b/.github/workflows/build_kernels.yaml
@@ -33,6 +33,11 @@ on:
         description: "Ref to build the kernels from. Empty = the ref the workflow was started on."
         required: false
         type: string
+      overwrite:
+        description: "Replace wheels that already exist on a published release. Breaks every uv.lock pinning their hash — re-lock in the same motion."
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       release_tag:
@@ -148,8 +153,19 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TAG: ${{ inputs.release_tag }}
         run: |
-          gh release upload "$TAG" dist/*.whl --clobber
-          # The `[tool.uv.sources]` pin has to name the wheel exactly, ABI suffix and all.
           WHEEL=$(basename dist/*.whl)
+          # Replacing an asset on a published release breaks every uv.lock that pins
+          # its hash (kernel builds are not byte-reproducible), so overwriting is
+          # opt-in. Drafts are safe: nothing can pin their assets yet.
+          IS_DRAFT=$(gh release view "$TAG" --json isDraft -q .isDraft)
+          EXISTS=$(gh release view "$TAG" --json assets -q '.assets[].name' | grep -Fxc "$WHEEL" || true)
+          if [ "$IS_DRAFT" != "true" ] && [ "$EXISTS" != "0" ] && [ "${{ inputs.overwrite }}" != "true" ]; then
+            echo "::error::$WHEEL already exists on published release $TAG. Re-run with overwrite=true only if uv.lock is re-locked against the new wheel in the same motion." >&2
+            exit 1
+          fi
+          gh release upload "$TAG" dist/*.whl --clobber
+          # The `[tool.uv.sources]` pin has to name the wheel exactly, ABI suffix and all,
+          # and uv.lock pins the sha256 printed here.
           URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${WHEEL}"
           echo "\`{ url = \"$URL\", marker = \"platform_machine == '${{ matrix.arch }}'\" },\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`sha256:$(sha256sum dist/*.whl | cut -d' ' -f1)\`" >> "$GITHUB_STEP_SUMMARY"

--- a/skills/kernels/SKILL.md
+++ b/skills/kernels/SKILL.md
@@ -139,6 +139,12 @@ release always carries its wheels. To backfill a release that predates this, dis
 gh workflow run build_kernels.yaml -f release_tag=vX.Y.Z -f ref=vX.Y.Z
 ```
 
+The upload refuses to replace a wheel that already exists on a **published** release:
+kernel builds are not byte-reproducible, so a re-upload changes the asset's sha256 and
+breaks every `uv.lock` that pins it. Pass `-f overwrite=true` only for a deliberate
+replacement, and re-lock `uv.lock` against the new wheel (the job summary prints its
+sha256) in the same motion. Draft releases are always safe to re-upload to.
+
 The wheel version carries the ABI it was built against, e.g.
 `prime_kernels-0.1.0+cu128torch2.11.0-cp312-cp312-linux_x86_64.whl` — it imports only under
 that exact torch, so the build installs the torch pinned in `uv.lock`, not the newest one.


### PR DESCRIPTION
## Summary

- `Build Kernels`' release upload refuses to replace a wheel that already exists on a **published** release. Kernel builds are not byte-reproducible, so a re-upload changes the asset's sha256 and breaks every `uv.lock` that pins it — every `uv sync --locked` (all CI jobs and users) fails with a hash mismatch until main is re-locked.
- Deliberate replacement is opt-in via a new `overwrite` dispatch input, and the job summary now prints each wheel's sha256 alongside the `[tool.uv.sources]` snippet so re-locking in the same motion is easy.
- Draft releases stay clobber-safe: nothing can pin their assets yet, and `tag-and-release.yaml` uploads before promoting the draft, so the release flow is unaffected.
- `skills/kernels/SKILL.md`'s backfill section documents the guard and the `overwrite=true` escape hatch.

## Verification

Not exercised in CI (the guard only triggers on a `workflow_dispatch` against a published release with pre-existing assets). The failure mode it prevents happened today: a manual v0.8.0 backfill re-uploaded `prime_kernels-0.1.0+cu128torch2.11.0-cp312-cp312-linux_x86_64.whl` minutes after #3154 merged with `uv.lock` pinning the previous upload's hash (`aab0776e…` pinned vs `6ce9fc5a…` served), breaking `uv sync --locked` everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
