### PR TITLE
fix(orchestrator): make dispatch failures explicit

### DIFF
--- a/src/prime_rl/evals/evals.py
+++ b/src/prime_rl/evals/evals.py
@@ -417,13 +417,11 @@ class Evals:
         eff, full = effective.metrics, episodes.metrics
         triggered_at = self.eval_triggered_at.pop((batch.env_name, batch.step), None)
         elapsed = (time.perf_counter() - triggered_at) if triggered_at is not None else 0.0
-        dispatch_failure_rate = len(batch.failures) / total_attempts
         get_logger().success(
             f"Evaluated {batch.env_name} (Step {batch.step}) | "
             f"{format_time(elapsed):>7} | Reward {eff.reward.mean():.4f} | "
             f"Turns {eff.num_turns.mean():.1f} | Branches {eff.num_branches.mean():.1f} | "
-            f"Error {full.has_error.mean():.1%} | Dispatch Failure {dispatch_failure_rate:.1%} | "
-            f"Truncation {eff.is_truncated.mean():.1%}"
+            f"Error {full.has_error.mean():.1%} | Truncation {eff.is_truncated.mean():.1%}"
         )
 
     def collect_pipeline_view(self) -> tuple[str, dict[str, float]]:

--- a/src/prime_rl/evals/evals.py
+++ b/src/prime_rl/evals/evals.py
@@ -40,12 +40,13 @@ from prime_rl.orchestrator.envs import EvalEnvs
 from prime_rl.orchestrator.eval_sink import EvalSink
 from prime_rl.orchestrator.eval_source import EvalSource
 from prime_rl.orchestrator.inference_metrics import InferenceMetricsCollector
+from prime_rl.orchestrator.metrics import dispatch_failure_metrics
 from prime_rl.orchestrator.patches import (
     monkey_patch_chat_completion_logprobs,
     monkey_patch_oai_iterable_types,
 )
 from prime_rl.orchestrator.periodic_logger import PeriodicLogger
-from prime_rl.orchestrator.types import EvalBatch, Policy
+from prime_rl.orchestrator.types import DispatchFailure, EvalBatch, GroupCancellation, Policy
 from prime_rl.orchestrator.utils import eval_work, intercept_vf_logging, set_default_executor
 from prime_rl.transports.weights import WeightReceiver, setup_weight_receiver
 from prime_rl.utils.config import dump_resolved_config
@@ -375,10 +376,15 @@ class Evals:
         # An env with no examples emits no episodes, so its epoch can never finalize.
         pending = {env_name for env_name in fired if self.eval_sink.batch_size_for(env_name) > 0}
         while pending:
-            episode = await self.dispatcher.out_q.get()
-            step = eval_work(episode).step
-            await monitors.log([episode], step, "eval", "all")
-            eval_batch = self.eval_sink.add(episode)
+            item = await self.dispatcher.out_q.get()
+            if isinstance(item, GroupCancellation):
+                raise RuntimeError("Eval dispatcher emitted a group cancellation")
+            if isinstance(item, DispatchFailure):
+                eval_batch = self.eval_sink.fail(item)
+            else:
+                step = eval_work(item).step
+                await monitors.log([item], step, "eval", "all")
+                eval_batch = self.eval_sink.add(item)
             if eval_batch is not None:
                 await self.finalize_eval_batch(eval_batch)
                 pending.discard(eval_batch.env_name)
@@ -386,17 +392,24 @@ class Evals:
     async def finalize_eval_batch(self, batch: EvalBatch) -> None:
         """Persist + log one completed eval epoch through the monitors, mirroring the
         orchestrator: effective episodes plus the ``eval/{env}/...`` metric dict."""
-        if not batch.episodes:
-            get_logger().warning(f"Eval @ step={batch.step} env={batch.env_name}: no episodes returned, skipping log")
+        if not batch.episodes and not batch.failures:
+            get_logger().warning(f"Eval @ step={batch.step} env={batch.env_name}: no attempts returned, skipping log")
             return
 
-        await monitors.log(batch.episodes.effective.vf_episodes, batch.step, "eval", "effective")
+        if batch.episodes.effective:
+            await monitors.log(batch.episodes.effective.vf_episodes, batch.step, "eval", "effective")
 
         episodes = batch.episodes
         effective = episodes.effective
         metrics: dict[str, float] = {}
         for subset, pool in (("all", episodes), ("effective", effective)):
             metrics |= pool.metrics.to_wandb(prefix=f"eval/{batch.env_name}", subset=subset)
+        total_attempts = len(episodes) + len(batch.failures)
+        metrics |= dispatch_failure_metrics(
+            batch.failures,
+            prefix=f"eval/{batch.env_name}/all",
+            total_attempts=total_attempts,
+        )
         metrics[f"eval/{batch.env_name}/policy_version"] = float(batch.step)
         metrics["step"] = float(batch.step)
         await monitors.log(metrics, step=batch.step)
@@ -404,11 +417,13 @@ class Evals:
         eff, full = effective.metrics, episodes.metrics
         triggered_at = self.eval_triggered_at.pop((batch.env_name, batch.step), None)
         elapsed = (time.perf_counter() - triggered_at) if triggered_at is not None else 0.0
+        dispatch_failure_rate = len(batch.failures) / total_attempts
         get_logger().success(
             f"Evaluated {batch.env_name} (Step {batch.step}) | "
             f"{format_time(elapsed):>7} | Reward {eff.reward.mean():.4f} | "
             f"Turns {eff.num_turns.mean():.1f} | Branches {eff.num_branches.mean():.1f} | "
-            f"Error {full.has_error.mean():.1%} | Truncation {eff.is_truncated.mean():.1%}"
+            f"Error {full.has_error.mean():.1%} | Dispatch Failure {dispatch_failure_rate:.1%} | "
+            f"Truncation {eff.is_truncated.mean():.1%}"
         )
 
     def collect_pipeline_view(self) -> tuple[str, dict[str, float]]:

