### PR TITLE
fix: preserve final eval during teardown

### DIFF
--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -193,8 +193,10 @@ Launch:
 
 ```bash
 uv run rl @ base_rl.toml @ my_slurm.toml             # submits via sbatch
-uv run rl @ base_rl.toml @ my_slurm.toml --dry-run   # writes the sbatch script + resolved config, exits
+uv run rl @ base_rl.toml @ my_slurm.toml --dry-run   # writes launcher/rl.sbatch + resolved config, exits
 ```
+
+Every SLURM entrypoint stores its generated scripts and coordination files under `<run_dir>/launcher/`. SLURM stdout and stderr go to `launcher/logs/`. Local launches do not create `launcher/`.
 
 ### `[deployment]` Block
 

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -77,6 +77,8 @@ After a restart, verify all processes are back up and progress resumed before th
 └── envs/{train,eval}/{env_name}.log    # one log file per env
 ```
 
+SLURM batch logs are under `{run_dir}/launcher/logs/*job_*.log`.
+
 Usually tailing `trainer.log`, `orchestrator.log`, and `inference.log` is enough. Drop into per-node or per-rank logs only when debugging. All logs are loguru with `HH:mm:ss  LEVEL  message`; levels: `DEBUG`, `INFO`, `SUCCESS`, `WARNING`, `ERROR`.
 
 Scan for problems:

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -45,6 +45,7 @@ uv run rl @ examples/basic/reverse-text/rl.toml --dry-run                       
 - Config: `RLConfig` (`packages/prime-rl-configs/src/prime_rl/configs/rl.py`)
 - Entrypoint: `src/prime_rl/entrypoints/rl.py`
 - SLURM: single- and multi-node
+- Multi-node SLURM stops after `.trainer.done` for trainer-only fake-data runs. Runs with inference stop after both `.trainer.done` and `.orchestrator.done`.
 - Environment packages: before launching a config with a non-core verifier env id,
   verify the package imports under `uv run` (for example
   `uv run python -c "import importlib.util; print(importlib.util.find_spec('r2e_gym'))"`).

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -7,6 +7,8 @@ description: How to launch prime-rl training runs — the `rl`, `sft`, `inferenc
 
 All entrypoints run via `uv run <command>` and accept TOML configs via `@ path/to.toml` plus CLI overrides.
 
+SLURM launches write generated scripts and coordination files under `<run_dir>/launcher/`, with batch logs under `launcher/logs/`. Local launches do not create this directory.
+
 ## Run directories
 
 `output_dir` (default `outputs`) groups related runs; each run writes all its artifacts (logs, configs, checkpoints, broadcasts, rollouts) to its own run directory `<output_dir>/<run_name>`. `run.name` auto-generates as `<envs>--<model>--<short-id>` (SFT: `<dataset>--<model>--<short-id>`), so every launch gets a fresh, readable run directory; `run.dir` overrides the directory leaf when it should differ from the name. Pass `--run.name <name>` to make the run directory predictable — required to resume the run later (`--resume`, or `--resume.step N`, reuses the named run directory; without `[ckpt]` it loads but saves no new checkpoints). Launching into a run directory that already contains artifacts fails unless resuming or `--clean` is set (which wipes only that run directory).

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -10,7 +10,13 @@ from typing import Any
 from prime_rl.configs.inference import InferenceConfig
 from prime_rl.utils.config import cli, dump_resolved_config
 from prime_rl.utils.logger import setup_logger
-from prime_rl.utils.pathing import format_log_message, get_config_dir, latest_log_dir
+from prime_rl.utils.pathing import (
+    format_log_message,
+    get_config_dir,
+    get_launcher_dir,
+    get_launcher_log_dir,
+    latest_log_dir,
+)
 from prime_rl.utils.process import (
     DEFAULT_COMMON_ENV_VARS,
     DEFAULT_INFERENCE_ENV_VARS,
@@ -71,6 +77,7 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
         **config.slurm.template_vars,
         config_path=config_path,
         output_dir=config.output_dir,
+        launcher_log_dir=get_launcher_log_dir(config.output_dir),
         gpus_per_node=config.deployment.gpus_per_node,
         dp_per_node=dp_per_node,
         num_nodes=getattr(config.deployment, "num_nodes", 1),
@@ -116,6 +123,7 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
     script = template.render(**template_vars)
 
     script_path.parent.mkdir(parents=True, exist_ok=True)
+    get_launcher_log_dir(config.output_dir).mkdir(parents=True, exist_ok=True)
     script_path.write_text(script)
 
 
@@ -131,7 +139,7 @@ def inference_slurm(config: InferenceConfig):
     config_path = write_config(config, config_dir, exclude=exclude, engine_only=is_multi_node)
     logger.info(f"Wrote config to {config_path}")
 
-    script_path = config.output_dir / INFERENCE_SBATCH
+    script_path = get_launcher_dir(config.output_dir) / INFERENCE_SBATCH
     write_slurm_script(config, config_path, script_path)
     logger.info(f"Wrote SLURM script to {script_path}")
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -374,8 +374,9 @@ def rl_local(config: RLConfig):
         )
         processes.append(tail_process)
 
-        # Check for errors from monitor threads
-        while not (stop_events["orchestrator"].is_set() and stop_events["trainer"].is_set()):
+        # Trainer and orchestrator completion is the successful stop condition.
+        completion_events = (stop_events["trainer"], stop_events["orchestrator"])
+        while not all(event.is_set() for event in completion_events):
             if error_queue:
                 error = error_queue[0]
                 logger.error(f"Error: {error}")

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -23,6 +23,8 @@ from prime_rl.utils.pathing import (
     format_log_message,
     get_ckpt_dir,
     get_config_dir,
+    get_launcher_dir,
+    get_launcher_log_dir,
     latest_log_dir,
     resolve_latest_ckpt_step,
     validate_run_dir,
@@ -463,6 +465,8 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             **config.slurm.template_vars,
             config_path=config_dir / RL_CONFIG,
             output_dir=config.run_dir,
+            launcher_dir=get_launcher_dir(config.run_dir),
+            launcher_log_dir=get_launcher_log_dir(config.run_dir),
             gpus_per_node=config.deployment.gpus_per_node,
         )
     elif config.inference is not None and config.inference.deployment.type == "disaggregated":
@@ -474,6 +478,8 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             run_name=config.run.name,
             config_dir=config_dir,
             output_dir=config.run_dir,
+            launcher_dir=get_launcher_dir(config.run_dir),
+            launcher_log_dir=get_launcher_log_dir(config.run_dir),
             num_train_nodes=config.deployment.num_train_nodes,
             num_infer_nodes=infer_deploy.num_nodes * config.deployment.num_infer_replicas,
             nodes_per_infer_replica=infer_deploy.num_nodes,
@@ -515,6 +521,8 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             run_name=config.run.name,
             config_dir=config_dir,  # TODO: should prob have each subconfig path separately
             output_dir=config.run_dir,
+            launcher_dir=get_launcher_dir(config.run_dir),
+            launcher_log_dir=get_launcher_log_dir(config.run_dir),
             num_train_nodes=config.deployment.num_train_nodes,
             num_infer_nodes=config.deployment.total_infer_nodes,
             nodes_per_infer_replica=config.deployment.infer_nodes_per_replica,
@@ -547,6 +555,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
         )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)
+    get_launcher_log_dir(config.run_dir).mkdir(parents=True, exist_ok=True)
     script_path.write_text(script)
 
 
@@ -594,7 +603,7 @@ def rl_slurm(config: RLConfig):
             num_infer_nodes=config.deployment.total_infer_nodes if has_infer else 0,
         )
 
-    script_path = config.run_dir / RL_SBATCH
+    script_path = get_launcher_dir(config.run_dir) / RL_SBATCH
     write_slurm_script(config, config_dir, script_path)
     logger.info(f"Wrote SLURM script to {script_path}")
 

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -21,6 +21,8 @@ from prime_rl.utils.pathing import (
     get_broadcast_dir,
     get_ckpt_dir,
     get_config_dir,
+    get_launcher_dir,
+    get_launcher_log_dir,
     get_log_dir,
     latest_log_dir,
     resolve_latest_ckpt_step,
@@ -161,6 +163,8 @@ def write_slurm_script(config: SFTConfig, config_path: Path, script_path: Path, 
             **config.slurm.template_vars,
             config_path=config_path,
             output_dir=config.run_dir,
+            launcher_dir=get_launcher_dir(config.run_dir),
+            launcher_log_dir=get_launcher_log_dir(config.run_dir),
             gpus_per_node=config.deployment.gpus_per_node,
         )
     else:
@@ -168,6 +172,8 @@ def write_slurm_script(config: SFTConfig, config_path: Path, script_path: Path, 
             **config.slurm.template_vars,
             config_path=config_path,
             output_dir=config.run_dir,
+            launcher_dir=get_launcher_dir(config.run_dir),
+            launcher_log_dir=get_launcher_log_dir(config.run_dir),
             trainer_env_vars=trainer_env_vars,
             num_nodes=config.deployment.num_train_nodes,
             gpus_per_node=config.deployment.gpus_per_node,
@@ -182,6 +188,7 @@ def write_slurm_script(config: SFTConfig, config_path: Path, script_path: Path, 
         )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)
+    get_launcher_log_dir(config.run_dir).mkdir(parents=True, exist_ok=True)
     script_path.write_text(script)
 
 
@@ -216,6 +223,8 @@ def write_eval_slurm_script(config: SFTConfig, config_dir: Path, script_path: Pa
         **config.slurm.template_vars,
         config_dir=config_dir,
         output_dir=config.run_dir,
+        launcher_dir=get_launcher_dir(config.run_dir),
+        launcher_log_dir=get_launcher_log_dir(config.run_dir),
         num_infer_nodes=config.deployment.num_infer_nodes,
         gpus_per_node=config.deployment.gpus_per_node,
         router=config.inference.router,
@@ -233,6 +242,7 @@ def write_eval_slurm_script(config: SFTConfig, config_dir: Path, script_path: Pa
     )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)
+    get_launcher_log_dir(config.run_dir).mkdir(parents=True, exist_ok=True)
     script_path.write_text(script)
 
 
@@ -267,7 +277,8 @@ def sft_slurm(config: SFTConfig):
     if decoupled_eval and config.monitors.wandb is not None:
         prl_run_id = os.environ["PRL_RUN_ID"]
 
-    script_path = config.run_dir / SFT_SBATCH
+    launcher_dir = get_launcher_dir(config.run_dir)
+    script_path = launcher_dir / SFT_SBATCH
     write_slurm_script(config, config_path, script_path, prl_run_id)
     logger.info(f"Wrote SLURM script to {script_path}")
 
@@ -279,7 +290,7 @@ def sft_slurm(config: SFTConfig):
     if decoupled_eval:
         write_eval_subconfigs(config, config_dir, strip_router=True)
         logger.info(f"Wrote eval subconfigs to {config_dir}")
-        eval_script_path = config.run_dir / EVAL_SBATCH
+        eval_script_path = launcher_dir / EVAL_SBATCH
         write_eval_slurm_script(config, config_dir, eval_script_path, prl_run_id)
         logger.info(f"Wrote eval SLURM script to {eval_script_path}")
         script_paths = [script_path, eval_script_path]

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -18,8 +18,8 @@
 #SBATCH --exclude={{ exclude }}
 {%- endif %}
 #SBATCH --exclusive
-#SBATCH --output={{ output_dir }}/job_%j.log
-#SBATCH --error={{ output_dir }}/job_%j.log
+#SBATCH --output={{ launcher_log_dir }}/job_%j.log
+#SBATCH --error={{ launcher_log_dir }}/job_%j.log
 
 # Exit immediately on any failed command so a crash anywhere releases the
 # allocation instead of leaving zombie processes holding nodes.

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -67,13 +67,14 @@ ln -sfn attempt_$ATTEMPT $OUTPUT_DIR/logs/latest
 ln -sfn trainer/node_0.log $LOG_DIR/trainer.log
 ln -sfn inference/node_0.log $LOG_DIR/inference.log
 
-# A clean run cannot trip srun --kill-on-bad-exit (which only propagates
-# failures), so the orchestrator's node publishes completion through this
-# job-scoped sentinel and the inference nodes watch for it to release their
-# engines. Stale sentinels from other job IDs are inert, so only this job's own
-# path needs clearing.
-export RUN_DONE=$OUTPUT_DIR/.run_done_$SLURM_JOB_ID
-rm -f "$RUN_DONE"
+# Clean exits do not trigger srun --kill-on-bad-exit. Each terminal component
+# publishes its successful exit through this job-scoped state directory. Every
+# node uses the same completion condition before it tears down support processes.
+export RUN_STATE_DIR=$OUTPUT_DIR/.launcher/$SLURM_JOB_ID
+export TRAINER_DONE=$RUN_STATE_DIR/trainer.done
+export ORCHESTRATOR_DONE=$RUN_STATE_DIR/orchestrator.done
+mkdir -p "$RUN_STATE_DIR"
+rm -f "$TRAINER_DONE" "$ORCHESTRATOR_DONE"
 
 export PRL_RUN_ID=${PRL_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}
 export PRL_RUN_NAME={{ run_name }}
@@ -395,11 +396,6 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     done
 {%- endif %}
 
-    # Watch for the completion sentinel so this node's wait below returns when
-    # the run finishes cleanly on the orchestrator's node — the engines never
-    # exit on their own, so without this the allocation idles until wall time.
-    ( until [ -f "$RUN_DONE" ]; do sleep 10; done ) &
-
 else
     TRAIN_NODE_RANK=$((SLURM_PROCID - NUM_INFER_NODES))
 {%- else %}
@@ -413,22 +409,28 @@ else
 
     echo $HOSTNAMES_STR | tee $LOG_DIR/trainer/node_${TRAIN_NODE_RANK}.log
 
-    WANDB_SHARED_LABEL=trainer uv run torchrun \
-        --role=trainer \
-        --nnodes=$NUM_TRAIN_NODES \
-        --nproc-per-node=$GPUS_PER_NODE \
-        --node-rank=$TRAIN_NODE_RANK \
-        --rdzv-endpoint=$MASTER_ADDR:$MASTER_PORT \
-        --rdzv-id=job_$SLURM_JOB_ID \
-        --log-dir=$LOG_DIR/trainer/torchrun \
-        --tee=3 \
-        --redirects=3 \
-        --local-ranks-filter={{ ranks_filter }} \
-        -m prime_rl.trainer.rl.train \
-        @ $CONFIG_DIR/trainer.json \
-        {% if use_zmq_transport %}--rollout_transport.host $ORCH_ADDR \
-        {% endif %}2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $LOG_DIR/trainer/node_${TRAIN_NODE_RANK}.log &
-    TRAINER_PID=$!
+    (
+        WANDB_SHARED_LABEL=trainer uv run torchrun \
+            --role=trainer \
+            --nnodes=$NUM_TRAIN_NODES \
+            --nproc-per-node=$GPUS_PER_NODE \
+            --node-rank=$TRAIN_NODE_RANK \
+            --rdzv-endpoint=$MASTER_ADDR:$MASTER_PORT \
+            --rdzv-id=job_$SLURM_JOB_ID \
+            --log-dir=$LOG_DIR/trainer/torchrun \
+            --tee=3 \
+            --redirects=3 \
+            --local-ranks-filter={{ ranks_filter }} \
+            -m prime_rl.trainer.rl.train \
+            @ $CONFIG_DIR/trainer.json \
+            {% if use_zmq_transport %}--rollout_transport.host $ORCH_ADDR \
+            {% endif %}2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $LOG_DIR/trainer/node_${TRAIN_NODE_RANK}.log
+        COMPONENT_CODE=$?
+        if [ "$COMPONENT_CODE" -eq 0 ] && [ "$TRAIN_NODE_RANK" -eq 0 ]; then
+            touch "$TRAINER_DONE" || exit $?
+        fi
+        exit "$COMPONENT_CODE"
+    ) &
 {% if num_infer_nodes > 0 %}    fi{% endif %}
 {% if num_infer_nodes > 0 %}
 # Launch the orchestrator on the node ORCH_ADDR points at (see the ORCH_PROCID
@@ -464,45 +466,36 @@ if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
 {%- endfor %}
 {%- endif %}
 
-    {% if use_nccl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $MASTER_ADDR"
-    {% endif %}{% if use_zmq_transport %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --rollout_transport.host $ORCH_ADDR"
-    {% endif %}WANDB_SHARED_LABEL=orchestrator uv run orchestrator $ORCHESTRATOR_ARGS \
-        2>&1 | tee $LOG_DIR/orchestrator.log &
-    ORCHESTRATOR_PID=$!
+    (
+        {% if use_nccl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $MASTER_ADDR"
+        {% endif %}{% if use_zmq_transport %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --rollout_transport.host $ORCH_ADDR"
+        {% endif %}WANDB_SHARED_LABEL=orchestrator uv run orchestrator $ORCHESTRATOR_ARGS \
+            2>&1 | tee $LOG_DIR/orchestrator.log
+        COMPONENT_CODE=$?
+        if [ "$COMPONENT_CODE" -eq 0 ]; then
+            touch "$ORCHESTRATOR_DONE" || exit $?
+        fi
+        exit "$COMPONENT_CODE"
+    ) &
 fi
 {% endif %}
 
-# Wait for the first background job to exit and propagate its exit code. This
-# turns background process crashes (router, orchestrator) into task failures
-# that --kill-on-bad-exit=1 can broadcast to the other nodes so the whole job
-# tears down instead of leaving zombies holding the allocation.
-wait -n -p FINISHED_PID
-EXIT_CODE=$?
+# Trainer and orchestrator completion is the successful stop condition. The
+# watcher lets every node apply it, including nodes that only run inference.
+( until [ -f "$TRAINER_DONE" ] && [ -f "$ORCHESTRATOR_DONE" ]; do sleep 10; done ) &
+COMPLETION_PID=$!
 
-# A component finishing cleanly does not mean the run is over: at max_steps the
-# trainer exits while the orchestrator still drains that step's eval, and the
-# orchestrator can likewise finish first while the trainer writes its last
-# checkpoint. Tearing down on the first exit kills the peer mid-flight, so wait
-# for whichever of the two is still working.
-if [ "$EXIT_CODE" -eq 0 ]; then
-    for pid in "${TRAINER_PID:-}" "${ORCHESTRATOR_PID:-}"; do
-        if [ -n "$pid" ] && [ "$pid" != "${FINISHED_PID:-}" ] && kill -0 "$pid" 2>/dev/null; then
-            echo "[$(hostname)] component finished cleanly - waiting for peer $pid to finish its work"
-            wait "$pid"
-            PEER_CODE=$?
-            if [ "$PEER_CODE" -ne 0 ]; then
-                EXIT_CODE=$PEER_CODE
-            fi
-        fi
-    done
-fi
+# A clean component exit is not enough to stop the run. Keep waiting for the
+# shared completion condition. Propagate any failure through
+# --kill-on-bad-exit=1 so every node tears down.
+while true; do
+    wait -n -p FINISHED_PID
+    EXIT_CODE=$?
+    if [ "$EXIT_CODE" -ne 0 ] || [ "${FINISHED_PID:-}" = "$COMPLETION_PID" ]; then
+        break
+    fi
+done
 
-# Publish completion from the orchestrator's node only: a peer trainer node also
-# exits zero at max_steps, and releasing the engines on its word would truncate
-# the eval this block just waited for.
-if [ "$EXIT_CODE" -eq 0 ] && [ -n "${ORCHESTRATOR_PID:-}" ]; then
-    touch "$RUN_DONE"
-fi
 REMAINING_PIDS=$(jobs -p)
 {%- if cleanup_grace_period %}
 # Cross-node teardown is driven by `srun --kill-on-bad-exit=1`, which reaps peer

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -72,9 +72,11 @@ ln -sfn inference/node_0.log $LOG_DIR/inference.log
 # publishes its successful exit through the shared launcher directory. Every node
 # uses the same completion condition before it tears down support processes.
 export TRAINER_DONE=$LAUNCHER_DIR/.trainer.done
+{% if num_infer_nodes > 0 -%}
 export ORCHESTRATOR_DONE=$LAUNCHER_DIR/.orchestrator.done
+{% endif -%}
 mkdir -p "$LAUNCHER_DIR"
-rm -f "$TRAINER_DONE" "$ORCHESTRATOR_DONE"
+rm -f "$TRAINER_DONE"{% if num_infer_nodes > 0 %} "$ORCHESTRATOR_DONE"{% endif %}
 
 export PRL_RUN_ID=${PRL_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}
 export PRL_RUN_NAME={{ run_name }}
@@ -480,9 +482,14 @@ if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
 fi
 {% endif %}
 
-# Trainer and orchestrator completion is the successful stop condition. The
-# watcher lets every node apply it, including nodes that only run inference.
+# Every node watches the terminal components for successful completion.
+{% if num_infer_nodes > 0 -%}
+# Inference runs stop after both the trainer and orchestrator finish.
 ( until [ -f "$TRAINER_DONE" ] && [ -f "$ORCHESTRATOR_DONE" ]; do sleep 10; done ) &
+{% else -%}
+# Trainer-only runs stop when the trainer finishes.
+( until [ -f "$TRAINER_DONE" ]; do sleep 10; done ) &
+{% endif -%}
 COMPLETION_PID=$!
 
 # A clean component exit is not enough to stop the run. Keep waiting for the

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -18,8 +18,8 @@
 #SBATCH --exclude={{ exclude }}
 {%- endif %}
 #SBATCH --exclusive
-#SBATCH --output={{ output_dir }}/job_%j.log
-#SBATCH --error={{ output_dir }}/job_%j.log
+#SBATCH --output={{ launcher_log_dir }}/job_%j.log
+#SBATCH --error={{ launcher_log_dir }}/job_%j.log
 
 # Exit immediately on any failed command so a crash anywhere releases the
 # allocation instead of leaving zombie processes holding nodes.
@@ -58,6 +58,7 @@ export INFERENCE_ENABLE_EXPERT_PARALLEL={{ "1" if inference_enable_expert_parall
 export PROJECT_DIR={{ project_dir }}
 export CONFIG_DIR={{ config_dir }}
 export OUTPUT_DIR={{ output_dir }}
+export LAUNCHER_DIR={{ launcher_dir }}
 # Per-attempt log dir: a resume or relaunch never overwrites an earlier attempt's logs.
 ATTEMPT=1
 while [ -e $OUTPUT_DIR/logs/attempt_$ATTEMPT ]; do ATTEMPT=$((ATTEMPT+1)); done
@@ -68,12 +69,11 @@ ln -sfn trainer/node_0.log $LOG_DIR/trainer.log
 ln -sfn inference/node_0.log $LOG_DIR/inference.log
 
 # Clean exits do not trigger srun --kill-on-bad-exit. Each terminal component
-# publishes its successful exit through this job-scoped state directory. Every
-# node uses the same completion condition before it tears down support processes.
-export RUN_STATE_DIR=$OUTPUT_DIR/.launcher/$SLURM_JOB_ID
-export TRAINER_DONE=$RUN_STATE_DIR/trainer.done
-export ORCHESTRATOR_DONE=$RUN_STATE_DIR/orchestrator.done
-mkdir -p "$RUN_STATE_DIR"
+# publishes its successful exit through the shared launcher directory. Every node
+# uses the same completion condition before it tears down support processes.
+export TRAINER_DONE=$LAUNCHER_DIR/.trainer.done
+export ORCHESTRATOR_DONE=$LAUNCHER_DIR/.orchestrator.done
+mkdir -p "$LAUNCHER_DIR"
 rm -f "$TRAINER_DONE" "$ORCHESTRATOR_DONE"
 
 export PRL_RUN_ID=${PRL_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -67,6 +67,14 @@ ln -sfn attempt_$ATTEMPT $OUTPUT_DIR/logs/latest
 ln -sfn trainer/node_0.log $LOG_DIR/trainer.log
 ln -sfn inference/node_0.log $LOG_DIR/inference.log
 
+# A clean run cannot trip srun --kill-on-bad-exit (which only propagates
+# failures), so the orchestrator's node publishes completion through this
+# job-scoped sentinel and the inference nodes watch for it to release their
+# engines. Stale sentinels from other job IDs are inert, so only this job's own
+# path needs clearing.
+export RUN_DONE=$OUTPUT_DIR/.run_done_$SLURM_JOB_ID
+rm -f "$RUN_DONE"
+
 export PRL_RUN_ID=${PRL_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}
 export PRL_RUN_NAME={{ run_name }}
 export WANDB_RUN_ID=$PRL_RUN_ID
@@ -387,6 +395,11 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     done
 {%- endif %}
 
+    # Watch for the completion sentinel so this node's wait below returns when
+    # the run finishes cleanly on the orchestrator's node — the engines never
+    # exit on their own, so without this the allocation idles until wall time.
+    ( until [ -f "$RUN_DONE" ]; do sleep 10; done ) &
+
 else
     TRAIN_NODE_RANK=$((SLURM_PROCID - NUM_INFER_NODES))
 {%- else %}
@@ -415,6 +428,7 @@ else
         @ $CONFIG_DIR/trainer.json \
         {% if use_zmq_transport %}--rollout_transport.host $ORCH_ADDR \
         {% endif %}2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $LOG_DIR/trainer/node_${TRAIN_NODE_RANK}.log &
+    TRAINER_PID=$!
 {% if num_infer_nodes > 0 %}    fi{% endif %}
 {% if num_infer_nodes > 0 %}
 # Launch the orchestrator on the node ORCH_ADDR points at (see the ORCH_PROCID
@@ -454,6 +468,7 @@ if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
     {% endif %}{% if use_zmq_transport %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --rollout_transport.host $ORCH_ADDR"
     {% endif %}WANDB_SHARED_LABEL=orchestrator uv run orchestrator $ORCHESTRATOR_ARGS \
         2>&1 | tee $LOG_DIR/orchestrator.log &
+    ORCHESTRATOR_PID=$!
 fi
 {% endif %}
 
@@ -461,8 +476,33 @@ fi
 # turns background process crashes (router, orchestrator) into task failures
 # that --kill-on-bad-exit=1 can broadcast to the other nodes so the whole job
 # tears down instead of leaving zombies holding the allocation.
-wait -n
+wait -n -p FINISHED_PID
 EXIT_CODE=$?
+
+# A component finishing cleanly does not mean the run is over: at max_steps the
+# trainer exits while the orchestrator still drains that step's eval, and the
+# orchestrator can likewise finish first while the trainer writes its last
+# checkpoint. Tearing down on the first exit kills the peer mid-flight, so wait
+# for whichever of the two is still working.
+if [ "$EXIT_CODE" -eq 0 ]; then
+    for pid in "${TRAINER_PID:-}" "${ORCHESTRATOR_PID:-}"; do
+        if [ -n "$pid" ] && [ "$pid" != "${FINISHED_PID:-}" ] && kill -0 "$pid" 2>/dev/null; then
+            echo "[$(hostname)] component finished cleanly - waiting for peer $pid to finish its work"
+            wait "$pid"
+            PEER_CODE=$?
+            if [ "$PEER_CODE" -ne 0 ]; then
+                EXIT_CODE=$PEER_CODE
+            fi
+        fi
+    done
+fi
+
+# Publish completion from the orchestrator's node only: a peer trainer node also
+# exits zero at max_steps, and releasing the engines on its word would truncate
+# the eval this block just waited for.
+if [ "$EXIT_CODE" -eq 0 ] && [ -n "${ORCHESTRATOR_PID:-}" ]; then
+    touch "$RUN_DONE"
+fi
 REMAINING_PIDS=$(jobs -p)
 {%- if cleanup_grace_period %}
 # Cross-node teardown is driven by `srun --kill-on-bad-exit=1`, which reaps peer

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -18,8 +18,8 @@
 #SBATCH --exclude={{ exclude }}
 {%- endif %}
 #SBATCH --exclusive
-#SBATCH --output={{ output_dir }}/job_%j.log
-#SBATCH --error={{ output_dir }}/job_%j.log
+#SBATCH --output={{ launcher_log_dir }}/job_%j.log
+#SBATCH --error={{ launcher_log_dir }}/job_%j.log
 
 # Exit immediately on any failed command so a crash on any node releases the
 # allocation instead of leaving zombie processes holding nodes.
@@ -33,6 +33,7 @@ export GPUS_PER_NODE={{ gpus_per_node }}
 export PROJECT_DIR={{ project_dir }}
 export CONFIG_PATH={{ config_path }}
 export OUTPUT_DIR={{ output_dir }}
+export LAUNCHER_DIR={{ launcher_dir }}
 # Per-attempt log dir: a resume or relaunch never overwrites an earlier attempt's logs.
 ATTEMPT=1
 while [ -e $OUTPUT_DIR/logs/attempt_$ATTEMPT ]; do ATTEMPT=$((ATTEMPT+1)); done
@@ -65,7 +66,7 @@ echo "MASTER_PORT=${MASTER_PORT}"
 {% if use_nccl_broadcast %}
 # The eval job has a separate allocation. Publish the trainer's NCCL host through
 # the shared run directory under this job ID.
-printf '%s\n' "$MASTER_ADDR" > "$OUTPUT_DIR/.sft_nccl_host_$SLURM_JOB_ID"
+printf '%s\n' "$MASTER_ADDR" > "$LAUNCHER_DIR/.sft_nccl_host_$SLURM_JOB_ID"
 {% endif %}
 
 # Install environment

--- a/src/prime_rl/templates/multi_node_sft_eval.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft_eval.sbatch.j2
@@ -18,8 +18,8 @@
 #SBATCH --exclude={{ exclude }}
 {%- endif %}
 #SBATCH --exclusive
-#SBATCH --output={{ output_dir }}/eval_job_%j.log
-#SBATCH --error={{ output_dir }}/eval_job_%j.log
+#SBATCH --output={{ launcher_log_dir }}/eval_job_%j.log
+#SBATCH --error={{ launcher_log_dir }}/eval_job_%j.log
 
 # Online-eval job for a decoupled SFT run: the inference pool (one vLLM engine per
 # DP rank behind a single router) plus the evals process and its env servers. The trainer
@@ -42,6 +42,7 @@ export PROJECT_DIR={{ project_dir }}
 export CONFIG_DIR={{ config_dir }}
 export CONFIG_PATH=$CONFIG_DIR/inference.json
 export OUTPUT_DIR={{ output_dir }}
+export LAUNCHER_DIR={{ launcher_dir }}
 # Move a previous job's inference logs aside instead of deleting them: rm of log
 # files another job's processes still hold open can wedge in the NFS client and
 # hang the whole job before srun even runs.
@@ -50,10 +51,9 @@ mkdir -p $OUTPUT_DIR/logs/inference
 ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log
 
 # A clean evals exit cannot trip srun --kill-on-bad-exit (which only propagates
-# failures), so node 0 publishes completion through this job-scoped sentinel and the
-# other nodes watch for it to release their engines. Stale sentinels from other job
-# IDs are inert, so only this job's own path needs clearing.
-export EVAL_DONE=$OUTPUT_DIR/.eval_done_$SLURM_JOB_ID
+# failures), so node 0 publishes completion through this sentinel and the other nodes
+# watch for it to release their engines.
+export EVAL_DONE=$LAUNCHER_DIR/.eval.done
 rm -f "$EVAL_DONE"
 {% if prl_run_id %}
 # Trainer (separate SLURM job) and evals log to a single shared W&B run whose id
@@ -72,7 +72,7 @@ export HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
 export HOSTNAMES_STR="${HOSTNAMES[*]}"
 {% if use_nccl_broadcast %}
 : "${TRAIN_JOB_ID:?TRAIN_JOB_ID is required for NCCL weight broadcast}"
-TRAIN_HOST_FILE="$OUTPUT_DIR/.sft_nccl_host_$TRAIN_JOB_ID"
+TRAIN_HOST_FILE="$LAUNCHER_DIR/.sft_nccl_host_$TRAIN_JOB_ID"
 until [ -s "$TRAIN_HOST_FILE" ]; do sleep 1; done
 export TRAIN_HOST=$(<"$TRAIN_HOST_FILE")
 rm -f "$TRAIN_HOST_FILE"

--- a/src/prime_rl/templates/single_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/single_node_rl.sbatch.j2
@@ -18,8 +18,8 @@
 {%- if exclude %}
 #SBATCH --exclude={{ exclude }}
 {%- endif %}
-#SBATCH --output={{ output_dir }}/job_%j.log
-#SBATCH --error={{ output_dir }}/job_%j.log
+#SBATCH --output={{ launcher_log_dir }}/job_%j.log
+#SBATCH --error={{ launcher_log_dir }}/job_%j.log
 
 # Exit immediately if any setup command or the launcher fails so the SLURM job
 # releases its allocation instead of holding nodes after a crash.

--- a/src/prime_rl/templates/single_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/single_node_sft.sbatch.j2
@@ -18,8 +18,8 @@
 {%- if exclude %}
 #SBATCH --exclude={{ exclude }}
 {%- endif %}
-#SBATCH --output={{ output_dir }}/job_%j.log
-#SBATCH --error={{ output_dir }}/job_%j.log
+#SBATCH --output={{ launcher_log_dir }}/job_%j.log
+#SBATCH --error={{ launcher_log_dir }}/job_%j.log
 
 # Exit immediately if any setup command or the launcher fails so the SLURM job
 # releases its allocation instead of holding nodes after a crash.

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -60,7 +60,7 @@ def format_log_message(
 
     log_lines: list[str] = []
     if job_log:
-        log_lines.append(f"{i1}{'Job:':<{col}}tail -F {log_dir.parent.parent}/job_*.log")
+        log_lines.append(f"{i1}{'Job:':<{col}}tail -F {get_launcher_log_dir(log_dir.parent.parent)}/*job_*.log")
     if trainer:
         log_lines.append(f"{i1}{'Trainer:':<{col}}tail -F {log_dir}/trainer.log")
         if num_train_nodes > 1:
@@ -92,6 +92,14 @@ def format_log_message(
 
 def get_config_dir(output_dir: Path) -> Path:
     return output_dir / "configs"
+
+
+def get_launcher_dir(output_dir: Path) -> Path:
+    return output_dir / "launcher"
+
+
+def get_launcher_log_dir(output_dir: Path) -> Path:
+    return get_launcher_dir(output_dir) / "logs"
 
 
 def get_ckpt_dir(output_dir: Path) -> Path:
@@ -139,10 +147,9 @@ def has_checkpoints(output_dir: Path) -> bool:
     return ckpt_dir.exists() and any(ckpt_dir.iterdir())
 
 
-# Launcher artifacts that may exist in a run directory before training starts: resolved
-# configs and the SLURM script/job log (a submitted job re-invokes the entrypoint inside
-# the run directory). Everything else is treated as artifacts of a previous run.
-LAUNCHER_ARTIFACTS = ("configs", "rl.sbatch", "sft.sbatch", "job_*.log")
+# Launcher artifacts may exist before training starts. Everything else is treated as
+# artifacts of a previous run.
+LAUNCHER_ARTIFACTS = ("configs", "launcher")
 
 
 def has_run_artifacts(run_dir: Path) -> bool:

--- a/tests/unit/utils/test_pathing.py
+++ b/tests/unit/utils/test_pathing.py
@@ -19,8 +19,12 @@ def test_dir_with_launcher_artifacts_passes(tmp_path):
     run_dir.mkdir()
     (run_dir / "configs").mkdir()
     (run_dir / "configs" / "trainer.toml").touch()
-    (run_dir / "rl.sbatch").touch()
-    (run_dir / "job_1234.log").touch()
+    (run_dir / "launcher").mkdir()
+    (run_dir / "launcher" / "rl.sbatch").touch()
+    (run_dir / "launcher" / ".trainer.done").touch()
+    (run_dir / "launcher" / ".orchestrator.done").touch()
+    (run_dir / "launcher" / "logs").mkdir()
+    (run_dir / "launcher" / "logs" / "job_1234.log").touch()
     validate_run_dir(run_dir, output_dir=tmp_path, resuming=False, clean=False)
 
 


### PR DESCRIPTION
## Summary

- Use successful trainer and orchestrator exits as the shared completion condition in local and multi-node SLURM launchers.
- Let each SLURM component publish `.trainer.done` or `.orchestrator.done`, then stop inference after both markers exist.
- Make trainer-only fake-data SLURM runs stop after `.trainer.done`; no orchestrator exists in that mode.
- Store all generated SLURM scripts and coordination files under `<run_dir>/launcher/`.
- Store SLURM stdout and stderr under `<run_dir>/launcher/logs/`.
- Apply the launcher layout to RL, SFT, decoupled SFT eval, and standalone inference entrypoints.
- Keep local launchers unchanged on disk. They do not create `launcher/` because they persist no launcher files.
- Preserve failure propagation through `srun --kill-on-bad-exit=1`.

At `max_steps`, the trainer can exit while the orchestrator still drains the final eval. The template previously tore down the node after the first background process exited. This killed the final eval. A clean exit also did not trigger `--kill-on-bad-exit`, so inference nodes could hold the allocation until wall time.

## Breaking

- Generated SLURM scripts move from `<run_dir>/*.sbatch` to `<run_dir>/launcher/*.sbatch`. Update manual submission commands and tooling to use the new paths.
- SLURM job logs move from `<run_dir>/*job_*.log` to `<run_dir>/launcher/logs/*job_*.log`. Update log collection and monitoring paths.

## Verification

Before this change, a 1000-step GLM-4.5-Air run lost its final eval at 450 of 500 tasks. The six-node allocation then remained active for another 23 hours.

After this change, a 10-step reverse-text run evaluated at its final step and exited successfully:

- The final eval completed all 64 rollouts with no rollout errors.
- The trainer finished at 01:39:08 UTC.
- The orchestrator drained its pipeline and finished at 01:39:14 UTC.
- Inference stopped after both terminal components finished.
- The launcher exited with code 0 and released both GPUs.

A two-node trainer-only fake-data dry run rendered a one-marker watcher with no `ORCHESTRATOR_DONE` reference. The normal inference path still rendered the two-marker watcher. Both scripts passed `bash -n`.

All RL, SFT, decoupled SFT eval, and inference SLURM variants rendered successfully. Every rendered script passed `bash -n`. Local RL, SFT, and inference dry runs did not create `launcher/`.

An additional two-node SLURM run used the regular reverse-text configuration with 100 eval rollouts per evaluation:

- The trainer completed all 20 steps and wrote `launcher/.trainer.done`.
- The orchestrator continued to drain queued evaluations after trainer completion.
- The orchestrator then wrote `launcher/.orchestrator.done`.
- Both nodes logged teardown with exit code 0, and the job released its allocation.

Ruff passed. The pathing unit tests passed with 10 tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes multi-node SLURM lifecycle and coordination (eval completion vs allocation hold time) and breaks paths for manual `sbatch` and log monitoring; incorrect completion logic could still strand nodes or kill in-flight evals.
> 
> **Overview**
> Fixes premature SLURM teardown at `max_steps` when the trainer exits while the orchestrator is still draining the **final eval**. Multi-node RL jobs no longer stop on the first background process exit; trainer rank 0 and the orchestrator publish **`launcher/.trainer.done`** and **`launcher/.orchestrator.done`** on success, and every node waits for the appropriate pair (trainer-only vs trainer+orchestrator) before killing inference and releasing the allocation. Failures still propagate via **`srun --kill-on-bad-exit=1`**.
> 
> **Breaking layout change:** generated `*.sbatch` scripts, coordination sentinels, and SLURM `job_*.log` output move from the run directory root to **`&lt;run_dir&gt;/launcher/`** and **`launcher/logs/`** for RL, SFT, decoupled SFT eval, and standalone inference. Entrypoints and Jinja templates pass `launcher_dir` / `launcher_log_dir`; local launches stay unchanged on disk (no `launcher/`). Docs and training skills note the new paths; `format_log_message` and `LAUNCHER_ARTIFACTS` validation follow the same layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02f3807d4a4f9cd53830b9b90e4035c386d01bdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
