### PR TITLE
feat: dashboard daemon auto-started by launchers

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/evals.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/evals.py
@@ -86,6 +86,10 @@ class EvalsConfig(BaseConfig):
     """Weight transport for online evals. The ``sft`` launcher fills this from its
     resolved trainer transport. None uses filesystem reloads."""
 
+    dashboard: bool = True
+    """Make sure a local dashboard daemon serves this run's output dir (started on
+    demand in interactive sessions; an already-running daemon's URL is logged)."""
+
     output_dir: Path = Path("outputs")
     """Directory to write outputs to — rollout traces and logs are written as
     subdirectories. Shared with the trainer for online evals."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -299,6 +299,10 @@ class RLConfig(BaseConfig):
     slurm: SlurmConfig | None = None
     """SLURM configuration. If None, runs locally."""
 
+    dashboard: bool = True
+    """Make sure a local dashboard daemon serves this run's output dir (started on
+    demand in interactive sessions; an already-running daemon's URL is logged)."""
+
     dry_run: bool = False
     """Only validate and dump resolved configs, then exit early."""
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -285,6 +285,10 @@ class SFTConfig(BaseConfig):
     slurm: SlurmConfig | None = None
     """SLURM configuration. When set, the run is submitted as a SLURM job instead of running locally."""
 
