### PR TITLE
fix(sft): resumed runs restart the data stream with num_workers > 0

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -46,8 +46,8 @@ class BaseDataConfig(BaseConfig):
     micro_batch_size: int = Field(1, ge=1)
     """Per-step micro batch size. ``batch_size`` must be divisible by this."""
 
-    num_workers: int = Field(1, ge=0)
-    """Number of dataloader worker processes. With ``>= 1``, batches are prepared and pinned in the background so tokenization/packing overlaps with training. ``0`` loads inline on the main process."""
+    num_workers: int = Field(1, ge=1)
+    """Number of dataloader worker processes. Batches are prepared and pinned in the background so tokenization/packing overlaps with training."""
 
     @model_validator(mode="after")
     def validate_batch_size(self):

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -692,5 +692,7 @@ def get_dataset_state(dataloader: StatefulDataLoader) -> dict:
     if "dataset_state" in state:
         return state["dataset_state"]
     worker_snapshots = (state.get("_snapshot") or {}).get("_worker_snapshots") or {}
-    (worker_state,) = worker_snapshots.values()
-    return worker_state["dataset_state"]
+    states = {worker_id: snapshot["dataset_state"] for worker_id, snapshot in sorted(worker_snapshots.items())}
+    if len(states) == 1:
+        return next(iter(states.values()))
+    return states

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -683,21 +683,17 @@ def setup_dataloader(dataset: StatefulIterableDataset, config: DataConfig) -> St
         batch_size=1,
         collate_fn=cat_collate,
         num_workers=config.num_workers,
-        pin_memory=config.num_workers > 0,
+        pin_memory=True,
     )
 
 
 def get_dataset_state(dataloader: StatefulDataLoader) -> dict:
-    """Dataset position(s) for the startup log, parsed from ``StatefulDataLoader.state_dict()``.
+    """Dataset position per worker for the startup log, parsed from ``StatefulDataLoader.state_dict()``.
 
     The loader is the only source that is correct in every case: after a resume's
     ``load_state_dict`` the restored position exists solely in the loader's stashed
     state (it reaches the dataset copies inside workers when the iterator forks them;
-    the main-process dataset object stays at position zero). The stashed layout uses
-    torchdata's private keys: inline for a fresh loader, per-worker snapshots for a
-    loaded or live ``num_workers > 0`` loader."""
-    state = dataloader.state_dict()
-    if "dataset_state" in state:
-        return state["dataset_state"]["dataset"]
-    snapshots = (state.get("_snapshot") or {}).get("_worker_snapshots") or {}
+    the main-process dataset object stays at position zero). The keys are torchdata's
+    private worker-snapshot layout."""
+    snapshots = dataloader.state_dict()["_snapshot"]["_worker_snapshots"]
     return {wid: snap["dataset_state"]["dataset"] for wid, snap in sorted(snapshots.items())}

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -688,11 +688,16 @@ def setup_dataloader(dataset: StatefulIterableDataset, config: DataConfig) -> St
 
 
 def get_dataset_state(dataloader: StatefulDataLoader) -> dict:
+    """Dataset position(s) for the startup log, parsed from ``StatefulDataLoader.state_dict()``.
+
+    The loader is the only source that is correct in every case: after a resume's
+    ``load_state_dict`` the restored position exists solely in the loader's stashed
+    state (it reaches the dataset copies inside workers when the iterator forks them;
+    the main-process dataset object stays at position zero). The stashed layout uses
+    torchdata's private keys: inline for a fresh loader, per-worker snapshots for a
+    loaded or live ``num_workers > 0`` loader."""
     state = dataloader.state_dict()
     if "dataset_state" in state:
-        return state["dataset_state"]
-    worker_snapshots = (state.get("_snapshot") or {}).get("_worker_snapshots") or {}
-    states = {worker_id: snapshot["dataset_state"] for worker_id, snapshot in sorted(worker_snapshots.items())}
-    if len(states) == 1:
-        return next(iter(states.values()))
-    return states
+        return state["dataset_state"]["dataset"]
+    snapshots = (state.get("_snapshot") or {}).get("_worker_snapshots") or {}
+    return {wid: snap["dataset_state"]["dataset"] for wid, snap in sorted(snapshots.items())}

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -248,10 +248,10 @@ def train(config: SFTConfig):
         f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples}, dataset_state={get_dataset_state(dataloader)})"
     )
 
