### PR TITLE
fix(trainer): distribute routing replay padding across experts

### DIFF
--- a/src/prime_rl/orchestrator/packing.py
+++ b/src/prime_rl/orchestrator/packing.py
@@ -1,7 +1,7 @@
 from transformers import AutoConfig
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
-from prime_rl.trainer.batch import build_bin_cost, prepare_batch
+from prime_rl.trainer.batch import build_bin_cost, get_model_num_experts, prepare_batch
 from prime_rl.transports.batch.types import MicroBatch, TrainingSample
 from prime_rl.utils.logger import get_logger
 
@@ -24,6 +24,7 @@ class BatchPacker:
             )
             model_config = None
         self.bin_cost = build_bin_cost(model_config)
+        self.num_experts = get_model_num_experts(model_config)
 
     def pack(self, samples: list[TrainingSample]) -> list[list[MicroBatch]]:
         return prepare_batch(
@@ -32,4 +33,5 @@ class BatchPacker:
             num_train_workers=self.num_train_workers,
             bin_cost=self.bin_cost,
             pad_to_multiple_of=self.pad_to_multiple_of,
+            num_experts=self.num_experts,
         )

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -19,6 +19,18 @@ def _text_config(model_config: Any) -> Any:
     return getattr(model_config, "text_config", model_config)
 
 
+def get_model_num_experts(model_config: Any | None) -> int | None:
+    """Return the routed-expert count exposed by supported model configs."""
+    if model_config is None:
+        return None
+
+    config = _text_config(model_config)
+    for field_name in ("num_experts", "n_routed_experts", "num_local_experts"):
+        if (num_experts := getattr(config, field_name, None)) is not None:
+            return int(num_experts)
+    return None
+
+
 def _is_mla(config: Any) -> bool:
     return bool(getattr(config, "multi_latent_attention", False) or hasattr(config, "q_lora_rank"))
 
@@ -270,11 +282,44 @@ def _slice_routed_experts(routed_experts: RoutedExperts, seq_len: int) -> Routed
     )
 
 
-def _pad_routed_experts(micro_batch: MicroBatch, padding_size: int) -> None:
+def _pad_routed_experts(micro_batch: MicroBatch, padding_size: int, num_experts: int) -> None:
     routed_experts = micro_batch.routed_experts
     assert routed_experts is not None
-    row_size = _routed_experts_row_size(routed_experts)
-    routed_experts.data += b"\0" * (padding_size * row_size)
+    dtype = np.dtype(routed_experts.dtype)
+    if not np.issubdtype(dtype, np.integer):
+        raise TypeError(f"routed_experts must use an integer dtype, got {dtype}")
+    if num_experts <= 0:
+        raise ValueError(f"num_experts must be positive, got {num_experts}")
+
+    _, num_layers, topk = routed_experts.shape
+    if not 0 < topk <= num_experts:
+        raise ValueError(f"Cannot pad routed_experts with {topk=} using {num_experts=}")
+
+    # Compact payloads are typed from observed routes. Widen before synthesizing
+    # padding when the model's full expert-ID range does not fit.
+    if num_experts - 1 > np.iinfo(dtype).max:
+        widened_dtype = np.min_scalar_type(num_experts - 1)
+        if not np.issubdtype(widened_dtype, np.integer):
+            raise ValueError(f"num_experts is too large for an integer routed_experts payload: {num_experts}")
+        existing = np.frombuffer(routed_experts.data, dtype=dtype).reshape(routed_experts.shape)
+        routed_experts.data = existing.astype(widened_dtype).tobytes()
+        routed_experts.dtype = widened_dtype.name
+        dtype = widened_dtype
+
+    num_padding_routes = padding_size * topk
+    route_ordinals = np.arange(num_padding_routes, dtype=np.int64)
+    remainder = num_padding_routes % num_experts
+    remainder_ordinals = np.arange(remainder, dtype=np.int64)
+    remainder_routes = remainder_ordinals * num_experts // remainder if remainder else remainder_ordinals
+    # Put the evenly spaced remainder first in an otherwise complete expert cycle.
+    expert_cycle = np.concatenate(
+        (remainder_routes, np.setdiff1d(np.arange(num_experts), remainder_routes, assume_unique=True))
+    )
+    padding_routes = expert_cycle[route_ordinals % num_experts]
+    padding_routes = padding_routes.reshape(padding_size, 1, topk)
+    layer_offsets = np.arange(num_layers, dtype=np.int64).reshape(1, num_layers, 1)
+    padding = ((padding_routes + layer_offsets) % num_experts).astype(dtype, copy=False)
+    routed_experts.data += padding.tobytes()
     routed_experts.shape[0] += padding_size
 
 