+    dashboard: bool = True
+    """Make sure a local dashboard daemon serves this run's output dir (started on
+    demand in interactive sessions; an already-running daemon's URL is logged)."""
+
     dry_run: bool = False
     """Only validate and dump resolved configs, then exit early."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ trainer = "prime_rl.entrypoints.trainer:main"
 orchestrator = "prime_rl.entrypoints.orchestrator:main"
 evals = "prime_rl.entrypoints.evals:main"
 env-server = "prime_rl.entrypoints.env_server:main"
-dashboard = "prime_rl.dashboard.server:main"
+dashboard = "prime_rl.entrypoints.dashboard:main"
 
 [project.entry-points."vllm.general_plugins"]
 prime_rl = "prime_rl.inference.patches:apply_shared_vllm_patches"

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -19,8 +19,10 @@ live — an already-running one absorbs the new dir automatically, whatever port
 it is on. `--no-dashboard` opts a run out; non-interactive launches (CI, nohup)
 register their dir but never spawn.
 
-`--isolated` opts an instance out of all of this: it serves only the given
-dirs, registers nothing, and launchers ignore it. Use it for focused views
+## Isolated mode
+
+`--isolated` serves only the given dirs: no registry read or write, no
+discovery claim, and launchers ignore the instance. Use it for focused views
 (demos, debugging one run dir) or to keep a scratch dir out of the registry.
 
 ## Finding the live dashboard
@@ -50,7 +52,7 @@ over by the next start. Killing a dashboard never affects runs (it only reads),
 and killing a run never takes the dashboard down (it runs in its own session).
 Restart by launching any run, or directly: `uv run dashboard`.
 
-## Without the training deps
+## Dependency-free dashboard
 
 On a machine that should not resolve GPU dependencies (cluster head node,
 laptop against a mounted outputs dir), run the standalone script — an isolated

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -6,9 +6,8 @@ description: Find, start, use, and stop the local run dashboard — the web UI f
 # Run dashboard
 
 `uv run dashboard [output_dir ...]` (default `outputs/`; needs the `dashboard`
-extra) serves a web UI at `http://localhost:7788` with four views per run:
-metrics, resolved configs, a rollout trace viewer, and merged component logs.
-It only reads run dirs — safe against live runs.
+extra) serves a web UI at `http://localhost:7788`. It only reads run dirs —
+safe against live runs.
 
 ## One dashboard per host per user
 

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -31,7 +31,7 @@ Ports spill over (a taken 7788 bumps to 7789, ...), so **never probe port
 ```bash
 cat ~/.cache/prime-rl/dashboard/daemon.json   # {"pid": ..., "url": "http://localhost:<actual port>"}
 curl -sf $(jq -r .url ~/.cache/prime-rl/dashboard/daemon.json)/api/runs > /dev/null && echo live
-ps aux | grep PRIME-RL::Dashboard             # process title
+ps aux | grep PRL::Dashboard             # process title
 ```
 
 Hand the researcher the `url` from `daemon.json`. Launcher logs also print it:
@@ -42,7 +42,7 @@ instance logs to `~/.cache/prime-rl/dashboard/daemon.log`.
 
 ```bash
 kill $(jq -r .pid ~/.cache/prime-rl/dashboard/daemon.json)   # the discovered instance
-pkill -f PRIME-RL::Dashboard                                 # every dashboard on the host
+pkill -f PRL::Dashboard                                 # every dashboard on the host
 ```
 
 A clean exit releases `daemon.json`; a stale file from a dead process is taken

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: dashboard
+description: Find, start, use, and stop the local run dashboard — the web UI for run output dirs (metrics, configs, traces, logs). Use when asked for the dashboard URL, when a run needs watching in the browser, or when a dashboard must be restarted or killed.
+---
+
+# Run dashboard
+
+`uv run dashboard [output_dir ...]` (default `outputs/`; needs the `dashboard`
+extra) serves a web UI at `http://localhost:7788` with four views per run:
+metrics, resolved configs, a rollout trace viewer, and merged component logs.
+It only reads run dirs — safe against live runs.
+
+## One dashboard per host per user
+
+Every dashboard instance serves the dirs it was started with **plus** every dir
+in the per-user registry (`~/.cache/prime-rl/dashboard/dirs.json`, re-read
+live). Launchers (`rl`, `sft`, `evals`) register their output dir on every
+start and, in interactive sessions, auto-start a dashboard only when none is
+live — an already-running one absorbs the new dir automatically, whatever port
+it is on. `--no-dashboard` opts a run out; non-interactive launches (CI, nohup)
+register their dir but never spawn.
+
+`--isolated` opts an instance out of all of this: it serves only the given
+dirs, registers nothing, and launchers ignore it. Use it for focused views
+(demos, debugging one run dir) or to keep a scratch dir out of the registry.
+
+## Finding the live dashboard
+
+Ports spill over (a taken 7788 bumps to 7789, ...), so **never probe port
+7788**. Discovery:
+
+```bash
+cat ~/.cache/prime-rl/dashboard/daemon.json   # {"pid": ..., "url": "http://localhost:<actual port>"}
+curl -sf $(jq -r .url ~/.cache/prime-rl/dashboard/daemon.json)/api/runs > /dev/null && echo live
+ps aux | grep PRIME-RL::Dashboard             # process title
+```
+
+Hand the researcher the `url` from `daemon.json`. Launcher logs also print it:
+`Dashboard running at <url>` / `Dashboard started at <url>`. The auto-started
+instance logs to `~/.cache/prime-rl/dashboard/daemon.log`.
+
+## Stopping / restarting
+
+```bash
+kill $(jq -r .pid ~/.cache/prime-rl/dashboard/daemon.json)   # the discovered instance
+pkill -f PRIME-RL::Dashboard                                 # every dashboard on the host
+```
+
+A clean exit releases `daemon.json`; a stale file from a dead process is taken
+over by the next start. Killing a dashboard never affects runs (it only reads),
+and killing a run never takes the dashboard down (it runs in its own session).
+Restart by launching any run, or directly: `uv run dashboard`.
+
+## Without the training deps
+
+On a machine that should not resolve GPU dependencies (cluster head node,
+laptop against a mounted outputs dir), run the standalone script — an isolated
+uv script environment with only small wheels:
+
+```bash
+uv run --script src/prime_rl/dashboard/server.py [output_dir ...]
+```
+
+Copy the whole `src/prime_rl/dashboard/` folder when moving it (the script
+needs its `static/` sibling).

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -64,9 +64,9 @@ free one, so several dashboards run side by side without coordination. Without t
 project's GPU deps (e.g. a head node), run it standalone:
 `uv run --script src/prime_rl/dashboard/server.py [output_dir ...]`.
 
-**Daemon (auto-start)**: launchers (`rl`, `sft`, `evals`) auto-start one shared
-dashboard daemon per user in interactive sessions and register their output dir with
-it, so every new run appears on one URL. To find it, never probe port 7788 (ports
+**Daemon (auto-start)**: launchers auto-start one dashboard per host per user and a
+live one absorbs each new run's output dir automatically — see the `dashboard` skill
+for discovery, kill/restart commands, and `--isolated`. The short version: To find it, never probe port 7788 (ports
 spill over) — read the discovery file:
 
 ```bash
@@ -74,13 +74,7 @@ cat ~/.cache/prime-rl/dashboard/daemon.json   # {"pid": ..., "url": "http://loca
 ps aux | grep PRIME-RL::Dashboard             # the daemon's process title
 ```
 
-Verify liveness with `curl -sf <url>/api/runs` and hand the researcher the `url` from
-the file. Tracked output dirs live in `~/.cache/prime-rl/dashboard/dirs.json` (the
-daemon re-reads it, so appending a dir there is enough to track it). The launcher
-logs `Dashboard running at <url>` / `Dashboard started at <url>` on every run start;
-`--no-dashboard` disables the auto-start, and non-interactive launches (CI, nohup)
-register their dir but never spawn. The daemon's own log is
-`~/.cache/prime-rl/dashboard/daemon.log`.
+Verify liveness with `curl -sf <url>/api/runs` and hand the researcher the `url`.
 
 ### Logs
 

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -64,6 +64,24 @@ free one, so several dashboards run side by side without coordination. Without t
 project's GPU deps (e.g. a head node), run it standalone:
 `uv run --script src/prime_rl/dashboard/server.py [output_dir ...]`.
 
+**Daemon (auto-start)**: launchers (`rl`, `sft`, `evals`) auto-start one shared
+dashboard daemon per user in interactive sessions and register their output dir with
+it, so every new run appears on one URL. To find it, never probe port 7788 (ports
+spill over) — read the discovery file:
+
+```bash
+cat ~/.cache/prime-rl/dashboard/daemon.json   # {"pid": ..., "url": "http://localhost:<actual port>"}
+ps aux | grep PRIME-RL::Dashboard             # the daemon's process title
+```
+
+Verify liveness with `curl -sf <url>/api/runs` and hand the researcher the `url` from
+the file. Tracked output dirs live in `~/.cache/prime-rl/dashboard/dirs.json` (the
+daemon re-reads it, so appending a dir there is enough to track it). The launcher
+logs `Dashboard running at <url>` / `Dashboard started at <url>` on every run start;
+`--no-dashboard` disables the auto-start, and non-interactive launches (CI, nohup)
+register their dir but never spawn. The daemon's own log is
+`~/.cache/prime-rl/dashboard/daemon.log`.
+
 ### Logs
 
 ```

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -71,7 +71,7 @@ spill over) — read the discovery file:
 
 ```bash
 cat ~/.cache/prime-rl/dashboard/daemon.json   # {"pid": ..., "url": "http://localhost:<actual port>"}
-ps aux | grep PRIME-RL::Dashboard             # the daemon's process title
+ps aux | grep PRL::Dashboard             # the daemon's process title
 ```
 
 Verify liveness with `curl -sf <url>/api/runs` and hand the researcher the `url`.
@@ -196,13 +196,13 @@ A few warnings are normal. Escalate when errors are persistent, growing, or hit 
 All processes use `setproctitle` so they're visible in `ps`/`htop`/`pstree`:
 
 ```
-PRIME-RL::Launcher
-├── PRIME-RL::Inference          (vLLM server, GPU 0)
-├── PRIME-RL::EnvServer          (verifiers' ZMQ env server, run in-process; one per train/eval source)
+PRL::Launcher
+├── PRL::Inference          (vLLM server, GPU 0)
+├── PRL::EnvServer          (verifiers' ZMQ env server, run in-process; one per train/eval source)
 │   └── Verifiers::EnvWorker0..N
-├── PRIME-RL::Orchestrator       (CPU-only; connects to each env server)
+├── PRL::Orchestrator       (CPU-only; connects to each env server)
 ├── torchrun
-│   └── PRIME-RL::Trainer        (GPU 1+)
+│   └── PRL::Trainer        (GPU 1+)
 └── tail trainer.log
 ```
 

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -139,3 +139,12 @@ env.agent.runtime.type = "subprocess"
 - `packages/prime-rl-configs/src/prime_rl/configs/` — all config classes
 - `configs/debug/` — minimal debug configs
 - `examples/` — full example configs (e.g. `reverse-text/`)
+
+## Dashboard
+
+Interactive launches auto-start one shared dashboard daemon per user (process title
+`PRIME-RL::Dashboard`) and log its URL (`Dashboard running/started at <url>`). Relay
+that URL to the researcher. Discovery: `~/.cache/prime-rl/dashboard/daemon.json` holds
+the live `url` (the port can differ from 7788 when it was taken). `--no-dashboard`
+opts a run out.
+

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -143,7 +143,7 @@ env.agent.runtime.type = "subprocess"
 ## Dashboard
 
 Interactive launches auto-start one shared dashboard daemon per user (process title
-`PRIME-RL::Dashboard`) and log its URL (`Dashboard running/started at <url>`). Relay
+`PRL::Dashboard`) and log its URL (`Dashboard running/started at <url>`). Relay
 that URL to the researcher. Discovery: `~/.cache/prime-rl/dashboard/daemon.json` holds
 the live `url` (the port can differ from 7788 when it was taken). `--no-dashboard`
 opts a run out.

--- a/src/prime_rl/dashboard/README.md
+++ b/src/prime_rl/dashboard/README.md
@@ -2,7 +2,11 @@
 
 `uv run dashboard [output_dir ...]` — a local web dashboard for run output
 directories (metrics, resolved configs, rollout traces, component logs) at
-http://localhost:7788. Needs the `dashboard` extra.
+http://localhost:7788. Needs the `dashboard` extra. Every instance also serves
+the dirs registered by launchers in `~/.cache/prime-rl/dashboard/dirs.json`
+(one dashboard per host per user); `--isolated` serves only the given dirs and
+skips the registry. See `skills/dashboard/SKILL.md` for discovery and
+kill/restart commands.
 
 To run it without resolving the project's GPU dependencies (a cluster head
 node, a laptop against a mounted outputs dir), use the standalone script form —

--- a/src/prime_rl/dashboard/server.py
+++ b/src/prime_rl/dashboard/server.py
@@ -104,13 +104,13 @@ CACHE_DIR = home_dir() / ".cache" / "prime-rl"
 STATE_DIR = CACHE_DIR / "dashboard"
 DAEMON_FILE = STATE_DIR / "daemon.json"
 DIRS_FILE = STATE_DIR / "dirs.json"
-daemon_mode = False
 _dirs_file_state: tuple[float, list[Path]] = (0.0, [])
 
 
 def registered_dirs() -> list[Path]:
-    """Output dirs registered by launchers in dirs.json (daemon mode only),
-    re-read when the file changes so new runs' dirs appear without a restart."""
+    """Output dirs registered in dirs.json (by launchers and by every dashboard's
+    own CLI dirs), re-read when the file changes so a run in a new output dir
+    appears on the one live dashboard without a restart."""
     global _dirs_file_state
     try:
         mtime = DIRS_FILE.stat().st_mtime
