### PR TITLE
POC: stop-gradient through context tokens (row-sparse backbone backward)

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -265,6 +265,19 @@ class ModelConfig(BaseModelConfig):
     skip_masked_lm_head_tokens: bool = True
     """Skip the LM-head vocabulary projection (forward and backward) on tokens no loss component reads — prompt tokens, env observations and pack padding. The head is the only layer that can skip them; the backbone still runs on the full sequence because attention needs it. Saves head time and activation memory in proportion to the masked fraction of the batch, and leaves every value the loss reads unchanged. Requires the fused LM head (``fused_lm_head_token_chunk_size``); ignored by the vanilla head, which materializes full-length logits by construction."""
 
+    stop_grad_context_tokens: bool = False
+    """EXPERIMENTAL: stop gradients through context tokens in the backbone. The forward pass is unchanged (context K/V are still built with current weights, so every value the loss reads is identical), but the backward only propagates through tokens some loss component reads: the backbone's linear-layer backward GEMMs run on kept rows only. Unlike ``skip_masked_lm_head_tokens`` this changes the training gradient — the loss no longer shapes how the model represents context tokens (it still learns to attend to them: k/v projections keep their full gradient). Requires ``skip_masked_lm_head_tokens`` (reuses its keep mask) and a custom-impl model whose backbone accepts ``keep_mask`` (currently Qwen3 dense)."""
+
+    @model_validator(mode="after")
+    def stop_grad_context_requires_masked_head_skip(self):
+        if self.stop_grad_context_tokens:
+            if not self.skip_masked_lm_head_tokens or not isinstance(self.fused_lm_head_token_chunk_size, int):
+                raise ValueError(
+                    "model.stop_grad_context_tokens requires model.skip_masked_lm_head_tokens=true and a fused LM "
+                    "head (model.fused_lm_head_token_chunk_size set to an int) — it reuses the same keep mask."
+                )
+        return self
+
     @model_validator(mode="after")
     def trust_remote_code_only_with_hf(self):
         """Trust remote code only if the model is from HF."""

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1351,7 +1351,13 @@ def setup_model(
     if isinstance(config.fused_lm_head_token_chunk_size, int):
         lm_head_chunk_size = config.fused_lm_head_token_chunk_size
 
-    inject_prime_lm_head(model, chunk_size=lm_head_chunk_size)
+    if config.stop_grad_context_tokens and not type(model).__module__.startswith("prime_rl.trainer.models.qwen3."):
+        raise ValueError(
+            "model.stop_grad_context_tokens currently requires the custom Qwen3 dense implementation "
+            f"(got {type(model).__module__}); other backbones don't accept keep_mask yet."
+        )
+
+    inject_prime_lm_head(model, chunk_size=lm_head_chunk_size, stop_grad_context=config.stop_grad_context_tokens)
 
     apply_quantization(model, config)
 

--- a/src/prime_rl/trainer/models/layers/attn.py
+++ b/src/prime_rl/trainer/models/layers/attn.py
@@ -7,6 +7,7 @@ from torch import nn
 
 from .norms import RMSNorm, RMSNormConfig
 from .rotary_emb import apply_rotary_pos_emb
+from .row_sparse import row_sparse_linear
 
 # flash-attention-2
 try:
@@ -124,11 +125,16 @@ class FlashAttention(nn.Module):
         self,
         hidden_states: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        keep_index: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         input_shape = hidden_states.shape[:-1]
         hidden_shape = (*input_shape, -1, self.head_dim)
 
-        query_states = self.q_proj(hidden_states)
+        # Under stop-grad-context, context-row q grads are exactly zero (their
+        # attention outputs are cut at the next layer input), so the q backward
+        # can run on kept rows only. k/v keep a full backward: kept queries
+        # attend to context k/v, so dK/dV on context rows feed the weight grads.
+        query_states = row_sparse_linear(self.q_proj, hidden_states, keep_index)
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)
 
@@ -159,8 +165,8 @@ class FlashAttention(nn.Module):
 
         return query_states, key_states, value_states
 
