### PR TITLE
refactor(orchestrator): rename sampler to generation source

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -153,7 +153,7 @@ type = "echo"
 
 ### The Algorithm Classes
 
-At runtime, each env's resolved config builds two objects: a `Sampler` (`prime_rl.orchestrator.sampler`) from the `sampling` component — the pool rollouts are generated from, and the home of future sampling strategies like replay buffers or branching — and one of the named algorithm classes in `prime_rl.orchestrator.algo` (one module per algorithm: `algo/grpo.py`, `algo/opd.py`, …) from the algorithm config. Algorithm dispatch is keyed on `algo.type` — it names the algorithm, and each config class's defaults are its vetted parameterization:
+At runtime, each env's resolved config builds two objects: a `GenerationSource` (`prime_rl.orchestrator.generation_source`) that resolves the `sampling.source` model into the inference pool used for train episodes, and one of the named algorithm classes in `prime_rl.orchestrator.algo` (one module per algorithm: `algo/grpo.py`, `algo/opd.py`, …) from the algorithm config. Algorithm dispatch is keyed on `algo.type` — it names the algorithm, and each config class's defaults are its vetted parameterization:
 
 | `algo.type` | Class | hook(s) — stage |
 |---|---|---|

--- a/src/prime_rl/orchestrator/algo/__init__.py
+++ b/src/prime_rl/orchestrator/algo/__init__.py
@@ -3,7 +3,7 @@
 The config side (``prime_rl.configs.algorithm``) defines *what* an algorithm
 is — a bundle of sampling and the per-token training signal. This package
 turns the signal half into runtime objects (the sampling half is the env's
-:class:`~prime_rl.orchestrator.sampler.Sampler`):
+:class:`~prime_rl.orchestrator.generation_source.GenerationSource`):
 
 - one module per algorithm (``grpo``, ``echo``, ``max_rl``, ``rae``,
   ``hierarchical_grpo``, ``opd``, ``opsd``, ``sft``) — each named class owns
@@ -55,7 +55,7 @@ def build_algorithm(config: AlgoConfig, policy_pool: InferencePool) -> Algorithm
     cls = ALGORITHM_CLASSES[config.type]
     assert cls.action_loss_type == config.action_loss_type  # config and runtime declare in two places
     # The Algorithm is the runtime of the algorithm config's training signal
-    # (its sibling Sampler interprets the sampling half). Every algorithm is
+    # (its sibling GenerationSource interprets the sampling half). Every algorithm is
     # handed the live policy pool — opsd self-distills against it, others may
     # judge against it or ignore it. Other models (a frozen teacher, a hint
     # renderer) are built from the algorithm's own config in setup().

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -163,7 +163,7 @@ class Dispatcher:
         self.progress = progress
         self.train_envs = train_envs
         self.eval_envs = eval_envs
-        # Train rollouts go to the env sampler's pool; eval always
+        # Train rollouts go to the env's generation source; eval always
         # evaluates the policy.
         self.policy_pool = policy_pool
         self.train_source = train_source
@@ -218,14 +218,14 @@ class Dispatcher:
         self.stopped = asyncio.Event()
         self.task: asyncio.Task | None = None
 
-    def _train_pool_for(self, env_name: str) -> tuple[InferencePool, str, bool]:
+    def _train_generation_for(self, env_name: str) -> tuple[InferencePool, str, bool]:
         """``(pool, model_name, is_live)`` for *train* rollouts of this env —
-        the env sampler's pool. (Eval always uses the policy.)"""
+        eval always uses the policy."""
         assert self.train_envs is not None  # train groups only exist when train is configured
-        sampler = self.train_envs.get(env_name).sampler
-        if sampler.samples_from_live_policy:
-            return sampler.pool, self.policy.model_name, True
-        return sampler.pool, sampler.pool.model_name, False
+        source = self.train_envs.get(env_name).generation_source
+        if source.uses_live_policy:
+            return source.pool, self.policy.model_name, True
+        return source.pool, source.pool.model_name, False
 
     @property
     def inflight_train_count(self) -> int:
@@ -374,10 +374,10 @@ class Dispatcher:
         for meta in self.inflight.values():
             if meta.kind != "train":
                 continue
-            # Frozen-sourced rollouts never go stale — their sampler doesn't
+            # Frozen-sourced rollouts never go stale — their generation source doesn't
             # change with policy updates.
             assert self.train_envs is not None
-            if not self.train_envs.get(meta.env_name).sampler.samples_from_live_policy:
+            if not self.train_envs.get(meta.env_name).generation_source.uses_live_policy:
                 continue
             meta.off_policy_steps += 1
             if meta.off_policy_steps > self.max_off_policy_steps:
@@ -490,7 +490,7 @@ class Dispatcher:
         ready, no permits). Returns True after issuing one task — the caller
         loops to keep scheduling.
         """
