### PR TITLE
feat(transports): add mx_refit weight-broadcast transport

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -214,7 +214,7 @@ class VllmConfig(BaseConfig):
 
 
 class WeightBroadcastConfig(BaseConfig):
-    type: Literal["nccl", "filesystem", "nixl"] = "filesystem"
+    type: Literal["nccl", "filesystem", "nixl", "mx_refit"] = "filesystem"
     """Weight broadcast transport."""
 
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -414,8 +414,18 @@ class NIXLWeightBroadcastConfig(InMemoryWeightBroadcastConfig):
     """ModelExpress session ID."""
 
 
+class MXRefitWeightBroadcastConfig(InMemoryWeightBroadcastConfig):
+    type: Literal["mx_refit"] = "mx_refit"
+
+    port: int = 8001
+    """ModelExpress gRPC port."""
+
+
 WeightBroadcastConfig: TypeAlias = Annotated[
-    FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig | NIXLWeightBroadcastConfig,
+    FileSystemWeightBroadcastConfig
+    | NCCLWeightBroadcastConfig
+    | NIXLWeightBroadcastConfig
+    | MXRefitWeightBroadcastConfig,
     Field(discriminator="type"),
 ]
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -18,6 +18,9 @@ from prime_rl.configs.orchestrator import (
     NIXLWeightBroadcastConfig as OrchestratorNIXLWeightBroadcastConfig,
 )
 from prime_rl.configs.orchestrator import (
+    MXRefitWeightBroadcastConfig as OrchestratorMXRefitWeightBroadcastConfig,
+)
+from prime_rl.configs.orchestrator import (
     OrchestratorConfig,
 )
 from prime_rl.configs.shared import (
@@ -36,6 +39,9 @@ from prime_rl.configs.trainer import (
 )
 from prime_rl.configs.trainer import (
     NIXLWeightBroadcastConfig as TrainerNIXLWeightBroadcastConfig,
+)
+from prime_rl.configs.trainer import (
+    MXRefitWeightBroadcastConfig as TrainerMXRefitWeightBroadcastConfig,
 )
 from prime_rl.configs.trainer import (
     TokenizerConfig,
@@ -159,12 +165,22 @@ class SharedNIXLWeightBroadcastConfig(SharedInMemoryWeightBroadcastConfig):
     """ModelExpress session ID."""
 
 
+class SharedMXRefitWeightBroadcastConfig(SharedInMemoryWeightBroadcastConfig):
+    type: Literal["mx_refit"] = "mx_refit"
+
+    port: int = 8001
+    """ModelExpress gRPC port."""
+
+
 class SharedFileSystemWeightBroadcastConfig(BaseConfig):
     type: Literal["filesystem"] = "filesystem"
 
 
 SharedWeightBroadcastConfig: TypeAlias = Annotated[
-    SharedFileSystemWeightBroadcastConfig | SharedNCCLWeightBroadcastConfig | SharedNIXLWeightBroadcastConfig,
+    SharedFileSystemWeightBroadcastConfig
+    | SharedNCCLWeightBroadcastConfig
+    | SharedNIXLWeightBroadcastConfig
+    | SharedMXRefitWeightBroadcastConfig,
     Field(discriminator="type"),
 ]
 
@@ -463,7 +479,7 @@ class RLConfig(BaseConfig):
                 "LoRA training is not yet supported with in-memory weight broadcast. "
                 "Set weight_broadcast.type = 'filesystem'."
             )
-        if self.weight_broadcast.type in ("nccl", "nixl"):
+        if self.weight_broadcast.type in ("nccl", "nixl", "mx_refit"):
             inference_world_size = (
                 self.inference.vllm.data_parallel_size * self.inference.vllm.tensor_parallel_size
                 if self.inference
@@ -481,10 +497,16 @@ class RLConfig(BaseConfig):
                 )
                 trainer_config_type = TrainerNCCLWeightBroadcastConfig
                 orchestrator_config_type = OrchestratorNCCLWeightBroadcastConfig
-            else:
+            elif self.weight_broadcast.type == "nixl":
                 transport_config = dict(session_id=self.weight_broadcast.session_id)
                 trainer_config_type = TrainerNIXLWeightBroadcastConfig
                 orchestrator_config_type = OrchestratorNIXLWeightBroadcastConfig
+            else:  # mx_refit
+                # mx_refit versions are keyed by model_name + version UID, so no
+                # session_id (unlike nixl, which names NIXL session buffers with it).
+                transport_config = dict()
+                trainer_config_type = TrainerMXRefitWeightBroadcastConfig
+                orchestrator_config_type = OrchestratorMXRefitWeightBroadcastConfig
             self.trainer.weight_broadcast = trainer_config_type(**common_config, **transport_config)
             self.orchestrator.weight_broadcast = orchestrator_config_type(**common_config, **transport_config)
         elif self.weight_broadcast.type == "filesystem":

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -589,8 +589,18 @@ class NIXLWeightBroadcastConfig(InMemoryWeightBroadcastConfig):
     """ModelExpress session ID."""
 
 
+class MXRefitWeightBroadcastConfig(InMemoryWeightBroadcastConfig):
+    type: Literal["mx_refit"] = "mx_refit"
+
+    port: int = 8001
+    """ModelExpress gRPC port."""
+
+
 WeightBroadcastConfig: TypeAlias = Annotated[
-    FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig | NIXLWeightBroadcastConfig,
+    FileSystemWeightBroadcastConfig
+    | NCCLWeightBroadcastConfig
+    | NIXLWeightBroadcastConfig
+    | MXRefitWeightBroadcastConfig,
     Field(discriminator="type"),
 ]
 

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -64,6 +64,7 @@ WORKER_EXTENSION_CLS = {
     "nccl": "prime_rl.inference.vllm.worker.nccl.NCCLWeightUpdateWorker",
     "filesystem": "prime_rl.inference.vllm.worker.filesystem.FileSystemWeightUpdateWorker",
     "nixl": "prime_rl.inference.vllm.worker.nixl.NIXLWeightUpdateWorker",
+    "mx_refit": "prime_rl.inference.vllm.worker.mx_refit.MXRefitUpdateWorker",
 }
 
 
@@ -83,7 +84,13 @@ async def resume(request: Request):
 @router.post("/update_weights")
 async def update_weights(request: Request):
     data = await request.json()
-    await engine_client(request).collective_rpc("update_weights_from_path", args=(data.get("weight_dir"),))
+    # version_uid is set only for the mx_refit transport, whose worker takes the
+    # extra positional arg; the other workers' update_weights_from_path takes only
+    # weight_dir, so pass the second arg only when it is present.
+    args = (data.get("weight_dir"), data["version_uid"]) if data.get("version_uid") is not None else (
+        data.get("weight_dir"),
+    )
+    await engine_client(request).collective_rpc("update_weights_from_path", args=args)
     return {"status": "ok"}
 
 

--- a/src/prime_rl/inference/vllm/worker/mx_refit.py
+++ b/src/prime_rl/inference/vllm/worker/mx_refit.py
@@ -27,9 +27,23 @@ class MXRefitUpdateWorker(Worker):
     def init_broadcaster(self, mx_server_host: str, mx_server_port: int, *args) -> None:
         del args  # unused extras from the shared init_broadcaster route
         model = cast(Module, self.model_runner.get_model())
+        # TODO: check if this prime-native -> HF conversion can move to the trainer
+        # side to decouple trainer and inference (avoids importing trainer models here).
+        from prime_rl.trainer.models import get_custom_causal_lm_cls
+        from prime_rl.trainer.models.conversion_ops import apply_prime_to_hf
+
+        hf_config = self.model_runner.model_config.hf_config
+        conversion_chain = get_custom_causal_lm_cls(hf_config).conversion_chain(hf_config)
+        convert_native_to_hf = (
+            (lambda sd: apply_prime_to_hf(sd, conversion_chain)) if conversion_chain else None
+        )
         self._generator = ModelExpressGeneratorClient.initialize(
             ModelExpressGeneratorConfig(
-                engine_context=VllmGeneratorContext(model=model, vllm_config=self.vllm_config),
+                engine_context=VllmGeneratorContext(
+                    model=model,
+                    vllm_config=self.vllm_config,
+                    convert_native_to_hf=convert_native_to_hf,
+                ),
                 model_name=self.model_runner.model_config.model,
                 server_url=f"{mx_server_host}:{mx_server_port}",
             )

--- a/src/prime_rl/inference/vllm/worker/mx_refit.py
+++ b/src/prime_rl/inference/vllm/worker/mx_refit.py
@@ -1,0 +1,51 @@
+from typing import TYPE_CHECKING, cast
+
+import torch
+from torch.nn import Module
+
+from modelexpress_rl import (
+    ModelExpressGeneratorClient,
+    ModelExpressGeneratorConfig,
+    VllmGeneratorContext,
+    WeightVersionRef,
+)
+
+# Type hints for the Worker class without extending it at runtime, as required by
+# the vLLM worker-extension mechanism.
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu_worker import Worker
+
+    Worker = Worker
+else:
+    Worker = object
+
+
+class MXRefitUpdateWorker(Worker):
+    """vLLM worker extension that pulls and installs weights through ModelExpress's
+    generator client: it stages, applies, and releases the version_uid it is given."""
+
+    def init_broadcaster(self, mx_server_host: str, mx_server_port: int, *args) -> None:
+        del args  # unused extras from the shared init_broadcaster route
+        model = cast(Module, self.model_runner.get_model())
+        self._generator = ModelExpressGeneratorClient.initialize(
+            ModelExpressGeneratorConfig(
+                engine_context=VllmGeneratorContext(model=model, vllm_config=self.vllm_config),
+                model_name=self.model_runner.model_config.model,
+                server_url=f"{mx_server_host}:{mx_server_port}",
+            )
+        )
+
+    def liveness_probe(self) -> None:
+        """No-op RPC used by the API server liveness endpoint."""
+        return None
+
+    @torch.no_grad()
+    def update_weights_from_path(self, weight_dir: str | None = None, version_uid: str | None = None) -> None:
+        del weight_dir  # mx_refit pulls by version, not a path
+        if version_uid is None:
+            raise ValueError("mx_refit update_weights requires version_uid")
+        staged = self._generator.stage_weight(version=WeightVersionRef(version_uid))
+        try:
+            self._generator.apply_weight(staged)
+        finally:
+            staged.release()

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -30,6 +30,10 @@ from typing import TYPE_CHECKING
 import verifiers.v1 as vf
 from modelexpress import p2p_pb2
 from modelexpress.client import MxClient
+from modelexpress_rl import ModelExpressControlClient
+
+from prime_rl.transports.weights.mx_refit import resolve_ready_version
+from prime_rl.utils.pathing import get_broadcast_dir
 from verifiers.v1.runtimes import set_base_sandbox_labels
 
 if TYPE_CHECKING:
@@ -77,7 +81,7 @@ from prime_rl.trainer.model import setup_tokenizer
 from prime_rl.transports.rollouts import setup_micro_batch_sender
 from prime_rl.transports.weights.nixl.model_express import ModelExpressSession
 from prime_rl.utils.async_utils import EventLoopLagMonitor, EventLoopLagStats, safe_cancel
-from prime_rl.utils.client import init_nccl_broadcast, init_nixl_broadcast
+from prime_rl.utils.client import init_mx_refit_broadcast, init_nccl_broadcast, init_nixl_broadcast
 from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.logger import format_time, get_logger, setup_logger
 from prime_rl.utils.utils import (
@@ -187,6 +191,7 @@ class Orchestrator:
         self.resume_step = None
         self.lag_task = None
         self.model_express = None
+        self.mx_control = None
 
     # ── lifecycle ──────────────────────────────────────────────────────────
 
@@ -304,6 +309,16 @@ class Orchestrator:
             )
             self.model_express.publish()
             await asyncio.to_thread(self.model_express.set_status, p2p_pb2.SOURCE_STATUS_INITIALIZING)
+        elif config.weight_broadcast.type == "mx_refit":
+            await init_mx_refit_broadcast(
+                self.policy_inference.admin_clients,
+                config.weight_broadcast.host,
+                config.weight_broadcast.port,
+                config.weight_broadcast.timeout,
+            )
+            self.mx_control = ModelExpressControlClient.connect(
+                server_url=f"{config.weight_broadcast.host}:{config.weight_broadcast.port}"
+            )
 
         self.lora_name = config.model.lora.name if config.model.lora else None
 
@@ -331,7 +346,8 @@ class Orchestrator:
         # with the trainer's startup broadcast (v{resume_step} on resume, v0 from
         # scratch).
         sync_version = self.resume_step if self.resume_step is not None else 0
-        if config.weight_broadcast.type == "nixl":
+        version_uid: str | None = None
+        if config.weight_broadcast.type in ("nixl", "mx_refit"):
             weights_path = None
         else:
             check_exists = config.weight_broadcast.type == "filesystem"
@@ -343,9 +359,17 @@ class Orchestrator:
             weights_path = get_weight_dir(
                 config.output_dir, sync_version, check_exists=check_exists, wait_timeout=wait_timeout
             )
+        if self.mx_control is not None:
+            # Same version lifecycle as steady state (v0 is not special); resolve the
+            # trainer's startup version and wait for it to be READY.
+            version_uid = await resolve_ready_version(
+                self.mx_control, get_broadcast_dir(config.output_dir), sync_version
+            )
         if self.model_express is not None:
             await asyncio.to_thread(self.model_express.set_status, p2p_pb2.SOURCE_STATUS_READY)
-        await self.policy_inference.update_weights(weights_path, lora_name=self.lora_name, step=sync_version)
+        await self.policy_inference.update_weights(
+            weights_path, lora_name=self.lora_name, step=sync_version, version_uid=version_uid
+        )
         if self.model_express is not None:
             await asyncio.to_thread(self.model_express.set_status, p2p_pb2.SOURCE_STATUS_INITIALIZING)
             # Complete the startup rendezvous before the watcher begins its next cycle.
@@ -356,6 +380,10 @@ class Orchestrator:
                 status=p2p_pb2.SOURCE_STATUS_INITIALIZING,
                 timeout=config.weight_broadcast.timeout,
             )
+        elif self.mx_control is not None:
+            # Retire the startup version (-> RELEASING) to unblock the trainer's
+            # startup broadcast, mirroring the watcher's post-update delete.
+            await asyncio.to_thread(self.mx_control.delete_weight_version, version_uid)
         if self.lora_name is not None:
             self.policy_inference.update_model_name(self.lora_name)
             self.policy.model_name = self.lora_name
@@ -421,6 +449,7 @@ class Orchestrator:
             lora_name=self.lora_name,
             ckpt_step=self.policy.version,
             model_express=self.model_express,
+            control=self.mx_control,
         )
         # Single periodic logger for the whole pipeline. It's the only
         # consumer of ``dispatcher.metrics.drained()`` (which clears on read)