-    def output_proj(self, attn_output: torch.Tensor) -> torch.Tensor:
-        return self.o_proj(attn_output)
+    def output_proj(self, attn_output: torch.Tensor, keep_index: torch.Tensor | None = None) -> torch.Tensor:
+        return row_sparse_linear(self.o_proj, attn_output, keep_index)
 
     def forward(
         self,
@@ -168,8 +174,11 @@ class FlashAttention(nn.Module):
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
+        keep_index: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        query_states, key_states, value_states = self.attn_projections(hidden_states, position_embeddings)
+        query_states, key_states, value_states = self.attn_projections(
+            hidden_states, position_embeddings, keep_index=keep_index
+        )
 
         attn_output = self._attention_core(
             query_states,
@@ -178,7 +187,7 @@ class FlashAttention(nn.Module):
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
         )
-        attn_output = self.output_proj(attn_output)
+        attn_output = self.output_proj(attn_output, keep_index=keep_index)
         return attn_output, None
 
 

--- a/src/prime_rl/trainer/models/layers/lm_head.py
+++ b/src/prime_rl/trainer/models/layers/lm_head.py
@@ -241,6 +241,7 @@ class _SequenceChunkedLogProbEntropyFn(torch.autograd.Function):
 def inject_prime_lm_head(
     model: nn.Module,
     chunk_size: int | None = None,
+    stop_grad_context: bool = False,
 ) -> None:
     """
     Inject a PrimeRL LM head into a model.
@@ -252,6 +253,8 @@ def inject_prime_lm_head(
         model: The model to wrap.
         chunk_size: When set to an int, uses FusedOutputLinear with sequence-token chunked
             logprob/entropy computation.
+        stop_grad_context: When True, also forward ``keep_mask`` to the backbone so it
+            can stop gradients through context rows (``model.stop_grad_context_tokens``).
     """
     # Guards so we have nicer error messages when a non-standard model is used
     assert hasattr(model, "model"), f"model doesnt have backbone in model.model:\n{model}"
@@ -267,6 +270,8 @@ def inject_prime_lm_head(
     # Check for Gemma-style softcapping - dispatch to specialized implementation.
     final_logit_softcapping = get_final_logit_softcapping(model.config)
     if final_logit_softcapping:
+        if stop_grad_context:
+            raise NotImplementedError("model.stop_grad_context_tokens is not supported for softcapped (Gemma) models")
         from prime_rl.trainer.models.layers.lm_head_gemma import inject_gemma_lm_head
 
         inject_gemma_lm_head(model, chunk_size, final_logit_softcapping)
@@ -285,10 +290,10 @@ def inject_prime_lm_head(
     model.lm_head.weight = old_lm_head.weight
     del old_lm_head
 
-    _patch_model_forward(model)
+    _patch_model_forward(model, stop_grad_context=stop_grad_context)
 
 
-def _patch_model_forward(model: nn.Module) -> None:
+def _patch_model_forward(model: nn.Module, stop_grad_context: bool = False) -> None:
     # Patch the forward method to use the new lm_head with labels and temperature
     def new_forward(
         self: nn.Module,
@@ -309,6 +314,9 @@ def _patch_model_forward(model: nn.Module) -> None:
         model_kwargs = {"input_ids": input_ids, "position_ids": position_ids, **kwargs}
         if inputs_embeds is not None:
             model_kwargs["inputs_embeds"] = inputs_embeds
+        if stop_grad_context:
+            # The backbone stops gradients through context rows (see row_sparse.py).
+            model_kwargs["keep_mask"] = keep_mask
         outputs = self.model(**model_kwargs)
         hidden_states = outputs.last_hidden_state
 

--- a/src/prime_rl/trainer/models/layers/mlp.py
+++ b/src/prime_rl/trainer/models/layers/mlp.py
@@ -4,6 +4,8 @@ import torch
 from torch import nn
 from transformers.activations import ACT2FN
 
+from .row_sparse import row_sparse_linear
+
 
 @dataclass
 class MLPConfig:
@@ -24,6 +26,10 @@ class MLP(nn.Module):
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
         self.gate_act_fn = ACT2FN[config.gate_act]
 
-    def forward(self, x, routed_experts: torch.Tensor | None = None):
-        down_proj = self.down_proj(self.gate_act_fn(self.gate_proj(x)) * self.up_proj(x))
+    def forward(self, x, routed_experts: torch.Tensor | None = None, keep_index: torch.Tensor | None = None):
+        # Under stop-grad-context all three projections' upstream grads are zero
+        # on context rows, so their backward runs on kept rows only.
+        gate = row_sparse_linear(self.gate_proj, x, keep_index)
+        up = row_sparse_linear(self.up_proj, x, keep_index)
+        down_proj = row_sparse_linear(self.down_proj, self.gate_act_fn(gate) * up, keep_index)
         return down_proj

--- a/src/prime_rl/trainer/models/layers/row_sparse.py
+++ b/src/prime_rl/trainer/models/layers/row_sparse.py
@@ -1,0 +1,106 @@
+"""Row-sparse backbone backward (stop-gradient through context tokens).
+
+The forward pass is unchanged — every token still runs through every layer so
+that context K/V exist for the kept queries to attend to. The backward pass is
+made row-sparse: gradients only propagate through the rows some loss component
+reads (the same ``keep_mask`` the LM head skipping uses), which cuts the
+backbone's linear-layer backward GEMMs proportionally to the kept fraction.
+
+Two pieces implement the semantics of a per-layer
+``torch.where(keep, h, h.detach())`` without paying full-size backward GEMMs:
+
+- ``mask_grad``: identity forward; backward zeroes context-row gradients.
+  Placed at every decoder-layer input, it stops gradients from propagating
+  into context hidden states (and from there into earlier layers).
+- ``row_sparse_linear``: full-row forward (all rows are consumed downstream),
+  backward compacted to kept rows: ``dW = dY[keep]^T @ X[keep]`` and
+  ``dX[keep] = dY[keep] @ W`` (zeros elsewhere). Only valid for projections
+  whose upstream gradient is exactly zero on context rows under the mask-grad
+  cut: q/o and the dense MLP. The k/v projections must keep a full backward
+  because ``dK``/``dV`` on context rows are nonzero (kept queries attend to
+  them) and feed the k/v weight gradients — that is the signal that lets the
+  model keep learning how to read context.
+
+This changes the training gradient (the loss no longer shapes how context
+tokens are represented); it is NOT a pure optimization like the LM head
+skipping.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor, nn
+
+
+def backbone_keep_index(keep_mask: Tensor) -> Tensor | None:
+    """Flattened indices of rows that keep gradients. None means keep all.
+
+    An all-masked micro batch keeps one dummy row so every backward GEMM stays
+    non-empty and weight grads exist on all ranks (mirrors the LM head skip).
+    """
+    index = keep_mask.reshape(-1).nonzero(as_tuple=True)[0]
+    if index.numel() == keep_mask.numel():
+        return None
+    if index.numel() == 0:
+        return torch.zeros(1, dtype=torch.long, device=keep_mask.device)
+    return index
+
+
+class _MaskGradFn(torch.autograd.Function):
+    """Identity forward; backward multiplies the gradient by the keep mask."""
+
+    @staticmethod
+    def forward(ctx, x: Tensor, keep_mask: Tensor) -> Tensor:
+        ctx.save_for_backward(keep_mask)
+        return x
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        (keep_mask,) = ctx.saved_tensors
+        return grad_output * keep_mask.unsqueeze(-1), None
+
+
+def mask_grad(x: Tensor, keep_mask: Tensor | None) -> Tensor:
+    """Stop gradients on rows where ``keep_mask`` is False. Values unchanged."""
+    if keep_mask is None or not torch.is_grad_enabled() or not x.requires_grad:
+        return x
+    return _MaskGradFn.apply(x, keep_mask)
+
+
+class _RowSparseLinearFn(torch.autograd.Function):
+    """Linear with a full-row forward and a kept-rows-only backward."""
+
+    @staticmethod
+    def forward(ctx, x: Tensor, weight: Tensor, keep_index: Tensor) -> Tensor:
+        x_2d = x.reshape(-1, x.shape[-1])
+        out = x_2d @ weight.t()
+        ctx.save_for_backward(x_2d.index_select(0, keep_index), weight, keep_index)
+        ctx.x_shape = x.shape
+        return out.reshape(*x.shape[:-1], weight.shape[0])
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        x_keep, weight, keep_index = ctx.saved_tensors
+        grad_2d = grad_output.reshape(-1, grad_output.shape[-1])
+        grad_keep = grad_2d.index_select(0, keep_index)
+
+        grad_x = grad_weight = None
+        if ctx.needs_input_grad[0]:
+            grad_x = grad_2d.new_zeros(grad_2d.shape[0], weight.shape[1])
+            grad_x.index_copy_(0, keep_index, grad_keep @ weight)
+            grad_x = grad_x.reshape(ctx.x_shape)
+        if ctx.needs_input_grad[1]:
+            grad_weight = grad_keep.t() @ x_keep
+        return grad_x, grad_weight, None
+
+
+def row_sparse_linear(linear: nn.Linear, x: Tensor, keep_index: Tensor | None) -> Tensor:
+    """Apply ``linear`` with a backward restricted to ``keep_index`` rows.
+
+    Falls back to the plain linear when there is nothing to skip, when grad is
+    disabled (eval), or when the module is not a plain bias-free ``nn.Linear``
+    (LoRA / quantized wrappers own their backward).
+    """
+    if keep_index is None or not torch.is_grad_enabled() or type(linear) is not nn.Linear or linear.bias is not None:
+        return linear(x)
+    return _RowSparseLinearFn.apply(x, linear.weight, keep_index)

--- a/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
+++ b/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
@@ -16,6 +16,7 @@ from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
+from prime_rl.trainer.models.layers.row_sparse import backbone_keep_index, mask_grad
 from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 
@@ -68,7 +69,12 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
+        keep_mask: torch.Tensor | None = None,
+        keep_index: torch.Tensor | None = None,
     ) -> torch.FloatTensor:
+        # Stop-grad through context rows: gradients flowing out of this layer's
+        # kept rows never propagate into context rows of the layer below.
+        hidden_states = mask_grad(hidden_states, keep_mask)
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
         hidden_states, _ = self.self_attn(
@@ -76,12 +82,13 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
             position_embeddings=position_embeddings,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
+            keep_index=keep_index,
         )
         hidden_states = residual + hidden_states
 
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.mlp(hidden_states, keep_index=keep_index)
         return residual + hidden_states
 
 
@@ -160,12 +167,16 @@ class Qwen3Model(Qwen3PreTrainedModel):
         *,
         seq_lens: torch.LongTensor,
         seq_lens_are_pre_shard: bool = False,
+        keep_mask: Optional[torch.Tensor] = None,
     ) -> BaseModelOutputWithPast:
         r"""
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
             Whether `seq_lens` holds pre-CP-shard (global) document boundaries.
+        keep_mask (`torch.Tensor` of shape `(batch, seq)`, *optional*):
+            Rows that keep gradients (``model.stop_grad_context_tokens``). The forward
+            is unchanged; the backward is row-sparse (see layers/row_sparse.py).
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -184,12 +195,22 @@ class Qwen3Model(Qwen3PreTrainedModel):
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
+        keep_index = None
+        if keep_mask is not None and torch.is_grad_enabled():
+            keep_index = backbone_keep_index(keep_mask)
+            if keep_index is not None:
+                torch._dynamo.mark_dynamic(keep_index, 0)
+            else:
+                keep_mask = None  # nothing masked — run the plain path
+
         for decoder_layer in self.layers[: self.config.num_hidden_layers]:
             hidden_states = decoder_layer(
                 hidden_states,
                 position_embeddings=position_embeddings,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
+                keep_mask=keep_mask,
+                keep_index=keep_index,
             )
 
         hidden_states = self.norm(hidden_states)

--- a/tests/unit/train/test_row_sparse.py
+++ b/tests/unit/train/test_row_sparse.py
@@ -1,0 +1,102 @@
+import pytest
+import torch
+
+from prime_rl.trainer.models.layers.row_sparse import backbone_keep_index, mask_grad, row_sparse_linear
+
+
+def _reference(x, weight, keep_mask, upstream):
+    """Dense reference: plain linear + torch.where stop-grad, upstream grad masked like the loss."""
+    x = x.detach().clone().requires_grad_(True)
+    w = weight.detach().clone().requires_grad_(True)
+    x_cut = torch.where(keep_mask.unsqueeze(-1), x, x.detach())
+    out = x_cut @ w.t()
+    (out * upstream).sum().backward()
+    return out, x.grad, w.grad
+
+
+def test_row_sparse_linear_matches_dense_stop_grad():
+    """Row-sparse backward must equal the dense torch.where(detach) reference when the
+    upstream gradient is zero on masked rows (guaranteed by mask_grad in the layer)."""
+    torch.manual_seed(0)
+    n, d_in, d_out = 32, 16, 24
+    x0 = torch.randn(n, d_in)
+    w0 = torch.randn(d_out, d_in)
+    keep_mask = torch.rand(n) > 0.6
+    upstream = torch.randn(n, d_out) * keep_mask.unsqueeze(-1)  # loss reads kept rows only
+
+    ref_out, ref_gx, ref_gw = _reference(x0, w0, keep_mask, upstream)
+
+    x = x0.detach().clone().requires_grad_(True)
+    linear = torch.nn.Linear(d_in, d_out, bias=False)
+    linear.weight = torch.nn.Parameter(w0.detach().clone())
+    keep_index = backbone_keep_index(keep_mask)
+    out = row_sparse_linear(linear, mask_grad(x, keep_mask), keep_index)
+    (out * upstream).sum().backward()
+
+    torch.testing.assert_close(out, ref_out)  # forward is full-row and identical
+    torch.testing.assert_close(x.grad, ref_gx)
+    torch.testing.assert_close(linear.weight.grad, ref_gw)
+    assert (x.grad[~keep_mask] == 0).all()
+
+
+def test_backbone_keep_index_edge_cases():
+    all_true = torch.ones(8, dtype=torch.bool)
+    assert backbone_keep_index(all_true) is None
+
+    all_false = torch.zeros(8, dtype=torch.bool)
+    index = backbone_keep_index(all_false)
+    assert index is not None and index.numel() == 1  # dummy row keeps grads/collectives alive
+
+
+@pytest.mark.parametrize("stop_grad", [False, True])
+def test_qwen3_stop_grad_context_forward_identical_ctx_grads_zero(stop_grad):
+    """Full model path: forward values must be identical with/without stop-grad;
+    with stop-grad, context rows of the embedding gradient must be exactly zero."""
+    from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+
+    from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
+    from prime_rl.trainer.models.qwen3.modeling_qwen3 import Qwen3ForCausalLM
+
+    torch.manual_seed(0)
+    config = Qwen3Config(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=64,
+        attn_implementation="flash_attention_2",
+    )
+    if not torch.cuda.is_available():
+        pytest.skip("flash-attn backbone requires CUDA")
+    device = torch.device("cuda")
+
+    torch.manual_seed(0)
+    model = Qwen3ForCausalLM(config).to(device=device, dtype=torch.bfloat16)
+    inject_prime_lm_head(model, chunk_size=8, stop_grad_context=stop_grad)
+
+    s = 16
+    input_ids = torch.randint(0, 128, (1, s), device=device)
+    labels = torch.randint(0, 128, (1, s), device=device)
+    keep_mask = torch.rand(1, s, device=device) > 0.5
+    temperature = torch.ones(1, s, device=device)
+    seq_lens = torch.tensor([s], device=device)
+
+    out = model(
+        input_ids=input_ids,
+        labels=labels,
+        temperature=temperature,
+        keep_mask=keep_mask,
+        seq_lens=seq_lens,
+    )
+    out["logprobs"][keep_mask].sum().backward()
+
+    grad = model.model.embed_tokens.weight.grad
+    assert grad is not None and grad.abs().sum() > 0
+    if stop_grad:
+        # Tokens that appear ONLY at context positions must have zero embedding grad.
+        ctx_only = set(input_ids[~keep_mask].tolist()) - set(input_ids[keep_mask].tolist())
+        for token in ctx_only:
+            assert (grad[token] == 0).all(), f"context-only token {token} received embedding grad"


### PR DESCRIPTION
> POC on top of #3326 — requires that PR's keep-mask plumbing. **Changes the training gradient by design; not a pure optimization.**

## What

`model.stop_grad_context_tokens` (default `false`): keep the forward pass bit-identical (context K/V are still built with current weights), but make the backbone **backward** row-sparse — gradients only propagate through tokens some loss component reads.

Mechanism (`layers/row_sparse.py`):
- `mask_grad` at every decoder-layer input: identity forward, backward zeroes context-row grads. This stops gradient propagation into context hidden states and everything below them.
- `row_sparse_linear` for q/o and the dense MLP: full-row forward, backward compacted to kept rows (`dW = dY[keep]^T @ X[keep]`, `dX[keep] = dY[keep] @ W`). Valid because under the `mask_grad` cut their upstream grads are exactly zero on context rows.
- k/v projections keep a **full** backward: kept queries attend to context k/v, so `dK`/`dV` on context rows are nonzero and feed the k/v weight grads — the model keeps learning how to *read* context; it stops learning how to *represent* it.

Reuses the label-aligned `keep_mask` from #3326 (hence the config validator requiring `skip_masked_lm_head_tokens` + fused head). Wired for the custom Qwen3 dense backbone only; other models raise.

## Measured (4x RTX 3090, Qwen3-1.7B)

Single-GPU fwd+bwd microbench, seq 2048, on top of head-skip:

| kept fraction | head-skip only | + stop-grad | speedup |
|---|---|---|---|
| 0.62 | 499.8 ms | 448.4 ms | 1.11x |
| 0.50 | 490.0 ms | 422.9 ms | 1.16x |
| 0.20 | 453.3 ms | 336.7 ms | 1.35x |
| 0.10 | 440.5 ms | 302.4 ms | 1.46x |

SFT A/B (wordle, 12 steps, 4 GPUs, `micro_batch_size=2`, kept fraction 0.62): loss curves track closely (step 12: 0.4719 off vs 0.4816 on; grad norms lower with stop-grad, as expected with fewer gradient paths). No e2e speedup visible in this config — the runs were **data-loader-bound** (~40.8s fwd+bwd wall vs ~15s of GPU compute at these shapes; tokenization/packing dominates on this box), which masks the compute win the microbench isolates.

Correctness tests (`tests/unit/train/test_row_sparse.py`, all passing on GPU):
- row-sparse linear backward == dense `torch.where(detach)` reference (grads exact)
- all-masked batch keeps a dummy row so weight grads/collectives survive
- full Qwen3 path: forward identical with/without the flag; context-only tokens get exactly zero embedding grad

## Known gaps (POC)

- Qwen3 dense only; MoE/VLM/other backbones raise. LoRA/quantized linears fall back to dense backward.
- Attention-kernel backward itself still runs full-length (FA2 computes dQ/dK/dV for all rows); only the projection/MLP GEMMs are row-sparse. A query-split attention (grad for kept queries only) is the next ~15-20%.
- `backbone_keep_index` uses `nonzero()` (one D2H sync per micro-batch, same as the head-skip path in #3326).
- Interaction with activation checkpointing is unvalidated (recompute is full-length; savings shrink).
- Needs a real convergence study before anything beyond experiments — this changes what the model learns.
