### PR TITLE
chore: bump verifiers to 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "setproctitle>=1.3.0",
     "uvloop>=0.21.0",
     "torchtitan",
-    "verifiers[harbor]>=0.3.1.dev59",
+    "verifiers[harbor]>=0.3.1",
     "renderers>=0.1.10",
     "dion",
     "tilelang>=0.1.8",


### PR DESCRIPTION
## Summary

- require the stable `verifiers[harbor]>=0.3.1` release instead of a development build
- point the Verifiers submodule at the published `v0.3.1` tag

## Verification

- `uv lock --check`
- built `verifiers-0.3.1-py3-none-any.whl` and `verifiers-0.3.1.tar.gz` from `deps/verifiers`
- verified the submodule commit has the exact `v0.3.1` tag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency constraint only—switches from a dev pre-release to the stable 0.3.1 minimum with no application code changes in this diff.
> 
> **Overview**
> Pins **`verifiers[harbor]`** to the stable **`>=0.3.1`** release instead of the prior **`>=0.3.1.dev59`** development build in `pyproject.toml`.
> 
> This moves dependency resolution off a pre-release dev tag onto the published 0.3.1 line while keeping the same optional **`harbor`** extra and existing editable **`deps/verifiers`** source configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f399e80c03ad6e26533aa770df28e90c69517891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->