@@ -125,11 +125,33 @@ def registered_dirs() -> list[Path]:
     return _dirs_file_state[1]
 
 
+def register_dirs(dirs: list[Path]) -> None:
+    """Add dirs to the shared registry (idempotent, atomic)."""
+    try:
+        known = list(orjson.loads(DIRS_FILE.read_bytes()))
+    except (OSError, ValueError):
+        known = []
+    fresh = [str(d.resolve()) for d in dirs if str(d.resolve()) not in known]
+    if not fresh:
+        return
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    tmp = DIRS_FILE.with_suffix(".tmp")
+    tmp.write_bytes(orjson.dumps(known + fresh))
+    tmp.replace(DIRS_FILE)
+
+
+isolated = False
+
+
 def tracked_dirs() -> list[Path]:
+    """One dashboard per user serves everything: the dirs it was started with
+    plus every dir any launcher (or other dashboard start) has registered.
+    --isolated opts out: only the CLI dirs, no registry."""
     dirs = list(output_dirs)
-    if daemon_mode:
-        known = {d.resolve() for d in dirs}
-        dirs.extend(d for d in registered_dirs() if d.resolve() not in known and d.is_dir())
+    if isolated:
+        return dirs
+    known = {d.resolve() for d in dirs}
+    dirs.extend(d for d in registered_dirs() if d.resolve() not in known and d.is_dir())
     return dirs
 
 