@@ -893,7 +922,7 @@ class Orchestrator:
         # The trainer skips the final in-memory weight broadcasts, so policy.version never
         # reaches the last step. Let the final batch through instead of waiting for it.
         building_final_batch_without_update = (
-            self.config.weight_broadcast.type in ("nccl", "nixl")
+            self.config.weight_broadcast.type in ("nccl", "nixl", "mx_refit")
             and self.config.max_steps is not None
             and self.progress.step >= self.config.max_steps - 1
         )

--- a/src/prime_rl/orchestrator/watcher.py
+++ b/src/prime_rl/orchestrator/watcher.py
@@ -8,9 +8,11 @@ import asyncio
 import time
 
 from modelexpress import p2p_pb2
+from modelexpress_rl import ModelExpressControlClient
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.types import Policy, VersionObserver
+from prime_rl.transports.weights.mx_refit import get_latest_uid_marker_step, resolve_ready_version
 from prime_rl.transports.weights.nixl.model_express import ModelExpressSession
 from prime_rl.utils.async_utils import safe_cancel
 from prime_rl.utils.client import InferencePool
@@ -33,6 +35,7 @@ class WeightWatcher:
         ckpt_step: int = 0,
         poll_interval: float = 1.0,
         model_express: ModelExpressSession | None = None,
