### PR TITLE
fix: adapt tmux script to auto-generated run dirs

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -335,15 +335,15 @@ tail -F <run_dir>/logs/latest/inference/router.log # multi-node only
 
 ### Console Output
 
-`scripts/tmux.sh` opens a 4-pane tmux session that follows `trainer.log`, `orchestrator.log`, `inference.log`, and the union of env worker logs. Start it before launching:
+`scripts/tmux.sh` opens a 4-pane tmux session that follows `trainer.log`, `orchestrator.log`, `inference.log`, and the union of env worker logs. The panes wait for the newest run under the output directory (`-o`, default `outputs`) and tail its `logs/latest`, so auto-generated run names work out of the box. Start it before launching:
 
 ```bash
-bash scripts/tmux.sh -o outputs/my-run
+bash scripts/tmux.sh
 # then in the Launcher window:
-uv run rl @ ... --run.name my-run
+uv run rl @ ...
 ```
 
-Pass `-s <session>` and `-o <run_dir>` (the run directory, `<output_dir>/<run_name>`) to run multiple parallel experiments side-by-side in different sessions. The helper also works on a SLURM head node — `bash scripts/tmux.sh my-rl-job /shared/outputs/my-rl-job`.
+Pass `-s <session>` to run multiple parallel experiments side-by-side in different sessions. `-o` also accepts a specific run directory (`<output_dir>/<run_name>`) to pin a session to one run. The helper also works on a SLURM head node — `bash scripts/tmux.sh my-rl-job /shared/outputs`.
 
 ### Weights & Biases
 

--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -7,8 +7,8 @@ AGENT="claude"
 # Optional CLI parsing
 # Supports:
 #   -s|--session-name NAME
-#   -o|--output-dir DIR
-#   -a|--agent AGENT       (claude|codex, default: claude)
+#   -o|--output-dir DIR     (directory grouping runs, or a specific run directory)
+#   -a|--agent AGENT        (claude|codex, default: claude)
 #   Positional: [SESSION_NAME [OUTPUT_DIR]]
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
@@ -39,7 +39,8 @@ while [[ $# -gt 0 ]]; do
       ;;
     -h|--help)
       echo "Usage: $0 [-s SESSION_NAME] [-o OUTPUT_DIR] [-a AGENT] [SESSION_NAME [OUTPUT_DIR]]" >&2
-      echo "  -a, --agent  claude|codex  (default: claude)" >&2
+      echo "  -o, --output-dir  directory grouping runs, or a specific run directory (default: outputs)" >&2
+      echo "  -a, --agent       claude|codex  (default: claude)" >&2
       exit 0
       ;;
     --)
