### PR TITLE
fix(orchestrator): apply taskset system_prompt override on the RL path

### DIFF
--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -80,11 +80,11 @@ class Env:
         await self.env_client.wait_for_server_startup(timeout=ENV_SERVER_STARTUP_TIMEOUT)
         taskset = vf.load_taskset(self.config.env.taskset)
         if type(taskset).INFINITE:
-            self.tasks = iter(taskset.load())
+            self.tasks = iter(taskset)
             self.num_tasks = None
         else:
-            # Materialize off the event loop — load() may pull a dataset.
-            materialized = await asyncio.to_thread(lambda: list(taskset.load()))
+            # Materialize off the event loop — iterating may pull a dataset.
+            materialized = await asyncio.to_thread(lambda: list(taskset))
             self.tasks = iter(materialized)
             self.num_tasks = len(materialized)
         num_tasks = self.num_tasks if self.num_tasks is not None else "infinite"


### PR DESCRIPTION
## Problem

`TasksetConfig.system_prompt` — the per-taskset system-prompt override (e.g. a GEPA `best_system_prompt.txt`) — is **silently ignored on the RL orchestrator path**. Tasks reach the harness with `system_prompt=None`, so the override never affects the model's prompt, and no error is raised.

## Root cause

The override is applied only in `Taskset.__iter__` (`with_system_prompt(self.system_prompt)`, verifiers `v1/taskset.py`). But `Env.start()` (`src/prime_rl/orchestrator/envs.py`) consumed the taskset via the raw `taskset.load()` hook instead of `iter(taskset)`:

```python
self.tasks = iter(taskset.load())
materialized = await asyncio.to_thread(lambda: list(taskset.load()))
```

`load()` yields undecorated tasks, so the config-layer `system_prompt` (and any `head`/`shuffle` view transform) is dropped. This affects both `TrainEnv` (inherits `Env.start`) and `EvalEnv` (calls `super().start()`) — i.e. training *and* eval.

## Fix

Iterate via `__iter__`, which is the intended read path (`load()` is the raw subclass hook):

```python
self.tasks = iter(taskset)
materialized = await asyncio.to_thread(lambda: list(taskset))
```

## Verification

Minimal repro — a taskset whose tasks carry no system prompt of their own, with a `system_prompt` override configured:

- `list(taskset.load())` → `[None, None, None]`   (before)
- `list(taskset)`        → `['<override>', ...]`   (after)

Also confirmed empirically: an RL run using `env.taskset.system_prompt` had the override missing from 100% of sampled rollout system prompts before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small but behavior-changing fix on the train/eval task loading path: prompts and taskset views will now differ from previous runs that used `load()`. No auth or data-handling changes.
> 
> **Overview**
> Fixes the RL orchestrator silently dropping `TasksetConfig.system_prompt` (and other `__iter__` view transforms like `head`/`shuffle`) on both train and eval.
> 
> `Env.start()` now consumes the taskset via `iter(taskset)` / `list(taskset)` instead of the raw `taskset.load()` hook, so overrides such as a GEPA `best_system_prompt.txt` actually reach the harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef45099ef10b5785c311c8811253d05c3d2aeb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->