### PR TITLE
docs(training): correct saved episode references

### DIFF
--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -58,7 +58,7 @@ After a restart, verify all processes are back up and progress resumed before th
 - `scripts/tmux.sh` launches the run with a `Launcher` window in the named tmux session. The Claude window receives the run dir and session name in its appended prompt — if either is missing, **ask** rather than guess.
 - `{run_dir}/configs/` — resolved configs, written as JSON so explicit None settings round-trip (`rl.json` has the full picture).
 - `{run_dir}/logs/latest/` — the current attempt's logs (each launch gets `logs/attempt_<n>/`; resumes never overwrite earlier attempts). See below.
-- `{run_dir}/rollouts/step_N/{train,eval}/` — saved rollout traces (see Traces below).
+- `{run_dir}/rollouts/step_N/{train,eval}/` — saved episodes (see Episodes below).
 
 ### Logs
 
@@ -152,7 +152,7 @@ JSONL files of native `vf.Episode` records (training tensors excluded), one line
 curriculum-rejected work, and work that never enters a batch — so it is crash-durable.
 `effective` contains the admitted clean trainable traces grouped into their original episodes
 (eval: the non-errored trainable epoch cohort). Each record carries its provenance at the
-episode level: `env` (`id` plus the orchestrator's `name`), full `task`, `group_id`,
+episode level: `env` (`id` plus the orchestrator's `name`), full `task`, `group` (`id`),
 and `run`. Training-run records discriminate train/eval work and include dispatch
 step plus an optional live-policy version span. Traces retain their own task,
 verifiers, agent, and runtime fields.


### PR DESCRIPTION
## Summary

- describe rollout JSONL artifacts as native episodes rather than loose rollout traces
- point readers to the existing Episodes section
- document group provenance using the current `group.id` wire shape

## Verification

- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and field-name corrections in a training runbook; no code or runtime behavior changes.
> 
> **Overview**
> Updates the monitor-run skill so rollout JSONL artifacts are described as saved **episodes**, with the pointer going to the existing **Episodes** section instead of a nonexistent Traces heading.
> 
> Also documents episode provenance as `group` (`id`) rather than `group_id`, matching the current wire shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d732e5749b17697b9841465729599a26bf5e05a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->