@@ -889,25 +911,29 @@ def release_daemon() -> None:
 
 
 def main() -> None:
-    global output_dirs, daemon_mode
+    global output_dirs, isolated
     parser = argparse.ArgumentParser(description="prime-rl run dashboard")
     parser.add_argument("output_dirs", nargs="*", default=None, type=Path, metavar="output_dir")
     parser.add_argument("--port", type=int, default=7788)
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument(
-        "--daemon",
+        "--isolated",
         action="store_true",
-        help="track every output dir launchers register in ~/.cache/prime-rl/dashboard/dirs.json "
-        "and record this instance's url for them to find",
+        help="serve only the given dirs: don't join the per-user registry, don't remember "
+        "these dirs, and don't claim discovery (launchers will ignore this instance)",
     )
     args = parser.parse_args()
-    daemon_mode = args.daemon
-    requested = args.output_dirs if args.output_dirs is not None else ([] if daemon_mode else [Path("outputs")])
+    isolated = args.isolated
+    requested = args.output_dirs if args.output_dirs is not None else [Path("outputs")]
     output_dirs = [d for d in requested if d.is_dir()]
     for missing in set(requested) - set(output_dirs):
         print(f"warning: output dir {missing} does not exist", file=sys.stderr)
-    if not output_dirs and not daemon_mode:
-        raise SystemExit("no existing output dir given")
+    if not isolated:
+        # this instance's dirs join the per-user registry, and it serves the union -
+        # one dashboard per host per user covers every run
+        register_dirs(output_dirs)
+    if not tracked_dirs():
+        raise SystemExit("no existing output dir given" + ("" if isolated else " (and none registered)"))
     try:
         # the shared prl proc-title util; the standalone script falls back to
         # setproctitle directly (it can't import prime_rl)
@@ -926,8 +952,8 @@ def main() -> None:
         print(f"port {args.port} is taken - serving on {port}", file=sys.stderr)
     args.port = port
     url = f"http://localhost:{args.port}"
-    if daemon_mode and not claim_daemon(url):
-        raise SystemExit(1)
+    # first non-isolated instance owns discovery; extras and --isolated still serve
+    claimed = False if isolated else claim_daemon(url)
     live = None
     stop = threading.Event()
     if sys.stdout.isatty():
@@ -956,7 +982,7 @@ def main() -> None:
         stop.set()
         if live is not None:
             live.stop()
-        if daemon_mode:
+        if claimed:
             release_daemon()
 
 

--- a/src/prime_rl/dashboard/server.py
+++ b/src/prime_rl/dashboard/server.py
@@ -8,6 +8,7 @@
 #   "tokenizers>=0.20",
 #   "huggingface_hub>=0.25",
 #   "rich>=14.0",
+#   "setproctitle>=1.3",
 # ]
 # ///
 """Local dashboard for prime-rl runs: logs, metrics, and rollout traces.
@@ -24,7 +25,9 @@ Multiple output directories can be tracked at once.
 
 import argparse
 import hashlib
+import os
 import sys
+import tempfile
 import threading
 import time
 from collections import OrderedDict
@@ -89,10 +92,51 @@ def is_run_dir(path: Path) -> bool:
     return any((path / marker).exists() for marker in ("configs", "logs", "metrics.jsonl", "rollouts"))
 
 
+def home_dir() -> Path:
+    """Best-effort home directory; fall back to the temp dir so import never fails."""
+    try:
+        return Path.home()
+    except RuntimeError:
+        return Path(tempfile.gettempdir())
+
+
+CACHE_DIR = home_dir() / ".cache" / "prime-rl"
+STATE_DIR = CACHE_DIR / "dashboard"
+DAEMON_FILE = STATE_DIR / "daemon.json"
+DIRS_FILE = STATE_DIR / "dirs.json"
+daemon_mode = False
+_dirs_file_state: tuple[float, list[Path]] = (0.0, [])
+
+
+def registered_dirs() -> list[Path]:
+    """Output dirs registered by launchers in dirs.json (daemon mode only),
+    re-read when the file changes so new runs' dirs appear without a restart."""
+    global _dirs_file_state
+    try:
+        mtime = DIRS_FILE.stat().st_mtime
+    except OSError:
+        return []
+    if mtime != _dirs_file_state[0]:
+        try:
+            dirs = [Path(d) for d in orjson.loads(DIRS_FILE.read_bytes())]
+        except (OSError, ValueError):
+            dirs = []
+        _dirs_file_state = (mtime, dirs)
+    return _dirs_file_state[1]
+
+
+def tracked_dirs() -> list[Path]:
+    dirs = list(output_dirs)
+    if daemon_mode:
+        known = {d.resolve() for d in dirs}
+        dirs.extend(d for d in registered_dirs() if d.resolve() not in known and d.is_dir())
+    return dirs
+
+
 def scan_runs() -> dict[str, Path]:
     global _run_registry
     by_name: dict[str, list[Path]] = {}