@@ -689,16 +734,8 @@ def _distribute_group(
     return [[group[i] for i in partition] for partition in partitions]
 
 
-def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBatch:
-    """
-    Pad a micro batch with the given padding size sample
-    Return the padded micro batch.
-    Args:
-        micro_batch: The micro batch to pad.
-        padding_size: The number of padding tokens to add.
-    Returns:
-        The padded micro batch.
-    """
+def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int, num_experts: int | None = None) -> MicroBatch:
+    """Pad every token-aligned field to a multiple of ``pad_to_multiple_of``."""
 
     padding_size = (pad_to_multiple_of - (len(micro_batch.input_ids) % pad_to_multiple_of)) % pad_to_multiple_of
 
@@ -710,6 +747,8 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
 
     if not (pad_to_multiple_of > 1 and padding_size > 0):
         return micro_batch
+    if micro_batch.routed_experts is not None and num_experts is None:
+        raise ValueError("num_experts is required when padding routed_experts")
 
     micro_batch.input_ids.extend([1] * padding_size)
     micro_batch.advantages.extend([0.0] * padding_size)
@@ -732,7 +771,8 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
     if micro_batch.mm_token_type_ids is not None:
         micro_batch.mm_token_type_ids.extend([0] * padding_size)
     if micro_batch.routed_experts is not None:
-        _pad_routed_experts(micro_batch, padding_size)
+        assert num_experts is not None
+        _pad_routed_experts(micro_batch, padding_size, num_experts)
     micro_batch.env_names.extend([""] * padding_size)
 
     return micro_batch
