### PR TITLE
feat: rename proc-title prefix to PRL

### DIFF
--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -184,13 +184,13 @@ A few warnings are normal. Escalate when errors are persistent, growing, or hit 
 All processes use `setproctitle` so they're visible in `ps`/`htop`/`pstree`:
 
 ```
-PRIME-RL::Launcher
-├── PRIME-RL::Inference          (vLLM server, GPU 0)
-├── PRIME-RL::EnvServer          (verifiers' ZMQ env server, run in-process; one per train/eval source)
+PRL::Launcher
+├── PRL::Inference          (vLLM server, GPU 0)
+├── PRL::EnvServer          (verifiers' ZMQ env server, run in-process; one per train/eval source)
 │   └── Verifiers::EnvWorker0..N
-├── PRIME-RL::Orchestrator       (CPU-only; connects to each env server)
+├── PRL::Orchestrator       (CPU-only; connects to each env server)
 ├── torchrun
-│   └── PRIME-RL::Trainer        (GPU 1+)
+│   └── PRL::Trainer        (GPU 1+)
 └── tail trainer.log
 ```
 

--- a/src/prime_rl/utils/process.py
+++ b/src/prime_rl/utils/process.py
@@ -10,7 +10,7 @@ import setproctitle
 
 from prime_rl.utils.logger import get_logger
 
-PRIME_RL_PROC_PREFIX = "PRIME-RL"
+PRIME_RL_PROC_PREFIX = "PRL"
 
 
 # Applied to every launched component (trainer, orchestrator, inference).


### PR DESCRIPTION
## Summary

- `PRIME_RL_PROC_PREFIX` becomes `PRL`, so every component's process title reads `PRL::Trainer`, `PRL::Orchestrator`, `PRL::Inference`, `PRL::EnvServer`, `PRL::Launcher`, ... — shorter to type and grep. The `monitor-run` skill's process tree is updated.

## Breaking

- Process titles change from `PRIME-RL::<Name>` to `PRL::<Name>`; anything matching the old prefix (`pgrep -f PRIME-RL`, dashboards, ops scripts) must switch.

First PR of a 3-stack: PRL prefix → CPU-only `uv sync` (GPU deps behind an extra) → dashboard daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change with no runtime logic impact; risk is limited to external tooling that still matches the old process-title prefix.
> 
> **Overview**
> Process titles set via `setproctitle` now use the shorter **`PRL::<component>`** prefix instead of **`PRIME-RL::<component>`**, by changing `PRIME_RL_PROC_PREFIX` in `process.py` from `PRIME-RL` to `PRL`. That affects every launched role (Launcher, Inference, EnvServer, Orchestrator, Trainer, Evals, SFT, etc.) without touching individual entrypoints.
> 
> The **monitor-run** skill’s process-tree diagram is updated so ops docs match what appears in `ps`/`htop`/`pstree`.
> 
> **Breaking for operations:** anything that filters on the old string (`pgrep -f PRIME-RL`, dashboards, kill scripts) must switch to `PRL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cd444d1f41f3e50dbc40f9e7895164a07f8a564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->