### PR TITLE
fix: drop resume block from the concurrency debug config

### DIFF
--- a/configs/debug/concurrency.toml
+++ b/configs/debug/concurrency.toml
@@ -49,8 +49,6 @@ timeout = 3600
 interval = 50
 keep_last = 1
 
-[resume]
-
 # --- Trainer ---
 
 [trainer]


### PR DESCRIPTION
## Summary
- An empty `[resume]` table is not a no-op: it constructs a `ResumeConfig` and resumes from the latest checkpoint, contradicting the fresh-start debug recipe added in #3307.

Addresses the outstanding review comment on #3307 (merged before the fix landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)