### PR TITLE
refactor(orchestrator): make dispatch contracts explicit

### DIFF
--- a/src/prime_rl/evals/evals.py
+++ b/src/prime_rl/evals/evals.py
@@ -357,7 +357,7 @@ class Evals:
                 await self.pool.update_weights(broadcast_dir, lora_name=lora_name, step=step)
             except Exception as exc:
                 # Skip this step instead of killing the run; drain the queued examples
-                # so they don't leak into a later epoch with the wrong eval_step.
+                # so they don't leak into a later epoch with the wrong step.
                 while self.eval_source.next_task() is not None:
                     pass
                 get_logger().error(f"Failed to update inference weights to step {step} - skipping evals: {exc!r}")

--- a/src/prime_rl/evals/evals.py
+++ b/src/prime_rl/evals/evals.py
@@ -358,7 +358,7 @@ class Evals:
             except Exception as exc:
                 # Skip this step instead of killing the run; drain the queued examples
                 # so they don't leak into a later epoch with the wrong eval_step.
-                while self.eval_source.next_example() is not None:
+                while self.eval_source.next_task() is not None:
                     pass
                 get_logger().error(f"Failed to update inference weights to step {step} - skipping evals: {exc!r}")
                 return

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -462,15 +462,16 @@ class Dispatcher:
         return await self.schedule_group_episode(gid, fresh)
 
     def next_fresh_group(self, kind: WorkKind, envs) -> GroupState | None:
-        """Pop the next example from the corresponding source and wrap it in
+        """Pop the next task from the corresponding source and wrap it in
         a ``GroupState``. Returns ``None`` if the source is empty."""
         if kind == "train":
             assert self.train_source is not None
-            source = self.train_source
+            if self.progress is None:
+                raise RuntimeError("Train dispatch requires progress state")
+            request = self.train_source.next_task(step=self.progress.step)
         else:
             assert self.eval_source is not None
-            source = self.eval_source
-        request = source.next_task()
+            request = self.eval_source.next_task()
         if request is None:
             return None
 
@@ -481,9 +482,9 @@ class Dispatcher:
             kind=kind,
             env_name=env_name,
             task=request.task,
+            step=request.step,
             episodes_to_schedule=group_size,
             target_episodes=group_size,
-            eval_step=request.eval_step,
             policy_version_at_start=self.policy.version,
         )
 
@@ -538,20 +539,11 @@ class Dispatcher:
             group_id=group_id,
             task=group.task,
             policy_version=group.policy_version_at_start,
-            step=self._work_step(group.kind, group.eval_step),
+            step=group.step,
             client_config=client,
-            eval_step=group.eval_step,
             started_at=time.monotonic(),
         )
         return True
-
-    def _work_step(self, kind: WorkKind, eval_step: int | None) -> int:
-        if kind == "eval":
-            assert eval_step is not None
-            return eval_step
-        if self.progress is None:
-            raise RuntimeError("Train dispatch requires progress state")
-        return self.progress.step
 
     async def acquire(self) -> None:
         """Reserve one permit + rate-limit it. Caller must precheck
@@ -632,17 +624,13 @@ class Dispatcher:
     ) -> None:
         """Stamp one completed episode with its dispatch provenance and emit it."""
         _validate_episode_task(episode, meta.task)
-        eval_step = meta.eval_step
         policy_version = meta.policy_version
         if group is not None:
-            eval_step = group.eval_step
             policy_version = group.policy_version_at_start
             group.emitted += 1
             if group.emitted >= group.target_episodes:
                 self.groups.pop(meta.group_id, None)
 
-        if meta.kind == "eval":
-            assert eval_step is not None, "eval episode missing eval_step"
         episode.env.name = meta.env_name
         episode.group = vf.GroupInfo(id=str(meta.group_id))
         live_policy = meta.kind == "eval"

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -8,7 +8,7 @@
 - Optional rate limiting via ``AsyncLimiter(tasks_per_minute, 60)``.
 - Emit-everything invariant: every dispatched episode eventually reaches
   ``out_q`` exactly once — as a native episode, or covered by its group's
