### PR TITLE
feat: serve the LoRA adapter under the base model name

### DIFF
--- a/configs/ci/integration/reverse-text-lora/resume.toml
+++ b/configs/ci/integration/reverse-text-lora/resume.toml
@@ -23,7 +23,6 @@ group_size = 16
 max_inflight = 128
 
 [orchestrator.model.lora]
-name = "r8-1e-4"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 128

--- a/configs/ci/integration/reverse-text-lora/start.toml
+++ b/configs/ci/integration/reverse-text-lora/start.toml
@@ -20,7 +20,6 @@ group_size = 16
 max_inflight = 128
 
 [orchestrator.model.lora]
-name = "r8-1e-4"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 128

--- a/examples/basic/wiki-search/rl.toml
+++ b/examples/basic/wiki-search/rl.toml
@@ -37,7 +37,6 @@ group_size = 16
 initial_inflight = 1024
 
 [orchestrator.model.lora]
-name = "qwen3-4b-wiki-search"
 
 [orchestrator.train.sampling]
 max_completion_tokens = 512

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -111,14 +111,8 @@ class VllmConfig(BaseConfig):
     enable_lora: bool = False
     """Enable LoRA."""
 
-    max_loras: int = 8
-    """Maximum number of LoRAs."""
-
-    # TODO: The default value is very high because our areal impl for lora isn't ideal
-    # We add a lora with the same name instead of changing weights inplace
-    # Because we dont cancel requests that are past max_async, these requests could be using a LoRA that gets unloaded which will crash the inference server
-    max_cpu_loras: int = 100
-    """Maximum number of LoRAs on CPU."""
+    max_loras: int = 1
+    """Maximum number of LoRAs. The single training adapter is reloaded in place every policy version, reusing one slot."""
 
     max_lora_rank: int | None = None
     """Maximum LoRA rank. Rounded up to the nearest value vLLM accepts."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -25,9 +25,6 @@ from prime_rl.utils.config import BaseConfig
 
 
 class LoRAConfig(BaseConfig):
-    name: str | None = None
-    """LoRA adapter name. If None, auto-generated from rank and alpha."""
-
     rank: int | None = Field(None, ge=1)
     """LoRA rank for this run. Must be ≤ trainer's max rank. If None, uses the trainer's rank."""
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -460,8 +460,9 @@ class RLConfig(BaseConfig):
                 self.weight_broadcast = SharedNCCLWeightBroadcastConfig()
         if self.weight_broadcast.type != "filesystem" and self.trainer.model.lora is not None:
             raise ValueError(
-                "LoRA training is not yet supported with in-memory weight broadcast. "
-                "Set weight_broadcast.type = 'filesystem'."
+                "LoRA requires weight_broadcast.type = 'filesystem': vLLM loads adapters only from a "
+                "PEFT-shaped directory on disk (LoRAModel.from_local_checkpoint) - in-memory transports "
+                "have no disk artifact to load from."
             )
         if self.weight_broadcast.type in ("nccl", "nixl"):
             inference_world_size = (
@@ -567,11 +568,6 @@ class RLConfig(BaseConfig):
 
             if self.orchestrator.model.lora.alpha is None:
                 self.orchestrator.model.lora.alpha = self.trainer.model.lora.alpha
-
-            if self.orchestrator.model.lora.name is None:
-                self.orchestrator.model.lora.name = (
-                    f"r{self.orchestrator.model.lora.rank}-a{self.orchestrator.model.lora.alpha}"
-                )
 
             if self.inference is not None:
                 self.inference.vllm.enable_lora = True

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -733,7 +733,15 @@ class TrainerConfig(BaseConfig):
     @model_validator(mode="after")
     def validate_lora_broadcast(self):
         if self.model.lora is not None and self.weight_broadcast.type in ("nccl", "nixl"):
-            raise ValueError("In-memory weight broadcast does not support LoRA yet.")
+            raise ValueError(
+                "LoRA requires weight_broadcast.type = 'filesystem': vLLM loads adapters only from a "
+                "PEFT-shaped directory on disk - in-memory transports have no disk artifact to load from."
+            )
+        if self.model.lora is not None and self.model.lora.modules_to_save and self.data.fake is None:
+            raise ValueError(
+                "model.lora.modules_to_save cannot be served: the weight broadcast ships only the "
+                "adapter tensors, so fully-trained modules would silently diverge from inference."
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/evals/evals.py
+++ b/src/prime_rl/evals/evals.py
@@ -59,7 +59,6 @@ POLL_INTERVAL_S = 2.0
 # Served model name for adapter broadcasts of LoRA runs. Reloading the same name
 # with fresh weights each step is supported (the server forces an in-place
 # reload, see /load_lora_adapter).
-LORA_NAME = "eval-adapter"
 
 
 class Evals:
@@ -353,9 +352,8 @@ class Evals:
             get_logger().info(f"Updating inference weights to broadcast step {step} ({broadcast_dir})")
             # LoRA runs broadcast the raw adapter; load it under a fixed adapter name
             # and serve the evals against that name (mirrors WeightWatcher).
-            lora_name = LORA_NAME if (broadcast_dir / "adapter_config.json").exists() else None
             try:
-                await update_weights(self.admin_clients.clients, broadcast_dir, lora_name=lora_name, step=step)
+                await update_weights(self.admin_clients.clients, broadcast_dir, self.clients.model_name, step=step)
             except Exception as exc:
                 # Skip this step instead of killing the run; drain the queued examples
                 # so they don't leak into a later epoch with the wrong step.
@@ -363,9 +361,6 @@ class Evals:
                     pass
                 get_logger().error(f"Failed to update inference weights to step {step} - skipping evals: {exc!r}")
                 return
-            if lora_name is not None:
-                self.clients.update_model_name(lora_name)
-                self.policy.model_name = lora_name
 
         # The dispatcher only schedules eval in PREFER_EVAL, so nothing dispatches
         # between the trigger above and the weight reload completing.

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -92,10 +92,14 @@ async def load_lora_adapter(lora_request: LoadLoRAAdapterRequest, raw_request: R
     """Wrapper around vLLM's /v1/load_lora_adapter.
 
     prime-rl reloads a fixed-name adapter with fresh weights every step (the path
-    changes per policy version; the name is constant, see orchestrator.lora_name).
-    vLLM's native loader rejects a same-name reload unless ``load_inplace=True``,
-    so we force it here — that makes the worker re-read the new weights during
-    ``add_lora``, reusing the existing ``lora_int_id``.
+    changes per policy version; the name is constant — the base model name, which
+    the adapter shadows: ``_maybe_get_adapters`` resolves ``lora_requests`` before
+    the base-model match, so requests keep addressing one stable name. If a future
+    vLLM rejects registering an adapter under a served model name, fall back to a
+    distinct constant adapter name set once at startup.) vLLM's native loader
+    rejects a same-name reload unless ``load_inplace=True``, so we force it here —
+    that makes the worker re-read the new weights during ``add_lora``, reusing the
+    existing ``lora_int_id``.
 
     We then reset the stored request's flag back to ``False``. ``load_inplace`` is
     a sticky field on the ``LoRARequest`` that ``_maybe_get_adapters`` hands to