-    for base in output_dirs:
+    for base in tracked_dirs():
         if not base.is_dir():
             continue
         for run_dir in sorted(base.iterdir()):
@@ -615,7 +659,7 @@ def episode_summaries(path: Path) -> list[dict]:
 # Parsing a step's traces file for the table can mean reading gigabytes; the
 # result is persisted outside the run dir (the dashboard never writes there),
 # so a revisit — or a dashboard restart — skips the parse entirely.
-SIDECAR_DIR = Path.home() / ".cache" / "prime-rl" / "dashboard"
+SIDECAR_DIR = STATE_DIR
 SIDECAR_WRITE_INTERVAL_S = 20.0
 _sidecar_written: dict[Path, tuple[float, int]] = {}  # path -> (last write time, count)
 
@@ -797,7 +841,7 @@ def render_status(url: str):
     text.append(" · ", style="dim")
     text.append(url + "\n", style="underline #B6FF3C")
     runs = scan_runs()
-    for base in output_dirs:
+    for base in tracked_dirs():
         text.append(f"\n  {base.resolve()}/\n", style="dim")
         names = sorted(name for name, run_dir in runs.items() if run_dir.parent == base) or ["(no runs yet)"]
         for i, name in enumerate(names):
@@ -821,23 +865,69 @@ def free_port(host: str, start: int) -> int:
     raise SystemExit(f"no free port in [{start}, {start + 100})")
 
 
+def claim_daemon(url: str) -> bool:
+    """Record this process as THE dashboard daemon (pid + actual url, port
+    spillover included) so launchers can find it instead of starting another."""
+    existing = read_json(DAEMON_FILE)
+    if existing.get("pid") and existing.get("pid") != os.getpid():
+        try:
+            os.kill(existing["pid"], 0)
+            print(f"another dashboard daemon is already running at {existing.get('url')}", file=sys.stderr)
+            return False
+        except OSError:
+            pass  # stale file from a dead daemon
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    tmp = DAEMON_FILE.with_suffix(".tmp")
+    tmp.write_bytes(orjson.dumps({"pid": os.getpid(), "url": url, "started": time.time()}))
+    tmp.replace(DAEMON_FILE)
+    return True
+
+
+def release_daemon() -> None:
+    if read_json(DAEMON_FILE).get("pid") == os.getpid():
+        DAEMON_FILE.unlink(missing_ok=True)
+
+
 def main() -> None:
-    global output_dirs
+    global output_dirs, daemon_mode
     parser = argparse.ArgumentParser(description="prime-rl run dashboard")
-    parser.add_argument("output_dirs", nargs="*", default=[Path("outputs")], type=Path, metavar="output_dir")
+    parser.add_argument("output_dirs", nargs="*", default=None, type=Path, metavar="output_dir")
     parser.add_argument("--port", type=int, default=7788)
     parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument(
+        "--daemon",
+        action="store_true",
+        help="track every output dir launchers register in ~/.cache/prime-rl/dashboard/dirs.json "
+        "and record this instance's url for them to find",
+    )
     args = parser.parse_args()
-    output_dirs = [d for d in args.output_dirs if d.is_dir()]
-    for missing in set(args.output_dirs) - set(output_dirs):
+    daemon_mode = args.daemon
+    requested = args.output_dirs if args.output_dirs is not None else ([] if daemon_mode else [Path("outputs")])
+    output_dirs = [d for d in requested if d.is_dir()]
+    for missing in set(requested) - set(output_dirs):
         print(f"warning: output dir {missing} does not exist", file=sys.stderr)
-    if not output_dirs:
+    if not output_dirs and not daemon_mode:
         raise SystemExit("no existing output dir given")
+    try:
+        # the shared prl proc-title util; the standalone script falls back to
+        # setproctitle directly (it can't import prime_rl)
+        from prime_rl.utils.process import set_proc_title
+
+        set_proc_title("Dashboard")
+    except ImportError:
+        try:
+            from setproctitle import setproctitle
+
+            setproctitle("PRIME-RL::Dashboard")
+        except ImportError:
+            pass
     port = free_port(args.host, args.port)
     if port != args.port:
         print(f"port {args.port} is taken - serving on {port}", file=sys.stderr)
     args.port = port
     url = f"http://localhost:{args.port}"
+    if daemon_mode and not claim_daemon(url):
+        raise SystemExit(1)
     live = None
     stop = threading.Event()
     if sys.stdout.isatty():
@@ -866,6 +956,8 @@ def main() -> None:
         stop.set()
         if live is not None:
             live.stop()
+        if daemon_mode:
+            release_daemon()
 
 
 if __name__ == "__main__":

--- a/src/prime_rl/dashboard/server.py
+++ b/src/prime_rl/dashboard/server.py
@@ -944,7 +944,7 @@ def main() -> None:
         try:
             from setproctitle import setproctitle
 
-            setproctitle("PRIME-RL::Dashboard")
+            setproctitle("PRL::Dashboard")
         except ImportError:
             pass
     port = free_port(args.host, args.port)