-  single ``Cancellation`` message when the group is dropped. Failures
+  single ``GroupCancellation`` message when the group is dropped. Failures
   remain episode errors; sinks decide drop / partial-train policy.
 - ``DispatcherMode.PREFER_TRAIN`` / ``PREFER_EVAL`` controls which kind to
   schedule next. Transitions are level-triggered (driven by the eval
@@ -42,8 +42,9 @@ from prime_rl.orchestrator.envs import EvalEnvs, TrainEnvs
 from prime_rl.orchestrator.eval_source import EvalSource
 from prime_rl.orchestrator.train_source import TrainSource
 from prime_rl.orchestrator.types import (
-    Cancellation,
     CancelReason,
+    DispatchResult,
+    GroupCancellation,
     GroupState,
     InflightEpisode,
     Policy,
@@ -201,9 +202,9 @@ class Dispatcher:
         # Bounded so the dispatcher backpressures on a slow sink (unbounded
         # when no hard ceiling is configured — the dynamic cap still bounds
         # in-flight work). One entry per episode — the sinks count episodes,
-        # never loose traces — plus one ``Cancellation`` per dropped group.
+        # never loose traces — plus one ``GroupCancellation`` per dropped group.
         maxsize = max(8, max_inflight_ceiling) if max_inflight_ceiling is not None else 0
-        self.out_q: asyncio.Queue[vf.WireEpisode | Cancellation] = asyncio.Queue(maxsize=maxsize)
+        self.out_q: asyncio.Queue[DispatchResult] = asyncio.Queue(maxsize=maxsize)
 
         self.mode: DispatcherMode = DispatcherMode.PREFER_TRAIN
         # Set by the orchestrator after the final train step; pipeline then
@@ -469,21 +470,20 @@ class Dispatcher:
         else:
             assert self.eval_source is not None
             source = self.eval_source
-        example = source.next_example()
-        if example is None:
+        request = source.next_task()
+        if request is None:
             return None
 
-        env_name = example["env_name"]
+        env_name = request.env_name
         group_size = envs.get(env_name).config.group_size
-        eval_step: int | None = example.get("eval_step") if kind == "eval" else None
 
         return GroupState(
             kind=kind,
             env_name=env_name,
-            task=example["task"],
+            task=request.task,
             episodes_to_schedule=group_size,
             target_episodes=group_size,
-            eval_step=eval_step,
+            eval_step=request.eval_step,
             policy_version_at_start=self.policy.version,
         )
 
@@ -661,7 +661,7 @@ class Dispatcher:
 
     async def drop_group(self, group_id: uuid.UUID, *, reason: CancelReason) -> int:
         """Cancel this group's remaining in-flight tasks and emit one
-        ``Cancellation`` covering every episode it still owes the sink (both
+        ``GroupCancellation`` covering every episode it still owes the sink (both
         in-flight and never-dispatched), so count-to-``group_size``
         finalization still fires. Returns the owed count for metrics."""
         group = self.groups.pop(group_id, None)
@@ -694,7 +694,13 @@ class Dispatcher:
                 f"cancelled={cancelled} (inflight={inflight_cancelled} unscheduled={unscheduled_cancelled})"
             )
             await self.out_q.put(
-                Cancellation(kind=kind, env_name=env_name, group_id=str(group_id), count=cancelled, reason=reason)
+                GroupCancellation(
+                    kind=kind,
+                    env_name=env_name,
+                    group_id=str(group_id),
+                    count=cancelled,
+                    reason=reason,
+                )
             )
 
         if claimed:

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -137,7 +137,7 @@ class EvalEnv(Env):
     def __init__(self, config: EvalSourceConfig, address: str):
         super().__init__(config, address)
         self.sampling_args = config.sampling.to_sampling_args()
-        self.examples: list[dict] = []
+        self.examples: list[vf.Task] = []
 
     async def start(self) -> None:
         await super().start()
@@ -146,7 +146,7 @@ class EvalEnv(Env):
             raise ValueError(f"Eval env {self.name} has an infinite taskset — set num_examples to bound it")
         # A fixed eval set, pulled off the tasks once and reused every epoch.
         tasks = list(self.tasks) if n < 0 else list(islice(self.tasks, n))
-        self.examples = [{"task": task} for task in tasks]
+        self.examples = tasks
 
 
 EnvT = TypeVar("EnvT", bound=Env)

--- a/src/prime_rl/orchestrator/eval_source.py
+++ b/src/prime_rl/orchestrator/eval_source.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from collections import deque
 from itertools import zip_longest
 
+import verifiers.v1 as vf
+
 from prime_rl.configs.orchestrator import EvalConfig
 from prime_rl.orchestrator.envs import EvalEnvs
 from prime_rl.orchestrator.types import TaskRequest
@@ -27,10 +29,10 @@ class EvalSource:
         self.eval_envs = eval_envs
         self.eval_config = eval_config
 
-        self.requests_by_env: dict[str, list[TaskRequest]] = {}
+        self.tasks_by_env: dict[str, list[vf.Task]] = {}
         self.intervals: dict[str, int] = {}
         for env in eval_envs:
-            self.requests_by_env[env.name] = [TaskRequest(env_name=env.name, task=task) for task in env.examples]
+            self.tasks_by_env[env.name] = list(env.examples)
             self.intervals[env.name] = env.config.interval
 
         self.queue: deque[TaskRequest] = deque()
@@ -55,12 +57,12 @@ class EvalSource:
         # dispatcher rotates at example granularity. ``try_schedule``'s
         # continue-group branch still keeps each example's group_size
         # rollouts back-to-back, so per-example prefix-cache locality holds
-        iters = [iter(self.requests_by_env[name]) for name in fired]
-        for round_requests in zip_longest(*iters):
-            for request in round_requests:
-                if request is None:
+        iters = [iter(self.tasks_by_env[name]) for name in fired]
+        for round_tasks in zip_longest(*iters):
+            for env_name, task in zip(fired, round_tasks, strict=True):
+                if task is None:
                     continue
-                self.queue.append(TaskRequest(env_name=request.env_name, task=request.task, eval_step=step))
+                self.queue.append(TaskRequest(env_name=env_name, task=task, step=step))
         return fired
 
     def next_task(self) -> TaskRequest | None:

--- a/src/prime_rl/orchestrator/eval_source.py
+++ b/src/prime_rl/orchestrator/eval_source.py
@@ -1,7 +1,7 @@
 """EvalSource: trigger-driven, finite-per-epoch pull of eval examples.
 
 The orchestrator pokes ``trigger(step)`` after each ship + once at
-startup; the dispatcher pulls via ``next_example()`` until
+startup; the dispatcher pulls via ``next_task()`` until
 ``bool(source) == False``. Constructed only when eval is configured."""
 
 from __future__ import annotations
@@ -11,6 +11,7 @@ from itertools import zip_longest
 
 from prime_rl.configs.orchestrator import EvalConfig
 from prime_rl.orchestrator.envs import EvalEnvs
+from prime_rl.orchestrator.types import TaskRequest
 
 
 class EvalSource:
@@ -26,18 +27,13 @@ class EvalSource:
         self.eval_envs = eval_envs
         self.eval_config = eval_config
 
-        self.examples_by_env: dict[str, list[dict]] = {}
+        self.requests_by_env: dict[str, list[TaskRequest]] = {}
         self.intervals: dict[str, int] = {}
         for env in eval_envs:
-            rows: list[dict] = []
-            for ex in env.examples:
-                row = dict(ex)
-                row["env_name"] = env.name
-                rows.append(row)
-            self.examples_by_env[env.name] = rows
+            self.requests_by_env[env.name] = [TaskRequest(env_name=env.name, task=task) for task in env.examples]
             self.intervals[env.name] = env.config.interval
 
-        self.queue: deque[dict] = deque()
+        self.queue: deque[TaskRequest] = deque()
 
         # On resume we skip the startup eval; on fresh start the first
         # trigger fires every env (subject to ``skip_first_step``)
@@ -59,18 +55,16 @@ class EvalSource:
         # dispatcher rotates at example granularity. ``try_schedule``'s
         # continue-group branch still keeps each example's group_size
         # rollouts back-to-back, so per-example prefix-cache locality holds
-        iters = [iter(self.examples_by_env[name]) for name in fired]
-        for round_examples in zip_longest(*iters):
-            for example in round_examples:
-                if example is None:
+        iters = [iter(self.requests_by_env[name]) for name in fired]
+        for round_requests in zip_longest(*iters):
+            for request in round_requests:
+                if request is None:
                     continue
-                row = dict(example)
-                row["eval_step"] = step
-                self.queue.append(row)
+                self.queue.append(TaskRequest(env_name=request.env_name, task=request.task, eval_step=step))
         return fired
 
-    def next_example(self) -> dict | None:
-        """Pop the next eval example, or ``None`` when the queue is empty."""
+    def next_task(self) -> TaskRequest | None:
+        """Pop the next eval task, or ``None`` when the queue is empty."""
         if not self.queue:
             return None
         return self.queue.popleft()

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -58,8 +58,8 @@ from prime_rl.orchestrator.periodic_logger import PeriodicLogger
 from prime_rl.orchestrator.train_sink import TrainSink
 from prime_rl.orchestrator.train_source import TrainSource
 from prime_rl.orchestrator.types import (
-    Cancellation,
     EvalBatch,
+    GroupCancellation,
     Policy,
     Progress,
     TrainBatch,
@@ -555,7 +555,7 @@ class Orchestrator:
             )
 
     async def main_loop(self) -> None:
-        """Consume completed episodes and group ``Cancellation``\\ s from the
+        """Consume completed episodes and ``GroupCancellation`` events from the
         dispatcher and route them to the train / eval sink. The sinks return a
         finalized batch (or ``None``); we just dispatch on the result."""
         while not self.stopped.is_set():
@@ -571,7 +571,7 @@ class Orchestrator:
                 self._raise_if_component_stopped()
                 continue
 
-            if isinstance(item, Cancellation):
+            if isinstance(item, GroupCancellation):
                 assert item.kind == "train"  # eval groups are never dropped
                 train_batch = await self.train_sink.cancel(item)
                 if train_batch is not None and not self.draining and not self.stopped.is_set():

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -1,7 +1,7 @@
 """Training-side episode, group, and batch assembly.
 
 ``add()`` takes one completed episode and ``cancel()`` a dropped group's
-``Cancellation``; both return ``TrainBatch | None``. Before every readiness
+``GroupCancellation``; both return ``TrainBatch | None``. Before every readiness
 check the sink sweeps ``pending_batch`` for traces past ``max_off_policy_steps`` —
 this sweep, not the dispatcher's in-flight cancel, is what guarantees nothing
 stale ships."""
@@ -20,7 +20,7 @@ from prime_rl.orchestrator.algo.routing import stamp_loss_routing
 from prime_rl.orchestrator.envs import TrainEnvs
 from prime_rl.orchestrator.metrics import TrainEpisodes
 from prime_rl.orchestrator.trajectories import trace_to_samples
-from prime_rl.orchestrator.types import Cancellation, Progress, TrainBatch
+from prime_rl.orchestrator.types import GroupCancellation, Progress, TrainBatch
 from prime_rl.orchestrator.utils import episode_env_name, episode_group_id, min_fresh_version, train_work
 from prime_rl.transports.rollouts import TrainingSample
 from prime_rl.utils.logger import get_logger
@@ -92,7 +92,7 @@ class TrainSink:
         self.pending_groups: dict[str, list[vf.Episode]] = defaultdict(list)
         # A dropped group's terminal marker; its ``count`` fills in for the
         # episodes the group will never deliver.
-        self.pending_group_cancellations: dict[str, Cancellation] = {}
+        self.pending_group_cancellations: dict[str, GroupCancellation] = {}
         self.pending_batch: dict[str, list[TrainingSample]] = {}
         self.episode_by_trace: dict[str, vf.Episode] = {}
         self.pending_tokens = 0
@@ -135,7 +135,7 @@ class TrainSink:
         await self.process_group(group_id)
         return self._maybe_batch()
 
-    async def cancel(self, cancellation: Cancellation) -> TrainBatch | None:
+    async def cancel(self, cancellation: GroupCancellation) -> TrainBatch | None:
         """Process a dropped group's terminal marker: its ``count`` completes
         the group's episode accounting so finalization still fires. A
         ``stale`` drop also voids the group's already-arrived episodes in

--- a/src/prime_rl/orchestrator/train_source.py
+++ b/src/prime_rl/orchestrator/train_source.py
@@ -10,6 +10,7 @@ import verifiers.v1 as vf
 
 from prime_rl.orchestrator.curriculum import Curriculum
 from prime_rl.orchestrator.envs import TrainEnvs
+from prime_rl.orchestrator.types import TaskRequest
 from prime_rl.orchestrator.utils import episode_env_name
 
 
@@ -34,12 +35,9 @@ class TrainSource:
         self._admitted: dict[str, int] = defaultdict(int)
         self._rejected: dict[str, int] = defaultdict(int)
 
-    def next_example(self) -> dict[str, Any]:
+    def next_task(self) -> TaskRequest:
         env_name = self.rng.choices(self.env_names, weights=self.weights, k=1)[0]
-        return {
-            "env_name": env_name,
-            "task": next(self.curricula[env_name].sampler),
-        }
+        return TaskRequest(env_name=env_name, task=next(self.curricula[env_name].sampler))
 
     def on_result(self, group: list[vf.Episode]) -> bool:
         """Report a finalized group and return whether it should train."""

--- a/src/prime_rl/orchestrator/train_source.py
+++ b/src/prime_rl/orchestrator/train_source.py
@@ -35,9 +35,9 @@ class TrainSource:
         self._admitted: dict[str, int] = defaultdict(int)
         self._rejected: dict[str, int] = defaultdict(int)
 
-    def next_task(self) -> TaskRequest:
+    def next_task(self, *, step: int) -> TaskRequest:
         env_name = self.rng.choices(self.env_names, weights=self.weights, k=1)[0]
-        return TaskRequest(env_name=env_name, task=next(self.curricula[env_name].sampler))
+        return TaskRequest(env_name=env_name, task=next(self.curricula[env_name].sampler), step=step)
 
     def on_result(self, group: list[vf.Episode]) -> bool:
         """Report a finalized group and return whether it should train."""

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -57,11 +57,11 @@ DispatchResult: TypeAlias = vf.WireEpisode | GroupCancellation
 
 @dataclass(frozen=True)
 class TaskRequest:
-    """A task selected by a train or eval source for dispatch."""
+    """A task selected by a train or eval source with its pinned run step."""
 
     env_name: str
     task: vf.Task
-    eval_step: int | None = None
+    step: int
 
 
 @dataclass
@@ -75,24 +75,22 @@ class InflightEpisode:
     policy_version: int
     step: int
     client_config: vf.ClientConfig | None = None
-    eval_step: int | None = None
     started_at: float = 0.0
     """``time.monotonic()`` at dispatch; feeds episode-duration estimates."""
 
 
 @dataclass
 class GroupState:
-    """Per-group dispatcher state: what's left to schedule + the pinned
-    client (for prefix-cache hits)."""
+    """Per-group dispatcher state with pinned run context and client."""
 
     kind: WorkKind
     env_name: str
     task: vf.Task
     """The group's task — its data is shipped on every dispatch."""
+    step: int
     episodes_to_schedule: int
     target_episodes: int
     emitted: int = 0
-    eval_step: int | None = None
     pinned_client: vf.ClientConfig | None = None
     policy_version_at_start: int = 0
 

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias
 
 import verifiers.v1 as vf
 
@@ -39,7 +39,7 @@ CancelReason = Literal["stale", "overload"]
 
 
 @dataclass
-class Cancellation:
+class GroupCancellation:
     """Terminal marker for a dropped group: one message covering every episode
     the group still owed the sink (in-flight and never-dispatched), so
     count-to-``group_size`` finalization still fires. ``reason`` distinguishes
@@ -50,6 +50,18 @@ class Cancellation:
     group_id: str
     count: int
     reason: CancelReason
+
+
+DispatchResult: TypeAlias = vf.WireEpisode | GroupCancellation
+
+
+@dataclass(frozen=True)
+class TaskRequest:
+    """A task selected by a train or eval source for dispatch."""
+
+    env_name: str
+    task: vf.Task
+    eval_step: int | None = None
 
 
 @dataclass

--- a/tests/unit/orchestrator/test_curriculum.py
+++ b/tests/unit/orchestrator/test_curriculum.py
@@ -110,7 +110,7 @@ def test_train_source_composes_sampler_and_all_gates_with_state_and_metrics() ->
     env = SimpleNamespace(name="test", tasks=iter(tasks), num_tasks=len(tasks), config=config)
     source = TrainSource([env])
 
-    sampled = source.next_task().task
+    sampled = source.next_task(step=1).task
     assert source.on_result(make_rollout(sampled, reward=0.25, advantages=[0.0])) is False
     assert source.metrics() == {
         "curriculum/test/admission_rate": 0.0,

--- a/tests/unit/orchestrator/test_curriculum.py
+++ b/tests/unit/orchestrator/test_curriculum.py
@@ -110,7 +110,7 @@ def test_train_source_composes_sampler_and_all_gates_with_state_and_metrics() ->
     env = SimpleNamespace(name="test", tasks=iter(tasks), num_tasks=len(tasks), config=config)
     source = TrainSource([env])
 
-    sampled = source.next_example()["task"]
+    sampled = source.next_task().task
     assert source.on_result(make_rollout(sampled, reward=0.25, advantages=[0.0])) is False
     assert source.metrics() == {
         "curriculum/test/admission_rate": 0.0,


### PR DESCRIPTION
## Summary

- replace the train/eval sources' dictionary payloads with an immutable `TaskRequest` returned by `next_task()`
- require every request's run step and pin it once per group, removing the duplicate optional `eval_step` fields and per-episode step resolution
- rename the group-scoped terminal event to `GroupCancellation` and name the dispatcher queue union `DispatchResult`
- keep source requests separate from mutable `GroupState`, and store eval examples as native `vf.Task` objects end to end

## API

```python
@dataclass(frozen=True)
class TaskRequest:
    env_name: str
    task: vf.Task
    step: int


@dataclass
class GroupCancellation:
    kind: WorkKind
    env_name: str
    group_id: str
    count: int
    reason: CancelReason


DispatchResult: TypeAlias = vf.WireEpisode | GroupCancellation
```

The zero-output accounting fix from #3313 remains unchanged: a freshly inserted group whose traces are all dropped as stale advances the watchdog instead of resetting it.

## Verification

- Ruff format and lint passed, including the commit hooks.
- `tests/unit/orchestrator/test_curriculum.py`: 5 passed.
- Eval-source round-robin, required-step propagation, and changed-module import smoke checks passed.
- `tests/unit/orchestrator`, excluding the unrelated Qwen3-VL renderer-fixture mismatch: 79 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestrator scheduling and step pinning, so a typing/rename mistake could mis-tag train vs eval work. Runtime policy is unchanged.
> 
> **Overview**
> Makes train/eval dispatch payloads typed instead of dicts, and pins the run **step** on the request rather than reconstructing it later.
> 
> Sources now return a frozen `TaskRequest` from `next_task()`. Eval examples stay as native `vf.Task` objects. `GroupState` / `InflightEpisode` carry a single `step` field, dropping the eval-only `eval_step` split and `_work_step`.
> 
> The dispatcher queue union is named `DispatchResult`, and the group-drop marker is renamed to `GroupCancellation`. Behavior is otherwise the same: failed weight reloads still drain the eval queue so leftover work cannot leak into a later epoch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4294fc9703e66b6f0d78447c56aa609bb2684df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->