### PR TITLE
fix(nccl): avoid cloning received weight tensors

### DIFF
--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -51,7 +51,7 @@ def receive_state_dict(communicator: PyNcclCommunicator) -> Generator[tuple[str,
         # Split concatenated tensor back into individual tensors
         offset = 0
         for key, shape, numel in tensor_info_list:
-            tensor = concatenated[offset : offset + numel].view(shape).clone()
+            tensor = concatenated[offset : offset + numel].view(shape)
             offset += numel
             try:
                 yield key, tensor


### PR DESCRIPTION
## Summary

- yield tensor views into the contiguous NCCL receive buffer instead of cloning every reconstructed tensor
- avoid duplicating checkpoint payloads while vLLM performs layerwise weight loading

The change intentionally keeps the existing flat receive stream and vLLM reload lifecycle. Trainer state-dict boundaries are transport framing, not loader semantics: vLLM tracks layer completion from the weights loaded for each module.

## Safety

Each yielded tensor is a disjoint view of the receive buffer. A view retains its underlying storage, so the buffer cannot be released while the loader still references one of its tensors. The existing consumers either copy tensors directly into model parameters or synchronously process the ordered checkpoint stream.

## H200 reproduction

The reported Laguna-S-2.1 failure was reproduced with one EP8 trainer node, one TP8 inference node, BF16 checkpoint transfer, and `gpu_memory_utilization = 0.94`. The receiver code at the tested baseline (`f53e4d9c`) is unchanged on current `main`.

| Receiver | Startup v0 | Post-training v1 |
|---|---:|---:|
| `main` | OOM on a 20 MiB clone in state dict 3/49; HTTP 500; retry decoded `54639` state dicts | — |
| this change | 49/49 on all 8 ranks; HTTP 200 | 49/49 on all 8 ranks; HTTP 200 |

Both successful transfers took approximately 12 seconds by broadcast markers; the trainer reported `time/broadcast_weights = 13.2418s` for v1. The inference server subsequently completed two rollout batches, and the trainer completed its first optimization step.

At `gpu_memory_utilization = 0.97`, the baseline failed earlier while allocating the 4.64 GiB receive buffer itself, so `0.94` was used to isolate the additional clone allocation.

## Validation

- `uv run --no-sync pytest -q tests/unit/inference tests/unit/transports/test_nccl_broadcast.py` — 14 passed, 1 existing skip
- `uv run --no-sync ruff check src/prime_rl/inference/vllm/worker/nccl.py`
- `uv run --no-sync python -m py_compile src/prime_rl/inference/vllm/worker/nccl.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed weight-transfer memory semantics on the inference path; incorrect view lifetime could corrupt loads, but consumers copy into model parameters synchronously.
> 
> **Overview**
> Fixes GPU OOM during NCCL weight broadcast by **not cloning** each tensor when splitting the per-dtype receive buffer in `receive_state_dict`.
> 
> Reconstructed weights are now **views** into the contiguous `concatenated` buffer (`view(shape)` only), so checkpoint payloads are not duplicated while vLLM runs layerwise loading via `load_weights_checkpoint_layerwise` / `load_weights_kernel`. The flat NCCL stream and per-state-dict receive lifecycle stay the same; disjoint views keep the buffer alive until consumers finish using yielded tensors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7bd908099d5cffb6792b9b40bdbd322851bc19a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->