-    # Create the iterator only after a potential resume: with num_workers > 0, iter()
-    # forks workers with a copy of the dataset's *current* state, so a later
-    # load_state_dict never reaches an already-running worker (the run silently
-    # restarts the data from the beginning and re-saves the stale position).
+    # Create the iterator only after a potential resume: iter() forks workers with a
+    # copy of the dataset's *current* state, so a later load_state_dict never reaches
+    # an already-running worker (the run silently restarts the data from the beginning
+    # and re-saves the stale position).
     dataiter = iter(dataloader)
 
     cp_enabled = parallel_dims.cp_enabled

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -216,7 +216,6 @@ def train(config: SFTConfig):
     multimodal = config.model.vlm is not None
     dataset = setup_dataset(tokenizer, config.data, config.model.cp, renderer=renderer, multimodal=multimodal)
     dataloader = setup_dataloader(dataset, config.data)
-    dataiter = iter(dataloader)
 
     val_raw_dataset = None
     if config.val is not None:
@@ -248,6 +247,12 @@ def train(config: SFTConfig):
     logger.info(
         f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples}, dataset_state={get_dataset_state(dataloader)})"
     )
+
+    # Create the iterator only after a potential resume: with num_workers > 0, iter()
+    # forks workers with a copy of the dataset's *current* state, so a later
+    # load_state_dict never reaches an already-running worker (the run silently
+    # restarts the data from the beginning and re-saves the stale position).
+    dataiter = iter(dataloader)
 
     cp_enabled = parallel_dims.cp_enabled
     cp_rank = parallel_dims.world_mesh["cp"].get_local_rank() if cp_enabled else 0

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -20,22 +20,22 @@ def test_fake_dataset_single_rank_state():
     dataiter = iter(dataloader)
 
     # Initial state