-        # Train rollouts use the env sampler's pool via the
+        # Train rollouts use the env's generation source via the
         # renderer/token train client. Eval always evaluates the policy and
         # goes through the eval client (chat-completions) so eval scores stay
         # comparable.
@@ -498,7 +498,7 @@ class Dispatcher:
             pool, model_name = self.policy_pool, self.policy.model_name
             live_sourced = True
         else:
-            pool, model_name, live_sourced = self._train_pool_for(group.env_name)
+            pool, model_name, live_sourced = self._train_generation_for(group.env_name)
 
         if group.pinned_client is None:
             group.pinned_client = pool.eval_client if group.kind == "eval" else pool.train_client
@@ -644,7 +644,7 @@ class Dispatcher:
         live_policy = meta.kind == "eval"
         if meta.kind == "train":
             assert self.train_envs is not None
-            live_policy = self.train_envs.get(meta.env_name).sampler.samples_from_live_policy
+            live_policy = self.train_envs.get(meta.env_name).generation_source.uses_live_policy
         policy = vf.PolicySpan(start=policy_version, end=self.policy.version) if live_policy else None
         work: vf.WorkInfo = (
             vf.EvalWorkInfo(step=meta.step, policy=policy)

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -29,7 +29,7 @@ from verifiers.v1.serve import EnvClient
 
 from prime_rl.configs.orchestrator import EnvConfig, EvalSourceConfig, TrainSourceConfig
 from prime_rl.orchestrator.algo import Algorithm, build_algorithm
-from prime_rl.orchestrator.sampler import Sampler
+from prime_rl.orchestrator.generation_source import GenerationSource
 from prime_rl.utils.logger import get_logger
 
 # Max wait for the env server to answer health. Generous because the launcher spawns
@@ -118,11 +118,17 @@ class Env:
 class TrainEnv(Env):
     config: TrainSourceConfig
 
-    def __init__(self, config: TrainSourceConfig, address: str, sampler: Sampler, algorithm: Algorithm):
+    def __init__(
+        self,
+        config: TrainSourceConfig,
+        address: str,
+        generation_source: GenerationSource,
+        algorithm: Algorithm,
+    ):
         super().__init__(config, address)
-        self.sampler = sampler
+        self.generation_source = generation_source
         self.algorithm = algorithm
-        self.sampling_args = sampler.sampling_args(config.sampling.to_sampling_args())
+        self.sampling_args = generation_source.sampling_args(config.sampling.to_sampling_args())
 
 
 class EvalEnv(Env):
@@ -175,8 +181,8 @@ class Envs(Generic[EnvT]):
 
 
 class TrainEnvs(Envs[TrainEnv]):
-    """Collection of training environments, each paired with its rollout
-    :class:`Sampler` and runtime :class:`Algorithm`, built from the env's
+    """Collection of training environments, each paired with its
+    :class:`GenerationSource` and runtime :class:`Algorithm`, built from the env's
     resolved algorithm config."""
 
     def __init__(
@@ -193,7 +199,7 @@ class TrainEnvs(Envs[TrainEnv]):
             env = TrainEnv(
                 config,
                 addresses[("train", config.resolved_name)],
-                Sampler(config.algo.sampling, policy_pool, renderer_config),
+                GenerationSource(config.algo.sampling, policy_pool, renderer_config),
                 build_algorithm(config.algo, policy_pool),
             )
             self._envs[env.name] = env

--- a/src/prime_rl/orchestrator/generation_source.py
+++ b/src/prime_rl/orchestrator/generation_source.py
@@ -1,12 +1,4 @@
-"""How an env's train rollouts are produced — the sample strategy.
-
-The algorithm (``algo/``) consumes finalized rollouts and compiles them into
-per-token loss-component weights; the sampler owns where those rollouts come
-from. Today that is one question — which model generates them — and its
-consequences (sampling logprobs, prefix-cache salting, and off-policy
-staleness are all liveness questions about the source). Future sampling
-strategies (replay buffers, branching) extend here, not the algorithm.
-"""
+"""Resolve the model source used to generate an env's train episodes."""
 
 from __future__ import annotations
 
@@ -21,8 +13,8 @@ if TYPE_CHECKING:
     from prime_rl.utils.client import InferencePool
 
 
-class Sampler:
-    """One env's rollout source.
+class GenerationSource:
+    """One env's generation model and inference pool.
 
     ``pool`` is the pool train rollouts are generated from: the policy pool,
     swapped for a connected frozen pool in :meth:`setup` when the source is an
@@ -40,20 +32,20 @@ class Sampler:
         self.connected_pools: list[InferencePool] = []  # client pools connected in setup(); closed at shutdown
 
     async def setup(self) -> None:
-        """Connect a client pool to a frozen sampling source and wait for
+        """Connect a client pool to a frozen generation source and wait for
         readiness. Must run before dispatching."""
         if isinstance(self.config.source, FrozenModelConfig):
             self.pool = await connect_frozen_pool(self.config.source, renderer_config=self.renderer_config)
             self.connected_pools.append(self.pool)
 
     @property
-    def samples_from_live_policy(self) -> bool:
+    def uses_live_policy(self) -> bool:
         return self.config.source == "policy"
 
     def sampling_args(self, args: dict) -> dict:
         """Source-specific sampling-arg overrides. Sampling logprobs are only
         needed for importance ratios on policy-sampled tokens — frozen
         endpoints may reject the knob."""
-        if not self.samples_from_live_policy:
+        if not self.uses_live_policy:
             args.pop("logprobs", None)
         return args

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -270,10 +270,10 @@ class Orchestrator:
         get_logger().info("Waiting for policy inference pool to be ready")
         await self.policy_inference.wait_for_ready(config.model.name)
         get_logger().success("Policy inference pool ready")
-        # Build + ready pools for each env's frozen sampling source and the
+        # Build + ready pools for each env's frozen generation source and the
         # algorithm's frozen reference model
         await asyncio.gather(
-            *(env.sampler.setup() for env in self.train_envs),
+            *(env.generation_source.setup() for env in self.train_envs),
             *(env.algorithm.setup() for env in self.train_envs),
         )
 
@@ -965,7 +965,7 @@ class Orchestrator:
                 await self.policy_inference.stop()
             if self.train_envs is not None:
                 for env in self.train_envs:
-                    for pool in (*env.sampler.connected_pools, *env.algorithm.connected_pools):
+                    for pool in (*env.generation_source.connected_pools, *env.algorithm.connected_pools):
                         await pool.stop()
 
         task = asyncio.create_task(teardown())


### PR DESCRIPTION
## Summary

- rename the env-level `Sampler` runtime to `GenerationSource`
- rename `TrainEnv.sampler` and its dispatcher/orchestrator call sites to match
- define the component narrowly as the resolver for `sampling.source`, its inference pool, and live-versus-frozen generation behavior
- reserve sampler terminology for curriculum task sampling and remove the claim that replay buffers or branching belong in this component

## Verification

- `uv run pytest tests/unit/orchestrator --ignore=tests/unit/orchestrator/test_qwen3_vl_e2e.py -q` — 79 passed
- `uv run ruff check ...` and `uv run ruff format --check ...`

The ignored Qwen3-VL test requires downloading its processor from Hugging Face, which was unavailable in the sandbox.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only refactor of orchestrator internals with no behavior change to pooling, liveness, or dispatch.
> 
> **Overview**
> Renames the env-level rollout `Sampler` to `GenerationSource` so “sampler” stays reserved for curriculum task sampling.
> 
> The class now only resolves `sampling.source` into the train inference pool and live-vs-frozen generation behavior (`uses_live_policy`). Docs and call sites (`TrainEnv`, dispatcher, orchestrator setup/shutdown) follow the rename; replay/branching is no longer claimed as this component’s job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d52b5aee72323b824fb960b58915123a8dab4c06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->