+        control: ModelExpressControlClient | None = None,
     ) -> None:
         self.config = config
         self.policy = policy
@@ -42,6 +45,7 @@ class WeightWatcher:
         self.ckpt_step = ckpt_step
         self.poll_interval = poll_interval
         self.model_express = model_express
+        self.control = control
 
         self.last_update_weights_time: float = 0.0
         self.last_wait_for_ckpt_time: float = 0.0
@@ -76,6 +80,15 @@ class WeightWatcher:
 
     def compute_next_ckpt_step(self) -> int:
         """Return the next policy version exposed by the configured transport."""
+        if self.control is not None:
+            # mx_refit carries the trainer's step explicitly in the uid marker,
+            # so read the latest published step rather than assume lockstep.
+            # TODO: replace the filesystem marker with a clean MX API that returns
+            # the latest version_id + version_number the trainer published.
+            broadcast_dir = get_broadcast_dir(self.config.output_dir)
+            latest = get_latest_uid_marker_step(broadcast_dir)
+            return max(self.ckpt_step, latest if latest is not None else self.ckpt_step)
+
         if self.model_express is not None:
             if self.config.max_steps is not None and self.ckpt_step >= self.config.max_steps - 2:
                 return self.ckpt_step
@@ -95,7 +108,20 @@ class WeightWatcher:
 
             t0 = time.perf_counter()
             weights_path = None
