### PR TITLE
chore: fold source sub-configs into dotted keys

### DIFF
--- a/configs/basic/alphabet-sort/rl.toml
+++ b/configs/basic/alphabet-sort/rl.toml
@@ -34,20 +34,12 @@ max_completion_tokens = 768
 
 [[orchestrator.train.source]]
 name = "alphabet-sort"
-
-[orchestrator.train.source.env.taskset]
-id = "alphabet-sort"
-min_turns = 3
-max_turns = 5
-
-[orchestrator.train.source.env.taskset.task]
-power_per_turn = false
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "alphabet-sort"
+env.taskset.min_turns = 3
+env.taskset.max_turns = 5
+env.taskset.task.power_per_turn = false
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [ckpt] # Checkpoint at the end of training
 

--- a/configs/basic/hendrycks-sanity/rl.toml
+++ b/configs/basic/hendrycks-sanity/rl.toml
@@ -21,17 +21,11 @@ seq_len = 8192
 
 [[orchestrator.train.source]]
 name = "hendrycks-math"
-
-[orchestrator.train.source.env.taskset]
-id = "math-env"
-dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B"
-dataset_subset = "default"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "math-env"
+env.taskset.dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B"
+env.taskset.dataset_subset = "default"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.model]
 seq_len = 16384

--- a/configs/basic/reverse-text/rl.toml
+++ b/configs/basic/reverse-text/rl.toml
@@ -24,15 +24,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/basic/reverse-text/sft.toml
+++ b/configs/basic/reverse-text/sft.toml
@@ -29,14 +29,8 @@ max_completion_tokens = 1024
 
 [[eval.source]]
 name = "reverse-text"