--- a/src/prime_rl/entrypoints/dashboard.py
+++ b/src/prime_rl/entrypoints/dashboard.py
@@ -11,6 +11,7 @@ process title ``PRL::Dashboard``.
 
 Stdlib-only on purpose: the launcher must work without the ``dashboard`` extra
 (then it registers the dir and points at the missing extra instead of spawning).
+``main`` is the ``dashboard`` console script, delegating to the actual server.
 """
 
 import json
@@ -90,3 +91,9 @@ def ensure_dashboard(output_dir: Path, logger) -> str | None:
         time.sleep(0.25)
     logger.warning(f"Dashboard daemon did not come up - see {DAEMON_LOG}")
     return None
+
+
+def main() -> None:
+    from prime_rl.dashboard.server import main as server_main
+
+    server_main()

--- a/src/prime_rl/entrypoints/evals.py
+++ b/src/prime_rl/entrypoints/evals.py
@@ -19,7 +19,7 @@ def main():
 
     write_launch_toml(config.output_dir, "evals")
     if config.dashboard:
-        from prime_rl.utils.dashboard_daemon import ensure_dashboard
+        from prime_rl.entrypoints.dashboard import ensure_dashboard
         from prime_rl.utils.logger import get_logger, setup_logger
 
         ensure_dashboard(config.output_dir, get_logger() or setup_logger(config.log.level))

--- a/src/prime_rl/entrypoints/evals.py
+++ b/src/prime_rl/entrypoints/evals.py
@@ -18,6 +18,11 @@ def main():
     from prime_rl.utils.pathing import write_launch_toml
 
     write_launch_toml(config.output_dir, "evals")
+    if config.dashboard:
+        from prime_rl.utils.dashboard_daemon import ensure_dashboard
+        from prime_rl.utils.logger import get_logger, setup_logger
+
+        ensure_dashboard(config.output_dir, get_logger() or setup_logger(config.log.level))
     from prime_rl.evals.evals import run_evals
 
     asyncio.run(run_evals(config))

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -16,6 +16,7 @@ from prime_rl.configs.orchestrator import EnvConfig
 from prime_rl.configs.rl import RLConfig
 from prime_rl.entrypoints.inference import vllm_overrides_fragment
 from prime_rl.utils.config import cli, dump_resolved_config
+from prime_rl.utils.dashboard_daemon import ensure_dashboard
 from prime_rl.utils.logger import get_logger, setup_logger
 from prime_rl.utils.pathing import (
     clean_future_steps,
@@ -128,6 +129,9 @@ def rl_local(config: RLConfig):
     if config.dry_run:
         logger.success("Dry run complete. To start an RL run locally, remove --dry-run from your command.")
         return
+
+    if config.dashboard:
+        ensure_dashboard(config.output_dir, logger)
 
     # Derive launcher-local GPU IDs from deployment config
     gpu_offset = 0
@@ -603,6 +607,9 @@ def rl_slurm(config: RLConfig):
     if config.dry_run:
         logger.success(f"Dry run complete. To submit manually:\n\n  sbatch {script_path}\n\n{log_message}")
         return
+
+    if config.dashboard:
+        ensure_dashboard(config.output_dir, logger)
 
     logger.info(f"Submitting: sbatch {script_path}")
     result = subprocess.run(["sbatch", str(script_path)], capture_output=True, text=True)

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -14,9 +14,9 @@ from prime_rl.configs.algorithm import FrozenModelConfig
 from prime_rl.configs.inference import VllmRouterConfig
 from prime_rl.configs.orchestrator import EnvConfig
 from prime_rl.configs.rl import RLConfig
+from prime_rl.entrypoints.dashboard import ensure_dashboard
 from prime_rl.entrypoints.inference import vllm_overrides_fragment
 from prime_rl.utils.config import cli, dump_resolved_config
-from prime_rl.utils.dashboard_daemon import ensure_dashboard
 from prime_rl.utils.logger import get_logger, setup_logger
 from prime_rl.utils.pathing import (
     clean_future_steps,

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -12,8 +12,8 @@ from prime_rl.configs.evals import EvalsConfig, OnlineConfig
 from prime_rl.configs.orchestrator import EvalSourceConfig
 from prime_rl.configs.sft import SFTConfig
 from prime_rl.configs.shared import LogConfig
+from prime_rl.entrypoints.dashboard import ensure_dashboard
 from prime_rl.utils.config import cli, dump_resolved_config, find_package_resource
-from prime_rl.utils.dashboard_daemon import ensure_dashboard
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import (
     clean_future_steps,

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -13,6 +13,7 @@ from prime_rl.configs.orchestrator import EvalSourceConfig
 from prime_rl.configs.sft import SFTConfig
 from prime_rl.configs.shared import LogConfig
 from prime_rl.utils.config import cli, dump_resolved_config, find_package_resource
+from prime_rl.utils.dashboard_daemon import ensure_dashboard
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import (
     clean_future_steps,
@@ -367,6 +368,9 @@ def sft_local(config: SFTConfig):
     if config.dry_run:
         logger.success("Dry run complete. To start an SFT run locally, remove --dry-run from your command.")
         return
+
+    if config.dashboard:
+        ensure_dashboard(config.output_dir, logger)
 
     log_dir = create_attempt_log_dir(config.run_dir)
 

--- a/src/prime_rl/utils/dashboard_daemon.py
+++ b/src/prime_rl/utils/dashboard_daemon.py
@@ -1,0 +1,91 @@
+"""Launcher-side dashboard auto-start.
+
+Every launcher registers its output dir in a shared registry and makes sure one
+dashboard daemon is running (``dashboard --daemon``): the daemon tracks every
+registered dir, so each new run shows up on one URL. If a live daemon already
+exists, its URL is logged instead of starting another. Discovery goes through
+``~/.cache/prime-rl/dashboard/daemon.json`` (pid + actual url), which survives
+port spillover — never probe port 7788 directly. The daemon also carries the
+process title ``PRIME-RL::Dashboard``.
+
+Stdlib-only on purpose: the launcher must work without the ``dashboard`` extra
+(then it registers the dir and points at the missing extra instead of spawning).
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+from prime_rl.utils.pathing import CACHE_DIR
+
+STATE_DIR = CACHE_DIR / "dashboard"
+DAEMON_FILE = STATE_DIR / "daemon.json"
+DIRS_FILE = STATE_DIR / "dirs.json"
+DAEMON_LOG = STATE_DIR / "daemon.log"
+SPAWN_TIMEOUT_S = 10.0
+
+
+def register_output_dir(output_dir: Path) -> None:
+    """Add the dir to the daemon's registry (idempotent, atomic)."""
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        dirs = json.loads(DIRS_FILE.read_text())
+    except (OSError, ValueError):
+        dirs = []
+    entry = str(output_dir.resolve())
+    if entry in dirs:
+        return
+    dirs.append(entry)
+    tmp = DIRS_FILE.with_suffix(".tmp")
+    tmp.write_text(json.dumps(dirs))
+    tmp.replace(DIRS_FILE)
+
+
+def find_daemon(timeout: float = 1.0) -> dict | None:
+    """The live daemon's record ({pid, url, ...}), or None."""
+    try:
+        info = json.loads(DAEMON_FILE.read_text())
+        os.kill(info["pid"], 0)
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+    try:
+        with urllib.request.urlopen(f"{info['url']}/api/runs", timeout=timeout):
+            return info
+    except OSError:
+        return None
+
+
+def ensure_dashboard(output_dir: Path, logger) -> str | None:
+    """Register the run's output dir and make sure one dashboard daemon serves it.
+
+    Returns the dashboard URL, or None when no daemon could be found or started
+    (missing extra, non-interactive session, or startup failure).
+    """
+    register_output_dir(output_dir)
+    daemon = find_daemon()
+    if daemon is not None:
+        logger.info(f"Dashboard running at {daemon['url']}")
+        return daemon["url"]
+    if not sys.stdout.isatty():
+        return None  # never spawn daemons from CI or scripted launches
+    binary = shutil.which("dashboard")
+    if binary is None:
+        logger.warning("Dashboard entry point not found - install with `uv sync --extra dashboard`")
+        return None
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    with open(DAEMON_LOG, "ab") as log_file:
+        subprocess.Popen([binary, "--daemon"], stdout=log_file, stderr=log_file, start_new_session=True)
+    deadline = time.monotonic() + SPAWN_TIMEOUT_S
+    while time.monotonic() < deadline:
+        daemon = find_daemon()
+        if daemon is not None:
+            logger.info(f"Dashboard started at {daemon['url']}")
+            return daemon["url"]
+        time.sleep(0.25)
+    logger.warning(f"Dashboard daemon did not come up - see {DAEMON_LOG}")
+    return None

