### PR TITLE
perf(nixl): pipeline reusable weight pulls

### DIFF
--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -245,6 +245,10 @@ The generated job starts a job-scoped ModelExpress server and Redis backend on t
 
 The launcher requires the CUDA and InfiniBand transports from `third_party/ucx`. Each NIXL process selects the active InfiniBand port nearest its GPU; an explicitly configured `UCX_NET_DEVICES` takes precedence. Inference ranks start their pulls at different trainer ranks so concurrent workers distribute traffic across all available source rails.
 
+ModelExpress exchanges peer metadata during startup. Weight updates reuse prepared NIXL requests, post every trainer-rank read in a transfer group concurrently, and use versioned NIXL notifications for source readiness and buffer credits.
+
+By default, the trainer and inference worker each allocate one transfer arena. Set `weight_broadcast.overlap_transfer_and_replay = true` to allocate two arenas on both sides and replay one weight group while receiving the next. The additional arena is the size of the largest transfer group per GPU; allocation errors are reported instead of silently disabling overlap.
+
 ### Custom Templates
 
 For unusual partitions, module loads, or environment setup, supply your own Jinja2 template:

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -408,6 +408,9 @@ class NIXLWeightBroadcastConfig(InMemoryWeightBroadcastConfig):
     session_id: str = "default"
     """ModelExpress session ID."""
 
