### PR TITLE
fix: health-check only the router when admin clients bypass it

### DIFF
--- a/src/prime_rl/orchestrator/clients.py
+++ b/src/prime_rl/orchestrator/clients.py
@@ -86,8 +86,9 @@ class AdminClients:
 
     def __init__(self, client_config: ClientConfig):
         self.clients = setup_admin_clients(client_config)
-        # When admin URLs bypass a router, also health-check the client-facing
-        # (router) endpoint - it only starts serving once its workers are healthy.
+        # When admin URLs bypass a router, health-check the client-facing
+        # (router) endpoint instead of each engine - it only turns healthy
+        # once all engines are healthy.
         self._router_clients = (
             setup_admin_clients(client_config.model_copy(update={"admin_base_url": None}))
             if client_config.admin_base_url
@@ -97,7 +98,7 @@ class AdminClients:
         self._wait_for_ready_timeout = client_config.wait_for_ready_timeout
 
     async def wait_for_ready(self, model_name: str) -> None:
-        await check_health(self.clients + self._router_clients, timeout=self._wait_for_ready_timeout)
+        await check_health(self._router_clients or self.clients, timeout=self._wait_for_ready_timeout)
         await maybe_check_has_model(self.clients, model_name, skip_model_check=self._skip_model_check)
 
     async def aclose(self) -> None:

--- a/src/prime_rl/orchestrator/clients.py
+++ b/src/prime_rl/orchestrator/clients.py
@@ -86,9 +86,8 @@ class AdminClients:
 
     def __init__(self, client_config: ClientConfig):
         self.clients = setup_admin_clients(client_config)
-        # When admin URLs bypass a router, health-check the client-facing
-        # (router) endpoint instead of each engine - it only turns healthy
-        # once all engines are healthy.
+        # When admin URLs bypass a router, also health-check the client-facing
+        # (router) endpoint - it only starts serving once its workers are healthy.
         self._router_clients = (
             setup_admin_clients(client_config.model_copy(update={"admin_base_url": None}))
             if client_config.admin_base_url
@@ -98,7 +97,14 @@ class AdminClients:
         self._wait_for_ready_timeout = client_config.wait_for_ready_timeout
 
     async def wait_for_ready(self, model_name: str) -> None:
-        await check_health(self._router_clients or self.clients, timeout=self._wait_for_ready_timeout)
+        # The engines are waited on even when a router fronts them: the llm-d
+        # router (Envoy) 404s /health, which check_health treats as "no health
+        # route", so the router alone is not a readiness signal. The router
+        # owns the info-level waiting log; the per-engine waits log at debug.
+        await asyncio.gather(
+            check_health(self.clients, timeout=self._wait_for_ready_timeout, quiet=bool(self._router_clients)),
+            check_health(self._router_clients, timeout=self._wait_for_ready_timeout),
+        )
         await maybe_check_has_model(self.clients, model_name, skip_model_check=self._skip_model_check)
 
     async def aclose(self) -> None:
@@ -191,8 +197,15 @@ async def maybe_check_has_model(
 
 
 async def check_health(
-    admin_clients: list[AsyncClient], interval: int = 1, log_interval: int = 30, timeout: int = 1800
+    admin_clients: list[AsyncClient],
+    interval: int = 1,
+    log_interval: int = 30,
+    timeout: int = 1800,
+    quiet: bool = False,
 ) -> None:
+    """Wait until every client's /health responds. With ``quiet``, the periodic
+    waiting lines log at debug instead of info - used for engines fronted by a
+    router, so startup logs one waiting line instead of one per engine."""
     logger = get_logger()
 
     async def _check_health(admin_client: AsyncClient) -> None:
@@ -209,9 +222,8 @@ async def check_health(
                 return
             except Exception as e:
                 if wait_time % log_interval == 0 and wait_time > 0:
-                    logger.info(
-                        f"Waiting for inference server at {admin_client.base_url} to start up ({wait_time}s elapsed)"
-                    )
+                    log = logger.debug if quiet else logger.info
+                    log(f"Waiting for inference server at {admin_client.base_url} to start up ({wait_time}s elapsed)")
                     logger.debug(f"Inference server at {admin_client.base_url} not reachable: {e!r}")
                 await asyncio.sleep(interval)
                 wait_time += interval


### PR DESCRIPTION
## Summary

- `AdminClients.wait_for_ready` still health-checks every engine and the router, but when admin URLs bypass a router, the per-engine waiting lines log at debug. Startup then logs one info waiting line instead of one per engine plus the router:

```
03:18:09    INFO Waiting for inference server at http://localhost:8000 to start up (30s elapsed)
03:18:09    INFO Waiting for inference server at http://localhost:8100 to start up (30s elapsed)
```

- `check_health` grows a `quiet` flag that demotes its periodic waiting lines to debug.
- Deployments without a router (no `client.admin_base_url`) keep logging at info, as before.

Waiting only on the router is not enough: the llm-d router (Envoy) only routes `/v1/` and `/inference/v1/`, so `/health` 404s and `check_health` treats that as "no health route" and skips. The engines therefore stay part of the readiness wait for correctness; the router just owns the info-level log. Caveat: on llm-d deployments the info-level waiting line disappears once Envoy binds its port (the engine waits continue at debug).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Readiness polling and log-level only; no change to auth, weights, or request serving. Timeout behavior is the same, just split across two concurrent health waits.
> 
> **Overview**
> Fixes readiness for llm-d/Envoy routers: `/health` on the router 404s and was treated as “no health route,” so waiting on the router alone was not a real ready signal.
> 
> `AdminClients.wait_for_ready` now health-checks engines and router in parallel. Engine waits use a new `quiet` flag so periodic “waiting” lines log at debug when a router is present; the router still logs at info. Deployments without `admin_base_url` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5167b63bac1ed60edf3f79a99ed470d25a6a026e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->