--- a/src/prime_rl/utils/dashboard_daemon.py
+++ b/src/prime_rl/utils/dashboard_daemon.py
@@ -7,7 +7,7 @@ per host per user. If a live daemon already
 exists, its URL is logged instead of starting another. Discovery goes through
 ``~/.cache/prime-rl/dashboard/daemon.json`` (pid + actual url), which survives
 port spillover — never probe port 7788 directly. The daemon also carries the
-process title ``PRIME-RL::Dashboard``.
+process title ``PRL::Dashboard``.
 
 Stdlib-only on purpose: the launcher must work without the ``dashboard`` extra
 (then it registers the dir and points at the missing extra instead of spawning).

--- a/src/prime_rl/utils/dashboard_daemon.py
+++ b/src/prime_rl/utils/dashboard_daemon.py
@@ -1,8 +1,9 @@
 """Launcher-side dashboard auto-start.
 
 Every launcher registers its output dir in a shared registry and makes sure one
-dashboard daemon is running (``dashboard --daemon``): the daemon tracks every
-registered dir, so each new run shows up on one URL. If a live daemon already
+dashboard is running: every dashboard instance serves its own dirs plus the
+registry (re-read live), so each new run shows up on one URL - one dashboard
+per host per user. If a live daemon already
 exists, its URL is logged instead of starting another. Discovery goes through
 ``~/.cache/prime-rl/dashboard/daemon.json`` (pid + actual url), which survives
 port spillover — never probe port 7788 directly. The daemon also carries the
@@ -79,7 +80,7 @@ def ensure_dashboard(output_dir: Path, logger) -> str | None:
         return None
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     with open(DAEMON_LOG, "ab") as log_file:
-        subprocess.Popen([binary, "--daemon"], stdout=log_file, stderr=log_file, start_new_session=True)
+        subprocess.Popen([binary], stdout=log_file, stderr=log_file, start_new_session=True)
     deadline = time.monotonic() + SPAWN_TIMEOUT_S
     while time.monotonic() < deadline:
         daemon = find_daemon()

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -100,7 +100,7 @@ def home_dir() -> Path:
 
 
 CACHE_DIR = home_dir() / ".cache" / "prime-rl"
-"""User-scoped cache root (mirrors verifiers' CACHE_DIR convention)."""
+"""User-scoped cache root."""
 
 
 def get_config_dir(output_dir: Path) -> Path:

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import shutil
+import tempfile
 import time
 from pathlib import Path
 
@@ -88,6 +89,18 @@ def format_log_message(
                 short = name if len(name) <= max_name else name[: max_name - 3] + "..."
                 log_lines.append(f"{i3}{f'{short}:':<{col - 2}}tail -F {env_log_dir}/eval/{name}.log")
     return "Logs:\n" + "\n".join(log_lines)
+
+
+def home_dir() -> Path:
+    """Best-effort home directory; fall back to the temp dir so import never fails."""
+    try:
+        return Path.home()
+    except RuntimeError:
+        return Path(tempfile.gettempdir())
+
+
+CACHE_DIR = home_dir() / ".cache" / "prime-rl"
+"""User-scoped cache root (mirrors verifiers' CACHE_DIR convention)."""
 
 
 def get_config_dir(output_dir: Path) -> Path:

--- a/src/prime_rl/utils/process.py
+++ b/src/prime_rl/utils/process.py
@@ -10,7 +10,7 @@ import setproctitle
 
 from prime_rl.utils.logger import get_logger
 
-PRIME_RL_PROC_PREFIX = "PRIME-RL"
+PRIME_RL_PROC_PREFIX = "PRL"
 
 
 # Applied to every launched component (trainer, orchestrator, inference).


### PR DESCRIPTION
## Summary

- **One dashboard per host per user.** Every dashboard instance serves the dirs it was started with **plus** every dir in the per-user registry (`~/.cache/prime-rl/dashboard/dirs.json`, re-read live) — daemon is a launch style, not a mode. Launchers (`rl`, `sft`, `evals`) register their output dir on every start; if a dashboard is already live (whatever its port, manually started included) it absorbs the new dir and its URL is logged (`Dashboard running at <url>`); otherwise interactive sessions auto-start one detached (`Dashboard started at <url>`). `--no-dashboard` opts a run out; CI/nohup launches register but never spawn.
- **Discovery is robust to port spillover**: `~/.cache/prime-rl/dashboard/daemon.json` records the first instance's pid and *actual* URL (the server auto-bumps past a taken 7788), with stale-file takeover; the process carries the `PRL::Dashboard` title for `ps`/`pgrep`. Never probe port 7788.
- **`--isolated`** opts an instance out entirely: only the given dirs, no registry read/write, no discovery claim — for focused views and scratch dirs that shouldn't be remembered.
- A run can never take the dashboard down: the spawned instance runs in its own session (survives SIGKILL of the whole launcher process group).
- The launcher-side helper (`prime_rl/utils/dashboard_daemon.py`) is stdlib-only, so it works without the `dashboard` extra (registers the dir and logs the install hint instead of spawning).
- `~/.cache/prime-rl` becomes a `CACHE_DIR` constant in `utils/pathing.py` (mirroring verifiers' convention); the dashboard's summary sidecars share it.
- New `skills/dashboard/SKILL.md`: start, discovery, kill/restart commands, `--isolated`, and the standalone no-GPU-deps form; `monitor-run`/`start-run` point at it.

- The proc-title prefix changes from `PRIME-RL::` to `PRL::` for **every** component (`PRL::Trainer`, `PRL::Orchestrator`, `PRL::Dashboard`, ...); anything matching the old prefix must switch.

## Verification

End-to-end on a live box with port 7788 already held by a running dashboard: a non-interactive `ensure_dashboard` registers the dir without spawning; an interactive one spawns on the spilled port and serves the registered run; a second ensure with a new output dir reuses the same instance and its runs appear within a poll; a **manually started** dashboard claims discovery and absorbs a launcher-registered dir live; `--isolated` shows only its own dirs, writes nothing to the registry, and claims nothing; the daemon survives SIGKILL of the launcher's process group; a stale `daemon.json` is taken over after the daemon dies; `pgrep -f PRL::Dashboard` finds it. `tests/unit/test_configs.py` (122 passed) and the dashboard browser smoke pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are local dev UX (dashboard daemon and docs); no training, auth, or data-path logic. The proc-title prefix change may break scripts that grep for `PRIME-RL::`.
> 
> **Overview**
> **Launchers** (`rl`, `sft`, `evals`) now default to ensuring a local run dashboard serves the run’s output dir via new `dashboard: bool = True` config (opt out with `--no-dashboard`). A stdlib-only `ensure_dashboard` registers dirs in `~/.cache/prime-rl/dashboard/dirs.json`, reuses a live daemon discovered through `daemon.json` (pid + actual URL), or spawns one detached in interactive TTY sessions only.
> 
> The **dashboard server** merges CLI dirs with the live registry, claims/releases discovery in `daemon.json`, adds **`--isolated`** (no registry/discovery), sets process title **`PRL::Dashboard`**, and shares cache layout under `CACHE_DIR` in `pathing.py`. The **`dashboard`** console script now enters through `prime_rl.entrypoints.dashboard`.
> 
> **Process titles** for all components switch prefix from `PRIME-RL::` to **`PRL::`** (docs/skills updated). New **`skills/dashboard/SKILL.md`** documents discovery, isolation, and lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57872333c17000b4737fe3078518545349ee792c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

