### PR TITLE
docs(install): document pre-commit hook install step

### DIFF
--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -29,6 +29,8 @@ uv sync --all-extras --all-packages        # + all env packages (needed to train
 uv sync --package prime-rl --package gsm8k  # core + just one env
 ```
 
+`uv sync --group dev` installs the `pre-commit` package but leaves the git hook inert until it's wired up — run `uv run pre-commit install` once per clone (see `README.md`'s Development section).
+
 Environment packages are uv **workspace members**. Those under `deps/prime-envs/environments/*/*` are auto-discovered — adding a new env there needs no `pyproject.toml` change. verifiers' example envs are enumerated explicitly in `[tool.uv.workspace].members` (only the ones prime-rl trains or tests on) — to use another, add its path to the list. Members are opt-in: a plain `uv sync` / `--all-extras` does not install them (and would remove them if already present — re-run with `--all-packages`, or `--inexact` to keep them). Install all with `--all-packages`, or a subset with repeated `--package <env>` (include `--package prime-rl` to keep the core). If two envs pin conflicting transitive versions (all members share one lock), add the loser to `[tool.uv.workspace].exclude`.
 
 When bumping a package past the workspace-wide `exclude-newer = "7 days"` window, add it (and any newly-required transitives) to `[tool.uv.exclude-newer-package]` before refreshing `uv.lock`.


### PR DESCRIPTION
`uv sync --group dev` only installs the pre-commit package; the git hook stays inert until `uv run pre-commit install` runs, which the install skill omitted (README's Development section already covers it).