+    overlap_transfer_and_replay: bool = False
+    """Allocate two transfer arenas so inference can replay one weight group while receiving the next."""
+
 
 WeightBroadcastConfig: TypeAlias = Annotated[
     FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig | NIXLWeightBroadcastConfig,

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -158,6 +158,9 @@ class SharedNIXLWeightBroadcastConfig(SharedInMemoryWeightBroadcastConfig):
     session_id: str = "default"
     """ModelExpress session ID."""
 
+    overlap_transfer_and_replay: bool = False
+    """Allocate two transfer arenas so inference can replay one weight group while receiving the next."""
+
 
 class SharedFileSystemWeightBroadcastConfig(BaseConfig):
     type: Literal["filesystem"] = "filesystem"
@@ -490,7 +493,10 @@ class RLConfig(BaseConfig):
                 trainer_config_type = TrainerNCCLWeightBroadcastConfig
                 orchestrator_config_type = OrchestratorNCCLWeightBroadcastConfig
             else:
-                transport_config = dict(session_id=self.weight_broadcast.session_id)
+                transport_config = dict(
+                    session_id=self.weight_broadcast.session_id,
+                    overlap_transfer_and_replay=self.weight_broadcast.overlap_transfer_and_replay,
+                )
                 trainer_config_type = TrainerNIXLWeightBroadcastConfig
                 orchestrator_config_type = OrchestratorNIXLWeightBroadcastConfig
             self.trainer.weight_broadcast = trainer_config_type(**common_config, **transport_config)

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -565,6 +565,9 @@ class NIXLWeightBroadcastConfig(InMemoryWeightBroadcastConfig):
     session_id: str = "default"
     """ModelExpress session ID."""
 
+    overlap_transfer_and_replay: bool = False
+    """Allocate two staging arenas so inference can replay one weight group while receiving the next."""
+
 
 WeightBroadcastConfig: TypeAlias = Annotated[
     FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig | NIXLWeightBroadcastConfig,

--- a/src/prime_rl/inference/vllm/worker/nixl.py
+++ b/src/prime_rl/inference/vllm/worker/nixl.py
@@ -13,17 +13,21 @@ from typing import TYPE_CHECKING, Any, cast
 
 import torch
 import torch.nn as nn
-from modelexpress import p2p_pb2
 from modelexpress.client import MxClient
 from vllm.config import set_current_vllm_config
 from vllm.logger import init_logger
 
 from prime_rl.inference.vllm.worker.weight_transfer import update_mla_absorbed_weights
-from prime_rl.transports.weights.nixl.agent import MemDesc, NixlAgent, make_agent_name, set_ucx_env_defaults
-from prime_rl.transports.weights.nixl.cuda_malloc_memory import (
-    size_cuda_buffers,
-    use_cuda_malloc_pool,
+from prime_rl.transports.weights.nixl.agent import (
+    MemDesc,
+    NixlAgent,
+    NixlPeer,
+    PreparedRead,
+    group_notification,
+    make_agent_name,
+    set_ucx_env_defaults,
 )
+from prime_rl.transports.weights.nixl.cuda_malloc_memory import use_cuda_malloc_pool
 from prime_rl.transports.weights.nixl.graph import (
     Destination,
     OperationChain,
@@ -44,7 +48,6 @@ else:
     Worker = object
 
 logger = init_logger("vllm.inference.vllm.worker_nixl")
-_BUFFER_POLL_INTERVAL = 0.01
 
 
 @dataclass
@@ -69,13 +72,14 @@ class LayerWeightTransferPlan:
 class WeightTransferGroup:
     name: str
     layers: list[LayerWeightTransferPlan]
-    pulls: list[tuple[Any, Any, list[int]]]
+    pulls: list[PreparedRead]
 
 
 @dataclass
 class WeightTransferPlan:
     receive_arenas: dict[torch.dtype, torch.Tensor]
     receive_buffer_count: int
+    trainer_peers: list[NixlPeer]
     groups: list[WeightTransferGroup]
 
 
@@ -109,6 +113,7 @@ class NIXLWeightUpdateWorker(Worker):
             session_id=session_id,
             worker_id=f"inference-{global_rank}",
         )
+        self.model_express.publish(nixl_metadata=self.nixl_agent.get_metadata())
         self.weight_transfer_timeout = timeout
         self.weight_transfer_plan: WeightTransferPlan | None = None
         logger.info(
@@ -126,30 +131,13 @@ class NIXLWeightUpdateWorker(Worker):
         trainer_ref = self.model_express.wait_for(
             "trainer",
             count=1,
-            status=None,
             timeout=self.weight_transfer_timeout,
         )[0]
         table = TrainerTensorTable.decode(self.model_express.fetch(trainer_ref).nixl_metadata)
         copies = self.trace_weight_loads(table)
         plan = self.build_transfer_plan(table, copies)
-        self.buffer_sessions = []
-        for buffer_index in range(table.staging_buffer_count):
-            session = ModelExpressSession(
-                client=self.model_express.client,
-                role="inference",
-                rank=self.model_express.rank,
-                session_id=f"{self.model_express.session_id}:layers:{buffer_index}",
-                worker_id=f"inference-buffer-{self.model_express.rank}-{buffer_index}",
-            )
-            session.publish()
-            session.set_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
-            self.buffer_sessions.append(session)
-        # Join the current generation directly. Publishing a transient READY
-        # before the first pull would let the trainer mistake initialization
-        # for a completed acknowledgement.
-        self.model_express.publish(nixl_metadata=self.nixl_agent.get_metadata())
-        self.model_express.set_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
         self.weight_transfer_plan = plan
+        self.group_generations = [0] * len(plan.groups)
         logger.info(
             "Initialized NIXL transfer plan on rank %d with %d groups",
             self.model_express.rank,
@@ -255,14 +243,16 @@ class NIXLWeightUpdateWorker(Worker):
             copies,
             replay_plans,
         )
-        receive_buffer_count = self.choose_receive_buffer_count(
-            receive_buffer_elements,
-            table.staging_buffer_count,
-        )
+        receive_buffer_count = table.staging_buffer_count
         receive_arenas = self.allocate_receive_arenas(
             receive_buffer_elements,
             receive_buffer_count,
         )
+        peers: list[NixlPeer] = []
+        for agent in table.agents:
+            peer = self.nixl_agent.add_remote_agent(agent.metadata)
+            self.nixl_agent.make_connection(peer)
+            peers.append(peer)
         groups = self.build_transfer_groups(
             table,
             copies,
@@ -270,10 +260,12 @@ class NIXLWeightUpdateWorker(Worker):
             receive_buffer_elements,
             receive_arenas,
             receive_buffer_count,
+            peers,
         )
         return WeightTransferPlan(
             receive_arenas=receive_arenas,
             receive_buffer_count=receive_buffer_count,
+            trainer_peers=peers,
             groups=groups,
         )
 
@@ -310,31 +302,6 @@ class NIXLWeightUpdateWorker(Worker):
             group_elements[source_dtype][tensor_groups[source.name]] += prod(replay_plans[id(copy)].source_shape)
         return {dtype: max(elements, default=0) for dtype, elements in group_elements.items()}
 
-    def choose_receive_buffer_count(
-        self,
-        receive_buffer_elements: dict[torch.dtype, int],
-        staging_buffer_count: int,
-    ) -> int:
-        receive_buffer_bytes = max(
-            1,
-            sum(elements * dtype.itemsize for dtype, elements in receive_buffer_elements.items()),
-        )
-        allocated_bytes = torch.cuda.memory_allocated(self.device)
-        peak_growth_bytes = max(
-            0,
-            torch.cuda.max_memory_allocated(self.device) - allocated_bytes,
-        )
-        free_bytes, _ = torch.cuda.mem_get_info(self.device)
-        max_receive_buffers = min(2, staging_buffer_count) if peak_growth_bytes else 1
-        if peak_growth_bytes or free_bytes < receive_buffer_bytes:
-            torch.cuda.empty_cache()
-        return size_cuda_buffers(
-            receive_buffer_bytes,
-            max_receive_buffers,
-            self.device,
-            extra_headroom_bytes=receive_buffer_bytes + peak_growth_bytes,
-        )
-
     def allocate_receive_arenas(
         self,
         receive_buffer_elements: dict[torch.dtype, int],
@@ -362,6 +329,7 @@ class NIXLWeightUpdateWorker(Worker):
         receive_buffer_elements: dict[torch.dtype, int],
         receive_arenas: dict[torch.dtype, torch.Tensor],
         receive_buffer_count: int,
+        peers: list[NixlPeer],
     ) -> list[WeightTransferGroup]:
         tensors = {tensor.name: tensor for group in table.groups for tensor in group.tensors}
         tensor_groups = {
@@ -390,7 +358,6 @@ class NIXLWeightUpdateWorker(Worker):
                 )
 
         agent_devices = {agent_index: agent.device_id for agent_index, agent in enumerate(table.agents)}
-        peer_names: dict[int, str] = {}
         transfer_groups: list[WeightTransferGroup] = []
 
         for group_index, group in enumerate(table.groups):
@@ -432,10 +399,9 @@ class NIXLWeightUpdateWorker(Worker):
                         persistent_plans_by_layer,
                     ),
                     pulls=self.prepare_group_pulls(
-                        table,
                         local_descs,
                         remote_descs,
-                        peer_names,
+                        peers,
                     ),
                 )
             )
@@ -486,44 +452,37 @@ class NIXLWeightUpdateWorker(Worker):
 
     def prepare_group_pulls(
         self,
-        table: TrainerTensorTable,
         local_descs: dict[int, list[MemDesc]],
         remote_descs: dict[int, list[MemDesc]],
-        peer_names: dict[int, str],
-    ) -> list[tuple[Any, Any, list[int]]]:
-        pulls: list[tuple[Any, Any, list[int]]] = []
+        peers: list[NixlPeer],
+    ) -> list[PreparedRead]:
+        pulls: list[PreparedRead] = []
         agent_indices = sorted(remote_descs)
         rotation = self.model_express.rank % len(agent_indices) if agent_indices else 0
         agent_indices = agent_indices[rotation:] + agent_indices[:rotation]
         for agent_index in agent_indices:
             remote = remote_descs[agent_index]
-            peer_name = peer_names.get(agent_index)
-            if peer_name is None:
-                peer_name = self.nixl_agent.add_remote_agent(table.agents[agent_index].metadata)
-                self.nixl_agent.make_connection(peer_name)
-                peer_names[agent_index] = peer_name
+            peer = peers[agent_index]
             local_prepared = self.nixl_agent.prepare_xfer_dlist(local_descs[agent_index])
-            remote_prepared = self.nixl_agent.prepare_xfer_dlist(remote, agent_name=peer_name)
-            pulls.append((local_prepared, remote_prepared, list(range(len(remote)))))
+            remote_prepared = self.nixl_agent.prepare_xfer_dlist(remote, peer=peer)
+            pulls.append(
+                self.nixl_agent.prepare_read(
+                    local_prepared,
+                    list(range(len(remote))),
+                    remote_prepared,
+                )
+            )
         return pulls
 
     @torch.no_grad()
     def update_weights_from_path(self, weight_dir: str | None = None) -> None:
         del weight_dir
         plan = self.initialize_transfer()