-    assert get_dataset_state(dataloader) == {"dataset": {"step": 0, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"worker_0": {"step": 0, "epoch": 0}}
 
     # Iterate over samples
     micro_batch = next(dataiter)
     print(micro_batch)
     assert micro_batch["input_ids"].unique().item() == 0
-    assert get_dataset_state(dataloader) == {"dataset": {"step": 1, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"worker_0": {"step": 1, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 1
-    assert get_dataset_state(dataloader) == {"dataset": {"step": 2, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"worker_0": {"step": 2, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 2
-    assert get_dataset_state(dataloader) == {"dataset": {"step": 3, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"worker_0": {"step": 3, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 3
-    assert get_dataset_state(dataloader) == {"dataset": {"step": 4, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"worker_0": {"step": 4, "epoch": 0}}
 
 
 @pytest.mark.parametrize("rank", [0, 1], ids=["rank0", "rank1"])
@@ -55,26 +55,26 @@ def test_fake_dataset_multi_rank_state(rank: int):
     dataiter = iter(dataloader)
 
     # Initial state
-    assert get_dataset_state(dataloader) == {"dataset": {"step": 0, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"worker_0": {"step": 0, "epoch": 0}}
 
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 0 + rank
-    assert get_dataset_state(dataloader) == {"dataset": {"step": 1 + rank, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"worker_0": {"step": 1 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 2 + rank
-    assert get_dataset_state(dataloader) == {"dataset": {"step": 3 + rank, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"worker_0": {"step": 3 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 4 + rank
-    assert get_dataset_state(dataloader) == {"dataset": {"step": 5 + rank, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"worker_0": {"step": 5 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 6 + rank
-    assert get_dataset_state(dataloader) == {"dataset": {"step": 7 + rank, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"worker_0": {"step": 7 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 8 + rank
-    assert get_dataset_state(dataloader) == {"dataset": {"step": 9 + rank, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"worker_0": {"step": 9 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 10 + rank
-    assert get_dataset_state(dataloader) == {"dataset": {"step": 11 + rank, "epoch": 0}}
+    assert get_dataset_state(dataloader) == {"worker_0": {"step": 11 + rank, "epoch": 0}}
 
 
 def test_fake_dataset_single_rank_resume():
@@ -89,7 +89,7 @@ def test_fake_dataset_single_rank_resume():
         micro_batch = next(dataiter)
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["input_ids"].unique().item() == step
-        assert get_dataset_state(dataloader) == {"dataset": {"step": step + 1, "epoch": 0}}
+        assert get_dataset_state(dataloader) == {"worker_0": {"step": step + 1, "epoch": 0}}
 
     # Reload dataloader
     state_dict = dataloader.state_dict()
@@ -102,7 +102,7 @@ def test_fake_dataset_single_rank_resume():
         micro_batch = next(dataiter)
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["input_ids"].unique().item() == step
-        assert get_dataset_state(dataloader) == {"dataset": {"step": step + 1, "epoch": 0}}
+        assert get_dataset_state(dataloader) == {"worker_0": {"step": step + 1, "epoch": 0}}
 
 
 def test_fake_dataset_single_rank_state_with_packing():
@@ -119,10 +119,10 @@ def test_fake_dataset_single_rank_state_with_packing():
         step += num_packed_examples
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["seq_lens"].sum() == micro_batch["input_ids"].shape[1]
-        dataset_state = get_dataset_state(dataloader)
-        pending_sample = dataset_state.get("pending_sample")
+        worker_state = dataloader.state_dict()["_snapshot"]["_worker_snapshots"]["worker_0"]["dataset_state"]
+        pending_sample = worker_state.get("pending_sample")
         expected_dataset_step = step + (pending_sample is not None)
-        assert dataset_state["dataset"] == {"step": expected_dataset_step, "epoch": 0}
+        assert get_dataset_state(dataloader) == {"worker_0": {"step": expected_dataset_step, "epoch": 0}}
         if pending_sample is not None:
             assert pending_sample["input_ids"][0] == step
 


### PR DESCRIPTION
## Summary

Since #3299 made `data.num_workers` default to 1, **every resumed SFT run silently restarts the training data from the beginning** and freezes the data position it writes into subsequent checkpoints.

Root cause: `train()` called `iter(dataloader)` before the resume path's `ckpt_manager.load(..., dataloader=dataloader)`. With worker processes, `iter()` forks the worker with a copy of the dataset in its *initial* state; the later `load_state_dict` only stashes state for a future iterator that is never created. Two symptoms:

- the resumed run consumes the dataset from row 0 again (visible as a loss-slope kink at every resume — repeated data);
- `state_dict()` keeps returning the stashed loaded state, so every post-resume checkpoint stores the resume-point position instead of the live one, compounding across restarts.

Fix: create the iterator only after the potential resume load, with a comment stating the constraint.

Also: `get_dataset_state` unpacked exactly one worker snapshot, crashing **any** run with `num_workers > 1` at the startup log line (start or resume) — it now returns positions keyed per worker, and stops dumping `pending_sample` token buffers into the log. It keeps parsing the loader's stashed state rather than the dataset object: after a resume the restored position exists only there (the main-process dataset object stays at position 0; workers receive the state on fork). This is now the single code path: `num_workers = 0` (the only case with a different, inline state layout) is no longer supported.

## Breaking

- `data.num_workers = 0` is rejected at config time (`ge=1`). Inline main-process data loading is gone; use `num_workers = 1` (the default).

## Verification

A/B on `configs/ci/integration/reverse-text-sft/{start,resume}.toml` (Qwen3-0.6B, 1 node, 2 GPUs, 5 steps + resume to 10), comparing `checkpoints/step_N/trainer/dataloader/rank_0.pt` worker-snapshot dataset state:

| variant | ckpt step_5 | ckpt step_10 (post-resume) |
|---|---|---|
| main, `num_workers=1` | `{'step': 213}` | `{'step': 213}` — frozen, data restarted from row 0 |
| main, `num_workers=2` | — | crashes at startup (`ValueError: too many values to unpack` in `get_dataset_state`) |
| this PR, `num_workers=1` | `{'step': 213}` | `{'step': 407}` — advanced correctly |
| this PR, `num_workers=2` | `{'worker_0': 111, 'worker_1': 111}` | `{'worker_0': 213, 'worker_1': 213}` — per-worker state restored and advanced; workers consume disjoint shards |

Discovered on a production 500-step GLM-4.5-Air SFT run (india): after two crash-resumes, both post-resume checkpoints carried the identical dataset position (`{'step': 6657}` at step 150 *and* step 300) and the loss slope steepened at each resume boundary from re-trained data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
