### PR TITLE
fix: stream-ordering crash in SignSGD under FSDP2

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -84,7 +84,11 @@ def train(config: TrainerConfig):
     # Setup the monitors
     asyncio.run(
         monitors.setup(
-            wandb=config.monitors.wandb, file=config.monitors.file, output_dir=config.output_dir, run_config=config
+            producer="trainer",
+            wandb=config.monitors.wandb,
+            file=config.monitors.file,
+            output_dir=config.output_dir,
+            run_config=config,
         )
     )
 
@@ -600,7 +604,12 @@ def train(config: TrainerConfig):
                 broadcast_weights_start_time = time.perf_counter()
                 # The per-layer gather + fp8 conversion peaks ~50 GiB above the
                 # resident weights; release cached blocks (incl. offload-stream
-                # pools) so the broadcast gets the full headroom.
+                # pools) so the broadcast gets the full headroom. Drain all
+                # pending work first: empty_cache returns blocks to the driver,
+                # so a still-running kernel holding a cached block (e.g. the
+                # optimizer step's tail) faults with an illegal memory access
+                # once its block is freed under it.
+                torch.cuda.synchronize()
                 torch.cuda.empty_cache()
                 weight_sender.broadcast(model, step=progress.step)
                 broadcast_weights_time = time.perf_counter() - broadcast_weights_start_time

--- a/src/prime_rl/trainer/sign_sgd.py
+++ b/src/prime_rl/trainer/sign_sgd.py
@@ -1,6 +1,7 @@
 from typing import Callable
 
 import torch
+from torch.distributed.tensor import DTensor
 from torch.optim import Optimizer
 
 
@@ -39,10 +40,9 @@ class SignSGD(Optimizer):
                 loss = closure()
 
         for group in self.param_groups:
-            # Batch per (device, dtype): foreach ops need homogeneous lists,
-            # and a few fused launches (vs thousands of per-param kernels)
-            # keep the step's kernel tail from overlapping the grad frees and
-            # collectives that follow it
+            # Batch per (device, dtype): a few fused launches (vs thousands of
+            # per-param kernels) keep the step's kernel tail from overlapping
+            # the grad frees and collectives that follow it
             buckets: dict[tuple, list] = {}
             for p in group["params"]:
                 if p.grad is None:
@@ -50,10 +50,16 @@ class SignSGD(Optimizer):
                 buckets.setdefault((p.device, p.dtype), []).append(p)
 
             for params in buckets.values():
-                grads = [p.grad for p in params]
+                # Update the local shards directly: every op below is
+                # pointwise and grads share the param's placement at step
+                # time, so the update commutes with sharding — and plain
+                # tensors keep foreach dispatch available
+                # (aten._foreach_sign has no DTensor sharding strategy)
+                local_params = [p.to_local() if isinstance(p, DTensor) else p for p in params]
+                local_grads = [p.grad.to_local() if isinstance(p.grad, DTensor) else p.grad for p in params]
                 if group["weight_decay"] > 0.0:
-                    torch._foreach_mul_(params, 1 - group["lr"] * group["weight_decay"])
-                signs = torch._foreach_sign(grads)
-                torch._foreach_add_(params, signs, alpha=-group["lr"])
+                    torch._foreach_mul_(local_params, 1 - group["lr"] * group["weight_decay"])
+                signs = torch._foreach_sign(local_grads)
+                torch._foreach_add_(local_params, signs, alpha=-group["lr"])
 
         return loss

--- a/src/prime_rl/trainer/sign_sgd.py
+++ b/src/prime_rl/trainer/sign_sgd.py
@@ -39,15 +39,21 @@ class SignSGD(Optimizer):
                 loss = closure()
 
         for group in self.param_groups:
+            # Batch per (device, dtype): foreach ops need homogeneous lists,
+            # and a few fused launches (vs thousands of per-param kernels)
+            # keep the step's kernel tail from overlapping the grad frees and
+            # collectives that follow it
+            buckets: dict[tuple, list] = {}
             for p in group["params"]:
                 if p.grad is None:
                     continue
+                buckets.setdefault((p.device, p.dtype), []).append(p)
 
-                sign_grad = torch.sign(p.grad)
-
+            for params in buckets.values():
+                grads = [p.grad for p in params]
                 if group["weight_decay"] > 0.0:
-                    p.add_(p, alpha=-group["lr"] * group["weight_decay"])
-
-                p.add_(sign_grad, alpha=-group["lr"])
+                    torch._foreach_mul_(params, 1 - group["lr"] * group["weight_decay"])
+                signs = torch._foreach_sign(grads)
+                torch._foreach_add_(params, signs, alpha=-group["lr"])
 
         return loss


### PR DESCRIPTION
## Summary

Fixes the deterministic `CUDA error: an illegal memory access` that killed every SignSGD run without full optimizer offload (crash right after step 1, all attempts, plain and `optim_cpu_offload` paths alike).

- **Root cause**: the pre-broadcast `torch.cuda.empty_cache()` (added in #3234 for FP8 gather headroom) runs immediately after `optimizer.step()` and returns cached blocks to the driver. A kernel still in flight that references a cached block faults once the block is freed under it. SignSGD's per-param loop launches thousands of tiny kernels whose async tail is still running at that point; AdamW's compact foreach step happens to finish in time, which is why only SignSGD crashed. `CUDA_LAUNCH_BLOCKING=1` makes the crash vanish (ordering, not indexing), and the failing stack points at `empty_cache` itself.
- **Fix**: `torch.cuda.synchronize()` before that `empty_cache()` — drain pending work before releasing blocks. Costs ~ms once per step, protects every optimizer.
- **Hardening**: rewrite `SignSGD.step` with foreach ops over local shards, bucketed per (device, dtype) — a few fused launches instead of thousands (`aten._foreach_sign` has no DTensor sharding strategy, hence `to_local()`; every op is pointwise and grads share the param's placement at step time, so the update commutes with sharding). Update semantics are unchanged and verified against the previous formula (decoupled decay `p *= 1 - lr*wd`, then `p -= lr * sign(g)`).

## Verification

Before/after on GLM-4.5-Air scaleswe, 2 trainer + 2 inference nodes, `sign_sgd` + `optim_cpu_offload`, no full offload:

| state | outcome |
|---|---|
| main (per-param SignSGD, no sync) | illegal memory access right after step 1, 2/2 slurm attempts |
| foreach SignSGD alone, no sync | same crash after step 3 (narrowed, not fixed) |
| main + `CUDA_LAUNCH_BLOCKING=1` | no crash — confirms stream-ordering race |
| **this PR (sync + foreach)** | [runs clean](https://wandb.ai/primeintellect/swe-ablations?nw=nwuser&search=sgd-nooffload): 6+ steps and counting through the previously fatal step-1→2 boundary, healthy grad norms and KL |

Also verified on the fake-data debug config (`torchrun --nproc-per-node=2 -m prime_rl.entrypoints.trainer @ configs/debug/fake/rl.toml --optim.type sign_sgd`): 5/5 steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)