-
-[eval.source.env.taskset]
-id = "reverse-text"
-
-[eval.source.env.agent.harness]
-id = "null"
-
-[eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [inference]

--- a/configs/basic/wiki-search/rl.toml
+++ b/configs/basic/wiki-search/rl.toml
@@ -42,15 +42,9 @@ max_completion_tokens = 512
 
 [[orchestrator.train.source]]
 name = "wiki-search"
-
-[orchestrator.train.source.env.taskset]
-id = "wiki-search"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "wiki-search"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [ckpt] # Checkpoint at the end of training
 

--- a/configs/basic/wordle/rl.toml
+++ b/configs/basic/wordle/rl.toml
@@ -23,15 +23,9 @@ group_size = 8
 
 [[orchestrator.train.source]]
 name = "wordle"
-
-[orchestrator.train.source.env.taskset]
-id = "wordle"
-
-[orchestrator.train.source.env.player.harness]
-id = "null"
-
-[orchestrator.train.source.env.player.runtime]
-type = "subprocess"
+env.taskset.id = "wordle"
+env.player.harness.id = "null"
+env.player.runtime.type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 1024

--- a/configs/ci/integration/alphabet_sort.toml
+++ b/configs/ci/integration/alphabet_sort.toml
@@ -27,23 +27,15 @@ max_completion_tokens = 384
 
 [[orchestrator.train.source]]
 name = "alphabet-sort"
-
-[orchestrator.train.source.env.taskset]
-id = "alphabet-sort"
-min_turns = 2
-max_turns = 2
-min_names_per_turn = 1
-max_names_per_turn = 3
-
-[orchestrator.train.source.env.taskset.task]
-similarity_power = 4
-power_per_turn = false
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "alphabet-sort"
+env.taskset.min_turns = 2
+env.taskset.max_turns = 2
+env.taskset.min_names_per_turn = 1
+env.taskset.max_names_per_turn = 3
+env.taskset.task.similarity_power = 4
+env.taskset.task.power_per_turn = false
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [inference]
 

--- a/configs/ci/integration/reverse-text-lora/resume.toml
+++ b/configs/ci/integration/reverse-text-lora/resume.toml
@@ -30,15 +30,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [inference]
 

--- a/configs/ci/integration/reverse-text-lora/start.toml
+++ b/configs/ci/integration/reverse-text-lora/start.toml
@@ -27,15 +27,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [inference]
 

--- a/configs/ci/integration/reverse-text-moe/start.toml
+++ b/configs/ci/integration/reverse-text-moe/start.toml
@@ -30,15 +30,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [inference]
 

--- a/configs/ci/integration/reverse-text-rl-opd/start.toml
+++ b/configs/ci/integration/reverse-text-rl-opd/start.toml
@@ -42,15 +42,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -61,15 +55,9 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-
-[orchestrator.eval.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/ci/integration/reverse-text-rl-sft/start.toml
+++ b/configs/ci/integration/reverse-text-rl-sft/start.toml
@@ -48,15 +48,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -67,15 +61,9 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-
-[orchestrator.eval.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/ci/integration/reverse-text/resume.toml
+++ b/configs/ci/integration/reverse-text/resume.toml
@@ -30,15 +30,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [inference]
 

--- a/configs/ci/integration/reverse-text/start.toml
+++ b/configs/ci/integration/reverse-text/start.toml
@@ -27,15 +27,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [inference]
 

--- a/configs/ci/nightly-fft/alphabet-sort.toml
+++ b/configs/ci/nightly-fft/alphabet-sort.toml
@@ -23,20 +23,12 @@ max_inflight = 128
 
 [[orchestrator.train.source]]
 name = "alphabet-sort"
-
-[orchestrator.train.source.env.taskset]
-id = "alphabet-sort"
-min_turns = 3
-max_turns = 5
-
-[orchestrator.train.source.env.taskset.task]
-power_per_turn = false
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "alphabet-sort"
+env.taskset.min_turns = 3
+env.taskset.max_turns = 5
+env.taskset.task.power_per_turn = false
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 768

--- a/configs/ci/nightly-fft/hendrycks-sanity.toml
+++ b/configs/ci/nightly-fft/hendrycks-sanity.toml
@@ -23,17 +23,11 @@ max_inflight = 128
 
 [[orchestrator.train.source]]
 name = "hendrycks-math"
-
-[orchestrator.train.source.env.taskset]
-id = "math-env"
-dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B"
-dataset_subset = "default"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "math-env"
+env.taskset.dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B"
+env.taskset.dataset_subset = "default"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 50
@@ -41,15 +35,9 @@ interval = 50
 [[orchestrator.eval.source]]
 name = "aime2024"
 group_size = 32
-
-[orchestrator.eval.source.env.taskset]
-id = "aime24"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "aime24"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer]
 

--- a/configs/ci/nightly-fft/reverse-text.toml
+++ b/configs/ci/nightly-fft/reverse-text.toml
@@ -23,15 +23,9 @@ max_inflight = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 128

--- a/configs/ci/nightly-fft/wiki-search.toml
+++ b/configs/ci/nightly-fft/wiki-search.toml
@@ -24,15 +24,9 @@ max_inflight = 128
 
 [[orchestrator.train.source]]
 name = "wiki-search"
-
-[orchestrator.train.source.env.taskset]
-id = "wiki-search"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "wiki-search"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 512

--- a/configs/ci/nightly-fft/wordle.toml
+++ b/configs/ci/nightly-fft/wordle.toml
@@ -23,15 +23,9 @@ max_inflight = 128
 
 [[orchestrator.train.source]]
 name = "wordle"
-
-[orchestrator.train.source.env.taskset]
-id = "wordle"
-
-[orchestrator.train.source.env.player.harness]
-id = "null"
-
-[orchestrator.train.source.env.player.runtime]
-type = "subprocess"
+env.taskset.id = "wordle"
+env.player.harness.id = "null"
+env.player.runtime.type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 1024

--- a/configs/ci/nightly/multimodal_color_codeword.toml
+++ b/configs/ci/nightly/multimodal_color_codeword.toml
@@ -25,16 +25,10 @@ max_completion_tokens = 64
 
 [[orchestrator.train.source]]
 name = "color-codeword"
-
-[orchestrator.train.source.env.taskset]
-id = "color-codeword"
-images_per_turn = 1
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "color-codeword"
+env.taskset.images_per_turn = 1
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer]
 

--- a/configs/debug/algo/echo.toml
+++ b/configs/debug/algo/echo.toml
@@ -26,20 +26,12 @@ alpha = 0.1
 
 [[orchestrator.train.source]]
 name = "alphabet-sort"
-
-[orchestrator.train.source.env.taskset]
-id = "alphabet-sort"
-min_turns = 3
-max_turns = 5
-
-[orchestrator.train.source.env.taskset.task]
-power_per_turn = false
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "alphabet-sort"
+env.taskset.min_turns = 3
+env.taskset.max_turns = 5
+env.taskset.task.power_per_turn = false
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 512

--- a/configs/debug/algo/grpo.toml
+++ b/configs/debug/algo/grpo.toml
@@ -23,15 +23,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -42,15 +36,9 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-
-[orchestrator.eval.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/max_rl.toml
+++ b/configs/debug/algo/max_rl.toml
@@ -23,15 +23,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -42,15 +36,9 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-
-[orchestrator.eval.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/mixed_grpo_opd.toml
+++ b/configs/debug/algo/mixed_grpo_opd.toml
@@ -33,34 +33,18 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text-grpo"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [[orchestrator.train.source]]
 name = "reverse-text-opd"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
-
-[orchestrator.train.source.algo]
-type = "opd"
-
-[orchestrator.train.source.algo.teacher]
-name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL"
-base_url = "http://localhost:8001/v1"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
+algo.type = "opd"
+algo.teacher.name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL"
+algo.teacher.base_url = "http://localhost:8001/v1"
 
 [orchestrator.eval]
 interval = 5
@@ -71,15 +55,9 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-
-[orchestrator.eval.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/opd.toml
+++ b/configs/debug/algo/opd.toml
@@ -35,15 +35,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -54,15 +48,9 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-
-[orchestrator.eval.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/opd_lora.toml
+++ b/configs/debug/algo/opd_lora.toml
@@ -35,15 +35,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -54,15 +48,9 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-
-[orchestrator.eval.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 1e-4

--- a/configs/debug/algo/rae.toml
+++ b/configs/debug/algo/rae.toml
@@ -23,21 +23,11 @@ max_completion_tokens = 512
 
 [[orchestrator.train.source]]
 name = "kuhn-poker"
-
-[orchestrator.train.source.env.taskset]
-id = "kuhn-poker"
-
-[orchestrator.train.source.env.player0.harness]
-id = "null"
-
-[orchestrator.train.source.env.player0.runtime]
-type = "subprocess"
-
-[orchestrator.train.source.env.player1.harness]
-id = "null"
-
-[orchestrator.train.source.env.player1.runtime]
-type = "subprocess"
+env.taskset.id = "kuhn-poker"
+env.player0.harness.id = "null"
+env.player0.runtime.type = "subprocess"
+env.player1.harness.id = "null"
+env.player1.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -48,21 +38,11 @@ max_completion_tokens = 512
 
 [[orchestrator.eval.source]]
 name = "kuhn-poker"
-
-[orchestrator.eval.source.env.taskset]
-id = "kuhn-poker"
-
-[orchestrator.eval.source.env.player0.harness]
-id = "null"
-
-[orchestrator.eval.source.env.player0.runtime]
-type = "subprocess"
-
-[orchestrator.eval.source.env.player1.harness]
-id = "null"
-
-[orchestrator.eval.source.env.player1.runtime]
-type = "subprocess"
+env.taskset.id = "kuhn-poker"
+env.player0.harness.id = "null"
+env.player0.runtime.type = "subprocess"
+env.player1.harness.id = "null"
+env.player1.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/self_distill.toml
+++ b/configs/debug/algo/self_distill.toml
@@ -31,15 +31,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -50,15 +44,9 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-
-[orchestrator.eval.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/sft_distill.toml
+++ b/configs/debug/algo/sft_distill.toml
@@ -40,15 +40,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -59,15 +53,9 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-
-[orchestrator.eval.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/algo/sft_distill_lora.toml
+++ b/configs/debug/algo/sft_distill_lora.toml
@@ -40,15 +40,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 1
@@ -59,15 +53,9 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-
-[orchestrator.eval.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 1e-4

--- a/configs/debug/concurrency.toml
+++ b/configs/debug/concurrency.toml
@@ -41,6 +41,8 @@ num_infer_replicas = 1
 project = "swe-ablations"
 name = "debug-concurrency"
 
+[monitors.prime]
+
 [weight_broadcast]
 type = "nccl"
 timeout = 3600
@@ -104,17 +106,9 @@ thinking_retention = "all"
 
 [[orchestrator.train.source]]
 name = "scaleswe"
-
-[orchestrator.train.source.env.taskset]
-id = "scaleswe"
-
-[orchestrator.train.source.env.agent.harness]
-id = "bash"
-
-[orchestrator.train.source.env.agent.runtime]
-labels = ["debug-concurrency"]
-
-[monitors.prime]
+env.taskset.id = "scaleswe"
+env.agent.harness.id = "bash"
+env.agent.runtime.labels = ["debug-concurrency"]
 
 # --- Eval: SWE-Bench Verified at step 0 + every 20 steps, rlm harness on prime ---
 
@@ -124,18 +118,10 @@ interval = 20
 [[orchestrator.eval.source]]
 name = "swebench-verified"
 num_examples = 100
-
-[orchestrator.eval.source.env.taskset]
-id = "swebench-verified"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "bash"
-
-[orchestrator.eval.source.env.agent.runtime]
-labels = ["debug-concurrency"]
-
-[orchestrator.eval.source.env.agent.timeout]
-rollout = 3600
+env.taskset.id = "swebench-verified"
+env.agent.harness.id = "bash"
+env.agent.runtime.labels = ["debug-concurrency"]
+env.agent.timeout.rollout = 3600
 
 # --- Inference ---
 

--- a/configs/debug/multi-env/rl.toml
+++ b/configs/debug/multi-env/rl.toml
@@ -19,27 +19,15 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text-a"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [[orchestrator.train.source]]
 name = "reverse-text-b"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 5
@@ -50,15 +38,9 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.source]]
 name = "reverse-text"
-
-[orchestrator.eval.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -124,31 +124,17 @@ type = "grpo"
 
 [[orchestrator.train.source]]
 name = "math"  # inherits the top-level grpo
-
-[orchestrator.train.source.env.taskset]
-id = "math"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "math"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [[orchestrator.train.source]]
 name = "terminal"
-
-[orchestrator.train.source.env.taskset]
-id = "terminal"
-
-[orchestrator.train.source.env.agent.harness]
-id = "bash"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
-
+env.taskset.id = "terminal"
+env.agent.harness.id = "bash"
+env.agent.runtime.type = "subprocess"
 # this env runs its own algorithm
-[orchestrator.train.source.algo]
-type = "echo"
+algo.type = "echo"
 ```
 
 ### The Algorithm Classes
@@ -365,21 +351,11 @@ episode_agents = ["solver"]
 name = "proposer-solver"
 group_size = 4  # proposed problems per source task
 env.n = 4  # solver attempts per proposed problem
-
-[orchestrator.train.source.env.taskset]
-id = "proposer-solver"
-
-[orchestrator.train.source.env.proposer.harness]
-id = "null"
-
-[orchestrator.train.source.env.proposer.runtime]
-type = "subprocess"
-
-[orchestrator.train.source.env.solver.harness]
-id = "null"
-
-[orchestrator.train.source.env.solver.runtime]
-type = "subprocess"
+env.taskset.id = "proposer-solver"
+env.proposer.harness.id = "null"
+env.proposer.runtime.type = "subprocess"
+env.solver.harness.id = "null"
+env.solver.runtime.type = "subprocess"
 ```
 
 `group_size` controls how many problems are proposed from each source task. `env.n` controls how many solvers attempt each proposed problem. If a comparison contains only one trace—for example, a solver when `env.n = 1`—its advantage is zero.
@@ -399,21 +375,11 @@ decay = 0.95
 
 [[orchestrator.train.source]]
 name = "kuhn-poker"
-
-[orchestrator.train.source.env.taskset]
-id = "kuhn-poker"
-
-[orchestrator.train.source.env.player0.harness]
-id = "null"
-
-[orchestrator.train.source.env.player0.runtime]
-type = "subprocess"
-
-[orchestrator.train.source.env.player1.harness]
-id = "null"
-
-[orchestrator.train.source.env.player1.runtime]
-type = "subprocess"
+env.taskset.id = "kuhn-poker"
+env.player0.harness.id = "null"
+env.player0.runtime.type = "subprocess"
+env.player1.harness.id = "null"
+env.player1.runtime.type = "subprocess"
 ```
 
 Both of `kuhn-poker`'s agents late-bind to the run's own model — shared-policy self-play against a continuously improving opponent. Pin one agent to a frozen endpoint (`env.player1.model = ...`) for asymmetric play; its traces are marked untrainable by the env and never reach the advantage computation. A single-agent env under `rae` degrades to REINFORCE with an EMA baseline.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,10 +106,8 @@ uv run rl @ rl.toml --orchestrator.train.source.0.args \
 
 ```toml
 [[orchestrator.train.source]]
-
-[orchestrator.train.source.args]
-dataset_name = "openai/gsm8k"
-dataset_subset = "main"
+args.dataset_name = "openai/gsm8k"
+args.dataset_subset = "main"
 ```
 
 ### Optional Sub-Configs
@@ -153,42 +151,24 @@ Training and evaluation sources are arrays of tables. Set one source per environ
 [[orchestrator.train.source]]
 name = "gsm8k"
 ratio = 3  # 75% of batches
-
-[orchestrator.train.source.env.taskset]
-id = "gsm8k"
-split = "train"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "gsm8k"
+env.taskset.split = "train"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [[orchestrator.train.source]]
 name = "reverse-text"
 ratio = 1  # default — 25% of batches
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [[orchestrator.eval.source]]
 name = "gsm8k-eval"
-
-[orchestrator.eval.source.env.taskset]
-id = "gsm8k"
-split = "test"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "gsm8k"
+env.taskset.split = "test"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 ```
 
 `ratio` defaults to `1` (equal weight per env); values are relative weights normalized to probabilities across envs.

--- a/docs/training.md
+++ b/docs/training.md
@@ -187,15 +187,9 @@ num_examples = 32
 
 [[eval.source]]
 name = "reverse-text"
-
-[eval.source.env.taskset]
-id = "reverse-text"
-
-[eval.source.env.agent.harness]
-id = "null"
-
-[eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [inference]
 

--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -25,6 +25,8 @@ num_infer_replicas = 4
 project = "search-ablations"
 name = "glm45air-search"
 
+[monitors.prime]
+
 [weight_broadcast]
 type = "nccl"
 timeout = 3600
@@ -88,8 +90,6 @@ num_output_tokens_weight = 0.0
 num_input_tokens_weight = 0.1
 num_turns_weight = 0.0
 
-[monitors.prime]
-
 # --- Train: the search envs with usable training data (rlm `search` skill, prime sandbox) ---
 
 # openseeker/redsearcher pre-plug a `reference` judge; declaring `judges` here replaces that
@@ -97,18 +97,12 @@ num_turns_weight = 0.0
 # the plugged BC-style prompt is replaced by the reference judge's stock prompt).
 [[orchestrator.train.source]]
 name = "openseeker"
-
-[orchestrator.train.source.env.agent.harness]
-id = "rlm"
-skills = ["search"]
-forward_env = ["SERPER_API_KEY"]
-summarize_at_tokens = [65536, 131072]
-
-[orchestrator.train.source.env.agent.runtime]
-labels = ["glm45air-search"]
-
-[orchestrator.train.source.env.taskset]
-id = "openseeker"
+env.agent.harness.id = "rlm"
+env.agent.harness.skills = ["search"]
+env.agent.harness.forward_env = ["SERPER_API_KEY"]
+env.agent.harness.summarize_at_tokens = [65536, 131072]
+env.agent.runtime.labels = ["glm45air-search"]
+env.taskset.id = "openseeker"
 
 [[orchestrator.train.source.env.taskset.task.judges]]
 id = "reference"
@@ -127,18 +121,12 @@ choices = ["A", "B"]
 
 [[orchestrator.train.source]]
 name = "redsearcher"
-
-[orchestrator.train.source.env.agent.harness]
-id = "rlm"
-skills = ["search"]
-forward_env = ["SERPER_API_KEY"]
-summarize_at_tokens = [65536, 131072]
-
-[orchestrator.train.source.env.agent.runtime]
-labels = ["glm45air-search"]
-
-[orchestrator.train.source.env.taskset]
-id = "redsearcher" # optional `difficulty` filter (easy/medium/hard)
+env.agent.harness.id = "rlm"
+env.agent.harness.skills = ["search"]
+env.agent.harness.forward_env = ["SERPER_API_KEY"]
+env.agent.harness.summarize_at_tokens = [65536, 131072]
+env.agent.runtime.labels = ["glm45air-search"]
+env.taskset.id = "redsearcher" # optional `difficulty` filter (easy/medium/hard)
 
 [[orchestrator.train.source.env.taskset.task.judges]]
 id = "reference"
@@ -163,24 +151,14 @@ interval = 20
 [[orchestrator.eval.source]]
 name = "browsecomp"
 num_examples = 500 # full set is 1266; cap eval at 500
-
-[orchestrator.eval.source.env.agent.harness]
-id = "rlm"
-skills = ["search"]
-forward_env = ["SERPER_API_KEY"]
-summarize_at_tokens = 98304
-
-[orchestrator.eval.source.env.agent.runtime]
-labels = ["glm45air-search"]
-
-[orchestrator.eval.source.env.agent.timeout]
-rollout = 3600
-
-[orchestrator.eval.source.env.taskset]
-id = "browsecomp"
-
-[orchestrator.eval.source.env.taskset.task.judge]
-model = "Qwen/Qwen3-235B-A22B-Instruct-2507"
+env.agent.harness.id = "rlm"
+env.agent.harness.skills = ["search"]
+env.agent.harness.forward_env = ["SERPER_API_KEY"]
+env.agent.harness.summarize_at_tokens = 98304
+env.agent.runtime.labels = ["glm45air-search"]
+env.agent.timeout.rollout = 3600
+env.taskset.id = "browsecomp"
+env.taskset.task.judge.model = "Qwen/Qwen3-235B-A22B-Instruct-2507"
 
 # # Metric-only monitor (weight 0): rlm harness-mechanics rubric, judged by GLM-5.2.
 # [[orchestrator.eval.source.env.taskset.task.judges]]

--- a/examples/advanced/glm-4.5-air/swe.toml
+++ b/examples/advanced/glm-4.5-air/swe.toml
@@ -40,6 +40,8 @@ num_infer_replicas = 3
 project = "swe-ablations"
 name = "glm45air-scaleswe"
 
+[monitors.prime]
+
 [weight_broadcast]
 type = "nccl"
 timeout = 3600
@@ -103,18 +105,10 @@ thinking_retention = "all"
 
 [[orchestrator.train.source]]
 name = "scaleswe"
-
-[orchestrator.train.source.env.taskset]
-id = "scaleswe"
-
-[orchestrator.train.source.env.agent.harness]
-id = "rlm"
-summarize_at_tokens = [65536, 131072]
-
-[orchestrator.train.source.env.agent.runtime]
-labels = ["glm45air-swe"]
-
-[monitors.prime]
+env.taskset.id = "scaleswe"
+env.agent.harness.id = "rlm"
+env.agent.harness.summarize_at_tokens = [65536, 131072]
+env.agent.runtime.labels = ["glm45air-swe"]
 
 # --- Eval: SWE-Bench Verified at step 0 + every 20 steps, rlm harness on prime ---
 
@@ -123,19 +117,11 @@ interval = 20
 
 [[orchestrator.eval.source]]
 name = "swebench-verified"
-
-[orchestrator.eval.source.env.taskset]
-id = "swebench-verified"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "rlm"
-summarize_at_tokens = 98304
-
-[orchestrator.eval.source.env.agent.runtime]
-labels = ["glm45air-swe"]
-
-[orchestrator.eval.source.env.agent.timeout]
-rollout = 3600
+env.taskset.id = "swebench-verified"
+env.agent.harness.id = "rlm"
+env.agent.harness.summarize_at_tokens = 98304
+env.agent.runtime.labels = ["glm45air-swe"]
+env.agent.timeout.rollout = 3600
 
 # --- Inference ---
 

--- a/examples/advanced/glm-4.5-air/terminal.toml
+++ b/examples/advanced/glm-4.5-air/terminal.toml
@@ -26,6 +26,8 @@ num_infer_replicas = 4
 project = "terminal-ablations"
 name = "glm45air-terminal"
 
+[monitors.prime]
+
 [weight_broadcast]
 type = "nccl"
 timeout = 3600
@@ -89,22 +91,14 @@ num_output_tokens_weight = 0.0
 num_input_tokens_weight = 0.1
 num_turns_weight = 0.1
 
-[monitors.prime]
-
 # --- Train: tmax (per-task Docker image in a prime sandbox, rlm ipython) ---
 
 [[orchestrator.train.source]]
 name = "tmax"
-
-[orchestrator.train.source.env.agent.harness]
-id = "rlm"
-summarize_at_tokens = [65536, 131072]
-
-[orchestrator.train.source.env.agent.runtime]
-labels = ["glm45air-terminal"]
-
-[orchestrator.train.source.env.taskset]
-id = "tmax"
+env.agent.harness.id = "rlm"
+env.agent.harness.summarize_at_tokens = [65536, 131072]
+env.agent.runtime.labels = ["glm45air-terminal"]
+env.taskset.id = "tmax"
 
 # # Metric-only monitors (weight 0): rlm harness-mechanics + swe code-usage rubrics, judged by GLM-5.2.
 # [[orchestrator.train.source.env.taskset.judges]]
@@ -128,27 +122,17 @@ interval = 20
 
 [[orchestrator.eval.source]]
 name = "swebench-verified"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "rlm"
-summarize_at_tokens = 98304
-
-[orchestrator.eval.source.env.agent.runtime]
-labels = ["glm45air-terminal"]
-
-[orchestrator.eval.source.env.agent.timeout]
-rollout = 3600
-
-[orchestrator.eval.source.env.taskset]
-id = "swebench-verified"
-
+env.agent.harness.id = "rlm"
+env.agent.harness.summarize_at_tokens = 98304
+env.agent.runtime.labels = ["glm45air-terminal"]
+env.agent.timeout.rollout = 3600
+env.taskset.id = "swebench-verified"
 # [[orchestrator.eval.source.env.taskset.judges]]
 # id = "rubric"
 # name = "rlm"
 # path = "deps/prime-envs/rubrics/rlm.toml"
 # model = "zai-org/GLM-5.2"
 # weight = 0.0
-
 # [[orchestrator.eval.source.env.taskset.judges]]
 # id = "rubric"
 # name = "swe"
@@ -159,19 +143,11 @@ id = "swebench-verified"
 [[orchestrator.eval.source]]
 name = "terminal-bench-2"
 group_size = 4 # avg@4
-
-[orchestrator.eval.source.env.agent.harness]
-id = "rlm"
-summarize_at_tokens = 98304
-
-[orchestrator.eval.source.env.agent.runtime]
-labels = ["glm45air-terminal"]
-
-[orchestrator.eval.source.env.agent.timeout]
-rollout = 3600
-
-[orchestrator.eval.source.env.taskset]
-id = "terminal-bench-2"
+env.agent.harness.id = "rlm"
+env.agent.harness.summarize_at_tokens = 98304
+env.agent.runtime.labels = ["glm45air-terminal"]
+env.agent.timeout.rollout = 3600
+env.taskset.id = "terminal-bench-2"
 
 # [[orchestrator.eval.source.env.taskset.judges]]
 # id = "rubric"

--- a/examples/advanced/glm-5.2/swe-llmd.toml
+++ b/examples/advanced/glm-5.2/swe-llmd.toml
@@ -134,15 +134,9 @@ clear_thinking = false
 
 [[orchestrator.train.source]]
 name = "r2e"
-
-[orchestrator.train.source.env.taskset]
-id = "r2e-gym"
-
-[orchestrator.train.source.env.agent.harness]
-id = "rlm"
-
-[orchestrator.train.source.env.agent.runtime]
-labels = ["glm5-llmd"]
+env.taskset.id = "r2e-gym"
+env.agent.harness.id = "rlm"
+env.agent.runtime.labels = ["glm5-llmd"]
 
 [inference]
 # <0.80 because glm5 layers are too large for 0.85

--- a/examples/advanced/glm-5.2/swe.toml
+++ b/examples/advanced/glm-5.2/swe.toml
@@ -78,15 +78,9 @@ interval = 20
 
 [[orchestrator.eval.source]]
 name = "swe-bench-verified"
-
-[orchestrator.eval.source.env.taskset]
-id = "swebench-verified"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "bash"
-
-[orchestrator.eval.source.env.agent.runtime]
-labels = ["glm5-pd-disag", "swe-bench-verified"]
+env.taskset.id = "swebench-verified"
+env.agent.harness.id = "bash"
+env.agent.runtime.labels = ["glm5-pd-disag", "swe-bench-verified"]
 
 [inference]
 # we need <0.85 bc glm5 layers are too large for 0.85

--- a/examples/advanced/intellect-3.1/rl.toml
+++ b/examples/advanced/intellect-3.1/rl.toml
@@ -54,103 +54,59 @@ max_inflight = 4096
 name = "swe"
 ratio = 0.3
 curriculum = { gates = { zero_advantage = { type = "advantage_range" } } }
-
-[orchestrator.train.source.env.taskset]
-id = "r2e-gym"
-
-[orchestrator.train.source.env.agent.harness]
-id = "bash"
-
-[orchestrator.train.source.env.agent.runtime]
-labels = ["intellect-3.1", "swe"]
+env.taskset.id = "r2e-gym"
+env.agent.harness.id = "bash"
+env.agent.runtime.labels = ["intellect-3.1", "swe"]
 
 [[orchestrator.train.source]]
 name = "deepdive"
 ratio = 0.2
 curriculum = { gates = { zero_advantage = { type = "advantage_range" } } }
-
-[orchestrator.train.source.env.taskset]
-id = "deepdive"
-
-[orchestrator.train.source.env.agent.harness]
-id = "rlm"
-skills = ["search"]
-forward_env = ["SERPER_API_KEY"]
-
-[orchestrator.train.source.env.agent.runtime]
-labels = ["intellect-3.1", "deepdive"]
+env.taskset.id = "deepdive"
+env.agent.harness.id = "rlm"
+env.agent.harness.skills = ["search"]
+env.agent.harness.forward_env = ["SERPER_API_KEY"]
+env.agent.runtime.labels = ["intellect-3.1", "deepdive"]
 
 [[orchestrator.train.source]]
 name = "math"
 ratio = 0.3
 curriculum = { gates = { zero_advantage = { type = "advantage_range" } } }
-
-[orchestrator.train.source.env.taskset]
-id = "i3_math"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "i3_math"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [[orchestrator.train.source]]
 name = "logic"
 ratio = 0.2
 curriculum = { gates = { zero_advantage = { type = "advantage_range" } } }
-
-[orchestrator.train.source.env.taskset]
-id = "i3_logic"
-
-[orchestrator.train.source.env.taskset.filter]
-max = 0.874
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "i3_logic"
+env.taskset.filter.max = 0.874
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [[orchestrator.train.source]]
 name = "code"
 ratio = 0.2
 curriculum = { gates = { zero_advantage = { type = "advantage_range" } } }
-
-[orchestrator.train.source.env.taskset]
-id = "i3_code"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "i3_code"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 25
 
 [[orchestrator.eval.source]]
 name = "swe-bench-verified"
-
-[orchestrator.eval.source.env.taskset]
-id = "swebench-verified"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "bash"
-
-[orchestrator.eval.source.env.agent.runtime]
-labels = ["intellect-3.1", "swe-bench-verified"]
+env.taskset.id = "swebench-verified"
+env.agent.harness.id = "bash"
+env.agent.runtime.labels = ["intellect-3.1", "swe-bench-verified"]
 
 [[orchestrator.eval.source]]
 name = "aime2025"
-
-[orchestrator.eval.source.env.taskset]
-id = "aime25"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "aime25"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [inference.vllm]
 tensor_parallel_size = 8

--- a/examples/advanced/minimax-m2.5/swe.toml
+++ b/examples/advanced/minimax-m2.5/swe.toml
@@ -53,30 +53,18 @@ max_inflight = 4096
 
 [[orchestrator.train.source]]
 name = "swe"
-
-[orchestrator.train.source.env.taskset]
-id = "r2e-gym"
-
-[orchestrator.train.source.env.agent.harness]
-id = "bash"
-
-[orchestrator.train.source.env.agent.runtime]
-labels = ["minimax-swe", "swe"]
+env.taskset.id = "r2e-gym"
+env.agent.harness.id = "bash"
+env.agent.runtime.labels = ["minimax-swe", "swe"]
 
 [orchestrator.eval]
 interval = 25
 
 [[orchestrator.eval.source]]
 name = "swe-bench-verified"
-
-[orchestrator.eval.source.env.taskset]
-id = "swebench-verified"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "bash"
-
-[orchestrator.eval.source.env.agent.runtime]
-labels = ["minimax-swe", "swe-bench-verified"]
+env.taskset.id = "swebench-verified"
+env.agent.harness.id = "bash"
+env.agent.runtime.labels = ["minimax-swe", "swe-bench-verified"]
 
 [inference.vllm]
 tensor_parallel_size = 8

--- a/examples/advanced/nemotron-3-super/swe.toml
+++ b/examples/advanced/nemotron-3-super/swe.toml
@@ -22,6 +22,8 @@ num_infer_replicas = 4
 project = "nemotron-3-super"
 name = "nemotron-3-super-swe"
 
+[monitors.prime]
+
 [weight_broadcast]
 type = "nccl"
 timeout = 3600
@@ -85,37 +87,21 @@ truncate_history_thinking = false
 
 [[orchestrator.train.source]]
 name = "scaleswe"
-
-[orchestrator.train.source.env.taskset]
-id = "scaleswe"
-
-[orchestrator.train.source.env.agent.harness]
-id = "rlm"
-summarize_at_tokens = [65536, 131072]
-
-[orchestrator.train.source.env.agent.runtime]
-labels = ["nemotron-3-super-swe"]
-
-[monitors.prime]
+env.taskset.id = "scaleswe"
+env.agent.harness.id = "rlm"
+env.agent.harness.summarize_at_tokens = [65536, 131072]
+env.agent.runtime.labels = ["nemotron-3-super-swe"]
 
 [orchestrator.eval]
 interval = 20
 
 [[orchestrator.eval.source]]
 name = "swebench-verified"
-
-[orchestrator.eval.source.env.taskset]
-id = "swebench-verified"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "rlm"
-summarize_at_tokens = 98304
-
-[orchestrator.eval.source.env.agent.runtime]
-labels = ["nemotron-3-super-swe"]
-
-[orchestrator.eval.source.env.agent.timeout]
-rollout = 3600
+env.taskset.id = "swebench-verified"
+env.agent.harness.id = "rlm"
+env.agent.harness.summarize_at_tokens = 98304
+env.agent.runtime.labels = ["nemotron-3-super-swe"]
+env.agent.timeout.rollout = 3600
 
 [inference]
 # vLLM disables prefix caching by default for hybrid-Mamba models; SWE turns share long prefixes.

--- a/examples/advanced/qwen3-30b-a3b/math.toml
+++ b/examples/advanced/qwen3-30b-a3b/math.toml
@@ -52,30 +52,18 @@ max_completion_tokens = 32768
 
 [[orchestrator.train.source]]
 name = "math"
-
-[orchestrator.train.source.env.taskset]
-id = "i3_math"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "i3_math"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 25
 
 [[orchestrator.eval.source]]
 name = "aime2025"
-
-[orchestrator.eval.source.env.taskset]
-id = "aime25"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "aime25"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [inference.vllm]
 tensor_parallel_size = 8

--- a/examples/advanced/qwen3-30b-a3b/swe.toml
+++ b/examples/advanced/qwen3-30b-a3b/swe.toml
@@ -50,30 +50,18 @@ initial_inflight = 1024
 
 [[orchestrator.train.source]]
 name = "swe"
-
-[orchestrator.train.source.env.taskset]
-id = "r2e-gym"
-
-[orchestrator.train.source.env.agent.harness]
-id = "bash"
-
-[orchestrator.train.source.env.agent.runtime]
-labels = ["qwen30b-swe", "swe"]
+env.taskset.id = "r2e-gym"
+env.agent.harness.id = "bash"
+env.agent.runtime.labels = ["qwen30b-swe", "swe"]
 
 [orchestrator.eval]
 interval = 25
 
 [[orchestrator.eval.source]]
 name = "swe-bench-verified"
-
-[orchestrator.eval.source.env.taskset]
-id = "swebench-verified"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "bash"
-
-[orchestrator.eval.source.env.agent.runtime]
-labels = ["qwen30b-swe", "swe-bench-verified"]
+env.taskset.id = "swebench-verified"
+env.agent.harness.id = "bash"
+env.agent.runtime.labels = ["qwen30b-swe", "swe-bench-verified"]
 
 [inference.vllm]
 tensor_parallel_size = 8

--- a/examples/advanced/qwen3-30b-a3b/tool.toml
+++ b/examples/advanced/qwen3-30b-a3b/tool.toml
@@ -36,19 +36,11 @@ group_size = 16
 max_off_policy_steps = 32
 
 [[orchestrator.train.source]]
-
-[orchestrator.train.source.env.taskset]
-id = "general-agent"
-min_tier = 1
-
-[orchestrator.train.source.env.taskset.task.tools]
-colocated = true
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "modal"
+env.taskset.id = "general-agent"
+env.taskset.min_tier = 1
+env.taskset.task.tools.colocated = true
+env.agent.harness.id = "null"
+env.agent.runtime.type = "modal"
 
 [inference]
 

--- a/examples/basic/alphabet-sort/rl.toml
+++ b/examples/basic/alphabet-sort/rl.toml
@@ -33,19 +33,11 @@ max_completion_tokens = 768
 
 [[orchestrator.train.source]]
 name = "alphabet-sort"
-
-[orchestrator.train.source.env.taskset]
-id = "alphabet-sort"
-min_turns = 3
-max_turns = 5
-
-[orchestrator.train.source.env.taskset.task]
-power_per_turn = false
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "alphabet-sort"
+env.taskset.min_turns = 3
+env.taskset.max_turns = 5
+env.taskset.task.power_per_turn = false
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [inference] # Default inference config

--- a/examples/basic/hendrycks-sanity/rl.toml
+++ b/examples/basic/hendrycks-sanity/rl.toml
@@ -18,17 +18,11 @@ seq_len = 8192
 
 [[orchestrator.train.source]]
 name = "hendrycks-math"
-
-[orchestrator.train.source.env.taskset]
-id = "math-env"
-dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B"
-dataset_subset = "default"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "math-env"
+env.taskset.dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B"
+env.taskset.dataset_subset = "default"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [orchestrator.eval]
 interval = 50
@@ -36,15 +30,9 @@ interval = 50
 [[orchestrator.eval.source]]
 name = "aime2024"
 group_size = 32
-
-[orchestrator.eval.source.env.taskset]
-id = "aime24"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "aime24"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.model]
 seq_len = 16384

--- a/examples/basic/reverse-text/rl.toml
+++ b/examples/basic/reverse-text/rl.toml
@@ -17,15 +17,9 @@ max_completion_tokens = 128
 
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [trainer.optim]
 lr = 3e-6

--- a/examples/basic/reverse-text/sft.toml
+++ b/examples/basic/reverse-text/sft.toml
@@ -22,15 +22,9 @@ max_completion_tokens = 1024
 
 [[eval.source]]
 name = "reverse-text"
-
-[eval.source.env.taskset]
-id = "reverse-text"
-
-[eval.source.env.agent.harness]
-id = "null"
-
-[eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [inference]
 

--- a/examples/basic/wiki-search/rl.toml
+++ b/examples/basic/wiki-search/rl.toml
@@ -45,15 +45,9 @@ max_completion_tokens = 512
 [[orchestrator.train.source]]
 name = "wiki-search"
 curriculum = { gates = { zero_advantage = { type = "advantage_range" } } }
-
-[orchestrator.train.source.env.taskset]
-id = "wiki-search"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "wiki-search"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [ckpt] # Checkpoint at the end of training
 

--- a/examples/basic/wordle/rl.toml
+++ b/examples/basic/wordle/rl.toml
@@ -20,15 +20,9 @@ group_size = 16
 
 [[orchestrator.train.source]]
 name = "wordle"
-
-[orchestrator.train.source.env.taskset]
-id = "wordle"
-
-[orchestrator.train.source.env.player.harness]
-id = "null"
-
-[orchestrator.train.source.env.player.runtime]
-type = "subprocess"
+env.taskset.id = "wordle"
+env.player.harness.id = "null"
+env.player.runtime.type = "subprocess"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 1024

--- a/examples/evals/swe.toml
+++ b/examples/evals/swe.toml
@@ -21,24 +21,12 @@ max_inflight = 32
 
 [[eval.source]]
 name = "swebench-verified"
-
-[eval.source.env.taskset]
-id = "swebench-verified"
-
-[eval.source.env.agent.harness]
-id = "bash"
-
-[eval.source.env.agent.timeout]
-rollout = 3600
+env.taskset.id = "swebench-verified"
+env.agent.harness.id = "bash"
+env.agent.timeout.rollout = 3600
 
 [[eval.source]]
 name = "terminal-bench-2"
-
-[eval.source.env.taskset]
-id = "terminal-bench-2"
-
-[eval.source.env.agent.harness]
-id = "bash"
-
-[eval.source.env.agent.timeout]
-rollout = 3600
+env.taskset.id = "terminal-bench-2"
+env.agent.harness.id = "bash"
+env.agent.timeout.rollout = 3600

--- a/k8s/prime-rl/examples/reverse-text/orch.toml
+++ b/k8s/prime-rl/examples/reverse-text/orch.toml
@@ -15,15 +15,9 @@ max_completion_tokens = 128
 
 [[train.source]]
 name = "reverse-text"
-
-[train.source.env.taskset]
-id = "reverse-text"
-
-[train.source.env.agent.harness]
-id = "null"
-
-[train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [renderer]
 name = "prime-qwen3"

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -34,7 +34,9 @@ Incompatible combinations (e.g. CP requires flash attention) must raise in a `mo
 
 ## Special syntax
 
-**No inline tables** — checked-in configs use `[section]` headers, never `key = { ... }`. Expand `env.taskset = { id = "..." }` to a full-path header (`[orchestrator.train.source.env.taskset]` — subtable headers after a `[[...]]` entry attach to that entry).
+**No inline tables** — checked-in configs use `[section]` headers or dotted keys, never `key = { ... }`.
+
+**Sources are one block** — inside a `[[...source]]` entry, write nested sub-configs as dotted keys in the same block (`env.taskset.id = "..."`, `env.agent.harness.id = "..."`), not one subsection header per nested config. Nested arrays of tables (e.g. `[[orchestrator.train.source.env.taskset.task.judges]]`) keep full-path headers — they attach to the preceding `[[...source]]` entry.
 
 **Booleans** — CLI `--flag` / `--no-flag`; TOML must be explicit (`enforce_eager = true`).
 
@@ -45,28 +47,16 @@ Incompatible combinations (e.g. CP requires flash attention) must raise in a `mo
 ```toml
 [[orchestrator.train.source]]
 name = "reverse-text"
-
-[orchestrator.train.source.env.taskset]
-id = "reverse-text"
-
-[orchestrator.train.source.env.agent.harness]
-id = "null"
-
-[orchestrator.train.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 
 [[orchestrator.eval.source]]
 name = "reverse-text-eval"
-
-[orchestrator.eval.source.env.taskset]
-id = "reverse-text"
-split = "test"
-
-[orchestrator.eval.source.env.agent.harness]
-id = "null"
-
-[orchestrator.eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "reverse-text"
+env.taskset.split = "test"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 ```
 
 CLI: `--orchestrator.train.source.0.env.taskset.id reverse-text` or `--orchestrator.eval.source.0.env.taskset.id reverse-text`.

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -114,15 +114,9 @@ max_inflight = 128
 [[eval.source]]
 num_examples = 32   # always cap eval size for smokes
 group_size = 4
-
-[eval.source.env.taskset]
-id = "aime25"
-
-[eval.source.env.agent.harness]
-id = "null"
-
-[eval.source.env.agent.runtime]
-type = "subprocess"
+env.taskset.id = "aime25"
+env.agent.harness.id = "null"
+env.agent.runtime.type = "subprocess"
 ```
 
 - Env servers: spawned by the evals process, one per source without an explicit `serve.address`, at `tcp://127.0.0.1:<eval.env_server_base_port + index>`; logs at `{output_dir}/logs/envs/eval/{name}.log`.


### PR DESCRIPTION
## Summary

- Fold every `[[...source]]` entry's nested sub-configs into dotted keys in one block (`env.taskset.id = "..."`, `env.agent.harness.id = "..."`) instead of one full-path subsection header per nested config. Applies to all train/eval source blocks in `configs/`, `examples/`, and `k8s/` (51 TOML files, −868/+322 lines).
- Move the top-level `[monitors.prime]` block up next to `[monitors.wandb]` in the 4 files where it sat inside the orchestrator section.
- Apply the same style to the TOML snippets in `docs/` and the `configs` / `training/start-run` skills, and document the convention in the configs skill. Nested arrays of tables (e.g. `[[...source.env.taskset.task.judges]]`) keep their full-path headers.

Purely cosmetic — no config semantics change. Verified by asserting `tomllib` parses every file to an identical dict before and after, and by diffing the resolved-config JSON from `rl --dry-run` (identical up to the CLI-passed `output_dir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic TOML/docs restyle with no intended semantic change. Residual risk is a mis-attached table if a nested array-of-tables header is wrong, but the PR claims parse-and-dry-run equivalence.
> 
> **Overview**
> Folds nested env/algo settings inside every `[[...source]]` (and `[[eval.source]]`) into dotted keys in the same table (`env.taskset.id`, `env.agent.harness.id`, …) instead of one full-path subsection per nested config. Nested arrays of tables (e.g. judges) still use full-path headers.
> 
> Applies across `configs/`, `examples/`, `k8s/`, plus docs and the configs/start-run skills. In a few advanced/debug files, `[monitors.prime]` is moved next to `[monitors.wandb]` so it is no longer nested under a source.
> 
> No runtime or schema change; style-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 758e06c984cf915a187bd0eeb5aa3550f54c100c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->