-            if self.model_express is not None:
+            version_uid: str | None = None
+            if self.control is not None:
+                # mx_refit: the trainer published this step's uid in a marker;
+                # resolve it and wait for the version to be READY (all ranks published).
+                # TODO: replace the filesystem marker with a clean MX API that returns
+                # the latest version_id + version_number the trainer published.
+                version_uid = await resolve_ready_version(
+                    self.control,
+                    get_broadcast_dir(self.config.output_dir),
+                    next_step,
+                    self.poll_interval,
+                    self.stopped,
+                )
+            elif self.model_express is not None:
                 await self.wait_for_model_express_status(p2p_pb2.SOURCE_STATUS_READY)
             else:
                 broadcast_dir = get_broadcast_dir(self.config.output_dir)
@@ -136,7 +162,9 @@ class WeightWatcher:
 
             get_logger().debug(f"Updating weights to step {next_step}")
             t1 = time.perf_counter()
-            await self.inference.update_weights(weights_path, lora_name=self.lora_name, step=next_step)
+            await self.inference.update_weights(
+                weights_path, lora_name=self.lora_name, step=next_step, version_uid=version_uid
+            )
             self.last_update_weights_time = time.perf_counter() - t1
             self.update_count += 1
             get_logger().debug(f"Updated weights to step {next_step} in {format_time(self.last_update_weights_time)}")