@@ -799,6 +839,7 @@ def prepare_batch(
     num_train_workers: int,
     bin_cost: Callable[[Sequence[int]], int],
     pad_to_multiple_of: int = 1,
+    num_experts: int | None = None,
 ) -> list[list[MicroBatch]]:
     """
     Prepare a batch of problems for each GPU. Each batch is a list of micro batches.
@@ -812,7 +853,7 @@ def prepare_batch(
     all_samples = [prepare_sample(rollout, seq_len) for rollout in rollouts]
 
     micro_batches = packed_samples_into_micro_bs(all_samples, seq_len, num_train_workers, bin_cost)
-    micro_batches = [pad_micro_batch(micro_batch, pad_to_multiple_of) for micro_batch in micro_batches]
+    micro_batches = [pad_micro_batch(micro_batch, pad_to_multiple_of, num_experts) for micro_batch in micro_batches]
 
     # Separate by modality so each step index has uniform modality across all ranks
     mm_batches = [b for b in micro_batches if _is_multimodal_sample(b)]

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -3,7 +3,14 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-from prime_rl.trainer.batch import _is_multimodal_sample, build_bin_cost, pad_micro_batch, prepare_batch, prepare_sample
+from prime_rl.trainer.batch import (
+    _is_multimodal_sample,
+    build_bin_cost,
+    get_model_num_experts,
+    pad_micro_batch,
+    prepare_batch,
+    prepare_sample,
+)
 from prime_rl.transports.batch.types import EncodedTensor, MicroBatch, RoutedExperts, TrainingSample
 
 
@@ -14,6 +21,38 @@ def _routed_experts(data, dtype=np.uint8):
         shape=list(routed_experts.shape),
         dtype=str(routed_experts.dtype),
     )
+
+
+def _sample_with_routed_experts(routed_experts: np.ndarray) -> TrainingSample:
+    num_tokens = len(routed_experts)
+    return TrainingSample(
+        token_ids=list(range(num_tokens)),
+        mask=[False] + [True] * (num_tokens - 1),
+        logprobs=[0.0] + [-0.1] * (num_tokens - 1),
+        temperatures=[1.0] * num_tokens,
+        advantages=[0.0] + [1.0] * (num_tokens - 1),
+        env_name="test-env",
+        routed_experts=_routed_experts(routed_experts),
+    )
+
+
+def _prepare_routed_padding(
+    original: np.ndarray, *, num_experts: int, padded_length: int
+) -> tuple[MicroBatch, np.ndarray]:
+    batches = prepare_batch(
+        rollouts=[_sample_with_routed_experts(original)],
+        seq_len=padded_length,
+        num_train_workers=1,
+        bin_cost=build_bin_cost(None),
+        pad_to_multiple_of=padded_length,
+        num_experts=num_experts,
+    )
+    micro_batch = batches[0][0]
+    assert micro_batch.routed_experts is not None
+    dtype = np.dtype(micro_batch.routed_experts.dtype)
+    actual = np.frombuffer(micro_batch.routed_experts.data, dtype=dtype).reshape(micro_batch.routed_experts.shape)
+    np.testing.assert_array_equal(actual[: len(original)], original)
+    return micro_batch, actual[len(original) :]
 
 
 def _encoded(arr) -> EncodedTensor:
@@ -78,6 +117,20 @@ def make_flops_config():
         num_hidden_layers=2,
         head_dim=8,
     )
+
+
+@pytest.mark.parametrize(
+    ("model_config", "expected"),
+    [
+        (SimpleNamespace(num_experts=64), 64),
+        (SimpleNamespace(n_routed_experts=128), 128),
+        (SimpleNamespace(num_local_experts=256), 256),
+        (SimpleNamespace(text_config=SimpleNamespace(num_experts=512)), 512),
+        (SimpleNamespace(hidden_size=1024), None),
+    ],
+)
+def test_get_model_num_experts(model_config, expected):
+    assert get_model_num_experts(model_config) == expected
 
 
 def test_training_sample_requires_env_name():
@@ -174,6 +227,84 @@ def test_pad_micro_batch_preserves_explicit_sequence_lengths():
     assert padded.seq_lens == [6]
     assert sum(padded.sequence_lengths) == len(padded.input_ids)
     assert padded.loss_mask[-2:] == [False, False]
+
+
+def test_prepare_batch_distributes_routed_expert_padding():
+    num_experts = 256
+    experts_per_rank = 32
+    original = np.arange(7 * 4 * 8, dtype=np.uint8).reshape(7, 4, 8)
+
+    micro_batch, padding = _prepare_routed_padding(original, num_experts=num_experts, padded_length=8)
+    expected = np.arange(0, num_experts, experts_per_rank, dtype=np.uint8) + np.arange(4, dtype=np.uint8)[:, None]
+    np.testing.assert_array_equal(padding[0], expected)
+    assert micro_batch.loss_mask[-1:] == [False]
+    assert (padding < num_experts).all()
+    assert np.all(np.diff(np.sort(padding, axis=-1), axis=-1) > 0)
+    for layer_routes in padding[0]:
+        np.testing.assert_array_equal(np.bincount(layer_routes // experts_per_rank, minlength=8), np.ones(8))
+
+
+def test_prepare_batch_distributes_low_topk_padding_across_ep_ranks():
+    num_experts = 256
+    experts_per_rank = 32
+    original = np.arange(9 * 4 * 2, dtype=np.uint8).reshape(9, 4, 2)
+
+    micro_batch, padding = _prepare_routed_padding(original, num_experts=num_experts, padded_length=16)
+    assert micro_batch.loss_mask[-7:] == [False] * 7
+    assert np.all(np.diff(np.sort(padding, axis=-1), axis=-1) > 0)
+    for layer in range(padding.shape[1]):
+        layer_routes = padding[:, layer].ravel()
+        expert_histogram = np.bincount(layer_routes, minlength=num_experts)
+        assert expert_histogram.max() - expert_histogram.min() <= 1
+        rank_histogram = np.bincount(layer_routes // experts_per_rank, minlength=8)
+        assert sorted(rank_histogram.tolist()) == [1, 1, 2, 2, 2, 2, 2, 2]
+
+
+def test_prepare_batch_balances_routing_remainder_across_ep_ranks():
+    num_experts = 256
+    experts_per_rank = 32
+    original = np.arange(2 * 8, dtype=np.uint8).reshape(1, 2, 8)
+
+    _, padding = _prepare_routed_padding(original, num_experts=num_experts, padded_length=34)
+    assert np.all(np.diff(np.sort(padding, axis=-1), axis=-1) > 0)
+    for layer in range(padding.shape[1]):
+        layer_routes = padding[:, layer].ravel()
+        expert_histogram = np.bincount(layer_routes, minlength=num_experts)
+        assert expert_histogram.max() - expert_histogram.min() == 1
+        rank_histogram = np.bincount(layer_routes // experts_per_rank, minlength=8)
+        np.testing.assert_array_equal(rank_histogram, np.full(8, 33))
+
+
+def test_prepare_batch_widens_routed_experts_for_full_domain_padding():
+    num_experts = 512
+    experts_per_rank = 64
+    original = np.arange(6 * 2 * 8, dtype=np.uint8).reshape(6, 2, 8)
+
+    micro_batch, padding = _prepare_routed_padding(original, num_experts=num_experts, padded_length=8)
+    assert micro_batch.routed_experts is not None
+    assert micro_batch.routed_experts.dtype == "uint16"
+    expected = np.arange(0, num_experts, experts_per_rank // 2, dtype=np.uint16).reshape(2, 8)
+    np.testing.assert_array_equal(padding[:, 0], expected)
+    np.testing.assert_array_equal(padding[:, 1], (expected + 1) % num_experts)
+    assert micro_batch.loss_mask[-2:] == [False, False]
+    assert (padding < num_experts).all()
+    assert np.all(np.diff(np.sort(padding, axis=-1), axis=-1) > 0)
+    for layer in range(padding.shape[1]):
+        rank_histogram = np.bincount(padding[:, layer].ravel() // experts_per_rank, minlength=8)
+        np.testing.assert_array_equal(rank_histogram, np.full(8, 2))
+
+
+def test_prepare_batch_requires_model_expert_count_for_routing_padding():
+    original = np.arange(7 * 2 * 2, dtype=np.uint8).reshape(7, 2, 2)
+
+    with pytest.raises(ValueError, match="num_experts is required when padding routed_experts"):
+        prepare_batch(
+            rollouts=[_sample_with_routed_experts(original)],
+            seq_len=8,
+            num_train_workers=1,
+            bin_cost=build_bin_cost(None),
+            pad_to_multiple_of=8,
+        )
 
 
 def test_split_to_align_avoids_dummy_micro_batches():


### PR DESCRIPTION
## Summary

Sequence packing appends loss-masked tokens to align training batches. With router replay enabled, those tokens still pass through MoE dispatch, but their replay payload was filled with zero bytes. Every synthetic route therefore selected expert 0, concentrating padding-only forward work on one expert and potentially one expert-parallel rank.

## Fix

- Read the model's routed-expert count from the same configuration already loaded by the batch packer, including composite text configs.
- Distribute each layer's complete padding route set as full expert cycles plus an evenly spaced remainder, then rotate assignments between layers. The cycle order keeps every row's top-k distinct across cycle boundaries, bounds per-expert count skew to one assignment, and spreads the unavoidable remainder optimally across any contiguous expert-parallel partition.
- Widen compact replay payloads when the model's expert range requires it, preserving all sampled route values. For example, a `uint8` payload for a 512-expert model becomes `uint16` before padding is appended.
- Fail closed before mutating the batch when routing padding is required but the expert count is unavailable.

Non-padding replay routes and loss-mask behavior are unchanged.

## Verification

- `uv run pytest -q tests/unit/orchestrator/test_batch.py`: 33 passed on Python 3.12.
- A 256-expert, top-k 8, one-row padding case assigns one route to each of eight contiguous EP ranks per layer.
- A 256-expert, top-k 2, seven-row padding case produces 14 distinct routes per layer; per-expert counts differ by at most one and the eight-rank histogram is `[1, 1, 2, 2, 2, 2, 2, 2]` up to rank ordering.
- A 256-expert, top-k 8, 33-row padding case crosses a full expert cycle while retaining distinct routes per row, per-expert skew of one, and exactly 33 assignments per EP rank.
- A 512-expert case verifies `uint8` to `uint16` widening, exact preservation of sampled routes, row/layer rotation, and balanced aggregate EP assignment.
- Ruff check, Ruff format check, and `git diff --check` pass for the changed files.

No multi-GPU or DeepEP end-to-end training run was performed; the regression coverage validates the production packing payload and its dispatch-facing invariants on CPU.
