### PR TITLE
fix: treat a resume past max_steps as the last step

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -270,7 +270,7 @@ def train(config: TrainerConfig):
         torch.cuda.reset_peak_memory_stats()
         if gc_handler is not None:
             gc_handler.run(progress.step)
-        is_last_step = config.max_steps is not None and progress.step == config.max_steps
+        is_last_step = config.max_steps is not None and progress.step >= config.max_steps
 
         logger.debug(f"Starting training step {progress.step}")
         step_start_time = time.perf_counter()


### PR DESCRIPTION
## Summary

- A run resumed from a checkpoint at or beyond `max_steps` never matched the `is_last_step ==` check, so the trainer idled forever waiting for a batch that would not come. `>=` makes it exit as the last step.

Part of the #3335 breakup (stack 1/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line loop-exit comparison change in the trainer; no auth, data, or protocol changes.
> 
> **Overview**
> Fixes RL trainer hang on resume when the checkpoint is already at or past `max_steps`.
> 
> `is_last_step` now uses `progress.step >= config.max_steps` instead of equality, so a resume that overshoots still ends the loop instead of waiting forever for a batch that will never arrive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96f0153b757e3fa208547f975653777ccd7eb4bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->