--- a/src/prime_rl/monitors/wandb/overview.py
+++ b/src/prime_rl/monitors/wandb/overview.py
@@ -29,6 +29,7 @@ OVERVIEW_NAME = "overview"
 # agent. Only the score metric differs — train scores with "reward/mean", eval with "avg@k" (its k
 # dynamic, so also a regex) — and each section builder prepends its own.
 COMMON_METRICS = [
+    "all/dispatch_failure/mean",
     "effective/num_total_tokens/mean",
     "effective/num_turns/mean",
     "effective/num_branches/mean",

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -6,10 +6,10 @@
   burst-capped so a raised (or drained) cap never lands all its prefills at
   once.
 - Optional rate limiting via ``AsyncLimiter(tasks_per_minute, 60)``.
-- Emit-everything invariant: every dispatched episode eventually reaches
-  ``out_q`` exactly once — as a native episode, or covered by its group's
-  single ``GroupCancellation`` message when the group is dropped. Failures
-  remain episode errors; sinks decide drop / partial-train policy.
+- Every dispatched attempt reaches ``out_q`` exactly once: as the native
+  episode returned by the environment, as a ``DispatchFailure`` when no
+  episode was produced, or under the group's ``GroupCancellation`` when the
+  orchestrator abandons it.
 - ``DispatcherMode.PREFER_TRAIN`` / ``PREFER_EVAL`` controls which kind to
   schedule next. Transitions are level-triggered (driven by the eval
   source's emptiness), so in-flight episodes of the opposite kind drain
@@ -44,6 +44,7 @@ from prime_rl.orchestrator.eval_source import EvalSource
 from prime_rl.orchestrator.train_source import TrainSource
 from prime_rl.orchestrator.types import (
     CancelReason,
+    DispatchFailure,
     DispatchResult,
     GroupCancellation,
     GroupState,
@@ -121,15 +122,6 @@ class DispatcherMetrics:
         return keys
 
 
-def _trace_task(task: vf.Task) -> vf.TraceTask:
-    return vf.TraceTask(
-        type=type(task).__name__,
-        data=task.data,
-        key=task.key,
-        hash=task.hash,
-    )
-
-
 def _validate_episode_task(episode: vf.WireEpisode, task: vf.Task) -> None:
     expected = (task.key, task.hash)
     actual = (episode.task.key, episode.task.hash)
@@ -202,7 +194,8 @@ class Dispatcher:
         # Bounded so the dispatcher backpressures on a slow sink (unbounded
         # when no hard ceiling is configured — the dynamic cap still bounds
         # in-flight work). One entry per episode — the sinks count episodes,
-        # never loose traces — plus one ``GroupCancellation`` per dropped group.
+        # never loose traces — plus terminal dispatcher events for attempts
+        # that produced no episode.
         maxsize = max(8, max_inflight_ceiling) if max_inflight_ceiling is not None else 0
         self.out_q: asyncio.Queue[DispatchResult] = asyncio.Queue(maxsize=maxsize)
 
@@ -353,7 +346,7 @@ class Dispatcher:
                     timeout=0.5,  # wake periodically to re-check fill (mode flips)
                 )
                 for task in done:
-                    await self.handle_completed_episode(task)
+                    await self.handle_completed_request(task)
         except asyncio.CancelledError:
             return
 
@@ -558,34 +551,40 @@ class Dispatcher:
         if refund_admission:
             self.admissions_in_window = max(0, self.admissions_in_window - 1)
 
-    async def handle_completed_episode(self, task: asyncio.Task) -> None:
-        """Emit every dispatched episode exactly once to ``out_q``."""
+    async def handle_completed_request(self, task: asyncio.Task) -> None:
+        """Emit the terminal result of one dispatched environment request."""
         meta = self.inflight.pop(task, None)
         if meta is None:
             return  # already handled by drop_group / cancel_inflight_episodes
         self.release(refund_admission=True)
         group = self.groups.get(meta.group_id)
 
-        is_synth_exception = False
         try:
             episode: vf.WireEpisode = task.result()
         except asyncio.CancelledError:
             return
         except Exception as exc:
-            get_logger().warning(f"Episode task failed in group {meta.group_id} ({meta.env_name}): {exc!r}")
-            episode = vf.WireEpisode(
-                env=vf.EnvInfo(id=meta.env_name),
-                task=_trace_task(meta.task),
-                ok=False,
-                errors=[
-                    vf.Error(
+            get_logger().warning(f"Environment request failed in group {meta.group_id} ({meta.env_name}): {exc!r}")
+            self.metrics.record_error(kind=meta.kind, env_name=meta.env_name)
+            policy_version = self.complete_group_member(meta, group)
+            await self.out_q.put(
+                DispatchFailure(
+                    kind=meta.kind,
+                    env_name=meta.env_name,
+                    group_id=str(meta.group_id),
+                    step=meta.step,
+                    policy_version=policy_version,
+                    task_type=type(meta.task).__name__,
+                    task_key=meta.task.key,
+                    task_hash=meta.task.hash,
+                    error=vf.Error(
                         type=type(exc).__name__,
                         message=str(exc),
                         traceback="".join(traceback.format_exception(exc)),
-                    )
-                ],
+                    ),
+                )
             )
-            is_synth_exception = True
+            return
 
         if not episode.traces and episode.ok:
             episode.ok = False
@@ -601,18 +600,28 @@ class Dispatcher:
                 get_logger().warning(f"Empty trajectory in group {meta.group_id} ({meta.env_name})")
             if trace.has_error:
                 self.metrics.record_error(kind=meta.kind, env_name=meta.env_name)
-                if not is_synth_exception and trace.last_error is not None:
+                if trace.last_error is not None:
                     get_logger().warning(
                         f"Trace failed in group {meta.group_id} ({meta.env_name}) — "
                         f"{trace.last_error.type}: {trace.last_error.message}"
                     )
         if not episode.ok and not episode.traces:
             self.metrics.record_error(kind=meta.kind, env_name=meta.env_name)
-        if not is_synth_exception and self.on_episode_complete is not None and meta.started_at > 0:
+        if self.on_episode_complete is not None and meta.started_at > 0:
             self.on_episode_complete(
                 meta.env_name, meta.kind, episode.num_total_tokens, time.monotonic() - meta.started_at
             )
         await self.emit_episode(meta, group, episode)
+
+    def complete_group_member(self, meta: InflightEpisode, group: GroupState | None) -> int:
+        """Advance group accounting and return the attempt's pinned policy version."""
+        policy_version = meta.policy_version
+        if group is not None:
+            policy_version = group.policy_version_at_start
+            group.emitted += 1
+            if group.emitted >= group.target_episodes:
+                self.groups.pop(meta.group_id, None)
+        return policy_version
 
     async def emit_episode(
         self,
@@ -622,12 +631,7 @@ class Dispatcher:
     ) -> None:
         """Stamp one completed episode with its dispatch provenance and emit it."""
         _validate_episode_task(episode, meta.task)
-        policy_version = meta.policy_version
-        if group is not None:
-            policy_version = group.policy_version_at_start
-            group.emitted += 1
-            if group.emitted >= group.target_episodes:
-                self.groups.pop(meta.group_id, None)
+        policy_version = self.complete_group_member(meta, group)
 
         episode.env.name = meta.env_name
         episode.group = vf.GroupInfo(id=str(meta.group_id))
@@ -654,7 +658,7 @@ class Dispatcher:
         # Sync claim phase: pop matching tasks from ``self.inflight`` and
         # release their permits in one non-yielding sweep. After this loop
         # the dropped tasks are no longer reachable from ``self.inflight``,
-        # so ``handle_completed_episode``'s existing None-guard makes the
+        # so ``handle_completed_request``'s existing None-guard makes the
         # subsequent async emit phase race-free.
         claimed: list[tuple[asyncio.Task, InflightEpisode]] = []
         for task, meta in list(self.inflight.items()):

--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -8,7 +8,7 @@ import verifiers.v1 as vf
 
 from prime_rl.orchestrator.envs import EvalEnvs
 from prime_rl.orchestrator.metrics import EvalEpisodes
-from prime_rl.orchestrator.types import EvalBatch
+from prime_rl.orchestrator.types import DispatchFailure, EvalBatch
 from prime_rl.orchestrator.utils import episode_env_name, episode_group_id, eval_work
 from prime_rl.utils.logger import get_logger
 
@@ -19,7 +19,9 @@ class EvalSink:
     def __init__(self, *, eval_envs: EvalEnvs) -> None:
         self.eval_envs = eval_envs
         self.pending_groups: dict[str, list[vf.Episode]] = defaultdict(list)
+        self.pending_group_failures: dict[str, list[DispatchFailure]] = defaultdict(list)
         self.pending_batches: dict[tuple[str, int], list[vf.Episode]] = defaultdict(list)
+        self.pending_batch_failures: dict[tuple[str, int], list[DispatchFailure]] = defaultdict(list)
 
     def add(self, episode: vf.Episode) -> EvalBatch | None:
         env_name = episode_env_name(episode)
@@ -28,11 +30,31 @@ class EvalSink:
         bkey = (env_name, eval_step)
         group = self.pending_groups[group_id]
         group.append(episode)
-        if len(group) >= self.group_size_for(env_name):
+        if self._group_size(group_id) >= self.group_size_for(env_name):
             self.process_group(group_id)
-        if len(self.pending_batches[bkey]) >= self.batch_size_for(env_name):
+        if self._batch_size(bkey) >= self.batch_size_for(env_name):
             return self.process_batch(bkey)
         return None
+
+    def fail(self, failure: DispatchFailure) -> EvalBatch | None:
+        """Count a request failure toward its group and eval epoch without
+        manufacturing a verifier episode."""
+        if failure.kind != "eval":
+            raise ValueError(f"EvalSink cannot process a {failure.kind} dispatch failure")
+        group_id = failure.group_id
+        bkey = (failure.env_name, failure.step)
+        self.pending_group_failures[group_id].append(failure)
+        if self._group_size(group_id) >= self.group_size_for(failure.env_name):
+            self.process_group(group_id)
+        if self._batch_size(bkey) >= self.batch_size_for(failure.env_name):
+            return self.process_batch(bkey)
+        return None
+
+    def _group_size(self, group_id: str) -> int:
+        return len(self.pending_groups[group_id]) + len(self.pending_group_failures[group_id])
+
+    def _batch_size(self, key: tuple[str, int]) -> int:
+        return len(self.pending_batches[key]) + len(self.pending_batch_failures[key])
 
     def group_size_for(self, env_name: str) -> int:
         return self.eval_envs.get(env_name).config.group_size
@@ -42,15 +64,23 @@ class EvalSink:
         return len(env.examples) * env.config.group_size
 
     def batch_progress(self) -> list[tuple[str, int, int, int, int]]:
-        batch_counts = {key: len(runs) for key, runs in self.pending_batches.items()}
+        keys = set(self.pending_batches) | set(self.pending_batch_failures)
+        batch_counts = {key: self._batch_size(key) for key in keys}
         buffered: dict[tuple[str, int], int] = {}
-        for group in self.pending_groups.values():
-            if not group:
+        group_ids = set(self.pending_groups) | set(self.pending_group_failures)
+        for group_id in group_ids:
+            group = self.pending_groups[group_id]
+            failures = self.pending_group_failures[group_id]
+            if not group and not failures:
                 continue
-            episode = group[0]
-            eval_step = eval_work(episode).step
-            key = (episode_env_name(episode), eval_step)
-            buffered[key] = buffered.get(key, 0) + len(group)
+            if group:
+                env_name = episode_env_name(group[0])
+                eval_step = eval_work(group[0]).step
+            else:
+                env_name = failures[0].env_name
+                eval_step = failures[0].step
+            key = (env_name, eval_step)
+            buffered[key] = buffered.get(key, 0) + len(group) + len(failures)
         return [
             (
                 env_name,
@@ -64,12 +94,18 @@ class EvalSink:
 
     def process_group(self, group_id: str) -> None:
         group = self.pending_groups.pop(group_id, [])
-        if not group:
+        failures = self.pending_group_failures.pop(group_id, [])
+        if not group and not failures:
             return
-        episode = group[0]
-        env_name = episode_env_name(episode)
-        eval_step = eval_work(episode).step
-        self.pending_batches[(env_name, eval_step)].extend(group)
+        if group:
+            env_name = episode_env_name(group[0])
+            eval_step = eval_work(group[0]).step
+        else:
+            env_name = failures[0].env_name
+            eval_step = failures[0].step
+        key = (env_name, eval_step)
+        self.pending_batches[key].extend(group)
+        self.pending_batch_failures[key].extend(failures)
 
         traces = [trace for episode in group for trace in episode.traces]
         survivors = [trace for trace in traces if not trace.has_error]
@@ -79,15 +115,17 @@ class EvalSink:
         task_idx = next((trace.task.data.idx for trace in traces), None)
         get_logger().debug(
             f"Finished group | env={env_name} task_idx={task_idx} "
-            f"eval_step={eval_step} | episodes={len(group)} traces={len(traces)} "
-            f"(errored={num_errored}) | reward={avg_reward:.4f}"
+            f"eval_step={eval_step} | episodes={len(group)} dispatch_failures={len(failures)} "
+            f"traces={len(traces)} (errored={num_errored + len(failures)}) | reward={avg_reward:.4f}"
         )
 
     def process_batch(self, key: tuple[str, int]) -> EvalBatch:
         env_name, step = key
         episodes = self.pending_batches.pop(key, [])
+        failures = self.pending_batch_failures.pop(key, [])
         return EvalBatch(
             env_name=env_name,
             step=step,
             episodes=EvalEpisodes(episodes, group_size=self.group_size_for(env_name)),
+            failures=failures,
         )

--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -9,9 +9,23 @@ from typing import Any, Literal
 import verifiers.v1 as vf
 
 from prime_rl.orchestrator.algo.routing import is_trainable, scalar_advantage
+from prime_rl.orchestrator.types import DispatchFailure
 from prime_rl.orchestrator.utils import compute_pass_metrics, episode_env_name, episode_group_id
 
 Subset = Literal["all", "effective"]
+
+
+def dispatch_failure_metrics(failures: list[DispatchFailure], *, prefix: str, total_attempts: int) -> dict[str, float]:
+    """Metrics for requests that failed outside the verifier episode boundary."""
+    if total_attempts == 0:
+        return {}
+    out = {f"{prefix}/dispatch_failure/mean": len(failures) / total_attempts}
+    error_types = [failure.error.type for failure in failures]
+    out |= {
+        f"{prefix}/dispatch_failure/{error_type}": float(error_types.count(error_type))
+        for error_type in sorted(set(error_types))
+    }
+    return out
 
 
 @dataclass(frozen=True)
@@ -317,8 +331,7 @@ class EpisodeMetrics:
     def cancelled(self) -> Stat:
         """Per-episode pipeline-cancellation rate — same denominator as
         ``has_error``. Read from the id-set, not the trace records, so
-        trace-less episodes (synthetic error episodes inside a voided group)
-        still count."""
+        trace-less episodes still count."""
         return Stat([float(episode.id in self.cancelled_ids) for episode in self.episodes])
 
     def to_wandb(self, *, prefix: str, subset: Subset) -> dict[str, float]:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -968,13 +968,11 @@ class Orchestrator:
         eff, full = effective.metrics, episodes.metrics
         triggered_at = self.eval_triggered_at.pop((batch.env_name, batch.step), None)
         elapsed = (time.perf_counter() - triggered_at) if triggered_at is not None else 0.0
-        dispatch_failure_rate = len(batch.failures) / total_attempts
         get_logger().success(
             f"Evaluated {batch.env_name} (Step {batch.step}) | "
             f"Policy v{policy_version} | {format_time(elapsed):>7} | Reward {eff.reward.mean():.4f} | "
             f"Turns {eff.num_turns.mean():.1f} | Branches {eff.num_branches.mean():.1f} | "
-            f"Error {full.has_error.mean():.1%} | Dispatch Failure {dispatch_failure_rate:.1%} | "
-            f"Truncation {eff.is_truncated.mean():.1%}"
+            f"Error {full.has_error.mean():.1%} | Truncation {eff.is_truncated.mean():.1%}"
         )
 
     async def maybe_save_ckpt(self, step: int) -> float:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -45,7 +45,7 @@ from prime_rl.orchestrator.envs import EvalEnvs, TrainEnvs
 from prime_rl.orchestrator.eval_sink import EvalSink
 from prime_rl.orchestrator.eval_source import EvalSource
 from prime_rl.orchestrator.inference_metrics import InferenceMetricsCollector
-from prime_rl.orchestrator.metrics import TrainEpisodes
+from prime_rl.orchestrator.metrics import TrainEpisodes, dispatch_failure_metrics
 from prime_rl.orchestrator.packing import BatchPacker
 from prime_rl.orchestrator.patches import (
     monkey_patch_chat_completion_logprobs,
@@ -55,6 +55,7 @@ from prime_rl.orchestrator.periodic_logger import PeriodicLogger
 from prime_rl.orchestrator.train_sink import TrainSink
 from prime_rl.orchestrator.train_source import TrainSource
 from prime_rl.orchestrator.types import (
+    DispatchFailure,
     EvalBatch,
     GroupCancellation,
     Policy,
@@ -524,9 +525,13 @@ class Orchestrator:
         await self.wait_for_version(self.final_version, reason="before shutdown")
 
     async def main_loop(self) -> None:
-        """Consume completed episodes and ``GroupCancellation`` events from the
-        dispatcher and route them to the train / eval sink. The sinks return a
-        finalized batch (or ``None``); we just dispatch on the result."""
+        """Consume dispatcher results and route them to the train / eval sink.
+
+        Native episodes are persisted as verifier artifacts. Dispatch failures
+        and group cancellations remain internal accounting events.
+
+        The sinks return a finalized batch (or ``None``); we just dispatch on
+        the result."""
         while not self.stopped.is_set():
             self._raise_if_component_stopped()
             if self.draining and self.dispatcher.is_idle:
@@ -545,6 +550,17 @@ class Orchestrator:
                 train_batch = await self.train_sink.cancel(item)
                 if train_batch is not None and not self.draining and not self.stopped.is_set():
                     await self.finalize_train_batch(train_batch)
+                continue
+            if isinstance(item, DispatchFailure):
+                if item.kind == "eval":
+                    assert self.eval_sink is not None
+                    eval_batch = self.eval_sink.fail(item)
+                    if eval_batch is not None:
+                        await self.finalize_eval_batch(eval_batch)
+                else:
+                    train_batch = await self.train_sink.fail(item)
+                    if train_batch is not None and not self.draining and not self.stopped.is_set():
+                        await self.finalize_train_batch(train_batch)
                 continue
             episode = item
 
@@ -669,6 +685,20 @@ class Orchestrator:
             metrics |= pool.metrics.to_wandb(prefix="train/agg", subset=subset)
             for env_name, env_pool in pool.by_env().items():
                 metrics |= env_pool.metrics.to_wandb(prefix=f"train/{env_name}", subset=subset)
+        total_attempts = len(batch.episodes) + len(batch.failures)
+        metrics |= dispatch_failure_metrics(batch.failures, prefix="train/agg/all", total_attempts=total_attempts)
+        failures_by_env: dict[str, list[DispatchFailure]] = {}
+        for failure in batch.failures:
+            failures_by_env.setdefault(failure.env_name, []).append(failure)
+        episodes_by_env = batch.episodes.by_env()
+        for env_name in set(episodes_by_env) | set(failures_by_env):
+            env_failures = failures_by_env.get(env_name, [])
+            env_attempts = len(episodes_by_env.get(env_name, TrainEpisodes())) + len(env_failures)
+            metrics |= dispatch_failure_metrics(
+                env_failures,
+                prefix=f"train/{env_name}/all",
+                total_attempts=env_attempts,
+            )
 
         # Progress / timing / env-share accounting (assembled here, not in the metrics
         # objects). ``num_tokens`` is over the full arrival window; the input/output breakdown is over
@@ -678,7 +708,9 @@ class Orchestrator:
         num_input = sum(record.trace.num_input_tokens for record in effective.records)
         num_output = sum(record.trace.num_output_tokens for record in effective.records)
         num_rollouts = batch.episodes.num_traces
-        num_unique_examples = len({episode_group_id(episode) for episode in batch.episodes})
+        group_ids = {episode_group_id(episode) for episode in batch.episodes}
+        group_ids.update(failure.group_id for failure in batch.failures)
+        num_unique_examples = len(group_ids)
         metrics |= {
             "progress/tokens": num_tokens,
             "progress/input_tokens": num_input,
@@ -839,10 +871,10 @@ class Orchestrator:
         """Per-step ``Step …`` success line. Multi-env runs append an indented ``╰─`` line per env.
         Every quality metric (Reward, Trainable, Turns, Branches, Max Off-Policy, Truncation) is
         computed over exactly the traces shipped to the trainer this step (``batch.cohort``).
-        ``Error``, ``Cancelled``, and ``Ratio`` are rates over the step's full arrival window —
+        ``Error``, ``Dispatch Failure``, ``Cancelled``, and ``Ratio`` describe the step's full arrival window —
         over the shipped set they are 0/0/share-of-shipped by construction, so the window is the
         only scope where they carry signal (and they stay disjoint: a cancellation is a pipeline
-        decision, not a rollout failure)."""
+        decision, an episode error came from the environment, and a dispatch failure produced no episode)."""
         episodes = batch.episodes
         effective = batch.cohort.effective
         eff = effective.metrics
@@ -851,13 +883,16 @@ class Orchestrator:
         n_trainable = sum(is_trainable(record.trace) for record in effective.records)
         trainable_rate = (n_trainable / n_effective) if n_effective else 0.0
         max_off_policy_steps = max((episode_staleness(episode, step)[0] for episode in effective), default=0)
+        num_attempts = len(episodes) + len(batch.failures)
+        dispatch_failure_rate = len(batch.failures) / num_attempts if num_attempts else 0.0
 
         head = (
             f"Step {step} | {format_time(step_time):>7} | Reward {eff.reward.mean():.4f} | "
             f"Trainable {n_trainable}/{n_effective} ({trainable_rate:.1%}) | "
             f"Turns {eff.num_turns.mean():.1f} | Branches {eff.num_branches.mean():.1f} | "
             f"Max Off-Policy {max_off_policy_steps} | "
-            f"Error {episodes.metrics.has_error.mean():.1%} | Cancelled {episodes.metrics.cancelled.mean():.1%} | "
+            f"Error {episodes.metrics.has_error.mean():.1%} | Dispatch Failure {dispatch_failure_rate:.1%} | "
+            f"Cancelled {episodes.metrics.cancelled.mean():.1%} | "
             f"Truncation {eff.is_truncated.mean():.1%}"
         )
         if len(self.train_envs) <= 1:
@@ -866,7 +901,10 @@ class Orchestrator:
 
         window_by_env = episodes.by_env()
         shipped_by_env = effective.by_env()
-        env_names = sorted(set(window_by_env) | set(shipped_by_env))
+        failures_by_env: dict[str, list[DispatchFailure]] = {}
+        for failure in batch.failures:
+            failures_by_env.setdefault(failure.env_name, []).append(failure)
+        env_names = sorted(set(window_by_env) | set(shipped_by_env) | set(failures_by_env))
         name_width = max((len(name) for name in env_names), default=0)
         lines = [head]
         for env_name in env_names:
@@ -874,29 +912,35 @@ class Orchestrator:
             env_eff_pool = shipped_by_env.get(env_name, TrainEpisodes())
             env_eff = env_eff_pool.metrics
             ratio = (pool.num_traces / n_generated) if n_generated else 0.0
+            env_failures = failures_by_env.get(env_name, [])
+            env_attempts = len(pool) + len(env_failures)
+            env_failure_rate = len(env_failures) / env_attempts if env_attempts else 0.0
             lines.append(
                 f"╰─ {env_name:<{name_width}} | Ratio {ratio:.1%} | Reward {env_eff.reward.mean():.4f} | "
                 f"Turns {env_eff.num_turns.mean():.1f} | Branches {env_eff.num_branches.mean():.1f} | "
                 f"Max Off-Policy {max((episode_staleness(episode, step)[0] for episode in env_eff_pool), default=0)} | "
-                f"Error {pool.metrics.has_error.mean():.1%} | Cancelled {pool.metrics.cancelled.mean():.1%} | "
+                f"Error {pool.metrics.has_error.mean():.1%} | Dispatch Failure {env_failure_rate:.1%} | "
+                f"Cancelled {pool.metrics.cancelled.mean():.1%} | "
                 f"Truncation {env_eff.is_truncated.mean():.1%}"
             )
         get_logger().success("\n\t\t ".join(lines))
 
     async def finalize_eval_batch(self, batch: EvalBatch) -> None:
         """Persist + log one completed eval epoch through the monitors."""
-        if not batch.episodes:
-            get_logger().warning(f"Eval @ step={batch.step} env={batch.env_name}: no episodes returned, skipping log")
+        if not batch.episodes and not batch.failures:
+            get_logger().warning(f"Eval @ step={batch.step} env={batch.env_name}: no attempts returned, skipping log")
             return
 
         # The non-errored subset is logged on epoch completion (multiple eval envs share the
         # step's trace file — each epoch appends its cohort once, and every record carries
         # ``env_name``); the full returned cohort already streamed into ``all`` on arrival.
-        await monitors.log(batch.episodes.effective.vf_episodes, batch.step, "eval", "effective")
+        if batch.episodes.effective:
+            await monitors.log(batch.episodes.effective.vf_episodes, batch.step, "eval", "effective")
         policy_spans = [eval_work(episode).policy for episode in batch.episodes]
         if any(span is None for span in policy_spans):
             raise ValueError(f"Eval {batch.env_name} step {batch.step} is missing policy provenance")
         policy_versions = {span.start for span in policy_spans if span is not None}
+        policy_versions.update(failure.policy_version for failure in batch.failures)
         policy_version = min(policy_versions)
         if len(policy_versions) > 1:
             get_logger().warning(
@@ -909,6 +953,12 @@ class Orchestrator:
         metrics: dict[str, float] = {}
         for subset, pool in (("all", episodes), ("effective", effective)):
             metrics |= pool.metrics.to_wandb(prefix=f"eval/{batch.env_name}", subset=subset)
+        total_attempts = len(episodes) + len(batch.failures)
+        metrics |= dispatch_failure_metrics(
+            batch.failures,
+            prefix=f"eval/{batch.env_name}/all",
+            total_attempts=total_attempts,
+        )
         metrics[f"eval/{batch.env_name}/policy_version"] = float(policy_version)
         metrics["step"] = float(batch.step)
         await monitors.log(metrics, step=batch.step)
@@ -918,11 +968,13 @@ class Orchestrator:
         eff, full = effective.metrics, episodes.metrics
         triggered_at = self.eval_triggered_at.pop((batch.env_name, batch.step), None)
         elapsed = (time.perf_counter() - triggered_at) if triggered_at is not None else 0.0
+        dispatch_failure_rate = len(batch.failures) / total_attempts
         get_logger().success(
             f"Evaluated {batch.env_name} (Step {batch.step}) | "
             f"Policy v{policy_version} | {format_time(elapsed):>7} | Reward {eff.reward.mean():.4f} | "
             f"Turns {eff.num_turns.mean():.1f} | Branches {eff.num_branches.mean():.1f} | "
-            f"Error {full.has_error.mean():.1%} | Truncation {eff.is_truncated.mean():.1%}"
+            f"Error {full.has_error.mean():.1%} | Dispatch Failure {dispatch_failure_rate:.1%} | "
+            f"Truncation {eff.is_truncated.mean():.1%}"
         )
 
     async def maybe_save_ckpt(self, step: int) -> float:

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -1,10 +1,10 @@
 """Training-side episode, group, and batch assembly.
 
-``add()`` takes one completed episode and ``cancel()`` a dropped group's
-``GroupCancellation``; both return ``TrainBatch | None``. Before every readiness
-check the sink sweeps ``pending_batch`` for traces past ``max_off_policy_steps`` —
-this sweep, not the dispatcher's in-flight cancel, is what guarantees nothing
-stale ships."""
+``add()`` takes one completed episode, ``fail()`` a request that produced no
+episode, and ``cancel()`` a dropped group's ``GroupCancellation``. Before every
+readiness check the sink sweeps ``pending_batch`` for traces past
+``max_off_policy_steps`` — this sweep, not the dispatcher's in-flight cancel,
+is what guarantees nothing stale ships."""
 
 from __future__ import annotations
 
@@ -20,7 +20,7 @@ from prime_rl.orchestrator.algo.routing import stamp_loss_routing
 from prime_rl.orchestrator.envs import TrainEnvs
 from prime_rl.orchestrator.metrics import TrainEpisodes
 from prime_rl.orchestrator.trajectories import trace_to_samples
-from prime_rl.orchestrator.types import GroupCancellation, Progress, TrainBatch
+from prime_rl.orchestrator.types import DispatchFailure, GroupCancellation, Progress, TrainBatch
 from prime_rl.orchestrator.utils import episode_env_name, episode_group_id, min_fresh_version, train_work
 from prime_rl.transports.batch import TrainingSample
 from prime_rl.utils.logger import get_logger
@@ -87,7 +87,9 @@ class TrainSink:
         self.on_result = on_result
 
         self.pending_episodes = TrainEpisodes()
+        self.pending_failures: list[DispatchFailure] = []
         self.pending_groups: dict[str, list[vf.Episode]] = defaultdict(list)
+        self.pending_group_failures: dict[str, list[DispatchFailure]] = defaultdict(list)
         # A dropped group's terminal marker; its ``count`` fills in for the
         # episodes the group will never deliver.
         self.pending_group_cancellations: dict[str, GroupCancellation] = {}
@@ -145,10 +147,22 @@ class TrainSink:
         await self.process_group(cancellation.group_id)
         return self._maybe_batch()
 
+    async def fail(self, failure: DispatchFailure) -> TrainBatch | None:
+        """Count a request failure toward its group without presenting it as
+        an episode to the algorithm or curriculum."""
+        if failure.kind != "train":
+            raise ValueError(f"TrainSink cannot process a {failure.kind} dispatch failure")
+        self.pending_group_failures[failure.group_id].append(failure)
+        if not self._group_complete(failure.group_id, failure.env_name):
+            return None
+        await self.process_group(failure.group_id)
+        return self._maybe_batch()
+
     def _group_complete(self, group_id: str, env_name: str) -> bool:
         cancellation = self.pending_group_cancellations.get(group_id)
         cancelled = cancellation.count if cancellation is not None else 0
-        return len(self.pending_groups[group_id]) + cancelled >= self.group_size_for(env_name)
+        failed = len(self.pending_group_failures[group_id])
+        return len(self.pending_groups[group_id]) + failed + cancelled >= self.group_size_for(env_name)
 
     def _maybe_batch(self) -> TrainBatch | None:
         """Sweep stale queued traces, then cut a batch if the survivors still
@@ -209,18 +223,24 @@ class TrainSink:
 
     async def process_group(self, group_id: str) -> None:
         group = self.pending_groups.pop(group_id, [])
+        failures = self.pending_group_failures.pop(group_id, [])
         cancellation = self.pending_group_cancellations.pop(group_id, None)
-        if not group and cancellation is None:
+        if not group and not failures and cancellation is None:
             return
 
-        env_name = episode_env_name(group[0]) if group else cancellation.env_name
+        env_name = (
+            episode_env_name(group[0]) if group else (failures[0].env_name if failures else cancellation.env_name)
+        )
         env = self.train_envs.get(env_name)
         traces = [trace for episode in group for trace in episode.traces]
         task_idx = next((trace.task.data.idx for trace in traces), None)
-        num_errored = sum(trace.has_error for trace in traces) + sum(
-            not episode.ok for episode in group if not episode.traces
+        num_errored = (
+            sum(trace.has_error for trace in traces)
+            + sum(not episode.ok for episode in group if not episode.traces)
+            + len(failures)
         )
-        n_owed = len(group) + (cancellation.count if cancellation is not None else 0)
+        n_owed = len(group) + len(failures) + (cancellation.count if cancellation is not None else 0)
+        self.pending_failures.extend(failures)
 
         # A stale drop voids the whole group: every member shares the dispatch
         # version, so the arrived episodes are exactly as stale as the
@@ -367,6 +387,8 @@ class TrainSink:
         cohort = TrainEpisodes(cohort_episodes, sampled_trace_ids=shipped_ids)
 
         episodes = self.pending_episodes
+        failures = self.pending_failures
         if samples:
             self.pending_episodes = TrainEpisodes()
-        return TrainBatch(episodes=episodes, cohort=cohort, samples=samples)
+            self.pending_failures = []
+        return TrainBatch(episodes=episodes, cohort=cohort, samples=samples, failures=failures)

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -115,7 +115,9 @@ class TrainSink:
         return self.pending_tokens, self.token_batch_size, "tokens"
 
     def buffered_count(self) -> int:
-        return sum(len(group) for group in self.pending_groups.values())
+        episodes = sum(len(group) for group in self.pending_groups.values())
+        failures = sum(len(group) for group in self.pending_group_failures.values())
+        return episodes + failures
 
     def pending_batch_by_env(self) -> dict[str, int]:
         counts: dict[str, int] = defaultdict(int)

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -54,12 +54,7 @@ class GroupCancellation:
 
 @dataclass(frozen=True)
 class DispatchFailure:
-    """An environment request that failed before producing an episode.
-
-    This is dispatcher accounting, not a verifier artifact: sinks count it
-    toward group completion without exposing it to algorithms, curricula, or
-    episode monitors.
-    """
+    """An environment request that failed before producing an episode."""
 
     kind: WorkKind
     env_name: str

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -52,7 +52,27 @@ class GroupCancellation:
     reason: CancelReason
 
 
-DispatchResult: TypeAlias = vf.WireEpisode | GroupCancellation
+@dataclass(frozen=True)
+class DispatchFailure:
+    """An environment request that failed before producing an episode.
+
+    This is dispatcher accounting, not a verifier artifact: sinks count it
+    toward group completion without exposing it to algorithms, curricula, or
+    episode monitors.
+    """
+
+    kind: WorkKind
+    env_name: str
+    group_id: str
+    step: int
+    policy_version: int
+    task_type: str
+    task_key: str
+    task_hash: str
+    error: vf.Error
+
+
+DispatchResult: TypeAlias = vf.WireEpisode | DispatchFailure | GroupCancellation
 
 
 @dataclass(frozen=True)
@@ -96,21 +116,26 @@ class GroupState:
 
 @dataclass
 class TrainBatch:
-    """Observation and shipped-cohort reports plus the trainer payload."""
+    """Returned episodes, dispatch failures, shipped cohort, and trainer payload."""
 
     episodes: TrainEpisodes
     cohort: TrainEpisodes
     samples: list[TrainingSample]
+    failures: list[DispatchFailure]
 
 
 @dataclass
 class EvalBatch:
-    """One env's eval epoch. ``episodes`` is the full returned cohort (errored included); its
-    ``.effective`` / ``.metrics`` views drive logging."""
+    """One env's eval epoch.
+
+    ``episodes`` is the full returned cohort (errored included), while
+    ``failures`` accounts for requests that returned no verifier artifact.
+    """
 
     env_name: str
     step: int
     episodes: EvalEpisodes
+    failures: list[DispatchFailure]
 
 
 class VersionObserver(Protocol):


### PR DESCRIPTION
## Summary

- represent environment requests that return no verifier artifact as `DispatchFailure`
- keep `WireEpisode` for real environment artifacts and route dispatch failures through explicit train/eval sink accounting
- report dispatch-failure rates separately, include them in pipeline buffer accounting, and allow failed-only eval epochs to complete
- retain dispatch-failure warnings and metrics without adding them to eval success summaries

## Motivation

An environment request can fail before an episode exists. Representing that outcome by manufacturing a `WireEpisode` crosses an abstraction boundary: it forces dispatcher-owned task data through the verifier wire schema, even though no verifier artifact was produced. With tasksets that use a concrete `TaskData` subtype, that conversion can itself raise during failure handling and wedge teardown.

This gives each terminal outcome one explicit representation: `WireEpisode` when the environment returned an artifact, `DispatchFailure` when the request produced none, and `GroupCancellation` when the orchestrator abandoned outstanding work. Sinks can still close groups, finish eval epochs, and advance zero-output accounting without exposing synthetic episodes to algorithms, curricula, or episode monitors.

## Validation

- `uv run ruff check` and `uv run ruff format --check` on the changed files
- `uv run pytest tests/unit/orchestrator -m 'not gpu' --ignore=tests/unit/orchestrator/test_qwen3_vl_e2e.py` (86 passed)
- injected a request failure with a custom `TaskData` subtype and verified dispatcher, train sink, eval sink, and metrics behavior
- ran a two-GPU reverse-text smoke through one train step, 11 in-flight cancellations, final eval 16/16, and clean process exit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core dispatcher-to-sink accounting and batch finalization paths for train and eval; behavior shifts when env requests fail early, but failures are now explicit rather than synthetic episodes that could wedge teardown.
> 
> **Overview**
> Environment requests that fail **before** any verifier episode exists are now represented as **`DispatchFailure`** instead of synthetic **`WireEpisode`** objects. The dispatcher emits **`WireEpisode`**, **`DispatchFailure`**, or **`GroupCancellation`** as the single terminal outcome per attempt.
> 
> **Train and eval sinks** route failures through new **`fail()`** paths so group and epoch completion still closes when attempts fail without artifacts (including failed-only eval epochs). Failures are **not** fed to algorithms, curricula, or episode monitors.
> 
> **Metrics and logging** add **`dispatch_failure/mean`** (and per-error-type counts) for train and eval, separate from episode **Error** and pipeline **Cancelled**. W&B overview includes **`all/dispatch_failure/mean`**. Train step logs show **Dispatch Failure** rates over the full arrival window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b008c60ab54c74ccb9327015cb5fbebdafdf1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

