### PR TITLE
chore: glm-4.5-air swe example to bf16 + bash harness

### DIFF
--- a/examples/advanced/glm-4.5-air/swe.toml
+++ b/examples/advanced/glm-4.5-air/swe.toml
@@ -1,4 +1,4 @@
-# v1 RL: GLM-4.5-Air (100B MoE) on the v1 `scaleswe` SWE taskset, rlm harness on a prime sandbox
+# v1 RL: GLM-4.5-Air (100B MoE) on the v1 `scaleswe` SWE taskset, bash harness on a prime sandbox
 # runtime; eval on SWE-Bench Verified. Router replay is enabled (trainer.enable_router_replay replays
 # the routed-expert decisions returned by inference via enable_return_routed_experts) — GLM-4.5-Air is
 # a glm4_moe model, which supports routed_experts.
@@ -7,9 +7,8 @@
 # term is pass_rate-scaled and normalized by the group's own max before the GRPO baseline
 # subtraction.
 #
-# 1 train + 3 infer nodes. Inference serves FP8 via online per-tensor quantization of the bf16
-# checkpoint; weight broadcasts re-quantize through the same path on every update. The trainer fits on one
-# node via cp=4 (ulysses), full CPU optimizer offload with the stateless sign-SGD optimizer, plus
+# 1 train + 3 infer nodes. Inference serves the bf16 checkpoint as-is (no quantization). The trainer
+# fits on one node via cp=4 (ulysses), full CPU optimizer offload with the stateless sign-SGD optimizer, plus
 # the memory improvements from the GLM-5.1 prod run (research-prod rlm5/prod.toml): LM-head token
 # chunking, activation checkpointing (freq=1) + activation offloading (max_inflight=1), and
 # skip-gather / skip-optimizer checkpointing.
@@ -108,15 +107,14 @@ name = "scaleswe"
 id = "scaleswe"
 
 [orchestrator.train.source.env.agent.harness]
-id = "rlm"
-summarize_at_tokens = [65536, 131072]
+id = "bash"
 
 [orchestrator.train.source.env.agent.runtime]
 labels = ["glm45air-swe"]
 
 [monitors.prime]
 
-# --- Eval: SWE-Bench Verified at step 0 + every 20 steps, rlm harness on prime ---
+# --- Eval: SWE-Bench Verified at step 0 + every 20 steps, bash harness on prime ---
 
 [orchestrator.eval]
 interval = 20
@@ -128,8 +126,7 @@ name = "swebench-verified"
 id = "swebench-verified"
 
 [orchestrator.eval.source.env.agent.harness]
-id = "rlm"
-summarize_at_tokens = 98304
+id = "bash"
 
 [orchestrator.eval.source.env.agent.runtime]
 labels = ["glm45air-swe"]
@@ -149,5 +146,4 @@ FLASHINFER_WORKSPACE_BASE = "/tmp/.flashinfer-cache"
 [inference.vllm]
 max_model_len = 131072
 tensor_parallel_size = 8
-quantization = "fp8"
 enable_return_routed_experts = true


### PR DESCRIPTION
## Summary

- `examples/advanced/glm-4.5-air/swe.toml`: serve inference from the bf16 checkpoint directly — drop `quantization = "fp8"` from `[inference.vllm]`.
- Switch the train and eval harnesses from `rlm` to `bash`. Drop the rlm-only `summarize_at_tokens` knobs.
- Update the header comments to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only TOML config; no training, inference, or harness code changes.
> 
> **Overview**
> Updates the GLM-4.5-Air SWE example so inference serves the **bf16** checkpoint directly (drops vLLM `fp8` quantization) and train/eval use the **bash** harness instead of **rlm**, including removing `summarize_at_tokens`. Header comments are aligned with that.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72032855baa5712daab635147683cf9c09541bf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->