### PR TITLE
docs(algorithms): document renderer template controls on the RL path

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -562,6 +562,16 @@ Hand-coded renderers ship for `qwen3`, `qwen3-vl`, `qwen3.5`, `glm-5`, `glm-4.5`
 name = "auto"   # detect from tokenizer; pass an explicit name for fine-tunes
 ```
 
+`[orchestrator.renderer]` is the typed `renderers.RendererConfig` discriminated union: `name` selects the renderer, and the block then accepts exactly that renderer's template controls — a control that doesn't exist on the selected renderer fails at config-load time instead of being silently ignored. For example, to roll out Qwen3.5 with thinking off:
+
+```toml
+[orchestrator.renderer]
+name = "qwen3.5"
+enable_thinking = false
+```
+
+A control you leave unset falls back to that renderer's per-model default, keyed off the checkpoint — `enable_thinking` defaults off for the small Qwen3.5 sizes and on for the larger ones, and unknown or fine-tuned checkpoints fall back to on. Set it explicitly when rolling out a fine-tune. SFT reads the same typed union from its own top-level `[renderer]` block (see [Training](training.md)).
+
 For the full design rationale (failure modes ruled out, empirical token-identity comparison against `apply_chat_template`, when to write a hand-coded renderer), see [the renderers writeup on the Prime Intellect blog](https://www.primeintellect.ai/blog/renderers) — the canonical reference.
 
 ### Discontinuous Trajectories


### PR DESCRIPTION
## Problem

`orchestrator.renderer` is typed as the `renderers.RendererConfig` discriminated union, so it accepts each renderer's own template controls (`enable_thinking`, `add_vision_id`, ...). But `docs/algorithms.md` only ever showed the selection form:

```toml
[orchestrator.renderer]
name = "auto"
```

so those controls are undiscoverable on the RL path. The SFT side already documents the equivalent top-level `[renderer]` block with `enable_thinking` in `docs/training.md`, which makes the omission read as deliberate rather than missing.

This is what #2662 ran into: the reporter could see `Qwen35Renderer(tokenizer, enable_thinking=False)` in `renderers`, found no config path to reach it from prime-rl, and worked around it by falling back to `DefaultRenderer`.

## Change

Ten lines in `docs/algorithms.md`, directly after the existing renderer-selection block:

- the block is the typed discriminated union, and a control that doesn't exist on the selected renderer fails at config-load time rather than being ignored
- a `name = "qwen3.5"` / `enable_thinking = false` example
- what an unset control falls back to, plus the fine-tune caveat
- a pointer to the SFT `[renderer]` block

## One note on the unset default

I documented the unset behaviour as a per-model default keyed off the checkpoint, rather than the "auto-detects from the tokenizer's chat-template default" phrasing from the issue thread. The implementation is a hard-coded table (`_ENABLE_THINKING_DEFAULTS` in `renderers/qwen35.py`): small Qwen3.5 sizes (0.8B / 2B) default off, larger sizes default on, and checkpoints absent from the table — including fine-tunes — fall back to on. The comment there notes the probing approach was dropped on purpose to keep `transformers` off the hot path. Happy to reword if the intended contract differs.

Docs-only; no code paths touched. Opened as a draft per `AGENTS.md` so this doesn't consume the GPU matrix — it's complete, so say the word and I'll mark it ready.

Closes #2662
