### PR TITLE
fix(orchestrator): label eval avg@k by episode group size

### DIFF
--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -86,4 +86,8 @@ class EvalSink:
     def process_batch(self, key: tuple[str, int]) -> EvalBatch:
         env_name, step = key
         episodes = self.pending_batches.pop(key, [])
-        return EvalBatch(env_name=env_name, step=step, episodes=EvalEpisodes(episodes))
+        return EvalBatch(
+            env_name=env_name,
+            step=step,
+            episodes=EvalEpisodes(episodes, group_size=self.group_size_for(env_name)),
+        )

--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -474,30 +474,19 @@ class TrainEpisodes(EpisodeCollection):
 class EvalEpisodes(EpisodeCollection):
     def __init__(
         self,
-        episodes: list[vf.Episode] | None = None,
+        episodes: list[vf.Episode],
+        group_size: int,
         predicate: Callable[[TraceRecord], bool] | None = None,
-        group_size: int | None = None,
     ) -> None:
         super().__init__(episodes, predicate=predicate)
-        self._group_size = group_size
-
-    @property
-    def group_size(self) -> int:
-        if self._group_size is not None:
-            return self._group_size
-        counts: dict = {}
-        for record in self.records:
-            if record.trace.agent.trainable:
-                group_id = episode_group_id(record.episode)
-                counts[group_id] = counts.get(group_id, 0) + 1
-        return max(counts.values(), default=0)
+        self.group_size = group_size
 
     @property
     def effective(self) -> EvalEpisodes:
         return EvalEpisodes(
             self.episodes,
+            self.group_size,
             predicate=lambda record: not record.trace.has_error and record.trace.agent.trainable,
-            group_size=self.group_size,
         )
 
     @property

--- a/tests/unit/orchestrator/test_metrics.py
+++ b/tests/unit/orchestrator/test_metrics.py
@@ -270,21 +270,33 @@ def test_train_only_metrics_absent_from_eval():
     assert out["train/agg/all/agent/is_trainable/mean"] == 0.5
     assert out["train/agg/all/agent/is_admitted/mean"] == 0.5
     assert "train/agg/all/is_trainable/mean" not in out  # pipeline verdicts are per-trace
-    eval_out = EvalEpisodes(rollouts).metrics.to_wandb(prefix="eval/x", subset="all")
+    eval_out = EvalEpisodes(rollouts, group_size=2).metrics.to_wandb(prefix="eval/x", subset="all")
     assert not any("is_trainable" in key or "is_admitted" in key for key in eval_out)
 
 
 def test_eval_avg_at_k_and_pass_k():
-    binary = EvalEpisodes([mk(reward=1.0, group_id="g0"), mk(reward=0.0, group_id="g0")])
+    binary = EvalEpisodes([mk(reward=1.0, group_id="g0"), mk(reward=0.0, group_id="g0")], group_size=2)
     eff = binary.effective.metrics.to_wandb(prefix="eval/x", subset="effective")
-    assert eff["eval/x/effective/agent/avg@2"] == 0.5  # mean reward under avg@<k> (k from the groups)
+    assert eff["eval/x/effective/agent/avg@2"] == 0.5  # k is the configured episode group size
     assert "eval/x/effective/avg@2" not in eff  # scores are per-agent, never pooled
     assert eff["eval/x/effective/agent/pass@1"] == 0.5 and eff["eval/x/effective/agent/pass^2"] == 0.0
     all_out = binary.metrics.to_wandb(prefix="eval/x", subset="all")
     assert all_out["eval/x/all/agent/avg@2"] == 0.5
     assert not any("pass@" in k or "pass^" in k for k in all_out)  # pass@k effective-only
-    non_binary = EvalEpisodes([mk(reward=0.5, group_id="g0"), mk(reward=1.0, group_id="g0")])
+    non_binary = EvalEpisodes([mk(reward=0.5, group_id="g0"), mk(reward=1.0, group_id="g0")], group_size=2)
     assert not any("pass@" in k for k in non_binary.effective.metrics.to_wandb(prefix="eval/x", subset="effective"))
+
+    multi_agent = EvalEpisodes(
+        [
+            combine(mk(agent_name="proposer"), mk(agent_name="solver"), mk(agent_name="solver")),
+            combine(mk(agent_name="proposer"), mk(agent_name="solver"), mk(agent_name="solver")),
+        ],
+        group_size=2,
+    )
+    multi_agent_out = multi_agent.metrics.to_wandb(prefix="eval/x", subset="all")
+    assert "eval/x/all/proposer/avg@2" in multi_agent_out
+    assert "eval/x/all/solver/avg@2" in multi_agent_out
+    assert not any("avg@4" in key for key in multi_agent_out)
 
 
 def test_compute_pass_metrics_matches_closed_form():


### PR DESCRIPTION
## Summary

- pass each eval environment's configured episode group size into `EvalEpisodes`
- remove the fallback that inferred `k` by counting trainable traces
- preserve the configured `k` through effective-subset filtering, including multi-agent episodes

## Verification

- `uv run pytest tests/unit/orchestrator/test_metrics.py -q` — 13 passed
- `uv run ruff check ...` and `uv run ruff format --check ...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small metrics-labeling fix with no change to scoring, training, or data handling. Wrong `avg@k` names were the only behavioral issue.
> 
> **Overview**
> Eval `avg@k` now uses each environment's configured episode `group_size` instead of inferring `k` from trainable-trace counts.
> 
> `EvalEpisodes` requires `group_size` and keeps that value through `effective` filtering, so multi-agent episodes no longer get mislabeled (e.g. `avg@4` when `k` is 2). `EvalSink.process_batch` passes `group_size_for(env_name)` into the batch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533b314c588750e9abe4310f3e59581b38913665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->