@@ -153,7 +181,11 @@ class WeightWatcher:
                         f"Observer {type(observer).__name__}.on_new_version({next_step}) raised: {exc!r}"
                     )
 
-            if self.model_express is not None:
+            if self.control is not None:
+                # Retire the version (-> RELEASING); unblocks the trainer's broadcast.
+                assert version_uid is not None
+                await asyncio.to_thread(self.control.delete_weight_version, version_uid)
+            elif self.model_express is not None:
                 await self.wait_for_model_express_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
 
     async def wait_for_model_express_status(self, status: int) -> None:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -185,6 +185,7 @@ def train(config: TrainerConfig):
             config.weight_broadcast,
             parallel_dims,
             config.model.lora,
+            model_name=config.model.name,
         )
 
     if parallel_dims.cp_enabled:
@@ -585,7 +586,7 @@ def train(config: TrainerConfig):
             broadcast_weights_time = 0
         else:
             broadcast_unused = (
-                config.weight_broadcast.type in ("nccl", "nixl")
+                config.weight_broadcast.type in ("nccl", "nixl", "mx_refit")
                 and config.max_steps is not None
                 and progress.step >= config.max_steps - 1
             )

--- a/src/prime_rl/transports/weights/__init__.py
+++ b/src/prime_rl/transports/weights/__init__.py
@@ -8,6 +8,7 @@ from prime_rl.transports.weights.base import WeightBroadcast
 from prime_rl.transports.weights.filesystem import FileSystemWeightBroadcast
 from prime_rl.transports.weights.nccl import NCCLWeightBroadcast
 from prime_rl.transports.weights.nixl import NIXLWeightBroadcast