@@ -60,7 +61,23 @@ if [[ ${#POSITIONAL[@]} -ge 2 ]]; then
   OUTPUT_DIR="${POSITIONAL[1]}"
 fi
 
-LOG_DIR="${OUTPUT_DIR}/logs/latest"
+# Each run writes its logs to <output_dir>/<run_name>/logs/latest, and run names
+# are auto-generated unless set via --run.name — so the run directory is unknown
+# when the session starts. LOG_DIR_GLOB matches both an output directory and a
+# run directory passed as OUTPUT_DIR; each pane polls it and tails the newest match.
+LOG_DIR_GLOB="${OUTPUT_DIR}/logs/latest ${OUTPUT_DIR}/*/logs/latest"
+
+# Build a pane command that waits for a run to appear, then tails PATTERN
+# (relative to the newest logs/latest), optionally filtered through grep.
+# ``command ls`` bypasses interactive aliases (e.g. ls=exa) in the pane shell.
+tail_cmd() {
+  local pattern="$1" filter="${2:-}"
+  local tail="tail -F \$files"
+  if [[ -n "$filter" ]]; then
+    tail+=" | grep --line-buffered $filter"
+  fi
+  echo "while true; do dir=\$(command ls -td ${LOG_DIR_GLOB} 2>/dev/null | head -1); files=\$(command ls \$dir/$pattern 2>/dev/null); [ -n \"\$files\" ] && $tail; sleep 1; done"
+}
 
 if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
   echo "Attaching to tmux session: $SESSION_NAME"
@@ -85,17 +102,10 @@ tmux select-pane -t "$SESSION_NAME:Logs.1" -T "Orchestrator"
 tmux select-pane -t "$SESSION_NAME:Logs.2" -T "Envs"
 tmux select-pane -t "$SESSION_NAME:Logs.3" -T "Inference"
 
-tmux send-keys -t "$SESSION_NAME:Logs.0" \
-  "tail -F ${LOG_DIR}/trainer.log 2>/dev/null" C-m
-
-tmux send-keys -t "$SESSION_NAME:Logs.1" \
-  "tail -F ${LOG_DIR}/orchestrator.log 2>/dev/null" C-m
-
-tmux send-keys -t "$SESSION_NAME:Logs.2" \
-  "tail -F ${LOG_DIR}/envs/*/*.log 2>/dev/null" C-m
-
-tmux send-keys -t "$SESSION_NAME:Logs.3" \
-  "tail -F ${LOG_DIR}/inference.log 2>/dev/null" C-m
+tmux send-keys -t "$SESSION_NAME:Logs.0" "$(tail_cmd trainer.log)" C-m
+tmux send-keys -t "$SESSION_NAME:Logs.1" "$(tail_cmd orchestrator.log)" C-m
+tmux send-keys -t "$SESSION_NAME:Logs.2" "$(tail_cmd 'envs/*/*.log')" C-m
+tmux send-keys -t "$SESSION_NAME:Logs.3" "$(tail_cmd inference.log)" C-m
 
 # Window 2: SUCCESS - grep SUCCESS on orch and trainer logs (two stacked panes)
 tmux new-window -t "$SESSION_NAME" -n "SUCCESS"
@@ -106,21 +116,20 @@ tmux select-layout -t "$SESSION_NAME:SUCCESS" even-vertical
 tmux select-pane -t "$SESSION_NAME:SUCCESS.0" -T "Orchestrator"
 tmux select-pane -t "$SESSION_NAME:SUCCESS.1" -T "Trainer"
 
-tmux send-keys -t "$SESSION_NAME:SUCCESS.0"   "tail -F ${LOG_DIR}/orchestrator.log 2>/dev/null | grep --line-buffered SUCCESS" C-m
-
-tmux send-keys -t "$SESSION_NAME:SUCCESS.1"   "tail -F ${LOG_DIR}/trainer.log 2>/dev/null | grep --line-buffered SUCCESS" C-m
+tmux send-keys -t "$SESSION_NAME:SUCCESS.0" "$(tail_cmd orchestrator.log SUCCESS)" C-m
+tmux send-keys -t "$SESSION_NAME:SUCCESS.1" "$(tail_cmd trainer.log SUCCESS)" C-m
 
 # Window 3: Agent (claude code or codex) with log context
 tmux new-window -t "$SESSION_NAME" -n "Agent"
 
-AGENT_PROMPT="You are monitoring a prime-rl training run. The output directory is ${OUTPUT_DIR}. Log paths:
-  Trainer:        ${LOG_DIR}/trainer.log
-  All nodes:      ${LOG_DIR}/trainer/node_*.log
-  All ranks:      ${LOG_DIR}/trainer/torchrun/*/*/*/*.log
-  Orchestrator:   ${LOG_DIR}/orchestrator.log
-  Inference:      ${LOG_DIR}/inference.log
-  Envs:           ${LOG_DIR}/envs/*/*.log
-  Train envs:     ${LOG_DIR}/envs/train/*.log
+AGENT_PROMPT="You are monitoring a prime-rl training run. The output directory is ${OUTPUT_DIR}. Each run writes its artifacts to a run directory (<output_dir>/<run_name>, name auto-generated unless set via --run.name) and its logs to <run_dir>/logs/latest. Find the active run's log directory with: ls -td ${LOG_DIR_GLOB} 2>/dev/null | head -1. Log files relative to it:
+  Trainer:        trainer.log
+  All nodes:      trainer/node_*.log
+  All ranks:      trainer/torchrun/*/*/*/*.log
+  Orchestrator:   orchestrator.log
+  Inference:      inference.log
+  Envs:           envs/*/*.log
+  Train envs:     envs/train/*.log
 You are running inside tmux session \"${SESSION_NAME}\". The Launcher window (window 0) is where the user runs launch commands. You can read its contents with: tmux capture-pane -t ${SESSION_NAME}:Launcher -p
 Help the user monitor and debug this run."
 

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -55,7 +55,7 @@ After a restart, verify all processes are back up and progress resumed before th
 
 ### Where to find things
 
-- `scripts/tmux.sh` launches the run with a `Launcher` window in the named tmux session. The Claude window receives the run dir and session name in its appended prompt — if either is missing, **ask** rather than guess.
+- `scripts/tmux.sh` launches the run with a `Launcher` window in the named tmux session. The Claude window receives the output directory, the session name, and a command that finds the active run's log directory in its appended prompt — if the output directory or session name is missing, **ask** rather than guess.
 - `{run_dir}/configs/` — resolved configs, written as JSON so explicit None settings round-trip (`rl.json` has the full picture).
 - `{run_dir}/logs/latest/` — the current attempt's logs (each launch gets `logs/attempt_<n>/`; resumes never overwrite earlier attempts). See below.
 - `{run_dir}/rollouts/step_N/{train,eval}/` — saved episodes (see Episodes below).


### PR DESCRIPTION
## Summary

- `scripts/tmux.sh` still tailed `<output_dir>/logs/latest/*.log`, but runs now write logs to `<output_dir>/<run_name>/logs/latest` — and run names are auto-generated (`<envs>--<model>--<short-id>`) unless set via `--run.name`. Every pane tailed paths that no longer exist.
- Since the run directory is unknown when the session starts, each pane now polls a glob (`<dir>/logs/latest` and `<dir>/*/logs/latest`), picks the newest match, and starts tailing once a run appears. This makes `-o` accept either an output directory (default `outputs`, auto-detects the newest run) or a specific run directory.
- The pane loops use `command ls` so interactive shell aliases (e.g. `ls=exa`) don't break the newest-run lookup.
- The agent prompt now describes the run-dir layout and gives the discovery command instead of hardcoded log paths.
- Docs (`docs/training.md`) and the `monitor-run` skill are updated to match.

## Verification

Before: all four log panes tailed `outputs/logs/latest/*.log`, which no longer exists — panes stayed empty.

After: launched the session against a live run with an auto-generated run name; all four `Logs` panes and the `SUCCESS` filter pane picked up the run's `logs/latest` and streamed output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