-        self.model_express.set_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
-        self.model_express.wait_for(
-            "trainer",
-            count=1,
-            status=p2p_pb2.SOURCE_STATUS_READY,
-            timeout=self.weight_transfer_timeout,
-        )
 
         started = time.perf_counter()
         self.apply_transfer_plan(plan)
         update_mla_absorbed_weights(self.raw_model)
         torch.cuda.synchronize(self.device)
-        self.model_express.set_status(p2p_pb2.SOURCE_STATUS_READY)
         logger.info(
             "Applied NIXL policy update on rank %d in %.2fs",
             self.model_express.rank,
@@ -546,44 +505,30 @@ class NIXLWeightUpdateWorker(Worker):
 
         def pull_group(group_index: int) -> WeightTransferGroup:
             transfer_group = plan.groups[group_index]
-            session = self.buffer_sessions[group_index % len(self.buffer_sessions)]
-            session.wait_for(
-                "trainer",
-                count=1,
-                status=p2p_pb2.SOURCE_STATUS_READY,
+            notification = group_notification(group_index, self.group_generations[group_index])
+            self.nixl_agent.wait_for_notification(
+                plan.trainer_peers,
+                notification,
                 timeout=self.weight_transfer_timeout,
-                poll_interval=_BUFFER_POLL_INTERVAL,
                 cancelled=cancelled.is_set,
             )
 
-            for local, remote, indices in transfer_group.pulls:
-                handle = self.nixl_agent.post_read(local, indices, remote)
+            for read in transfer_group.pulls:
+                self.nixl_agent.post_read(read, notification)
+            for read in transfer_group.pulls:
                 self.nixl_agent.wait(
-                    handle,
+                    read,
                     context=f"weight pull for {transfer_group.name}",
                     timeout=self.weight_transfer_timeout,
                     cancelled=cancelled.is_set,
                 )
-            return transfer_group
 
-        def acknowledge_group(group_index: int) -> None:
-            session = self.buffer_sessions[group_index % len(self.buffer_sessions)]
-            session.set_status(p2p_pb2.SOURCE_STATUS_READY)
-            session.wait_for(
-                "trainer",
-                count=1,
-                status=p2p_pb2.SOURCE_STATUS_INITIALIZING,
-                timeout=self.weight_transfer_timeout,
-                poll_interval=_BUFFER_POLL_INTERVAL,
-                cancelled=cancelled.is_set,
-            )
-            session.set_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
+            self.group_generations[group_index] += 1
+            return transfer_group
 
         def prefetch_group(group_index: int) -> WeightTransferGroup:
             torch.cuda.set_device(self.device)
-            transfer_group = pull_group(group_index)
-            acknowledge_group(group_index)
-            return transfer_group
+            return pull_group(group_index)
 
         def replay_group(transfer_group: WeightTransferGroup) -> None:
             for layer_plan in transfer_group.layers:
@@ -629,9 +574,6 @@ class NIXLWeightUpdateWorker(Worker):
 
                     replay_group(transfer_group)
                     torch.cuda.synchronize(self.device)
-
-                    if not pipelined:
-                        acknowledge_group(group_index)
             finally:
                 cancelled.set()
                 if executor is not None:

--- a/src/prime_rl/transports/weights/nixl/agent.py
+++ b/src/prime_rl/transports/weights/nixl/agent.py
@@ -5,12 +5,30 @@ from __future__ import annotations
 import os
 import socket
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
 from torch import Tensor
 
 MemDesc = tuple[int, int, int]
+
+
+@dataclass(slots=True)
+class PreparedRead:
+    """Reusable READ request with descriptor lists kept alive for its lifetime."""
+
+    local_descriptors: Any
+    remote_descriptors: Any
+    handle: Any
+
+
+def group_notification(group_index: int, generation: int) -> str:
+    return f"{group_index:08x}:{generation:016x}"
+
+
+def policy_notification(step: int, event: str) -> str:
+    return f"policy:{step:016x}:{event}"
 
 
 class NixlAgent:
@@ -22,6 +40,7 @@ class NixlAgent:
 
         self.name = name
         self._agent = nixl_agent(name, nixl_agent_config(backends=["UCX"]))
+        self._notifications: dict[str, list[bytes]] = {}
 
     def register_tensor(self, tensor: Tensor) -> None:
         self._agent.register_memory(tensor, backends=["UCX"])
@@ -29,21 +48,24 @@ class NixlAgent:
     def get_metadata(self) -> bytes:
         return self._agent.get_agent_metadata()
 
-    def add_remote_agent(self, metadata: bytes) -> str:
-        return self._agent.add_remote_agent(metadata)
+    def add_remote_agent(self, metadata: bytes) -> NixlPeer:
+        return NixlPeer(
+            local_agent=self,
+            remote_agent_name=self._agent.add_remote_agent(metadata).decode(),
+        )
 
-    def make_connection(self, peer_name: str) -> None:
-        self._agent.make_connection(peer_name)
+    def make_connection(self, peer: NixlPeer) -> None:
+        self._agent.make_connection(peer.remote_agent_name)
 
-    def prepare_xfer_dlist(self, descs: Sequence[MemDesc], agent_name: str | None = None) -> Any:
+    def prepare_xfer_dlist(self, descs: Sequence[MemDesc], peer: NixlPeer | None = None) -> Any:
         return self._agent.prep_xfer_dlist(
-            agent_name=agent_name or "",
+            agent_name=peer.remote_agent_name if peer is not None else "",
             xfer_list=list(descs),
             mem_type="cuda",
             backends=["UCX"],
         )
 
-    def post_read(self, local: Any, indices: Sequence[int], remote: Any) -> Any:
+    def prepare_read(self, local: Any, indices: Sequence[int], remote: Any) -> PreparedRead:
         handle = self._agent.make_prepped_xfer(
             operation="READ",
             local_xfer_side=local,
@@ -52,14 +74,49 @@ class NixlAgent:
             remote_indices=list(indices),
             backends=["UCX"],
         )
-        state = self._agent.transfer(handle)
+        return PreparedRead(
+            local_descriptors=local,
+            remote_descriptors=remote,
+            handle=handle,
+        )
+
+    def post_read(self, read: PreparedRead, notification: str) -> None:
+        state = self._agent.transfer(read.handle, notification.encode())
         if state in ("ERR", "ERROR", "FAIL"):
             raise RuntimeError(f"NIXL READ post failed with state {state}")
-        return handle
+
+    def send_notification(self, peer: NixlPeer, notification: str) -> None:
+        self._agent.send_notif(peer.remote_agent_name, notification)
+
+    def wait_for_notification(
+        self,
+        peers: Sequence[NixlPeer],
+        notification: str,
+        *,
+        timeout: float,
+        cancelled: Callable[[], bool] | None = None,
+    ) -> None:
+        pending = {peer.remote_agent_name for peer in peers}
+        encoded_notification = notification.encode()
+        deadline = time.monotonic() + timeout
+        while pending:
+            if cancelled is not None and cancelled():
+                raise RuntimeError("NIXL notification wait cancelled")
+            for sender, messages in self._agent.get_new_notifs(backends=["UCX"]).items():
+                self._notifications.setdefault(sender, []).extend(messages)
+            for sender in list(pending):
+                messages = self._notifications.get(sender, [])
+                if encoded_notification in messages:
+                    messages.remove(encoded_notification)
+                    pending.remove(sender)
+            if pending and time.monotonic() >= deadline:
+                raise TimeoutError(f"NIXL notification wait timed out after {timeout}s, missing={sorted(pending)}")
+            if pending:
+                time.sleep(0.0005)
 
     def wait(
         self,
-        handle: Any,
+        read: PreparedRead,
         context: str = "",
         timeout: float | None = None,
         cancelled: Callable[[], bool] | None = None,
@@ -67,19 +124,24 @@ class NixlAgent:
         deadline = None if timeout is None else time.monotonic() + timeout
         while True:
             if cancelled is not None and cancelled():
-                self._agent.release_xfer_handle(handle)
+                self._agent.release_xfer_handle(read.handle)
                 raise RuntimeError(f"NIXL transfer cancelled, context={context!r}")
-            state = self._agent.check_xfer_state(handle)
+            state = self._agent.check_xfer_state(read.handle)
             if state in ("DONE", "SUCCESS"):
-                self._agent.release_xfer_handle(handle)
                 return
             if state in ("ERR", "ERROR", "FAIL"):
-                self._agent.release_xfer_handle(handle)
+                self._agent.release_xfer_handle(read.handle)
                 raise RuntimeError(f"NIXL transfer failed with state={state}, context={context!r}")
             if deadline is not None and time.monotonic() >= deadline:
-                self._agent.release_xfer_handle(handle)
+                self._agent.release_xfer_handle(read.handle)
                 raise TimeoutError(f"NIXL transfer timed out after {timeout}s, context={context!r}")
             time.sleep(0.0005)
+
+
+@dataclass(frozen=True, slots=True)
+class NixlPeer:
+    local_agent: NixlAgent
+    remote_agent_name: str
 
 
 def make_agent_name(role: str, global_rank: int) -> str:

--- a/src/prime_rl/transports/weights/nixl/cuda_malloc_memory.py
+++ b/src/prime_rl/transports/weights/nixl/cuda_malloc_memory.py
@@ -1,4 +1,4 @@
-"""CUDA memory sizing and a cudaMalloc-backed pool for NIXL arenas."""
+"""cudaMalloc-backed pool for NIXL arenas."""
 
 from __future__ import annotations
 
@@ -17,17 +17,6 @@ from torch.utils.cpp_extension import load_inline  # noqa: E402
 
 _pool: torch.cuda.MemPool | None = None
 _allocator: torch.cuda.memory.CUDAPluggableAllocator | None = None
-
-
-def size_cuda_buffers(
-    buffer_bytes: int,
-    max_buffers: int,
-    device: torch.device,
-    extra_headroom_bytes: int,
-) -> int:
-    free_bytes, total_bytes = torch.cuda.mem_get_info(device)
-    headroom_bytes = max(4 * 1024**3, int(total_bytes * 0.02)) + extra_headroom_bytes
-    return max(1, min(max_buffers, (free_bytes - headroom_bytes) // buffer_bytes))
 
 
 def _get_pool() -> torch.cuda.MemPool:

--- a/src/prime_rl/transports/weights/nixl/model_express.py
+++ b/src/prime_rl/transports/weights/nixl/model_express.py
@@ -1,15 +1,10 @@
-"""Role-scoped synchronization over ModelExpress.
-
-The policy session coordinates a complete weight update with the orchestrator.
-A separate layer session uses the same READY/INITIALIZING handshake to keep a
-bounded transfer arena live until every inference worker has acknowledged it.
-"""
+"""ModelExpress startup discovery for NIXL peers."""
 
 from __future__ import annotations
 
 import time
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Literal
 
 import grpc
@@ -26,13 +21,6 @@ class ModelExpressSession:
     rank: int
     session_id: str
     worker_id: str
-    _source_id: str | None = field(init=False, default=None, repr=False)
-
-    @property
-    def source_id(self) -> str:
-        if self._source_id is None:
-            raise RuntimeError("ModelExpress metadata must be published before updating status")
-        return self._source_id
 
     def identity(self, role: Role) -> p2p_pb2.SourceIdentity:
         return p2p_pb2.SourceIdentity(
@@ -65,28 +53,23 @@ class ModelExpressSession:
             worker_rank=self.rank,
             nixl_metadata=nixl_metadata,
         )
-        self._source_id = self._rpc(
-            lambda: self.client.publish_metadata(self.identity(self.role), worker, self.worker_id)
+        return self._rpc(
+            lambda: self.client.publish_metadata(
+                self.identity(self.role),
+                worker,
+                self.worker_id,
+            )
         )
-        return self._source_id
 
-    def set_status(self, status: int) -> None:
-        if not self._rpc(lambda: self.client.update_status(self.source_id, self.worker_id, self.rank, status)):
-            raise RuntimeError(f"failed to set ModelExpress status {status} for {self.role} rank {self.rank}")
-
-    def list_sources(self, role: Role, status: int | None) -> list[p2p_pb2.SourceInstanceRef]:
-        response = self._rpc(lambda: self.client.list_sources(self.identity(role), status_filter=status))
+    def list_sources(self, role: Role) -> list[p2p_pb2.SourceInstanceRef]:
+        response = self._rpc(lambda: self.client.list_sources(self.identity(role)))
         return list(response.instances)
-
-    def exists_role_with_status(self, role: Role, status: int) -> bool:
-        return bool(self.list_sources(role, status))
 
     def wait_for(
         self,
         role: Role,
         *,
         count: int,
-        status: int | None,
         timeout: float,
         poll_interval: float = 0.05,
         cancelled: Callable[[], bool] | None = None,
@@ -96,14 +79,14 @@ class ModelExpressSession:
         while True:
             if cancelled is not None and cancelled():
                 raise RuntimeError(f"cancelled waiting for {count} {role} worker(s) in session {self.session_id!r}")
-            refs = self.list_sources(role, status)
+            refs = self.list_sources(role)
             by_rank = {ref.worker_rank: ref for ref in refs}
             if expected_ranks.issubset(by_rank):
                 return [by_rank[rank] for rank in range(count)]
             if time.monotonic() >= deadline:
                 raise TimeoutError(
                     f"timed out waiting for {count} {role} worker(s) in session {self.session_id!r} "
-                    f"with status={status}; found ranks={sorted(by_rank)}"
+                    f"with ranks={sorted(by_rank)}"
                 )
             time.sleep(poll_interval)
 

--- a/src/prime_rl/transports/weights/nixl/nixl.py
+++ b/src/prime_rl/transports/weights/nixl/nixl.py
@@ -15,7 +15,6 @@ from typing import cast
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from modelexpress import p2p_pb2
 from modelexpress.client import MxClient
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
@@ -25,11 +24,15 @@ from prime_rl.orchestrator.clients import init_nixl_broadcast, update_weights
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 from prime_rl.trainer.parallel_dims import ParallelDims
 from prime_rl.transports.weights.base import WeightReceiver, WeightSender
-from prime_rl.transports.weights.nixl.agent import NixlAgent, make_agent_name, set_ucx_env_defaults
-from prime_rl.transports.weights.nixl.cuda_malloc_memory import (
-    size_cuda_buffers,
-    use_cuda_malloc_pool,
+from prime_rl.transports.weights.nixl.agent import (
+    NixlAgent,
+    NixlPeer,
+    group_notification,
+    make_agent_name,
+    policy_notification,
+    set_ucx_env_defaults,
 )
+from prime_rl.transports.weights.nixl.cuda_malloc_memory import use_cuda_malloc_pool
 from prime_rl.transports.weights.nixl.model_express import ModelExpressSession
 from prime_rl.transports.weights.nixl.trainer_tensor_table import (
     TrainerAgent,
@@ -40,8 +43,6 @@ from prime_rl.transports.weights.nixl.trainer_tensor_table import (
 )
 
 LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?=\.|$)")
-BUFFER_POLL_INTERVAL = 0.01
-MAX_STAGING_BUFFER_COUNT = 8
 
 
 @dataclass
@@ -87,8 +88,10 @@ class NIXLWeightSender(WeightSender):
         self.staged_shards_by_group: dict[int, list[StagedTensorShard]] = {}
         self.staging_arenas: dict[torch.dtype, torch.Tensor] = {}
         self.staging_buffer_count: int
-        self.model_express: ModelExpressSession | None = None
-        self.buffer_sessions: list[ModelExpressSession] = []
+        self.inference_peers: list[NixlPeer]
+        self.orchestrator_peer: NixlPeer
+        self.group_generations: list[int]
+        self.broadcast_count = 0
 
     @property
     def is_serving_rank(self) -> bool:
@@ -184,31 +187,6 @@ class NIXLWeightSender(WeightSender):
                 )
         return local_shards
 
-    def choose_staging_buffer_count(self, largest_group_bytes: int) -> int:
-        local_buffer_count = min(len(self.transfer_group_names), MAX_STAGING_BUFFER_COUNT)
-        if self.is_serving_rank and largest_group_bytes:
-            device = self.staged_shards[0].source_tensor.device
-            allocated_bytes = torch.cuda.memory_allocated()
-            peak_growth_bytes = max(0, torch.cuda.max_memory_allocated() - allocated_bytes)
-            free_bytes, _ = torch.cuda.mem_get_info(device)
-            max_buffers = local_buffer_count if peak_growth_bytes else 1
-            if peak_growth_bytes or free_bytes < largest_group_bytes:
-                torch.cuda.empty_cache()
-            local_buffer_count = size_cuda_buffers(
-                largest_group_bytes,
-                max_buffers,
-                device,
-                extra_headroom_bytes=peak_growth_bytes,
-            )
-
-        staging_buffer_count = torch.tensor(
-            local_buffer_count,
-            dtype=torch.int64,
-            device=torch.device("cuda", torch.cuda.current_device()),
-        )
-        dist.all_reduce(staging_buffer_count, op=dist.ReduceOp.MIN)
-        return int(staging_buffer_count.item())
-
     def allocate_staging_arenas(self, largest_group_elements: dict[torch.dtype, int]) -> None:
         if not self.is_serving_rank or not any(largest_group_elements.values()):
             return
@@ -248,8 +226,10 @@ class NIXLWeightSender(WeightSender):
         for shard in self.staged_shards:
             group_elements[shard.wire_dtype][shard.group_index] += shard.source_tensor.numel()
         largest_group_elements = {dtype: max(elements, default=0) for dtype, elements in group_elements.items()}
-        largest_group_bytes = sum(elements * dtype.itemsize for dtype, elements in largest_group_elements.items())
-        self.staging_buffer_count = self.choose_staging_buffer_count(largest_group_bytes)
+        self.staging_buffer_count = min(
+            len(self.transfer_group_names),
+            2 if self.config.overlap_transfer_and_replay else 1,
+        )
         self.allocate_staging_arenas(largest_group_elements)
 
         grouped: dict[int, list[StagedTensorShard]] = defaultdict(list)
@@ -363,18 +343,6 @@ class NIXLWeightSender(WeightSender):
             table = self.merge_trainer_table_fragments(table_fragments)
             server_url = f"{self.config.host}:{self.config.port}"
             client = MxClient(server_url=server_url)
-            self.buffer_sessions = []
-            for buffer_index in range(self.staging_buffer_count):
-                session = ModelExpressSession(
-                    client=client,
-                    role="trainer",
-                    rank=0,
-                    session_id=f"{self.config.session_id}:layers:{buffer_index}",
-                    worker_id=f"trainer-buffer-{buffer_index}",
-                )
-                session.publish()
-                session.set_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
-                self.buffer_sessions.append(session)
             self.model_express = ModelExpressSession(
                 client=client,
                 role="trainer",
@@ -383,7 +351,6 @@ class NIXLWeightSender(WeightSender):
                 worker_id="trainer-table",
             )
             self.model_express.publish(nixl_metadata=table.encode())
-            self.model_express.set_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
             tensor_count = sum(len(group.tensors) for group in table.groups)
             self.logger.info(
                 f"Published {tensor_count} trainer tensors in {len(table.groups)} groups "
@@ -391,59 +358,75 @@ class NIXLWeightSender(WeightSender):
             )
         self.initialized = True
 
-    def finish_staging_buffer_transfer(self, buffer_index: int) -> None:
-        if self.world.is_master:
-            session = self.buffer_sessions[buffer_index]
-            session.wait_for(
-                "inference",
-                count=self.config.inference_world_size,
-                status=p2p_pb2.SOURCE_STATUS_READY,
-                timeout=self.config.timeout,
-                poll_interval=BUFFER_POLL_INTERVAL,
-            )
-            session.set_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
-            session.wait_for(
-                "inference",
-                count=self.config.inference_world_size,
-                status=p2p_pb2.SOURCE_STATUS_INITIALIZING,
-                timeout=self.config.timeout,
-                poll_interval=BUFFER_POLL_INTERVAL,
-            )
-        dist.barrier()
+    def finish_transfer_group(self, group_index: int) -> None:
+        if not self.is_serving_rank:
+            return
+        notification = group_notification(group_index, self.group_generations[group_index])
+        self.nixl_agent.wait_for_notification(
+            self.inference_peers,
+            notification,
+            timeout=self.config.timeout,
+        )
+        self.group_generations[group_index] += 1
 
     @torch.no_grad()
     def _broadcast(self, model: nn.Module, step: int, step_dir: Path) -> None:
         self.initialize_transfer(model)
         start = time.perf_counter()
 
-        if self.world.is_master:
-            self.model_express.set_status(p2p_pb2.SOURCE_STATUS_READY)
-            self.model_express.wait_for(
+        startup = self.broadcast_count == 0
+        if self.world.is_master and startup:
+            orchestrator_ref = self.model_express.wait_for(
                 "orchestrator",
                 count=1,
-                status=p2p_pb2.SOURCE_STATUS_READY,
                 timeout=self.config.timeout,
-            )
-            self.model_express.wait_for(
+            )[0]
+            inference_refs = self.model_express.wait_for(
                 "inference",
                 count=self.config.inference_world_size,
-                status=p2p_pb2.SOURCE_STATUS_INITIALIZING,
                 timeout=self.config.timeout,
+            )
+            inference_metadata: list[bytes] | None = [
+                self.model_express.fetch(ref).nixl_metadata for ref in inference_refs
+            ]
+            orchestrator_metadata = self.model_express.fetch(orchestrator_ref).nixl_metadata
+        else:
+            inference_metadata = None
+
+        if startup:
+            objects = [inference_metadata]
+            dist.broadcast_object_list(objects, src=0)
+            if self.is_serving_rank:
+                self.inference_peers = []
+                for metadata in cast(list[bytes], objects[0]):
+                    peer = self.nixl_agent.add_remote_agent(metadata)
+                    self.nixl_agent.make_connection(peer)
+                    self.inference_peers.append(peer)
+                self.group_generations = [0] * len(self.transfer_group_names)
+            if self.world.is_master:
+                self.orchestrator_peer = self.nixl_agent.add_remote_agent(orchestrator_metadata)
+                self.nixl_agent.make_connection(self.orchestrator_peer)
+
+        if self.world.is_master:
+            self.nixl_agent.send_notification(
+                self.orchestrator_peer,
+                policy_notification(step, "ready"),
             )
 
         for group, group_name in enumerate(self.transfer_group_names):
             group_start = time.perf_counter()
             buffer_index = group % self.staging_buffer_count
             if group >= self.staging_buffer_count:
-                self.finish_staging_buffer_transfer(buffer_index)
+                self.finish_transfer_group(group - self.staging_buffer_count)
 
             if self.is_serving_rank:
                 for shard in self.staged_shards_by_group.get(group, ()):
                     shard.copy_to_staging()
                 torch.cuda.synchronize()
-            dist.barrier()
+                notification = group_notification(group, self.group_generations[group])
+                for peer in self.inference_peers:
+                    self.nixl_agent.send_notification(peer, notification)
             if self.world.is_master:
-                self.buffer_sessions[buffer_index].set_status(p2p_pb2.SOURCE_STATUS_READY)
                 self.logger.debug(
                     f"NIXL+ModelExpress policy v{step} group {group_name} staged in buffer {buffer_index} in "
                     f"{time.perf_counter() - group_start:.2f}s"
@@ -451,35 +434,28 @@ class NIXLWeightSender(WeightSender):
 
         first_pending_group = max(0, len(self.transfer_group_names) - self.staging_buffer_count)
         for group in range(first_pending_group, len(self.transfer_group_names)):
-            buffer_index = group % self.staging_buffer_count
-            self.finish_staging_buffer_transfer(buffer_index)
+            self.finish_transfer_group(group)
 
         if self.world.is_master:
-            self.model_express.wait_for(
-                "inference",
-                count=self.config.inference_world_size,
-                status=p2p_pb2.SOURCE_STATUS_READY,
+            self.nixl_agent.wait_for_notification(
+                [self.orchestrator_peer],
+                policy_notification(step, "complete"),
                 timeout=self.config.timeout,
             )
-            self.model_express.wait_for(
-                "orchestrator",
-                count=1,
-                status=p2p_pb2.SOURCE_STATUS_INITIALIZING,
-                timeout=self.config.timeout,
-            )
-            self.model_express.set_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
         dist.barrier()
+        self.broadcast_count += 1
         self.logger.info(f"NIXL+ModelExpress policy v{step} synchronized in {time.perf_counter() - start:.2f}s")
 
 
 class NIXLWeightReceiver(WeightReceiver):
-    """Drives the orchestrator's side of the ModelExpress rendezvous. Version
-    discovery runs on the shared sentinels; the unversioned ModelExpress
-    statuses only choreograph the transfer itself."""
+    """Drives NIXL discovery and policy synchronization for the orchestrator."""
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.session = ModelExpressSession(
+        set_ucx_env_defaults(0)
+        self.nixl_agent = NixlAgent(make_agent_name("orchestrator", 0))
+        self.trainer_peer: NixlPeer | None = None
+        self.model_express = ModelExpressSession(
             client=MxClient(server_url=f"{self.config.host}:{self.config.port}"),
             role="orchestrator",
             rank=0,
@@ -496,23 +472,31 @@ class NIXLWeightReceiver(WeightReceiver):
             self.config.inference_world_size,
             self.config.session_id,
         )
-        self.session.publish()
-        await self.set_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
-
-    async def set_status(self, status: int) -> None:
-        await asyncio.to_thread(self.session.set_status, status)
+        self.model_express.publish(nixl_metadata=self.nixl_agent.get_metadata())
 
     async def receive(self, step: int) -> None:
-        # ACK the trainer (it waits for the orchestrator's READY before the
-        # engines' INITIALIZING), run the transfer, then close the cycle.
         self._ack(step)
-        await self.set_status(p2p_pb2.SOURCE_STATUS_READY)
-        await update_weights(self.admin_clients, None, step=step)
-        await self.set_status(p2p_pb2.SOURCE_STATUS_INITIALIZING)
+        if self.trainer_peer is None:
+            trainer_refs = await asyncio.to_thread(
+                self.model_express.wait_for,
+                "trainer",
+                count=1,
+                timeout=self.config.timeout,
+            )
+            trainer_worker = await asyncio.to_thread(self.model_express.fetch, trainer_refs[0])
+            trainer_table = TrainerTensorTable.decode(trainer_worker.nixl_metadata)
+            self.trainer_peer = self.nixl_agent.add_remote_agent(trainer_table.agents[0].metadata)
+            self.nixl_agent.make_connection(self.trainer_peer)
+
+        trainer_peer = self.trainer_peer
         await asyncio.to_thread(
-            self.session.wait_for,
-            "trainer",
-            count=1,
-            status=p2p_pb2.SOURCE_STATUS_INITIALIZING,
+            self.nixl_agent.wait_for_notification,
+            [trainer_peer],
+            policy_notification(step, "ready"),
             timeout=self.config.timeout,
+        )
+        await update_weights(self.admin_clients, None, step=step)
+        self.nixl_agent.send_notification(
+            trainer_peer,
+            policy_notification(step, "complete"),
         )


### PR DESCRIPTION
## Summary

- use ModelExpress only for startup peer discovery and the trainer tensor table, then use exact versioned NIXL notifications for all policy transfers, including startup
- prepare static NIXL READ requests once, repost them after completion, and post every trainer-rank pull in a group before waiting
- attach trainer arena credits to READ completion instead of performing a separate acknowledgement handshake
- add explicit, opt-in two-arena overlap through `weight_broadcast.overlap_transfer_and_replay`

The path remains receiver-driven PULL. The default remains one arena because the second arena has a model-dependent GPU-memory cost. This PR adds no fallback protocol, runtime sizing heuristic, profiling instrumentation, or inference-scheduler change.

## Protocol

ModelExpress is the one-time startup discovery plane. It exchanges the trainer tensor table and NIXL agent metadata, after which the fixed peers establish NIXL/UCX connections. The shared `WeightSender`/`WeightReceiver` sentinel handshake offers and acknowledges every policy version before the NIXL transport runs; this is the same outer lifecycle used by the other transports. MX source statuses are not used. Policy 0 and later policies use exact NIXL ready and complete notifications for the transfer itself.

```mermaid
sequenceDiagram
    participant T as Trainer ranks
    participant B as Broadcast directory
    participant R as NIXL weight receiver
    participant MX as ModelExpress
    participant I as Inference ranks

    Note over T,I: One-time setup
    I->>MX: Publish inference NIXL metadata
    R->>MX: Publish receiver NIXL metadata

    loop Each policy version
        T->>B: Offer version with sender ready marker
        R->>B: Acknowledge with receiver ready marker
        T->>B: Mark transfer started
        alt First version
            T->>MX: Publish tensor table and trainer metadata
            T->>MX: Fetch inference and receiver metadata
            R->>MX: Fetch trainer table and metadata
            Note over T,I: Establish NIXL and UCX connections once
        end
        T-->>R: NIXL policy ready notification
        R->>I: Update weights
        loop Each transfer group
            T-->>I: NIXL group ready notification
            I->>T: Post READs to every trainer rank
            T-->>I: RDMA payload
            I-->>T: READ completion returns arena credit
        end
        I-->>R: Update complete
        R-->>T: NIXL policy complete notification
        T->>B: Commit version with finished marker
    end
```

Each group signal contains `(group index, generation)`, and each policy signal contains `(step, event)`, so it is consumed exactly once. A trainer staging slot is reused only after every inference rank completes its READ from that slot.

`NIXLWeightReceiver` owns the ModelExpress discovery session, local NIXL agent, and typed trainer peer in the orchestrator process. The generic orchestrator and `WeightWatcher` only use the `WeightReceiver` API and contain no NIXL-specific state. Transfer plans and the trainer broadcaster store ordered `NixlPeer` lists, so positional trainer-agent indices stay direct list lookups and raw NIXL agent names remain inside the adapter. On the trainer, `finish_transfer_group` waits for every inference rank to complete a group before advancing its generation and allowing its arena slot to be reused.

Tensor addresses, shard routes, peers, and descriptor lists remain static for the worker lifetime. Requests are therefore prepared once and reposted after completion. For each group, inference waits for every serving trainer rank, posts all trainer-rank READs, and then waits for completion. Inference ranks rotate their trainer order, while #3340 pins each process to the active InfiniBand port nearest its GPU.

With overlap enabled, trainer and inference allocate exactly two largest-group-sized arenas. Inference replays and quantizes group N while receiving group N+1. Allocation is explicit: there is no free-memory probe, automatic downgrade, or hidden retry.

## Measured results

Every populated cell below is the median of the positive framework `time/broadcast_weights` samples; terminal zero entries are excluded. This is the only timing definition used in the description. Parentheses contain Slurm job IDs, and blank cells mean that configuration was not measured.

| Model | Old NIXL | New NIXL | New NIXL + overlap | NCCL |
|---|---:|---:|---:|---:|
| Qwen3-30B-A3B | 4.651 s (2260) | 1.898 s (2278) |  |  |
| GLM-4.5-Air | 8.676 s (2286) | 4.125 s (2288) | 3.043 s (2305) | 7.616 s (2289) |
| GLM-5.2 |  | 12.513 s (2297) | 8.577 s (2317, EP32) |  |

All NIXL baselines use the correct rail pinning, and router replay is disabled. The GLM-4.5-Air old, new, and overlap measurements are 20-step Hendrycks-math runs with 4096 maximum sampling tokens; the NCCL comparison uses the same model and node roles over three positive broadcasts. NCCL uses BF16 checkpoint-format transfer with `quantize_in_weight_transfer = false`.

GLM-5.2 job 2317 completed 20 rollout steps and 18 steady trainer broadcasts on 64 trainer and 32 inference H200s. Framework `time/broadcast_weights` was 8.577s median and 12.987s p95. At the inference client, end-to-end synchronization was 7.899s median and 12.577s p95: pause was 5.204s median / 9.882s p95, while the weight update itself was 2.842s median / 2.960s p95. Each inference GPU received 82.501 GB per policy; across all 576 rank/version samples, RDMA was 1.864s median / 2.027s p95, replay was 1.954s median / 1.993s p95, and their overlapped process time was 2.682s median / 2.836s p95. Median payload was 44.26 GB/s per GPU, or approximately 354 GB/s across an eight-GPU inference node. The [W&B run](https://wandb.ai/primeintellect/prime-rl/runs/c3bee790465640d88958f100fb3d74f4) contains the completed training metrics.

On this single framework metric, Qwen improves by 59.2% from old to new. GLM-4.5-Air improves by 52.5% from old to new and 64.9% from old to the final overlapped path; the final path is 60.1% faster than NCCL. GLM-5.2 improves by 31.5% from the measured EP16 one-arena path to the EP32 overlap run. Holding overlap constant, EP32 reduces median framework broadcast time by 11.4% from the EP16 result (9.683s, job 2301), while median client update time falls by 19.4% from 3.524s to 2.842s. Framework timing includes the unchanged vLLM pause/resume interval, whose variance dominates the EP32 tail, so it should not be interpreted as raw fabric bandwidth.

## Memory and scope

Overlap adds one largest-group arena rather than another model copy. For GLM-5.2, that is 0.308 GB per trainer GPU and 3.807 GB per inference GPU. The EP32 run therefore used a 7.613 GB two-buffer arena per inference GPU and added 141.5 GB across the tested 64-trainer/32-inference topology. The option is disabled by default; models without that headroom retain the one-arena path.

GLM-5.2 uses 64 trainer H200s with EP=8 and full offload, plus DP/EP inference with online blockwise FP8 and DeepGEMM. EP16 receives 127.800 GB per inference GPU and retains 5,056 host-side handles per rank; EP32 receives 82.501 GB per GPU and prepares 72,819 descriptors across 79 transfer groups per rank. These request structures add no model-sized GPU allocation.

Every serving trainer rank connects to every inference rank so completion returns exact source credits. Static membership is the expected hot path; elastic scaling and fault tolerance remain out of scope.

## Numerical validation

Jobs 2286 and 2305 completed the configured 20 GLM-4.5-Air rollout steps and finalized metrics. Step 20 of job 2305 contained 0/8 trainable traces, so it correctly emitted no optimizer or mismatch-KL row. Across the 19 steps with measurements in both runs, mean mismatch KL was 0.002602538 before and 0.002608075 after (+0.2%); median was 0.002786405 before and 0.002702605 after (-3.0%). Router replay was deliberately disabled, so individual steps include normal sampling variation.

## Validation

- Ruff 0.15.14: `uv run ruff format --check` and `uv run ruff check`
- `uv run python -m compileall` on changed Python modules
- `uv run pytest -q tests/unit/test_configs.py`
- ported onto main at `21a4a3245` through #3340 at `0d809b1e4`; the generic orchestrator and `WeightWatcher` are unchanged
- two-node, three-step Qwen3-0.6B end-to-end NIXL smoke (Slurm job 2451): startup policy v0 and policies v1-v3 synchronized; trainer and orchestrator completed
- Qwen3-30B-A3B and GLM-4.5-Air eight-rail transfer benchmarks
- GLM-5.2 ten-node EP16 and twelve-node EP32 runs with full trainer offload, online blockwise FP8 inference, and DeepGEMM
- matched NCCL comparison on GLM-4.5-Air
- final 20-step GLM-4.5-Air Hendrycks-math run with 4096 sampling tokens and router replay disabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core distributed weight-sync choreography between trainer, orchestrator, and vLLM; mis-sync would cause stale weights or hangs, though scope is limited to the NIXL transport path.
> 
> **Overview**
> **NIXL weight broadcast** is reworked so ModelExpress is only used for one-time peer discovery (trainer tensor table and NIXL agent metadata). Per-group and per-policy coordination now uses **versioned NIXL notifications** instead of ModelExpress READY/INITIALIZING buffer sessions.
> 
> The NIXL adapter gains **`PreparedRead`** / **`NixlPeer`**: READ descriptor lists are prepared once, reposted each update, and all trainer-rank pulls in a group are posted before waiting. Arena reuse is tied to READ completion via group `(index, generation)` signals; the orchestrator participates with policy `ready` / `complete` notifications over NIXL.
> 
> Inference follows the trainer’s **`staging_buffer_count`** (no GPU free-memory sizing heuristic). Optional **`weight_broadcast.overlap_transfer_and_replay`** allocates exactly **two** largest-group arenas on trainer and inference so the next group can be received while the current one is replayed; default remains one arena.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc85f865aa7850e5a123fbb2791a9670c631d44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->