--- a/src/prime_rl/orchestrator/clients.py
+++ b/src/prime_rl/orchestrator/clients.py
@@ -63,9 +63,6 @@ class InferenceClient:
         self._scorer = PrefillScorer()
         self.model_name = model_name
 
-    def update_model_name(self, model_name: str) -> None:
-        self.model_name = model_name
-
     async def score(self, token_ids: list[int]) -> list[float]:
         """Prefill-score ``token_ids`` under this endpoint's model (one logprob
         per token, 0.0 for the leading token)."""
@@ -294,7 +291,7 @@ async def _resume_engines(admin_clients: list[AsyncClient]) -> None:
 async def update_weights(
     admin_clients: list[AsyncClient],
     weight_dir: Path | None,
-    lora_name: str | None = None,
+    model_name: str,
     step: int = 0,
 ) -> None:
     """Update weights on static inference servers.
@@ -311,8 +308,12 @@ async def update_weights(
 
     weight_dir_posix = weight_dir.as_posix() if weight_dir is not None else None
 
-    if lora_name is not None and weight_dir is not None:
-        await load_lora_adapter(admin_clients, lora_name, weight_dir)
+    if weight_dir is not None and (weight_dir / "adapter_config.json").exists():
+        # A LoRA run broadcasts the PEFT-shaped adapter; register it under the
+        # base model name - the single adapter shadows it (vLLM resolves
+        # lora_requests before the base-model match), so requests keep
+        # addressing one stable name and no engine pause is needed.
+        await load_lora_adapter(admin_clients, model_name, weight_dir)
     else:
         # Pause engines so all DP workers drain in-flight work and can join the NCCL broadcast
         await _pause_engines(admin_clients, step=step)
@@ -393,19 +394,6 @@ async def load_lora_adapter(admin_clients: list[AsyncClient], lora_name: str, lo
         response.raise_for_status()
 
     await asyncio.gather(*[_load_lora_adapter(admin_client) for admin_client in admin_clients])
-
-
-async def unload_lora_adapter(admin_clients: list[AsyncClient], lora_name: str) -> None:
-    """Make a HTTP post request to the vLLM server to unload a LoRA adapter."""
-    logger = get_logger()
-
-    async def _unload_lora_adapter(admin_client: AsyncClient) -> None:
-        logger.debug(f"Sending request to unload LoRA adapter {lora_name}")
-        await admin_client.post("/v1/unload_lora_adapter", json={"lora_name": lora_name})
-        # TODO: The first one can fail, but subsequent ones should succeed.
-        # response.raise_for_status()
-
-    await asyncio.gather(*[_unload_lora_adapter(admin_client) for admin_client in admin_clients])
 
 
 async def init_nccl_broadcast(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -146,7 +146,6 @@ class Orchestrator:
     eval_envs: EvalEnvs | None
     eval_sink: EvalSink | None
     eval_source: EvalSource | None
-    lora_name: str | None
     resume_step: int | None
     lag_task: asyncio.Task | None
 
@@ -184,7 +183,6 @@ class Orchestrator:
         self.eval_envs = None
         self.eval_sink = None
         self.eval_source = None
-        self.lora_name = None
         self.resume_step = None
         self.lag_task = None
         self.model_express = None
@@ -254,7 +252,6 @@ class Orchestrator:
 
         # Resume below may bump ``policy.version`` and the LoRA model name
         self.policy.model_name = self.clients.model_name
-        self.lora_name = config.model.lora.name if config.model.lora else None
 
         # The checkpoint finished step ``resume_step``; resume at the next step. Derive the step
         # from ``resume_step`` (not the loaded progress.step) so it stays coordinated with the
@@ -361,7 +358,7 @@ class Orchestrator:
             )
         if self.model_express is not None:
             await asyncio.to_thread(self.model_express.set_status, p2p_pb2.SOURCE_STATUS_READY)
-        await update_weights(self.admin_clients.clients, weights_path, lora_name=self.lora_name, step=sync_version)
+        await update_weights(self.admin_clients.clients, weights_path, config.model.name, step=sync_version)
         if self.model_express is not None:
             await asyncio.to_thread(self.model_express.set_status, p2p_pb2.SOURCE_STATUS_INITIALIZING)
             # Complete the startup rendezvous before the watcher begins its next cycle.
@@ -372,9 +369,6 @@ class Orchestrator:
                 status=p2p_pb2.SOURCE_STATUS_INITIALIZING,
                 timeout=config.weight_broadcast.timeout,
             )
-        if self.lora_name is not None:
-            self.clients.update_model_name(self.lora_name)
-            self.policy.model_name = self.lora_name
         self.policy.version = sync_version
         get_logger().debug(f"Synced inference to policy v{sync_version} in {format_time(time.perf_counter() - t0)}")
 
@@ -443,7 +437,6 @@ class Orchestrator:
             clients=self.clients,
             admin_clients=self.admin_clients,
             observers=[self.dispatcher, self],
-            lora_name=self.lora_name,
             ckpt_step=self.policy.version,
             model_express=self.model_express,
         )

--- a/src/prime_rl/orchestrator/watcher.py
+++ b/src/prime_rl/orchestrator/watcher.py
@@ -30,7 +30,6 @@ class WeightWatcher:
         clients: InferenceClient,
         admin_clients: AdminClients,
         observers: list[VersionObserver],
-        lora_name: str | None,
         ckpt_step: int = 0,
         poll_interval: float = 1.0,
         model_express: ModelExpressSession | None = None,
@@ -40,7 +39,6 @@ class WeightWatcher:
         self.clients = clients
         self.admin_clients = admin_clients
         self.observers = observers
-        self.lora_name = lora_name
         self.ckpt_step = ckpt_step
         self.poll_interval = poll_interval
         self.model_express = model_express
@@ -136,16 +134,12 @@ class WeightWatcher:
 
             get_logger().debug(f"Updating inference weights to policy v{next_step}")
             t1 = time.perf_counter()
-            await update_weights(self.admin_clients.clients, weights_path, lora_name=self.lora_name, step=next_step)
+            await update_weights(self.admin_clients.clients, weights_path, self.clients.model_name, step=next_step)
             self.last_update_weights_time = time.perf_counter() - t1
             self.update_count += 1
             get_logger().debug(
                 f"Updated inference weights to policy v{next_step} in {format_time(self.last_update_weights_time)}"
             )
-
-            if self.lora_name is not None:
-                self.clients.update_model_name(self.lora_name)
-                self.policy.model_name = self.lora_name
 
             for observer in self.observers:
                 try:

--- a/src/prime_rl/trainer/lora.py
+++ b/src/prime_rl/trainer/lora.py
@@ -55,14 +55,6 @@ class LoRAState:
         """Register an adapted module with its FQN prefix (e.g. "model.layers.0.self_attn.q_proj")."""
         self._modules.append((prefix, module))
 
-    def named_adapter_parameters(self) -> list[tuple[str, nn.Parameter]]:
-        """Named parameters of the adapter across all registered modules."""
-        params = []
-        for prefix, module in self._modules:
-            for name, param in module.named_parameters_for_adapter(0):
-                params.append((f"{prefix}.{name}.weight", param))
-        return params
-
     def adapter_state_dict(self) -> dict[str, torch.Tensor]:
         """Adapter-only state dict, converted for HF compatibility when a converter is registered."""
         state_dict = {}


### PR DESCRIPTION
## Summary

- Register the single training adapter under `config.model.name`: the adapter shadows the base model (vLLM resolves `lora_requests` before the base-model match; verified on the pinned vLLM 0.26), so requests keep addressing one stable name and nothing switches model names mid-run.
- `update_weights` becomes artifact-driven: a weight dir holding `adapter_config.json` is hot-swapped as an adapter (a vLLM-native in-place reload, no engine pause); anything else is a full checkpoint load.
- Deletes the adapter-naming machinery: the per-version model-name rewrite in watcher/orchestrator/evals, evals' fixed `eval-adapter` name and disk-sniff dance, `update_model_name`, and the dead `unload_lora_adapter`.
- Guardrails: `modules_to_save` is rejected when the weight broadcast is live (only adapter tensors ship - fully-trained modules would silently diverge from inference); the LoRA/in-memory rejection states the real reason (vLLM loads adapters only from a PEFT-shaped directory on disk). The fallback, if a future vLLM rejects registering an adapter under a served model name, is documented in the `/load_lora_adapter` wrapper: a distinct constant name set once at startup.

## Breaking

- `orchestrator.model.lora.name` config field removed (with its `r{rank}-a{alpha}` auto-derivation). External clients that addressed the adapter name must use the base model name.
- Inference `max_loras` default 8 → 1 (in-place reload reuses one slot); the `max_cpu_loras = 100` unload-era override is removed.

Part of the #3335 breakup (stack 5/6). Verified e2e as part of #3335 (LoRA reverse-text 15→20 with resume, reward climbing under the base name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the LoRA weight-update and inference serving path (how adapters are named and loaded). Breaking config/API: `orchestrator.model.lora.name` is gone and clients must hit the base model name.
> 
> **Overview**
> Registers the single training LoRA under the **base model name** so the adapter shadows the served model. Clients keep one stable name; the orchestrator/evals no longer rewrite `model_name` after each broadcast.
> 
> **`update_weights` is artifact-driven:** a dir with `adapter_config.json` is an in-place LoRA reload (no engine pause); anything else is a full checkpoint load. Dead adapter-naming machinery is gone (`lora.name` + auto `r{rank}-a{alpha}`, `update_model_name`, `unload_lora_adapter`, evals' `eval-adapter`).
> 
> **Guardrails / defaults:** `modules_to_save` is rejected when broadcasting live (only adapter tensors ship). LoRA still requires filesystem broadcast, with a clearer error. `max_loras` default is **1**; `max_cpu_loras` is removed. Example/CI configs drop explicit adapter names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45457b89419b8b397b9a61c0eb0385a565033266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->