### PR TITLE
feat(slurm): launch ModelExpress for NIXL transfers

### DIFF
--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -241,7 +241,7 @@ uv pip install --reinstall --no-deps deps/nixl_cu12-*.whl
 bash scripts/install_modelexpress.sh
 ```
 
-With the default `weight_broadcast.host = "localhost"`, the generated job starts a job-scoped ModelExpress server and Redis backend on the trainer head node and passes that address to every component. Set `weight_broadcast.host` to a non-local hostname to connect to an externally managed ModelExpress service instead.
+The generated job starts a job-scoped ModelExpress server and Redis backend on the trainer head node and passes that address to every component. To use an existing service, set `slurm.launch_modelexpress = false` and configure `weight_broadcast.host` and `weight_broadcast.port`.
 
 The launcher requires the CUDA and InfiniBand transports from `third_party/ucx`. Each NIXL process selects the active InfiniBand port nearest its GPU; an explicitly configured `UCX_NET_DEVICES` takes precedence. Inference ranks start their pulls at different trainer ranks so concurrent workers distribute traffic across all available source rails.
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -231,6 +231,20 @@ Full multi-node configs ship under [`examples/advanced/`](https://github.com/Pri
 
 For inference-only multi-node, set `[deployment] type = "multi_node"` on an inference TOML — each node runs an independent vLLM replica (TP and DP must fit within one node), fronted by a single global router on node 0. Point clients at the router URL the launcher prints.
 
+### NIXL weight broadcast
+
+Set `[weight_broadcast] type = "nixl"` to use receiver-driven NIXL weight transfer. Before the first SLURM run, install the NIXL/UCX build and the ModelExpress service binaries on the shared filesystem:
+
+```bash
+bash scripts/install_nixl_from_source.sh
+uv pip install --reinstall --no-deps deps/nixl_cu12-*.whl
+bash scripts/install_modelexpress.sh
+```
+
+With the default `weight_broadcast.host = "localhost"`, the generated job starts a job-scoped ModelExpress server and Redis backend on the trainer head node and passes that address to every component. Set `weight_broadcast.host` to a non-local hostname to connect to an externally managed ModelExpress service instead.
+
+The launcher requires the CUDA and InfiniBand transports from `third_party/ucx`. Each NIXL process selects the active InfiniBand port nearest its GPU; an explicitly configured `UCX_NET_DEVICES` takes precedence. Inference ranks start their pulls at different trainer ranks so concurrent workers distribute traffic across all available source rails.
+
 ### Custom Templates
 
 For unusual partitions, module loads, or environment setup, supply your own Jinja2 template:

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -106,6 +106,9 @@ class SlurmConfig(BaseConfig):
     pre_run_command: str | None = None
     """Shell command to run on the head node after cd, .env sourcing, and venv activation. Useful for cleanup like ``sudo pkill -f vllm``; wrap with ``srun bash -c '...'`` to fan out to all nodes."""
 
+    launch_modelexpress: bool = True
+    """Start a job-scoped ModelExpress service for NIXL weight transfer."""
+
     cleanup_grace_period: int = Field(3600, ge=0)
     """Seconds to wait before tearing down a multi-node RL job that hit a non-zero exit, letting in-flight checkpoints flush. Set to 0 to tear down immediately."""
 

--- a/scripts/install_modelexpress.sh
+++ b/scripts/install_modelexpress.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Build the ModelExpress metadata server and Redis backend used by SLURM RL jobs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+MODELEXPRESS_REPOSITORY="https://github.com/ai-dynamo/modelexpress.git"
+MODELEXPRESS_REF="v0.3.0"
+REDIS_VERSION="7.4.2"
+REDIS_SHA256="4ddebbf09061cbb589011786febdb34f29767dd7f89dbe712d2b68e808af6a1f"
+
+if [[ $# -gt 0 ]]; then
+    echo "This installer does not accept arguments" >&2
+    exit 1
+fi
+
+BIN_DIR="$PROJECT_DIR/third_party/modelexpress/bin"
+mkdir -p "$BIN_DIR"
+
+if [[ -x "$BIN_DIR/modelexpress-server" ]] \
+    && "$BIN_DIR/modelexpress-server" --version 2>/dev/null | grep -q "${MODELEXPRESS_REF#v}"; then
+    echo "modelexpress-server $MODELEXPRESS_REF already installed at $BIN_DIR"
+else
+    command -v cargo >/dev/null || {
+        echo "cargo not found; install Rust 1.90 or newer before running this script" >&2
+        exit 1
+    }
+    command -v protoc >/dev/null || {
+        echo "protoc not found; install Protocol Buffers before running this script" >&2
+        exit 1
+    }
+    BUILD_DIR=$(mktemp -d)
+    trap 'rm -rf "$BUILD_DIR"' EXIT
+    git clone --depth 1 --branch "$MODELEXPRESS_REF" "$MODELEXPRESS_REPOSITORY" "$BUILD_DIR/modelexpress"
+    (
+        cd "$BUILD_DIR/modelexpress"
+        cargo build --release --bin modelexpress-server
+    )
+    cp "$BUILD_DIR/modelexpress/target/release/modelexpress-server" "$BIN_DIR/"
+fi
+
+if [[ -x "$BIN_DIR/redis-server" ]] \
+    && "$BIN_DIR/redis-server" --version | grep -q "v=$REDIS_VERSION"; then
+    echo "redis-server $REDIS_VERSION already installed at $BIN_DIR"
+else
+    BUILD_DIR="${BUILD_DIR:-$(mktemp -d)}"
+    trap 'rm -rf "$BUILD_DIR"' EXIT
+    REDIS_ARCHIVE="$BUILD_DIR/redis-${REDIS_VERSION}.tar.gz"
+    curl --fail --location --silent --show-error \
+        --output "$REDIS_ARCHIVE" \
+        "https://download.redis.io/releases/redis-${REDIS_VERSION}.tar.gz"
+    echo "$REDIS_SHA256  $REDIS_ARCHIVE" | sha256sum --check
+    tar -xzf "$REDIS_ARCHIVE" -C "$BUILD_DIR"
+    make -C "$BUILD_DIR/redis-${REDIS_VERSION}" -j redis-server MALLOC=libc
+    cp "$BUILD_DIR/redis-${REDIS_VERSION}/src/redis-server" "$BIN_DIR/"
+fi
+
+echo "Installed ModelExpress server dependencies in $BIN_DIR"

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -46,7 +46,7 @@ uv run rl @ examples/basic/reverse-text/rl.toml --dry-run                       
 - Entrypoint: `src/prime_rl/entrypoints/rl.py`
 - SLURM: single- and multi-node
 - Multi-node SLURM stops after `.trainer.done` for trainer-only fake-data runs. Runs with inference stop after both `.trainer.done` and `.orchestrator.done`.
-- NIXL on SLURM: install the UCX/NIXL build with `scripts/install_nixl_from_source.sh`, reinstall its wheel after `uv sync`, then install the ModelExpress and Redis binaries with `scripts/install_modelexpress.sh`. With the default local broadcast host, the generated job runs ModelExpress on the trainer head and injects its address into every component; a non-local `weight_broadcast.host` selects an external service. Each NIXL process pins UCX to its GPU's nearest active InfiniBand port unless `UCX_NET_DEVICES` is explicitly set, and inference ranks rotate their trainer-agent pull order across the available source rails.
+- NIXL on SLURM: install NIXL and ModelExpress with the provided scripts. The job starts ModelExpress and Redis unless `slurm.launch_modelexpress = false`.
 - Environment packages: before launching a config with a non-core verifier env id,
   verify the package imports under `uv run` (for example
   `uv run python -c "import importlib.util; print(importlib.util.find_spec('r2e_gym'))"`).

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -46,6 +46,7 @@ uv run rl @ examples/basic/reverse-text/rl.toml --dry-run                       
 - Entrypoint: `src/prime_rl/entrypoints/rl.py`
 - SLURM: single- and multi-node
 - Multi-node SLURM stops after `.trainer.done` for trainer-only fake-data runs. Runs with inference stop after both `.trainer.done` and `.orchestrator.done`.
+- NIXL on SLURM: install the UCX/NIXL build with `scripts/install_nixl_from_source.sh`, reinstall its wheel after `uv sync`, then install the ModelExpress and Redis binaries with `scripts/install_modelexpress.sh`. With the default local broadcast host, the generated job runs ModelExpress on the trainer head and injects its address into every component; a non-local `weight_broadcast.host` selects an external service. Each NIXL process pins UCX to its GPU's nearest active InfiniBand port unless `UCX_NET_DEVICES` is explicitly set, and inference ranks rotate their trainer-agent pull order across the available source rails.
 - Environment packages: before launching a config with a non-core verifier env id,
   verify the package imports under `uv run` (for example
   `uv run python -c "import importlib.util; print(importlib.util.find_spec('r2e_gym'))"`).

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -464,11 +464,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
         if config.weight_broadcast is not None and config.weight_broadcast.type == "nixl"
         else None
     )
-    launch_modelexpress = nixl_broadcast is not None and nixl_broadcast.host in {
-        "localhost",
-        "127.0.0.1",
-        "0.0.0.0",
-    }
+    launch_modelexpress = nixl_broadcast is not None and config.slurm.launch_modelexpress
     modelexpress_vars = {
         "use_nixl_broadcast": nixl_broadcast is not None,
         "launch_modelexpress": launch_modelexpress,

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -459,9 +459,28 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
     train_env_names = env_server_names(config, "train")
     eval_env_names = env_server_names(config, "eval")
 
+    nixl_broadcast = (
+        config.weight_broadcast
+        if config.weight_broadcast is not None and config.weight_broadcast.type == "nixl"
+        else None
+    )
+    launch_modelexpress = nixl_broadcast is not None and nixl_broadcast.host in {
+        "localhost",
+        "127.0.0.1",
+        "0.0.0.0",
+    }
+    modelexpress_vars = {
+        "use_nixl_broadcast": nixl_broadcast is not None,
+        "launch_modelexpress": launch_modelexpress,
+        "modelexpress_host": nixl_broadcast.host if nixl_broadcast is not None else "",
+        "modelexpress_port": nixl_broadcast.port if nixl_broadcast is not None else 0,
+        "modelexpress_redis_port": 6380 if nixl_broadcast is not None and nixl_broadcast.port == 6379 else 6379,
+    }
+
     if config.deployment.type == "single_node":
         script = template.render(
             **config.slurm.template_vars,
+            **modelexpress_vars,
             config_path=config_dir / RL_CONFIG,
             output_dir=config.run_dir,
             launcher_dir=get_launcher_dir(config.run_dir),
@@ -512,6 +531,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             orchestrator_on_inference=config.deployment.orchestrator_on_inference,
             train_env_names=train_env_names,
             eval_env_names=eval_env_names,
+            **modelexpress_vars,
         )
     else:
         script = template.render(
@@ -551,6 +571,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             inference_env_vars=inference_env_vars,
             train_env_names=train_env_names,
             eval_env_names=eval_env_names,
+            **modelexpress_vars,
         )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/prime_rl/inference/vllm/worker/nixl.py
+++ b/src/prime_rl/inference/vllm/worker/nixl.py
@@ -100,7 +100,7 @@ class NIXLWeightUpdateWorker(Worker):
         del inference_world_size, quantize_in_weight_transfer
         global_rank = rank_offset + self.device.index
         server_url = f"{host}:{port}"
-        set_ucx_env_defaults()
+        set_ucx_env_defaults(self.device.index)
         self.nixl_agent = NixlAgent(make_agent_name("inference", global_rank))
         self.model_express = ModelExpressSession(
             client=MxClient(server_url=server_url),
@@ -492,7 +492,11 @@ class NIXLWeightUpdateWorker(Worker):
         peer_names: dict[int, str],
     ) -> list[tuple[Any, Any, list[int]]]:
         pulls: list[tuple[Any, Any, list[int]]] = []
-        for agent_index, remote in sorted(remote_descs.items()):
+        agent_indices = sorted(remote_descs)
+        rotation = self.model_express.rank % len(agent_indices) if agent_indices else 0
+        agent_indices = agent_indices[rotation:] + agent_indices[:rotation]
+        for agent_index in agent_indices:
+            remote = remote_descs[agent_index]
             peer_name = peer_names.get(agent_index)
             if peer_name is None:
                 peer_name = self.nixl_agent.add_remote_agent(table.agents[agent_index].metadata)

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -140,6 +140,17 @@ export MASTER_ADDR="${HOSTNAMES[$NUM_INFER_NODES]}"
 export MASTER_PORT=29500
 echo "MASTER_ADDR=${MASTER_ADDR}"
 echo "MASTER_PORT=${MASTER_PORT}"
+{% if use_nixl_broadcast -%}
+{% if launch_modelexpress -%}
+export WEIGHT_BROADCAST_HOST="$MASTER_ADDR"
+{% else -%}
+export WEIGHT_BROADCAST_HOST="{{ modelexpress_host }}"
+{% endif -%}
+export MODEL_EXPRESS_PORT={{ modelexpress_port }}
+export MODEL_EXPRESS_REDIS_PORT={{ modelexpress_redis_port }}
+echo "WEIGHT_BROADCAST_HOST=${WEIGHT_BROADCAST_HOST}"
+echo "MODEL_EXPRESS_PORT=${MODEL_EXPRESS_PORT}"
+{% endif %}
 
 # The orchestrator runs on trainer rank 0's node (SLURM_PROCID == NUM_INFER_NODES) by
 # default; with orchestrator_on_inference it moves to the last inference node (a decode
@@ -235,6 +246,83 @@ srun --kill-on-bad-exit=1 bash -s <<'LAUNCH_SH'
     # Infiniband setup
     IB_HCA=$(ibv_devinfo | sed -n -e "/hca_id/p" -e "/link_layer:/p" | grep -B1 InfiniBand | grep hca_id | sed -e "s/^hca_id://g" | tr -d "[[:blank:]]" |paste -sd,)
     export NCCL_IB_HCA=$IB_HCA
+
+{% if use_nixl_broadcast -%}
+    UCX_DIR="$PROJECT_DIR/third_party/ucx"
+    if [ ! -x "$UCX_DIR/bin/ucx_info" ]; then
+        echo "NIXL requires the UCX build installed by scripts/install_nixl_from_source.sh" >&2
+        exit 1
+    fi
+    export LD_LIBRARY_PATH="$UCX_DIR/lib:$UCX_DIR/lib/ucx:${LD_LIBRARY_PATH:-}"
+    UCX_TRANSPORTS=$("$UCX_DIR/bin/ucx_info" -d)
+    grep -q "Transport: cuda_copy" <<< "$UCX_TRANSPORTS" || {
+        echo "NIXL requires UCX cuda_copy support" >&2
+        exit 1
+    }
+    grep -q "Transport: rc_verbs" <<< "$UCX_TRANSPORTS" || {
+        echo "NIXL requires UCX rc_verbs support" >&2
+        exit 1
+    }
+{% if launch_modelexpress %}
+
+    if [ "$SLURM_PROCID" -eq "$NUM_INFER_NODES" ]; then
+        MX_BIN="$PROJECT_DIR/third_party/modelexpress/bin"
+        if [ ! -x "$MX_BIN/modelexpress-server" ] || [ ! -x "$MX_BIN/redis-server" ]; then
+            echo "ModelExpress server dependencies are missing; run scripts/install_modelexpress.sh" >&2
+            exit 1
+        fi
+
+        MX_STATE_DIR="$LOG_DIR/modelexpress"
+        mkdir -p "$MX_STATE_DIR/cache"
+        "$MX_BIN/redis-server" \
+            --port "$MODEL_EXPRESS_REDIS_PORT" \
+            --bind 127.0.0.1 \
+            --protected-mode no \
+            --save "" \
+            --appendonly no \
+            --dir "$MX_STATE_DIR" \
+            > "$MX_STATE_DIR/redis.log" 2>&1 &
+        REDIS_PID=$!
+        trap '[ -z "${MODEL_EXPRESS_PID:-}" ] || kill -TERM "$MODEL_EXPRESS_PID" 2>/dev/null; kill -TERM "$REDIS_PID" 2>/dev/null || true' EXIT
+
+        for _ in $(seq 1 60); do
+            timeout 1 bash -c "echo > /dev/tcp/127.0.0.1/$MODEL_EXPRESS_REDIS_PORT" 2>/dev/null && break
+            kill -0 "$REDIS_PID" 2>/dev/null || {
+                tail -50 "$MX_STATE_DIR/redis.log" >&2
+                exit 1
+            }
+            sleep 1
+        done
+        timeout 1 bash -c "echo > /dev/tcp/127.0.0.1/$MODEL_EXPRESS_REDIS_PORT" 2>/dev/null || {
+            echo "Redis did not become ready on port $MODEL_EXPRESS_REDIS_PORT" >&2
+            exit 1
+        }
+
+        MX_METADATA_BACKEND=redis \
+        REDIS_URL="redis://127.0.0.1:$MODEL_EXPRESS_REDIS_PORT" \
+        MX_HEARTBEAT_TIMEOUT_SECS=31536000 \
+            "$MX_BIN/modelexpress-server" \
+            --port "$MODEL_EXPRESS_PORT" \
+            --database-path "$MX_STATE_DIR/models.db" \
+            --cache-directory "$MX_STATE_DIR/cache" \
+            > "$MX_STATE_DIR/server.log" 2>&1 &
+        MODEL_EXPRESS_PID=$!
+    fi
+{% endif %}
+
+    for _ in $(seq 1 120); do
+        timeout 1 bash -c "echo > /dev/tcp/$WEIGHT_BROADCAST_HOST/$MODEL_EXPRESS_PORT" 2>/dev/null && break
+        if [ -n "${MODEL_EXPRESS_PID:-}" ] && ! kill -0 "$MODEL_EXPRESS_PID" 2>/dev/null; then
+            tail -50 "$MX_STATE_DIR/server.log" >&2
+            exit 1
+        fi
+        sleep 1
+    done
+    timeout 1 bash -c "echo > /dev/tcp/$WEIGHT_BROADCAST_HOST/$MODEL_EXPRESS_PORT" 2>/dev/null || {
+        echo "ModelExpress is not reachable at $WEIGHT_BROADCAST_HOST:$MODEL_EXPRESS_PORT" >&2
+        exit 1
+    }
+{% endif %}
 
 {% if num_infer_nodes > 0 -%}
 
@@ -425,7 +513,8 @@ else
             --local-ranks-filter={{ ranks_filter }} \
             -m prime_rl.trainer.rl.train \
             @ $CONFIG_DIR/trainer.json \
-            {% if use_zmq_transport %}--rollout_transport.host $ORCH_ADDR \
+            {% if use_nixl_broadcast %}--weight-broadcast.host $WEIGHT_BROADCAST_HOST \
+            {% endif %}{% if use_zmq_transport %}--rollout_transport.host $ORCH_ADDR \
             {% endif %}2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $LOG_DIR/trainer/node_${TRAIN_NODE_RANK}.log
         COMPONENT_CODE=$?
         if [ "$COMPONENT_CODE" -eq 0 ] && [ "$TRAIN_NODE_RANK" -eq 0 ]; then
@@ -470,6 +559,7 @@ if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
 
     (
         {% if use_nccl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $MASTER_ADDR"
+        {% elif use_nixl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $WEIGHT_BROADCAST_HOST"
         {% endif %}{% if use_zmq_transport %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --rollout_transport.host $ORCH_ADDR"
         {% endif %}WANDB_SHARED_LABEL=orchestrator uv run orchestrator $ORCHESTRATOR_ARGS \
             2>&1 | tee $LOG_DIR/orchestrator.log

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -211,6 +211,10 @@ srun bash -s <<'CLEANUP_SH'
     # the exact process name, so it never hits the worktree path (e.g. mooncake-baby).
     pkill -9 -x mooncake_master 2>/dev/null
     pkill -9 -x mooncake_client 2>/dev/null
+{% if use_nixl_broadcast and launch_modelexpress %}
+    pkill -9 -f "[m]odelexpress-server" 2>/dev/null
+    pkill -9 -x redis-server 2>/dev/null
+{% endif %}
     sleep 2
     rm -rf /dev/shm/vllm-* /dev/shm/vllm_* /tmp/vllm-* /tmp/vllm_* /tmp/torch-* /tmp/torchelastic_* 2>/dev/null
     procs=$(ps -eo comm,args | grep -E "python|torchrun|vllm|vllm::|mooncake_|[e]pp |envoy|pd-sidecar" | grep -v grep | wc -l)

--- a/src/prime_rl/templates/single_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/single_node_rl.sbatch.j2
@@ -66,6 +66,8 @@ if [ ! -x "$MX_BIN/modelexpress-server" ] || [ ! -x "$MX_BIN/redis-server" ]; th
     echo "ModelExpress server dependencies are missing; run scripts/install_modelexpress.sh" >&2
     exit 1
 fi
+pkill -9 -f "[m]odelexpress-server" 2>/dev/null || true
+pkill -9 -x redis-server 2>/dev/null || true
 
 MX_STATE_DIR="{{ output_dir }}/modelexpress"
 mkdir -p "$MX_STATE_DIR/cache"

--- a/src/prime_rl/templates/single_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/single_node_rl.sbatch.j2
@@ -38,4 +38,86 @@ uv sync --all-extras --all-packages
 {{ pre_run_command }}
 {% endif %}
 export PRL_RUN_ID=${PRL_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}
+{% if use_nixl_broadcast %}
+UCX_DIR="$PROJECT_DIR/third_party/ucx"
+if [ ! -x "$UCX_DIR/bin/ucx_info" ]; then
+    echo "NIXL requires the UCX build installed by scripts/install_nixl_from_source.sh" >&2
+    exit 1
+fi
+export LD_LIBRARY_PATH="$UCX_DIR/lib:$UCX_DIR/lib/ucx:${LD_LIBRARY_PATH:-}"
+UCX_TRANSPORTS=$("$UCX_DIR/bin/ucx_info" -d)
+grep -q "Transport: cuda_copy" <<< "$UCX_TRANSPORTS" || {
+    echo "NIXL requires UCX cuda_copy support" >&2
+    exit 1
+}
+grep -q "Transport: rc_verbs" <<< "$UCX_TRANSPORTS" || {
+    echo "NIXL requires UCX rc_verbs support" >&2
+    exit 1
+}
+{% endif %}
+{% if launch_modelexpress %}
+MX_BIN="$PROJECT_DIR/third_party/modelexpress/bin"
+if [ ! -x "$MX_BIN/modelexpress-server" ] || [ ! -x "$MX_BIN/redis-server" ]; then
+    echo "ModelExpress server dependencies are missing; run scripts/install_modelexpress.sh" >&2
+    exit 1
+fi
+
+MX_STATE_DIR="{{ output_dir }}/modelexpress"
+mkdir -p "$MX_STATE_DIR/cache"
+"$MX_BIN/redis-server" \
+    --port {{ modelexpress_redis_port }} \
+    --bind 127.0.0.1 \
+    --protected-mode no \
+    --save "" \
+    --appendonly no \
+    --dir "$MX_STATE_DIR" \
+    > "$MX_STATE_DIR/redis.log" 2>&1 &
+REDIS_PID=$!
+trap '[ -z "${MODEL_EXPRESS_PID:-}" ] || kill -TERM "$MODEL_EXPRESS_PID" 2>/dev/null; kill -TERM "$REDIS_PID" 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 60); do
+    timeout 1 bash -c "echo > /dev/tcp/127.0.0.1/{{ modelexpress_redis_port }}" 2>/dev/null && break
+    kill -0 "$REDIS_PID" 2>/dev/null || {
+        tail -50 "$MX_STATE_DIR/redis.log" >&2
+        exit 1
+    }
+    sleep 1
+done
+timeout 1 bash -c "echo > /dev/tcp/127.0.0.1/{{ modelexpress_redis_port }}" 2>/dev/null || {
+    echo "Redis did not become ready on port {{ modelexpress_redis_port }}" >&2
+    exit 1
+}
+
+MX_METADATA_BACKEND=redis \
+REDIS_URL="redis://127.0.0.1:{{ modelexpress_redis_port }}" \
+MX_HEARTBEAT_TIMEOUT_SECS=31536000 \
+    "$MX_BIN/modelexpress-server" \
+    --port {{ modelexpress_port }} \
+    --database-path "$MX_STATE_DIR/models.db" \
+    --cache-directory "$MX_STATE_DIR/cache" \
+    > "$MX_STATE_DIR/server.log" 2>&1 &
+MODEL_EXPRESS_PID=$!
+
+for _ in $(seq 1 120); do
+    timeout 1 bash -c "echo > /dev/tcp/127.0.0.1/{{ modelexpress_port }}" 2>/dev/null && break
+    kill -0 "$MODEL_EXPRESS_PID" 2>/dev/null || {
+        tail -50 "$MX_STATE_DIR/server.log" >&2
+        exit 1
+    }
+    sleep 1
+done
+timeout 1 bash -c "echo > /dev/tcp/127.0.0.1/{{ modelexpress_port }}" 2>/dev/null || {
+    echo "ModelExpress did not become ready on port {{ modelexpress_port }}" >&2
+    exit 1
+}
+{% elif use_nixl_broadcast %}
+for _ in $(seq 1 120); do
+    timeout 1 bash -c "echo > /dev/tcp/{{ modelexpress_host }}/{{ modelexpress_port }}" 2>/dev/null && break
+    sleep 1
+done
+timeout 1 bash -c "echo > /dev/tcp/{{ modelexpress_host }}/{{ modelexpress_port }}" 2>/dev/null || {
+    echo "ModelExpress is not reachable at {{ modelexpress_host }}:{{ modelexpress_port }}" >&2
+    exit 1
+}
+{% endif %}
 uv run rl @ {{ config_path }}

--- a/src/prime_rl/templates/single_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/single_node_rl.sbatch.j2
@@ -39,6 +39,12 @@ uv sync --all-extras --all-packages
 {% endif %}
 export PRL_RUN_ID=${PRL_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}
 {% if use_nixl_broadcast %}
+{% if launch_modelexpress -%}
+export WEIGHT_BROADCAST_HOST="127.0.0.1"
+{% else -%}
+export WEIGHT_BROADCAST_HOST="{{ modelexpress_host }}"
+{% endif -%}
+export MODEL_EXPRESS_PORT={{ modelexpress_port }}
 UCX_DIR="$PROJECT_DIR/third_party/ucx"
 if [ ! -x "$UCX_DIR/bin/ucx_info" ]; then
     echo "NIXL requires the UCX build installed by scripts/install_nixl_from_source.sh" >&2
@@ -54,7 +60,6 @@ grep -q "Transport: rc_verbs" <<< "$UCX_TRANSPORTS" || {
     echo "NIXL requires UCX rc_verbs support" >&2
     exit 1
 }
-{% endif %}
 {% if launch_modelexpress %}
 MX_BIN="$PROJECT_DIR/third_party/modelexpress/bin"
 if [ ! -x "$MX_BIN/modelexpress-server" ] || [ ! -x "$MX_BIN/redis-server" ]; then
@@ -97,27 +102,21 @@ MX_HEARTBEAT_TIMEOUT_SECS=31536000 \
     --cache-directory "$MX_STATE_DIR/cache" \
     > "$MX_STATE_DIR/server.log" 2>&1 &
 MODEL_EXPRESS_PID=$!
+{% endif %}
 
 for _ in $(seq 1 120); do
-    timeout 1 bash -c "echo > /dev/tcp/127.0.0.1/{{ modelexpress_port }}" 2>/dev/null && break
+    timeout 1 bash -c "echo > /dev/tcp/$WEIGHT_BROADCAST_HOST/$MODEL_EXPRESS_PORT" 2>/dev/null && break
+{% if launch_modelexpress %}
     kill -0 "$MODEL_EXPRESS_PID" 2>/dev/null || {
         tail -50 "$MX_STATE_DIR/server.log" >&2
         exit 1
     }
+{% endif %}
     sleep 1
 done
-timeout 1 bash -c "echo > /dev/tcp/127.0.0.1/{{ modelexpress_port }}" 2>/dev/null || {
-    echo "ModelExpress did not become ready on port {{ modelexpress_port }}" >&2
-    exit 1
-}
-{% elif use_nixl_broadcast %}
-for _ in $(seq 1 120); do
-    timeout 1 bash -c "echo > /dev/tcp/{{ modelexpress_host }}/{{ modelexpress_port }}" 2>/dev/null && break
-    sleep 1
-done
-timeout 1 bash -c "echo > /dev/tcp/{{ modelexpress_host }}/{{ modelexpress_port }}" 2>/dev/null || {
-    echo "ModelExpress is not reachable at {{ modelexpress_host }}:{{ modelexpress_port }}" >&2
+timeout 1 bash -c "echo > /dev/tcp/$WEIGHT_BROADCAST_HOST/$MODEL_EXPRESS_PORT" 2>/dev/null || {
+    echo "ModelExpress is not reachable at $WEIGHT_BROADCAST_HOST:$MODEL_EXPRESS_PORT" >&2
     exit 1
 }
 {% endif %}
-uv run rl @ {{ config_path }}
+uv run rl @ {{ config_path }}{% if use_nixl_broadcast %} --weight-broadcast.host "$WEIGHT_BROADCAST_HOST"{% endif %}

--- a/src/prime_rl/transports/weights/nixl/agent.py
+++ b/src/prime_rl/transports/weights/nixl/agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import socket
 import time
+from pathlib import Path
 from typing import Any, Callable, Sequence
 
 from torch import Tensor
@@ -85,7 +86,60 @@ def make_agent_name(role: str, global_rank: int) -> str:
     return f"{role}-{socket.gethostname()}-r{global_rank}"
 
 
-def set_ucx_env_defaults() -> None:
+def set_ucx_env_defaults(device_index: int) -> None:
+    if "UCX_NET_DEVICES" not in os.environ:
+        import pynvml
+
+        visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+        visible_device = str(device_index)
+        if visible_devices:
+            visible_device = visible_devices.split(",")[device_index].strip()
+
+        pynvml.nvmlInit()
+        try:
+            if visible_device.isdecimal():
+                handle = pynvml.nvmlDeviceGetHandleByIndex(int(visible_device))
+            elif visible_device.startswith("GPU-"):
+                handle = pynvml.nvmlDeviceGetHandleByUUID(visible_device.encode())
+            else:
+                raise RuntimeError(f"Unsupported CUDA_VISIBLE_DEVICES entry for NIXL: {visible_device}")
+            bus_id = pynvml.nvmlDeviceGetPciInfo(handle).busId
+        finally:
+            pynvml.nvmlShutdown()
+
+        if isinstance(bus_id, bytes):
+            bus_id = bus_id.decode()
+        domain, bus, device = bus_id.rsplit(":", 2)
+        gpu_path = Path("/sys/bus/pci/devices") / f"{int(domain, 16):04x}:{bus.lower()}:{device.lower()}"
+        if not gpu_path.exists():
+            raise RuntimeError(f"GPU PCI device is missing from sysfs: {gpu_path}")
+
+        rdma_ports: list[tuple[str, Path]] = []
+        for hca_path in sorted(Path("/sys/class/infiniband").glob("*")):
+            for port_path in sorted((hca_path / "ports").glob("*")):
+                if (port_path / "link_layer").read_text().strip() != "InfiniBand":
+                    continue
+                if "ACTIVE" not in (port_path / "state").read_text():
+                    continue
+                rdma_ports.append((f"{hca_path.name}:{port_path.name}", (hca_path / "device").resolve()))
+        if not rdma_ports:
+            raise RuntimeError("NIXL requires an active InfiniBand port")
+
+        gpu_parts = gpu_path.resolve().parts
+        ports_by_distance: list[tuple[int, str]] = []
+        for port, device_path in rdma_ports:
+            device_parts = device_path.parts
+            common_parts = 0
+            for gpu_part, device_part in zip(gpu_parts, device_parts):
+                if gpu_part != device_part:
+                    break
+                common_parts += 1
+            distance = len(gpu_parts) + len(device_parts) - 2 * common_parts
+            ports_by_distance.append((distance, port))
+
+        os.environ["UCX_NET_DEVICES"] = min(ports_by_distance)[1]
+        os.environ.setdefault("UCX_MAX_RNDV_RAILS", "1")
+        os.environ.setdefault("UCX_MAX_RMA_RAILS", "1")
     os.environ.setdefault("UCX_TLS", "rc_x,rc,dc_x,dc,cuda_copy")
     os.environ.setdefault("UCX_IB_GPU_DIRECT_RDMA", "y")
     os.environ.setdefault("UCX_RNDV_SCHEME", "get_zcopy")

--- a/src/prime_rl/transports/weights/nixl/nixl.py
+++ b/src/prime_rl/transports/weights/nixl/nixl.py
@@ -79,7 +79,7 @@ class NIXLWeightSender(WeightSender):
         self.config = config
         self.parallel_dims = parallel_dims
         if self.is_serving_rank:
-            set_ucx_env_defaults()
+            set_ucx_env_defaults(torch.cuda.current_device())
             self.nixl_agent = NixlAgent(make_agent_name("trainer", self.world.rank))
         self.initialized = False
         self.transfer_group_names: list[str] = []


### PR DESCRIPTION
## Summary

- start a job-scoped Redis and ModelExpress service when `slurm.launch_modelexpress = true`
- inject the trainer-head service address into trainer, inference, and orchestrator processes, or use the configured host when `slurm.launch_modelexpress = false`
- pin every NIXL process to the active InfiniBand HCA nearest its GPU, so an eight-GPU node uses all eight rails
- add a pinned, idempotent installer for ModelExpress v0.3.0 and Redis 7.4.2
- remove stale job-scoped ModelExpress and Redis processes before managed-service startup

This is the launch prerequisite for the stacked transfer optimization in #3341. It does not change the NIXL transfer protocol itself.

## Design

With `slurm.launch_modelexpress = true`, the generated job removes stale ModelExpress and Redis processes from an interrupted managed launch, then starts both services on the trainer head before launching the three prime-rl components. The resolved ModelExpress address is passed to every component, and service logs stay in the run directory. With `slurm.launch_modelexpress = false`, the launcher performs no service cleanup, starts no service, and uses `weight_broadcast.host` and `weight_broadcast.port` unchanged.

Rail selection remains local to each NIXL process. Unless `UCX_NET_DEVICES` is explicitly configured, startup resolves the process GPU's PCI path, selects the nearest active InfiniBand port, and constrains UCX to that port. TP8 therefore uses one distinct local rail per GPU instead of relying on UCX's cluster-dependent default choice. `UCX_NET_DEVICES` remains an explicit site override.

The installer pins both service versions, verifies their checksums, and reuses valid existing installations. Generated jobs fail directly if a required binary or UCX capability is missing.

## Scope

- ModelExpress provides startup discovery for a fixed Slurm allocation.
- Elastic discovery, autoscaling, and fault tolerance are intentionally out of scope.
- The local service adds two small CPU processes on the trainer head and no GPU allocation.

## Validation

- `bash -n scripts/install_modelexpress.sh`
- ran `scripts/install_modelexpress.sh` twice and verified that the pinned binaries are reused
- rebased onto `main` at `21a4a3245`; rendered and shell-checked managed and external ModelExpress modes for single-node and multi-node NIXL Slurm jobs, including main’s trainer/orchestrator completion markers
- verified stale-service cleanup is present only in managed ModelExpress renders and absent in external-service renders
- Ruff 0.15.14: `uv run ruff format --check` and `uv run ruff check`
- `uv run python -m compileall` on changed Python modules
- `uv run pytest -q tests/unit/test_configs.py` (122 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-node SLURM launch and NIXL UCX/IB selection for weight sync; misconfiguration or rail selection bugs could break or degrade policy updates, but scope is limited to NIXL SLURM paths.
> 
> **Overview**
> Adds **job-scoped ModelExpress + Redis** startup for SLURM RL when `[weight_broadcast] type = "nixl"` and **`slurm.launch_modelexpress`** is true (default). Single- and multi-node sbatch templates verify the **`third_party/ucx`** build, optionally start pinned **modelexpress-server** / **redis-server** (new **`scripts/install_modelexpress.sh`**), wait for readiness, and pass **`--weight-broadcast.host`** into trainer, orchestrator, and the local `rl` launcher. With **`launch_modelexpress = false`**, jobs use configured **`weight_broadcast.host`** / **`port`** and skip managed-service cleanup.
> 
> **NIXL networking** now picks **`UCX_NET_DEVICES`** per process from the **InfiniBand port nearest each GPU** (unless already set), and inference workers **rotate which trainer ranks they pull from** so concurrent pulls spread across rails.
> 
> Docs and the start-run skill describe install steps and the new SLURM flag. **Does not change the NIXL transfer protocol** (prerequisite for stacked transfer work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d809b1e4d24121690faab3a22b1f7f832de4f53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->