### PR TITLE
fix: only pkill zombie torchrun/vLLM processes in CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,9 +38,11 @@ def setup_world():
 
 @pytest.fixture(autouse=True, scope="module")
 def cleanup_zombies():
-    """Auto-fixture to cleanup zombies between module tests. Used in CI to avoid zombie processes from previous tests."""
-    subprocess.run(["pkill", "-f", "torchrun"])
-    subprocess.run(["pkill", "-f", "VLLM"])
+    """Auto-fixture to cleanup zombies between module tests. Only runs in CI (USERNAME_CI is set)
+    to avoid killing training runs on local machines."""
+    if os.environ.get("USERNAME_CI"):
+        subprocess.run(["pkill", "-f", "torchrun"])
+        subprocess.run(["pkill", "-f", "VLLM"])
     yield
 
 


### PR DESCRIPTION
## Summary
- Gate the autouse `cleanup_zombies` fixture in `tests/conftest.py` on `USERNAME_CI`.
- The fixture pkills `-f torchrun` / `-f VLLM` host-wide at every test module start. In CI this cleans up zombies from previous tests, but locally it kills any concurrent training run on the box.
- `USERNAME_CI` is already set to `CI_RUNNER` by all CI pytest jobs (`cpu_tests`, `gpu_tests`, `nightly_tests`) and already keys the `user` fixture, so CI behavior is unchanged and no workflow changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture change; CI behavior is preserved. Residual risk is local leftover processes if tests leak zombies without USERNAME_CI.
> 
> **Overview**
> Stops the autouse `cleanup_zombies` fixture from host-wide `pkill` of `torchrun`/`VLLM` on local pytest runs, so concurrent training jobs are no longer killed.
> 
> The kill still runs when `USERNAME_CI` is set (already used by CI pytest jobs), so CI zombie cleanup is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 454f89e5c269d62410f2ea007b884537dd964045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->