+from prime_rl.transports.weights.mx_refit import MXRefitWeightBroadcast
 
 
 def setup_weight_broadcast(
@@ -15,6 +16,7 @@ def setup_weight_broadcast(
     config: WeightBroadcastConfig,
     parallel_dims: ParallelDims,
     lora_config: LoRAConfig | None = None,
+    model_name: str | None = None,
 ) -> WeightBroadcast:
     if config.type == "nccl":
         return NCCLWeightBroadcast(output_dir, config, torch.cuda.current_device())
@@ -22,5 +24,9 @@ def setup_weight_broadcast(
         return FileSystemWeightBroadcast(output_dir, config, lora_config)
     elif config.type == "nixl":
         return NIXLWeightBroadcast(output_dir, config, parallel_dims)
+    elif config.type == "mx_refit":
+        if model_name is None:
+            raise ValueError("mx_refit weight broadcast requires model_name")
+        return MXRefitWeightBroadcast(output_dir, config, parallel_dims, model_name)
     else:
         raise ValueError(f"Invalid weight broadcast type: {config.type}")

--- a/src/prime_rl/transports/weights/mx_refit.py
+++ b/src/prime_rl/transports/weights/mx_refit.py
@@ -1,0 +1,189 @@
+"""Publish FSDP weights through ModelExpress's slice-reshard transport (Model B).
+
+Every trainer rank hands its FSDP state_dict to MX's trainer client, which stages
+the rank-local shards and advertises them under a per-step WeightVersion. This
+rank owns the version lifecycle: rank 0 creates the version, every rank publishes
+its shard, and the version id is handed to the orchestrator through a
+broadcast-dir marker. ``broadcast_weights`` blocks until the generator has pulled
+(the orchestrator moves the version to RELEASING) before letting training reuse
+its staging buffers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import uuid
+from pathlib import Path
+
+import grpc
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from modelexpress_rl import (
+    ModelExpressControlClient,
+    ModelExpressTrainerClient,
+    ModelExpressTrainerConfig,
+    TrainerStagingMode,
+    WeightPayloadFormat,
+    WeightVersionRef,
+    WeightVersionState,
+)
+
+from prime_rl.configs.trainer import MXRefitWeightBroadcastConfig
+from prime_rl.trainer.parallel_dims import ParallelDims
+from prime_rl.trainer.world import get_world
+from prime_rl.transports.weights.base import WeightBroadcast
+from prime_rl.utils.pathing import get_broadcast_dir, get_step_path, wait_for_path
+
+# TODO: remove the filesystem uid marker (write here + reads in the orchestrator
+# watcher) once MX exposes an API to query the latest version_id/version_number the
+# trainer published, so the trainer->orchestrator handoff no longer needs a shared PVC.
+UID_MARKER = "MX_VERSION_UID"
+RELEASE_POLL_INTERVAL = 0.05
+
+
+def read_uid_marker(broadcast_dir: Path, step: int) -> str | None:
+    """Return the version uid the trainer published for ``step``, or None."""
+    marker = get_step_path(broadcast_dir, step) / UID_MARKER
+    return marker.read_text().strip() if marker.exists() else None
+
+
+def get_latest_uid_marker_step(broadcast_dir: Path) -> int | None:
+    """Return the highest step whose MX_VERSION_UID marker the trainer has written."""
+    step_dirs = list(broadcast_dir.glob("step_*"))
+    steps = sorted(int(step_dir.name.split("_")[-1]) for step_dir in step_dirs)
+    for step in reversed(steps):
+        if (broadcast_dir / f"step_{step}" / UID_MARKER).exists():
+            return step
+    return None
+
+
+async def resolve_ready_version(
+    control: ModelExpressControlClient,
+    broadcast_dir: Path,
+    step: int,
+    poll_interval: float = 0.5,
+    stopped: asyncio.Event | None = None,
+) -> str:
+    """Wait for the trainer's uid marker for ``step``, then for the version to be READY.
+
+    Shared by the orchestrator's startup sync and the watcher's steady-state gate:
+    the mx_refit version lifecycle is uniform, so v0 and every later version use
+    the same resolve path. ``stopped``, when given, lets the caller cancel the poll.
+    """
+    uid = read_uid_marker(broadcast_dir, step)
+    if uid is None:
+        await wait_for_path(get_step_path(broadcast_dir, step) / UID_MARKER)
+        uid = read_uid_marker(broadcast_dir, step)
+    assert uid is not None
+    while stopped is None or not stopped.is_set():
+        version = await asyncio.to_thread(control.get_weight_version, uid)
+        if version.state is WeightVersionState.READY:
+            return uid
+        await asyncio.sleep(poll_interval)
+    raise asyncio.CancelledError
+
+
+class MXRefitWeightBroadcast(WeightBroadcast):
+    def __init__(
+        self,
+        output_dir: Path,
+        config: MXRefitWeightBroadcastConfig,
+        parallel_dims: ParallelDims,
+        model_name: str,
+    ) -> None:
+        super().__init__(output_dir)
+        self.config = config
+        self.parallel_dims = parallel_dims
+        self.model_name = model_name
+        self.world = get_world()
+        self._run_id = uuid.uuid4().hex[:8]
+        self._initialized = False
+        self._client: ModelExpressTrainerClient | None = None
+        self._control: ModelExpressControlClient | None = None
+        self._expected_slots: list[str] = []
+
+    @property
+    def server_url(self) -> str:
+        return f"{self.config.host}:{self.config.port}"
+
+    def _initialize(self, model: nn.Module) -> None:
+        # FSDP adapter selection is env-gated in the MX client factory.
+        os.environ["MX_TRAINER_ENGINE"] = "FSDP"
+        self._client = ModelExpressTrainerClient.initialize(
+            ModelExpressTrainerConfig(
+                model_name=self.model_name,
+                device_id=self.world.local_rank,
+                server_url=self.server_url,
+                staging_mode=TrainerStagingMode.COPY_TO_DEVICE,
+                payload_format=WeightPayloadFormat.FULL_TENSOR,
+            )
+        )
+        slot = self._client.bind_tensors(model.state_dict())
+        if self.world.is_master:
+            self._control = ModelExpressControlClient.connect(server_url=self.server_url)
+
+        # Collect every rank's actual source slot so rank 0 can pass the complete
+        # expected_source_slots to create_weight_version. Reading the real slots
+        # avoids hardcoding the slot-naming convention; set() stays safe if DP
+        # replicas ever share a logical slot.
+        gathered: list[str] = [""] * self.world.world_size
+        dist.all_gather_object(gathered, slot)
+        self._expected_slots = sorted(set(gathered))
+        self._initialized = True
+
+    @torch.no_grad()
+    def broadcast_weights(self, model: nn.Module, step: int) -> None:
+        if not self._initialized:
+            self._initialize(model)
+        assert self._client is not None
+
+        # Rank 0 creates the per-step version; broadcast its uid to all ranks.
+        uid_holder: list[str | None] = [None]
+        if self.world.is_master:
+            assert self._control is not None
+            version = self._control.create_weight_version(
+                model_name=self.model_name,
+                idempotency_key=f"{self._run_id}:{step}",
+                payload_format=WeightPayloadFormat.FULL_TENSOR,
+                version_number=step,
+                expected_source_slots=self._expected_slots,
+            )
+            uid_holder[0] = version.version_id
+        dist.broadcast_object_list(uid_holder, src=0)
+        uid = uid_holder[0]
+        assert uid is not None
+
+        self._client.publish_version(version=WeightVersionRef(uid))
+        if self.world.is_master:
+            self._write_uid_marker(step, uid)
+
+        # Block until the generator has pulled (orchestrator moved the version to
+        # RELEASING) so training does not overwrite the staging arenas mid-read.
+        # Rank 0 observes RELEASING; the barrier propagates that to every rank
+        # before any of them withdraw their shard.
+        if self.world.is_master:
+            self._wait_released(uid)
+        dist.barrier()
+        self._client.release_version(version=WeightVersionRef(uid))
+
+    def _wait_released(self, uid: str) -> None:
+        assert self._control is not None
+        while True:
+            try:
+                state = self._control.get_weight_version(uid).state
+            except grpc.RpcError as error:
+                if error.code() is grpc.StatusCode.NOT_FOUND:
+                    return  # already retired == generator done
+                raise
+            if state is WeightVersionState.RELEASING:
+                return
+            time.sleep(RELEASE_POLL_INTERVAL)
+
+    def _write_uid_marker(self, step: int, uid: str) -> None:
+        step_dir = get_step_path(get_broadcast_dir(self.output_dir), step)
+        step_dir.mkdir(parents=True, exist_ok=True)
+        (step_dir / UID_MARKER).write_text(uid)

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -86,8 +86,16 @@ class InferencePool:
         )
         await maybe_check_has_model(self._admin_clients, model_name, skip_model_check=self._skip_model_check)
 
-    async def update_weights(self, weight_dir: Path | None, lora_name: str | None = None, step: int = 0) -> None:
-        await update_weights(self._admin_clients, weight_dir, lora_name=lora_name, step=step)
+    async def update_weights(
+        self,
+        weight_dir: Path | None,
+        lora_name: str | None = None,
+        step: int = 0,
+        version_uid: str | None = None,
+    ) -> None:
+        await update_weights(
+            self._admin_clients, weight_dir, lora_name=lora_name, step=step, version_uid=version_uid
+        )
 
     async def score(self, token_ids: list[int]) -> list[float]:
         """Prefill-score ``token_ids`` under this pool's model (one logprob per
@@ -276,6 +284,7 @@ async def update_weights(
     weight_dir: Path | None,
     lora_name: str | None = None,
     step: int = 0,
+    version_uid: str | None = None,
 ) -> None:
     """Update weights on static inference servers.
 
@@ -310,7 +319,7 @@ async def update_weights(
                     _admin_post(
                         admin_client,
                         "/update_weights",
-                        json={"weight_dir": weight_dir_posix},
+                        json={"weight_dir": weight_dir_posix, "version_uid": version_uid},
                         timeout_s=UPDATE_WEIGHTS_TIMEOUT_S,
                     )
                     for admin_client in admin_clients
@@ -474,6 +483,30 @@ async def init_nixl_broadcast(
     await asyncio.gather(
         *[initialize(admin_client, index * workers_per_server) for index, admin_client in enumerate(admin_clients)]
     )
+
+
+async def init_mx_refit_broadcast(
+    admin_clients: list[AsyncClient],
+    host: str,
+    port: int,
+    timeout: int,
+) -> None:
+    """Build a ModelExpress reshard generator client on every vLLM worker.
+
+    Only the MX server address is needed: the version lifecycle carries the trainer
+    sources, so there is no rank offset or source count to configure (the worker
+    absorbs the nixl/nccl-shaped extras of ``/init_broadcaster``).
+    """
+
+    async def initialize(admin_client: AsyncClient) -> None:
+        await _admin_post(
+            admin_client,
+            "/init_broadcaster",
+            timeout_s=max(ADMIN_TIMEOUT_S, timeout),
+            json={"host": host, "port": port},
+        )
+
+    await asyncio.gather(*[initialize(admin_client) for admin_client in admin_clients])
 
 
 async def prefill_logprobs(openai: AsyncOpenAI, model: str, token_ids: list[int]) -> list[float]:


### PR DESCRIPTION
Adds an `mx_refit` weight-broadcast transport so trainer weights reach the inference engines through ModelExpress's RefitService (its Control/Trainer/Generator clients), alongside the existing nixl/nccl/filesystem transports.

## Pieces
- **Trainer**: FSDP publisher creates a per-step WeightVersion; every rank publishes its shard and blocks until the generator has pulled (version → RELEASING) before reusing its staging buffers.
- **Orchestrator**: the watcher resolves the trainer's per-step version (broadcast-dir uid marker + READY wait), drives the inference update, then retires the version (→ RELEASING).
- **Inference**: a vLLM worker extension stages/applies/releases the given `version_uid` via the generator client.
- **Config**: MXRefit weight-broadcast config classes + auto_setup wiring.

## Notes
- The trainer→orchestrator handoff uses a broadcast-dir uid marker for now (TODO in code: replace with an MX API returning the latest version_id/version_number, which also drops the shared-PVC dependency).
- Requires a modelexpress build that serves `RefitService`; the receiver-side companion change ships separately in the modelexpress repo.

## Tested
Tested with dense Qwen3 model (FSDP dp_shard=2 trainer + vLLM tp=1 inference): startup and steady-state per-step weight updates transfer and install correctly end to end.
TODO: test with MoE and larger models once ModelExpress side resharding logic is refactor complete