### PR TITLE
fix(nccl): preserve checkpoint chunk boundaries during vLLM reload

### DIFF
--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -8,7 +8,7 @@ from vllm.distributed.utils import StatelessProcessGroup
 from vllm.logger import init_logger
 
 from prime_rl.inference.vllm.worker.weight_transfer import (
-    load_weights_checkpoint_layerwise,
+    load_weight_groups_checkpoint_layerwise,
     load_weights_kernel,
     update_mla_absorbed_weights,
 )
@@ -51,7 +51,7 @@ def receive_state_dict(communicator: PyNcclCommunicator) -> Generator[tuple[str,
         # Split concatenated tensor back into individual tensors
         offset = 0
         for key, shape, numel in tensor_info_list:
-            tensor = concatenated[offset : offset + numel].view(shape).clone()
+            tensor = concatenated[offset : offset + numel].view(shape)
             offset += numel
             try:
                 yield key, tensor
@@ -78,15 +78,22 @@ class NCCLWeightBroadcastReceiver:
         self.communicator = PyNcclCommunicator(pg, device=device)
 
     @torch.no_grad()
-    def receive_state_dict(self):
-        """Receives the state dict of a model from the trainer master rank using NCCL communicator."""
+    def receive_state_dicts(
+        self,
+    ) -> Generator[Generator[tuple[str, torch.Tensor], None, None], None, None]:
+        """Receive each trainer-broadcast state dict as a separate stream."""
         logger.info("Receiving weights from trainer")
         num_state_dict_to_receive = receive_integer(self.communicator)
         logger.info(f"Receiving {num_state_dict_to_receive} layer state dicts")
         for layer_id in range(num_state_dict_to_receive):
             logger.info(f"Receiving state dict {layer_id + 1}/{num_state_dict_to_receive}")
-            for key, value in receive_state_dict(self.communicator):
-                yield key, value
+            yield receive_state_dict(self.communicator)
+
+    @torch.no_grad()
+    def receive_state_dict(self):
+        """Receive trainer weights as one flat stream for kernel-format loading."""
+        for state_dict in self.receive_state_dicts():
+            yield from state_dict
 
 
 class NCCLWeightUpdateWorker(Worker):
@@ -144,15 +151,14 @@ class NCCLWeightUpdateWorker(Worker):
             model = model_runner.model
         assert isinstance(model, Module)
 
-        state_iter = self.nccl_broadcast_receiver.receive_state_dict()
         if self.quantize_in_weight_transfer:
-            load_weights_kernel(model, state_iter)
+            load_weights_kernel(model, self.nccl_broadcast_receiver.receive_state_dict())
             update_mla_absorbed_weights(model)
             return
 
-        load_weights_checkpoint_layerwise(
+        load_weight_groups_checkpoint_layerwise(
             model,
-            state_iter,
+            self.nccl_broadcast_receiver.receive_state_dicts(),
             self.model_runner.model_config,
             self.vllm_config,
         )

--- a/src/prime_rl/inference/vllm/worker/weight_transfer.py
+++ b/src/prime_rl/inference/vllm/worker/weight_transfer.py
@@ -16,11 +16,21 @@ def load_weights_checkpoint_layerwise(
     model_config,
     vllm_config,
 ) -> None:
+    load_weight_groups_checkpoint_layerwise(model, (state_iter,), model_config, vllm_config)
+
+
+def load_weight_groups_checkpoint_layerwise(
+    model: Module,
+    state_iters: Iterable[Iterable[tuple[str, torch.Tensor]]],
+    model_config,
+    vllm_config,
+) -> None:
     logger.info("Reloading checkpoint-format weights with vLLM layerwise processing")
     device = next(model.parameters()).device
     with torch.device(device), set_current_vllm_config(vllm_config):
         initialize_layerwise_reload(model)
-        model.load_weights(state_iter)  # type: ignore
+        for state_iter in state_iters:
+            model.load_weights(state_iter)  # type: ignore
         finalize_layerwise_reload(model, model_config)
 
 

--- a/tests/unit/inference/test_nccl_weight_update.py
+++ b/tests/unit/inference/test_nccl_weight_update.py
@@ -1,0 +1,92 @@
+import pickle
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from prime_rl.inference.vllm.worker import nccl, weight_transfer
+
+
+def test_receiver_preserves_state_dict_boundaries(monkeypatch):
+    receiver = object.__new__(nccl.NCCLWeightBroadcastReceiver)
+    receiver.communicator = object()
+    streams = [iter([("model.embed_tokens.weight", 0)]), iter([("model.layers.0.input_layernorm.weight", 1)])]
+
+    monkeypatch.setattr(nccl, "receive_integer", lambda _communicator: len(streams))
+    monkeypatch.setattr(nccl, "receive_state_dict", lambda _communicator: streams.pop(0))
+
+    assert [list(stream) for stream in receiver.receive_state_dicts()] == [
+        [("model.embed_tokens.weight", 0)],
+        [("model.layers.0.input_layernorm.weight", 1)],
+    ]
+
+
+def test_receive_state_dict_returns_views_of_receive_buffer():
+    metadata = {
+        torch.float32: [
+            ("model.embed_tokens.weight", torch.Size([2]), 2),
+            ("model.norm.weight", torch.Size([1]), 1),
+        ]
+    }
+    serialized_metadata = pickle.dumps(metadata)
+    payload = torch.tensor([1.0, 2.0, 3.0])
+
+    class FakeCommunicator:
+        device = torch.device("cpu")
+
+        def __init__(self):
+            self.call = 0
+            self.receive_buffer = None
+
+        def broadcast(self, tensor, src):
+            assert src == 0
+            if self.call == 0:
+                tensor.fill_(len(serialized_metadata))
+            elif self.call == 1:
+                tensor.copy_(torch.tensor(list(serialized_metadata), dtype=torch.uint8))
+            else:
+                tensor.copy_(payload)
+                self.receive_buffer = tensor
+            self.call += 1
+
+    communicator = FakeCommunicator()
+    received = list(nccl.receive_state_dict(communicator))
+
+    assert [key for key, _ in received] == ["model.embed_tokens.weight", "model.norm.weight"]
+    assert torch.equal(received[0][1], torch.tensor([1.0, 2.0]))
+    assert torch.equal(received[1][1], torch.tensor([3.0]))
+    receive_storage = communicator.receive_buffer.untyped_storage().data_ptr()
+    assert all(tensor.untyped_storage().data_ptr() == receive_storage for _, tensor in received)
+
+
+def test_layerwise_reload_consumes_each_state_dict_separately(monkeypatch):
+    events = []
+    model = Mock()
+    model.parameters.return_value = iter([SimpleNamespace(device="cpu")])
+    model.load_weights.side_effect = lambda state_iter: events.append(("load", list(state_iter)))
+
+    monkeypatch.setattr(weight_transfer, "set_current_vllm_config", lambda _config: nullcontext())
+    monkeypatch.setattr(weight_transfer, "initialize_layerwise_reload", lambda _model: events.append("initialize"))
+    monkeypatch.setattr(
+        weight_transfer,
+        "finalize_layerwise_reload",
+        lambda _model, _model_config: events.append("finalize"),
+    )
+
+    weight_transfer.load_weight_groups_checkpoint_layerwise(
+        model,
+        [
+            iter([("model.embed_tokens.weight", 0)]),
+            iter([("model.layers.0.input_layernorm.weight", 1)]),
+        ],
+        model_config=object(),
+        vllm_config=object(),
+    )
+
+    assert events == [
+        "initialize",
+        ("load", [("model.embed_tokens.weight", 0)]),
+        ("load", [("model.layers.0.input_layernorm.weight", 1)]),
+        "finalize",
+    ]


### PR DESCRIPTION
## Summary

- preserve trainer-broadcast state-dict chunk boundaries during checkpoint-format vLLM reloads
- load layer chunks within one layerwise reload lifecycle while retaining the flat stream for kernel-format loading
- avoid duplicating received tensors by yielding views into the NCCL receive buffer
- add regression coverage for framing, reload ordering, and receive-buffer storage sharing

## Failure behavior

Laguna-S-2.1 reaches the initial trainer-to-vLLM policy update, but every TP8 receiver fails while reconstructing state-dict chunk 3. The first failure is the extra tensor copy in the receive path:

```text
tensor = concatenated[offset : offset + numel].view(shape).clone()
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 20.00 MiB. GPU 2 has a total capacity of 79.18 GiB of which 11.94 MiB is free.
```

The update endpoint then reports:

```text
"POST /update_weights HTTP/1.1" 500 Internal Server Error
```

That exception aborts consumption of the current NCCL frame. The automatic retry reuses the already partially consumed stream, so payload bytes are interpreted as the next frame header. The first visible symptom is:

```text
Receiving 54639 layer state dicts
```

Subsequent impossible metadata lengths and very large allocation attempts are secondary stream-desynchronization symptoms, not the initiating error.

## Root cause

The NCCL sender broadcasts checkpoint weights as independently framed state-dict chunks, but the vLLM receiver flattened them into one stream. The receiver also cloned every split tensor, requiring an additional device allocation while the static model and KV cache occupied nearly all GPU memory. That first allocation failure interrupted a frame; retries then consumed payload bytes as metadata headers.

The fix preserves the sender's chunk boundaries through the checkpoint reload path and yields views into the contiguous NCCL receive buffer instead of cloning each tensor. vLLM is initialized once, loads each received chunk within that lifecycle, and finalizes once.

## Testing

- `uv run pytest -q tests/unit/inference tests/unit/transports/test_nccl_broadcast.py` — 17 passed, 1 skipped
- Ruff check and format checks passed
- controlled Laguna-S-2.1 BF16 GPU A/B with one trainer node and one TP8 inference node:
  - pristine `origin/main` at `f53e4d9c`: all ranks failed on the first additional 20 MiB receive clone; `/update_weights` returned HTTP 500 and a retry read the desynchronized `54639` chunk header
  - this PR at `8d2caf78`: all eight ranks received 49/49 chunks and `/update_weights` returned HTTP 200
- post-update Laguna-S-2.1 chat completion stopped normally and returned a coherent, factually correct response
