### PR TITLE
fix: misc dashboard improvs

### DIFF
--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -167,9 +167,8 @@ function applyRunTypeControls() {
   $("#trace-subset").hidden = isEval;
   $("#tm-step-prev").hidden = isEval;
   $("#tm-step-next").hidden = isEval;
-  $("#tm-kind").hidden = isEval || state.meta?.type === "sft";
-  $("#tm-subset").hidden = isEval;
-  $(".tm-filterhead").hidden = isEval;
+  $("#tm-kind-row").hidden = isEval || state.meta?.type === "sft";
+  $("#tm-subset-row").hidden = isEval;
 }
 
 async function selectRun(name) {

--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -1969,7 +1969,7 @@ function filteredRollouts() {
 
 function tmItemHtml(e) {
   return (
-    `<div class="tm-item ${e.line === currentLine ? "active" : ""}" data-line="${e.line}">` +
+    `<div class="tm-item ${e.line === currentLine ? "active" : ""}${e.num_errors || !e.ok ? " err" : ""}" data-line="${e.line}">` +
     `<span class="tm-num">#${e.line}</span><span class="tm-env muted" title="${esc(e.env ?? "")}">${esc(e.env ?? "")}</span>` +
     `<span class="tm-reward ${rewardClass(e.reward)}">${fmtReward(e.reward)}</span></div>`
   );

--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -259,7 +259,7 @@ function renderOverview() {
   // rollout dirs can run one step past max_steps (the final ship drains late
   // arrivals), so the headline caps at the configured horizon
   const shownStep = step != null && meta.max_steps ? Math.min(step, meta.max_steps) : step;
-  const stepText = `${shownStep != null ? shownStep.toLocaleString() : "n/a"}/${meta.max_steps ? meta.max_steps.toLocaleString() : "∞"}`;
+  const stepText = `${shownStep != null ? shownStep.toLocaleString() : "–"}/${meta.max_steps ? meta.max_steps.toLocaleString() : "∞"}`;
   const left = [
     ["status", `<span class="badge st-${status}">${status}</span>`],
     ["type", `<span class="val">${esc((meta.type ?? "n/a").toUpperCase())}</span>`],

--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -49,7 +49,7 @@ const state = {
 };
 
 function fmtNum(v) {
-  if (v == null || Number.isNaN(v)) return "–";
+  if (v == null || Number.isNaN(v)) return "n/a";
   if (v === 0) return "0";
   const abs = Math.abs(v);
   if (abs >= 1e6 || abs < 1e-3) return v.toExponential(2);
@@ -57,10 +57,10 @@ function fmtNum(v) {
   if (Number.isInteger(v)) return String(v);
   return v.toPrecision(4).replace(/(\.\d*?)0+$/, "$1").replace(/\.$/, "");
 }
-const fmtReward = (v) => (v == null || Number.isNaN(v) ? "–" : v.toFixed(3));
+const fmtReward = (v) => (v == null || Number.isNaN(v) ? "n/a" : v.toFixed(3));
 /* compact human counts that never overflow: 1.1K, 2.2M, 3.3B */
 function fmtCompact(n) {
-  if (n == null || Number.isNaN(n)) return "–";
+  if (n == null || Number.isNaN(n)) return "n/a";
   const abs = Math.abs(n);
   if (abs >= 1e9) return `${+(n / 1e9).toFixed(abs >= 1e10 ? 0 : 1)}B`;
   if (abs >= 1e6) return `${+(n / 1e6).toFixed(abs >= 1e7 ? 0 : 1)}M`;
@@ -68,7 +68,7 @@ function fmtCompact(n) {
   return String(n);
 }
 function fmtCost(v) {
-  if (v == null || Number.isNaN(v)) return "–";
+  if (v == null || Number.isNaN(v)) return "n/a";
   return `$${v >= 1 ? v.toFixed(2) : v.toFixed(4)}`;
 }
 
@@ -201,7 +201,7 @@ async function selectRun(name) {
 }
 
 function fmtDuration(secs) {
-  if (secs == null || !isFinite(secs) || secs < 0) return "–";
+  if (secs == null || !isFinite(secs) || secs < 0) return "n/a";
   const d = Math.floor(secs / 86400);
   const h = Math.floor((secs % 86400) / 3600);
   const m = Math.floor((secs % 3600) / 60);
@@ -215,7 +215,7 @@ function fmtDuration(secs) {
 }
 
 function fmtAgo(ts) {
-  if (!ts) return "–";
+  if (!ts) return "n/a";
   const secs = Date.now() / 1000 - ts;
   if (secs < 90) return "just now";
   if (secs < 3600) return `${Math.round(secs / 60)} min ago`;
@@ -238,7 +238,7 @@ function runStatus(step) {
 /* unbounded env lists: show the first two, fold the rest into "+N" (full list
    in the tooltip) */
 function envListField(envs) {
-  if (!envs?.length) return `<span class="val">–</span>`;
+  if (!envs?.length) return `<span class="val">n/a</span>`;
   const display = envs.length > 2 ? `${envs.slice(0, 2).join(", ")} +${envs.length - 2}` : envs.join(", ");
   return `<span class="val" title="${esc(envs.join(", "))}">${esc(display)}</span>`;
 }
@@ -254,24 +254,24 @@ function renderOverview() {
   const step = currentStep();
   const status = runStatus(step);
   const durationEnd = status === "running" ? Date.now() / 1000 : meta.updated;
-  const duration = meta.started && durationEnd ? fmtDuration(durationEnd - meta.started) : "–";
+  const duration = meta.started && durationEnd ? fmtDuration(durationEnd - meta.started) : "n/a";
   const field = ([label, value]) => `<div class="ov-field"><span class="lbl">${label}</span>${value}</div>`;
   // rollout dirs can run one step past max_steps (the final ship drains late
   // arrivals), so the headline caps at the configured horizon
   const shownStep = step != null && meta.max_steps ? Math.min(step, meta.max_steps) : step;
-  const stepText = `${shownStep != null ? shownStep.toLocaleString() : "–"}/${meta.max_steps ? meta.max_steps.toLocaleString() : "∞"}`;
+  const stepText = `${shownStep != null ? shownStep.toLocaleString() : "n/a"}/${meta.max_steps ? meta.max_steps.toLocaleString() : "∞"}`;
   const left = [
     ["status", `<span class="badge st-${status}">${status}</span>`],
-    ["type", `<span class="val">${esc((meta.type ?? "–").toUpperCase())}</span>`],
+    ["type", `<span class="val">${esc((meta.type ?? "n/a").toUpperCase())}</span>`],
     meta.type === "eval"
-      ? ["episodes", `<span class="val">${step != null ? step.toLocaleString() : "–"}</span>`]
+      ? ["episodes", `<span class="val">${step != null ? step.toLocaleString() : "n/a"}</span>`]
       : ["step", `<span class="val">${stepText}</span>`],
-    ["model", `<span class="val" title="${esc(meta.model ?? "")}">${esc(meta.model ?? "–")}</span>`],
+    ["model", `<span class="val" title="${esc(meta.model ?? "")}">${esc(meta.model ?? "n/a")}</span>`],
     ...(meta.type === "eval"
-      ? [["env", `<span class="val" title="${esc(meta.env ?? "")}">${esc(meta.env ?? "–")}</span>`]]
+      ? [["env", `<span class="val" title="${esc(meta.env ?? "")}">${esc(meta.env ?? "n/a")}</span>`]]
       : [
           meta.type === "sft"
-            ? ["dataset", `<span class="val" title="${esc(meta.dataset ?? "")}">${esc(meta.dataset ?? "–")}</span>`]
+            ? ["dataset", `<span class="val" title="${esc(meta.dataset ?? "")}">${esc(meta.dataset ?? "n/a")}</span>`]
             : ["train envs", envListField(meta.train_envs)],
           ["eval envs", envListField(meta.eval_envs)],
         ]),
@@ -477,7 +477,7 @@ function renderEvalCards(body) {
     );
   }
   const fmtVal = (key, v) => {
-    if (v == null) return "–";
+    if (v == null) return "n/a";
     if (key === "cost") return fmtCost(v);
     if (key.startsWith("timing/")) return fmtDuration(v);
     if (key.endsWith("tokens")) return fmtCompact(Math.round(v));
@@ -2223,9 +2223,11 @@ function errorBannersHtml(errors) {
         const message = record.message ?? "No error message";
         const traceback = Array.isArray(record.traceback) ? record.traceback.join("") : record.traceback;
         return (
-          `<section class="trace-error-banner"><div class="trace-error-head"><span>error</span><span>${esc(type)}</span></div>` +
-          `<div class="trace-error-message">${esc(message)}</div>` +
-          (traceback ? `<pre>${esc(traceback)}</pre>` : "") +
+          `<section class="trace-error-banner">` +
+          `<div class="trace-error-message"><span class="trace-error-type">${esc(type)}</span> ${esc(message)}</div>` +
+          (traceback
+            ? `<details class="trace-error-tb"><summary><span>traceback</span><span class="entry-chev">›</span></summary><pre>${esc(traceback)}</pre></details>`
+            : "") +
           `</section>`
         );
       })
@@ -2412,6 +2414,7 @@ function renderMeta(ep, trace, branches) {
   parts.push(metaRow("episode ID", ep.id, true));
   if (trace?.id) parts.push(metaRow("trace ID", trace.id, true));
   if (ep.group?.id) parts.push(metaRow("group ID", ep.group.id, true));
+  if (ep.task?.key) parts.push(metaRow("task ID", ep.task.key, true));
   if (trace?.agent?.runtime?.id) parts.push(metaRow("runtime ID", trace.agent.runtime.id, true));
 
   $("#tm-meta").innerHTML = parts.join("");

--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -2213,20 +2213,25 @@ function episodeErrors(ep, trace) {
 }
 
 function errorBannersHtml(errors) {
-  return errors
-    .map((error) => {
-      const record = error && typeof error === "object" ? error : { message: String(error) };
-      const type = record.type ?? "Error";
-      const message = record.message ?? "No error message";
-      const traceback = Array.isArray(record.traceback) ? record.traceback.join("") : record.traceback;
-      return (
-        `<section class="trace-error-banner"><div class="trace-error-head"><span>error</span><span>${esc(type)}</span></div>` +
-        `<div class="trace-error-message">${esc(message)}</div>` +
-        (traceback ? `<pre>${esc(traceback)}</pre>` : "") +
-        `</section>`
-      );
-    })
-    .join("");
+  if (!errors.length) return "";
+  return (
+    `<div class="trace-errors">` +
+    errors
+      .map((error) => {
+        const record = error && typeof error === "object" ? error : { message: String(error) };
+        const type = record.type ?? "Error";
+        const message = record.message ?? "No error message";
+        const traceback = Array.isArray(record.traceback) ? record.traceback.join("") : record.traceback;
+        return (
+          `<section class="trace-error-banner"><div class="trace-error-head"><span>error</span><span>${esc(type)}</span></div>` +
+          `<div class="trace-error-message">${esc(message)}</div>` +
+          (traceback ? `<pre>${esc(traceback)}</pre>` : "") +
+          `</section>`
+        );
+      })
+      .join("") +
+    `</div>`
+  );
 }
 
 function renderMessages(ep, trace, branches) {
@@ -2234,7 +2239,7 @@ function renderMessages(ep, trace, branches) {
   entriesObserver?.disconnect();
   const errorsHtml = errorBannersHtml(episodeErrors(ep, trace));
   if (!trace) {
-    container.innerHTML = errorsHtml + emptyState("no traces", "this episode carries no trace data");
+    container.innerHTML = emptyState("no traces", "this episode carries no trace data") + errorsHtml;
     return;
   }
   const signal = $("#token-signal").value;
@@ -2279,9 +2284,9 @@ function renderMessages(ep, trace, branches) {
   const CHUNK = 30;
   let rendered = Math.min(path.length, CHUNK);
   container.innerHTML =
-    errorsHtml +
     path.slice(0, rendered).map(entryHtml).join("") +
-    (rendered < path.length ? `<div id="tm-more" class="chart-empty">scroll for ${path.length - rendered} more entries</div>` : "");
+    (rendered < path.length ? `<div id="tm-more" class="chart-empty">scroll for ${path.length - rendered} more entries</div>` : "") +
+    errorsHtml;
   if (rendered < path.length) {
     const sentinel = container.querySelector("#tm-more");
     entriesObserver = new IntersectionObserver((hits) => {
@@ -2408,13 +2413,6 @@ function renderMeta(ep, trace, branches) {
   if (trace?.id) parts.push(metaRow("trace ID", trace.id, true));
   if (ep.group?.id) parts.push(metaRow("group ID", ep.group.id, true));
   if (trace?.agent?.runtime?.id) parts.push(metaRow("runtime ID", trace.agent.runtime.id, true));
-
-  const errors = episodeErrors(ep, trace);
-  if (errors.length)
-    parts.push(
-      `<details class="meta-fold" open><summary>errors (${errors.length})</summary>` +
-        `<pre class="json">${esc(JSON.stringify(errors, null, 2))}</pre></details>`
-    );
 
   $("#tm-meta").innerHTML = parts.join("");
 }

--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -237,8 +237,8 @@ function runStatus(step) {
 
 /* unbounded env lists: show the first two, fold the rest into "+N" (full list
    in the tooltip) */
-function envListField(envs) {
-  if (!envs?.length) return `<span class="val">n/a</span>`;
+function envListField(envs, empty = "n/a") {
+  if (!envs?.length) return `<span class="val">${empty}</span>`;
   const display = envs.length > 2 ? `${envs.slice(0, 2).join(", ")} +${envs.length - 2}` : envs.join(", ");
   return `<span class="val" title="${esc(envs.join(", "))}">${esc(display)}</span>`;
 }
@@ -273,7 +273,8 @@ function renderOverview() {
           meta.type === "sft"
             ? ["dataset", `<span class="val" title="${esc(meta.dataset ?? "")}">${esc(meta.dataset ?? "n/a")}</span>`]
             : ["train envs", envListField(meta.train_envs)],
-          ["eval envs", envListField(meta.eval_envs)],
+          // an empty eval env list is a known "none", not missing data
+          ["eval envs", envListField(meta.eval_envs, "–")],
         ]),
   ];
   const right = [

--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -12,7 +12,7 @@ const api = async (path) => {
 /* accent-first line palette, then the prime-context chart palette */
 const PALETTE = ["#b6ff3c", "#b7a6fa", "#78f8a5", "#fcdaa4", "#4a9eff", "#ff6b4a", "#bcbcbc"];
 const SINGLE_SERIES = "#b6ff3c";
-const POLL_MS = 3000;
+const POLL_MS = 5000;
 const prefs = JSON.parse(localStorage.getItem("prl-dash") || "{}");
 
 const state = {
@@ -1121,7 +1121,7 @@ function renderMetricsBody() {
   if (state.meta?.type === "eval") return renderEvalCards(body);
   activeFilter = makeFilter(state.metrics.search.trim());
   if (!state.meta?.has_metrics && !m.byKey.size) {
-    body.innerHTML = emptyState("no metrics", "this run has no metrics.jsonl yet");
+    body.innerHTML = emptyState("no metrics yet");
     $("#metrics-status").textContent = "";
     return;
   }
@@ -1806,6 +1806,7 @@ function renderStepControl() {
         ` title="${title}${hasEval ? " · eval" : ""}"></span>`
     );
   }
+  if (!cells.length) cells.push(`<span class="sb-cell placeholder"></span>`);
   const signature = cells.join("");
   if (signature === traces.stepControlSignature) return;
   traces.stepControlSignature = signature;
@@ -1816,7 +1817,7 @@ function renderStepControl() {
   const hasEval = info && (info.available["eval/all"] || info.available["eval/effective"]);
   $("#step-label").innerHTML =
     traces.step == null
-      ? ""
+      ? `<span class="muted">no steps yet</span>`
       : `step ${traces.step}${steps.length > 1 ? `<span class="muted">/${steps[steps.length - 1].step}</span>` : ""}` +
         (hasEval ? ' <span class="eval-dot" title="eval rollouts"></span>' : "");
 }
@@ -1830,19 +1831,18 @@ function selectStepByIndex(index) {
   loadEpisodes();
 }
 
+// the table chrome stays in place; the message renders as a spanning row so
+// arriving traces cause no layout shift
 function showTraceEmpty(title, detail) {
-  $("#episode-table-wrap").hidden = true;
-  const el = $("#trace-empty");
-  el.hidden = false;
-  el.innerHTML = emptyState(title, detail);
+  $("#episode-table tbody").innerHTML = `<tr class="empty"><td colspan="10">${emptyState(title, detail)}</td></tr>`;
 }
 
 async function loadEpisodes() {
   const traces = state.traces;
-  updateTraceFilterBtn();
+  syncTraceFilterControls();
   if (traces.step == null) {
     $("#trace-status").textContent = "";
-    showTraceEmpty("no traces", "this run has no saved traces yet");
+    showTraceEmpty("no traces yet");
     return;
   }
   const qs = new URLSearchParams({ sort: traces.sort, order: traces.order, errors_only: traces.errorsOnly });
@@ -1864,13 +1864,12 @@ async function loadEpisodes() {
   traces.etag = data.etag;
   traces.etagKey = etagKey;
   traces.episodes = data.episodes;
-  $("#trace-empty").hidden = true;
-  $("#episode-table-wrap").hidden = false;
-  const envSel = $("#trace-env");
   const currentEnv = traces.env;
-  envSel.innerHTML =
-    `<option value="">all envs</option>` +
-    data.envs.map((e) => `<option value="${esc(e)}" ${e === currentEnv ? "selected" : ""}>${esc(e)}</option>`).join("");
+  for (const sel of ["#trace-env", "#tm-env"])
+    $(sel).innerHTML =
+      `<option value="">all envs</option>` +
+      data.envs.map((e) => `<option value="${esc(e)}" ${e === currentEnv ? "selected" : ""}>${esc(e)}</option>`).join("");
+  syncDressedSelects();
   if (!data.total) {
     $("#trace-status").textContent = "";
     showTraceEmpty("no episodes", "nothing matches the current filters");
@@ -2531,9 +2530,16 @@ function dressSelect(select) {
   dressedSelects.add(select);
   syncDressedSelects();
 }
-function updateTraceFilterBtn() {
+/* the table and the trace viewer carry the same filter dropdown over one
+   shared state — a change in either view shows up in both */
+function syncTraceFilterControls() {
   const t = state.traces;
-  $("#trace-filter-btn").classList.toggle("active", !!(t.env || t.errorsOnly || t.sort !== "line"));
+  for (const sel of ["#trace-env", "#tm-env"]) $(sel).value = t.env;
+  for (const sel of ["#trace-sort", "#tm-sort"]) $(sel).value = `${t.sort}:${t.order}`;
+  for (const sel of ["#trace-errors", "#tm-errors"]) $(sel).checked = t.errorsOnly;
+  for (const sel of ["#trace-filter-btn", "#tm-filter-btn"])
+    $(sel).classList.toggle("active", !!(t.env || t.errorsOnly || t.sort !== "line"));
+  syncDressedSelects();
 }
 
 document.querySelectorAll("#tabs button").forEach((b) => b.addEventListener("click", () => activateTab(b.dataset.tab)));
@@ -2768,6 +2774,14 @@ async function setTraceSubset(subset, inModal = false) {
   if (inModal) await reopenFirstEpisode();
 }
 
+/* filter changes keep the open viewer in sync: hold the current episode when
+   it survives the filter, land on the first one otherwise */
+async function refreshModalList() {
+  if ($("#trace-modal").hidden) return;
+  if (filteredRollouts().some((e) => e.line === currentLine)) renderRolloutList();
+  else await reopenFirstEpisode();
+}
+
 /* after a filter change inside the viewer, land on the first episode of the
    new subset (line numbers don't correspond across files) */
 async function reopenFirstEpisode() {
@@ -2795,13 +2809,26 @@ for (const [sel, inModal] of [["#trace-subset", false], ["#tm-subset", true]])
       setTraceSubset(b.dataset.subset, inModal);
     })
   );
-$("#trace-env").addEventListener("change", (e) => { state.traces.env = e.target.value; loadEpisodes(); });
-$("#trace-errors").addEventListener("change", (e) => { state.traces.errorsOnly = e.target.checked; loadEpisodes(); savePrefs(); });
-$("#trace-sort").addEventListener("change", (e) => {
-  [state.traces.sort, state.traces.order] = e.target.value.split(":");
-  loadEpisodes();
-  savePrefs();
-});
+for (const sel of ["#trace-env", "#tm-env"])
+  $(sel).addEventListener("change", async (e) => {
+    state.traces.env = e.target.value;
+    await loadEpisodes();
+    await refreshModalList();
+  });
+for (const sel of ["#trace-errors", "#tm-errors"])
+  $(sel).addEventListener("change", async (e) => {
+    state.traces.errorsOnly = e.target.checked;
+    await loadEpisodes();
+    savePrefs();
+    await refreshModalList();
+  });
+for (const sel of ["#trace-sort", "#tm-sort"])
+  $(sel).addEventListener("change", async (e) => {
+    [state.traces.sort, state.traces.order] = e.target.value.split(":");
+    await loadEpisodes();
+    savePrefs();
+    await refreshModalList();
+  });
 $("#episode-table").addEventListener("click", (e) => {
   const row = e.target.closest("tr[data-line]");
   if (row) openEpisode(+row.dataset.line);
@@ -2977,10 +3004,9 @@ document.addEventListener("visibilitychange", () => {
   $("#log-search").value = prefs.logSearch ?? "";
   $("#config-search").value = prefs.configSearch ?? "";
   $("#token-signal").value = prefs.tokenSignal ?? "";
-  for (const sel of ["#run-select", "#trace-env", "#trace-sort", "#attempt-select", "#token-signal"])
+  for (const sel of ["#run-select", "#trace-env", "#trace-sort", "#tm-env", "#tm-sort", "#attempt-select", "#token-signal"])
     dressSelect($(sel));
-  $("#trace-sort").value = `${state.traces.sort}:${state.traces.order}`;
-  $("#trace-errors").checked = state.traces.errorsOnly;
+  syncTraceFilterControls();
   setActive("#metrics-mode", "mode", state.metrics.mode);
   setActive("#all-layout", "layout", state.metrics.allLayout);
   $("#all-layout").hidden = state.metrics.mode !== "all";

--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -120,7 +120,7 @@ async function loadRuns() {
   syncDressedSelects();
   const fresh = state.runs.find((r) => r.name === current);
   if (fresh && state.meta) {
-    Object.assign(state.meta, { updated: fresh.updated, started: fresh.started, last_step: fresh.last_step });
+    Object.assign(state.meta, fresh);
     renderOverview();
   }
 }
@@ -181,14 +181,18 @@ async function selectRun(name) {
   state.meta = state.runs.find((r) => r.name === name) ?? (await api(`/api/runs/${encodeURIComponent(name)}`));
   state.metrics = {
     ...state.metrics,
-    loaded: false, offset: 0, byKey: new Map(), charts: [], renderedKeys: -1,
+    loaded: false, fetching: false, offset: 0, byKey: new Map(), charts: [], renderedKeys: -1,
     timeKeys: new Set(), timeZero: null, maxStep: null,
     evalEtag: null, evalCount: 0, evalCost: null,
   };
   if (state.meta?.type === "eval") fetchEvalSeries(); // populates the overview cost early
   state.config = { loaded: false, files: [], file: null, fmt: state.config.fmt, cache: new Map() };
   state.logs = { ...state.logs, loaded: false, attempt: "latest", files: [], paneFile: {}, maximized: null, buffers: new Map() };
-  state.traces = { ...state.traces, loaded: false, steps: [], step: null, env: "", episodes: [], etag: null, kind: "train", subset: state.traces.preferred };
+  state.traces = {
+    ...state.traces,
+    loaded: false, fetching: false, steps: [], step: null, env: "", episodes: [], etag: null,
+    kind: "train", subset: state.traces.preferred,
+  };
   applyRunTypeControls();
   renderOverview();
   renderCompareMenu();
@@ -297,10 +301,16 @@ async function activateTab(tab, force = false) {
   setActive("#tabs", "tab", tab);
   document.querySelectorAll("main > section").forEach((s) => (s.hidden = s.id !== `tab-${tab}`));
   updateHash();
-  if (tab === "metrics" && !state.metrics.loaded) await initMetrics();
+  if (tab === "metrics") {
+    if (!state.metrics.loaded) await initMetrics();
+    else if (state.live) await fetchMetrics();
+  }
   if (tab === "config" && !state.config.loaded) await initConfig();
   if (tab === "logs" && !state.logs.loaded) await initLogs();
-  if (tab === "traces" && !state.traces.loaded) await initTraces();
+  if (tab === "traces") {
+    if (!state.traces.loaded) await initTraces();
+    else if (state.live) await refreshTraces();
+  }
 }
 
 /* ---------------------------------------------------------------- metrics */
@@ -384,6 +394,7 @@ async function fetchMetrics() {
   let showedProgress = false;
   try {
     for (let first = true; ; first = false) {
+      const requestedOffset = m.offset;
       const [data, compared] = await Promise.all([
         api(`/api/runs/${encodeURIComponent(state.run)}/metrics?offset=${m.offset}`),
         first ? fetchCompares() : false,
@@ -400,7 +411,9 @@ async function fetchMetrics() {
         if (m.byKey.size !== m.renderedKeys) renderMetricsBody();
         else updateCharts(compared ? null : touched); // compares may touch any panel
       }
-      if (data.offset >= (data.size ?? data.offset)) break;
+      // A writer can leave one incomplete JSONL record at EOF. Wait for the
+      // next poll instead of repeatedly requesting the same partial record.
+      if (data.offset >= (data.size ?? data.offset) || data.offset === requestedOffset) break;
       showedProgress = true;
       $("#metrics-status").textContent = `loading metrics · ${Math.round((data.offset / data.size) * 100)}%`;
     }
@@ -1121,7 +1134,7 @@ function renderMetricsBody() {
       }
       if (!grid.children.length) {
         // a configured eval env stays visible before its first eval fires
-        if (section.configured && !activeFilter) grid.innerHTML = `<div class="chart-empty">no eval data yet</div>`;
+        if (section.configured && !activeFilter) grid.innerHTML = `<div class="chart-empty">no data yet</div>`;
         else div.remove();
       } else applyPaneOrder(grid);
     }
@@ -1726,26 +1739,25 @@ async function initLogs() {
 
 async function loadRollouts() {
   const traces = state.traces;
+  const previousTarget = latestPreferredStep(traces.steps, traces.kind, traces.preferred);
+  const wasFollowing = traces.step == null || traces.step === previousTarget?.step;
   const data = await api(`/api/runs/${encodeURIComponent(state.run)}/rollouts`);
   traces.steps = data.steps;
-  if (traces.step == null && data.steps.length) {
-    // default to the newest step that already shipped the preferred subset —
-    // the newest step is usually in-flight with only "all" (no advantages yet)
-    const preferred = traces.preferred;
-    const newestFirst = [...data.steps].reverse();
-    const shipped =
-      newestFirst.find((s) => s.available[`${traces.kind}/${preferred}`]) ??
-      newestFirst.find((s) => Object.keys(s.available).some((k) => k.endsWith(`/${preferred}`)));
-    traces.step = (shipped ?? data.steps[data.steps.length - 1]).step;
-    adjustKindSubset();
-  } else if (traces.step != null) {
-    // the preferred subset may have shipped since the last poll (a live step's
-    // effective file lands late) — re-adjust and reload when it changes
-    const before = `${traces.kind}/${traces.subset}`;
-    adjustKindSubset();
-    if (`${traces.kind}/${traces.subset}` !== before) await loadEpisodes();
-  }
+  const target = latestPreferredStep(data.steps, traces.kind, traces.preferred);
+  // Follow new work while the user is on the latest preferred step. Keep a
+  // manually selected historical step stable, especially while its modal is open.
+  if (target && wasFollowing && $("#trace-modal").hidden) traces.step = target.step;
+  adjustKindSubset();
   renderStepControl();
+}
+
+function latestPreferredStep(steps, kind, preferred) {
+  const newestFirst = [...steps].reverse();
+  return (
+    newestFirst.find((s) => s.available[`${kind}/${preferred}`]) ??
+    newestFirst.find((s) => Object.keys(s.available).some((key) => key.endsWith(`/${preferred}`))) ??
+    newestFirst[0]
+  );
 }
 
 function stepInfo(step) {
@@ -1914,9 +1926,20 @@ function renderEpisodeRows(reset = false) {
 
 async function initTraces() {
   state.traces.loaded = true;
-  await loadRollouts();
-  adjustKindSubset();
-  await loadEpisodes();
+  await refreshTraces();
+}
+
+async function refreshTraces() {
+  const traces = state.traces;
+  if (traces.fetching) return;
+  traces.fetching = true;
+  try {
+    await loadRollouts();
+    if (state.traces !== traces) return;
+    await loadEpisodes();
+  } finally {
+    traces.fetching = false;
+  }
 }
 
 /* ----------------------------------------------------------- episode view */
@@ -2185,11 +2208,33 @@ function reasoningBlock(content) {
 
 let entriesObserver = null;
 
-function renderMessages(trace, branches) {
+function episodeErrors(ep, trace) {
+  return [...(ep.errors || []), ...(trace?.errors || [])];
+}
+
+function errorBannersHtml(errors) {
+  return errors
+    .map((error) => {
+      const record = error && typeof error === "object" ? error : { message: String(error) };
+      const type = record.type ?? "Error";
+      const message = record.message ?? "No error message";
+      const traceback = Array.isArray(record.traceback) ? record.traceback.join("") : record.traceback;
+      return (
+        `<section class="trace-error-banner"><div class="trace-error-head"><span>error</span><span>${esc(type)}</span></div>` +
+        `<div class="trace-error-message">${esc(message)}</div>` +
+        (traceback ? `<pre>${esc(traceback)}</pre>` : "") +
+        `</section>`
+      );
+    })
+    .join("");
+}
+
+function renderMessages(ep, trace, branches) {
   const container = $("#tm-messages");
   entriesObserver?.disconnect();
+  const errorsHtml = errorBannersHtml(episodeErrors(ep, trace));
   if (!trace) {
-    container.innerHTML = emptyState("no traces", "this episode carries no trace data");
+    container.innerHTML = errorsHtml + emptyState("no traces", "this episode carries no trace data");
     return;
   }
   const signal = $("#token-signal").value;
@@ -2234,6 +2279,7 @@ function renderMessages(trace, branches) {
   const CHUNK = 30;
   let rendered = Math.min(path.length, CHUNK);
   container.innerHTML =
+    errorsHtml +
     path.slice(0, rendered).map(entryHtml).join("") +
     (rendered < path.length ? `<div id="tm-more" class="chart-empty">scroll for ${path.length - rendered} more entries</div>` : "");
   if (rendered < path.length) {
@@ -2363,7 +2409,7 @@ function renderMeta(ep, trace, branches) {
   if (ep.group?.id) parts.push(metaRow("group ID", ep.group.id, true));
   if (trace?.agent?.runtime?.id) parts.push(metaRow("runtime ID", trace.agent.runtime.id, true));
 
-  const errors = [...(ep.errors || []), ...(trace?.errors || [])];
+  const errors = episodeErrors(ep, trace);
   if (errors.length)
     parts.push(
       `<details class="meta-fold" open><summary>errors (${errors.length})</summary>` +
@@ -2404,14 +2450,17 @@ function renderEpisode() {
       : "";
   $("#tm-tabs-row").hidden = traceTabs.hidden && branchTabs.hidden;
   renderRolloutList();
-  renderMessages(trace, branches);
+  renderMessages(ep, trace, branches);
   renderMeta(ep, trace, branches);
 }
 
 /* ---------------------------------------------------------------- wiring */
 
 $("#run-select").addEventListener("change", (e) => selectRun(e.target.value));
-$("#live-toggle").addEventListener("change", (e) => (state.live = e.target.checked));
+$("#live-toggle").addEventListener("change", async (e) => {
+  state.live = e.target.checked;
+  if (state.live) await pollDashboard();
+});
 $("#compare-menu").addEventListener("change", (e) => {
   const box = e.target.closest("[data-compare]");
   if (box) toggleCompare(box.dataset.compare, box.checked);
@@ -2885,12 +2934,10 @@ $("#smooth-range").addEventListener("input", (e) => {
   savePrefs();
 });
 
-let tickCount = 0;
 let ticking = false;
-setInterval(async () => {
+async function pollDashboard() {
   if (!state.live || ticking) return;
   ticking = true;
-  tickCount++;
   try {
     // keep the run list fresh so new runs register without a page refresh;
     // it runs concurrently with the tab poll (they're independent requests)
@@ -2905,17 +2952,19 @@ setInterval(async () => {
     syncDressedSelects();
     if (state.tab === "metrics" && state.metrics.loaded) await fetchMetrics();
     else if (state.tab === "logs" && state.logs.loaded) await pollLogs();
-    else if (state.tab === "traces" && state.traces.loaded) {
-      await loadRollouts();
-      if (tickCount % 5 === 0) await loadEpisodes();
-    }
+    else if (state.tab === "traces" && state.traces.loaded) await refreshTraces();
     await runsRefresh;
   } catch (err) {
     console.warn("poll failed", err);
   } finally {
     ticking = false;
   }
-}, POLL_MS);
+}
+
+setInterval(pollDashboard, POLL_MS);
+document.addEventListener("visibilitychange", () => {
+  if (!document.hidden) pollDashboard();
+});
 
 (async function init() {
   $("#smooth-range").value = state.metrics.smooth;

--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -2895,8 +2895,6 @@ $("#tm-list").addEventListener("click", (e) => {
   const item = e.target.closest("[data-line]");
   if (item) openEpisode(+item.dataset.line);
 });
-$("#tm-prev").addEventListener("click", () => stepRollout(-1));
-$("#tm-next").addEventListener("click", () => stepRollout(1));
 $("#tm-collapse").addEventListener("click", () =>
   document.querySelectorAll("#tm-messages details.entry").forEach((d) => (d.open = false))
 );

--- a/src/prime_rl/dashboard/static/index.html
+++ b/src/prime_rl/dashboard/static/index.html
@@ -103,7 +103,6 @@
         </div>
       </div>
     </div>
-    <div id="trace-empty" hidden></div>
     <div id="episode-table-wrap">
       <table id="episode-table">
         <thead><tr>
@@ -161,6 +160,27 @@
       <span class="t-label">episodes</span>
       <span id="tm-count" class="badge"></span>
       <div class="spacer"></div>
+      <div id="tm-filter-wrap" class="dd-wrap">
+        <button id="tm-filter-btn" class="btn dd-btn" title="filter &amp; sort">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 5h18l-7 8v6l-4-2v-4L3 5z"></path></svg>
+          filter
+        </button>
+        <div id="tm-filter-menu" class="dd-menu" hidden>
+          <label class="t-label">env</label>
+          <select id="tm-env"><option value="">all envs</option></select>
+          <label class="t-label">sort</label>
+          <select id="tm-sort">
+            <option value="line:asc">order: arrival</option>
+            <option value="reward:desc">reward ↓</option>
+            <option value="reward:asc">reward ↑</option>
+            <option value="advantage:desc">advantage ↓</option>
+            <option value="advantage:asc">advantage ↑</option>
+            <option value="output_tokens:desc">tokens ↓</option>
+            <option value="group:asc">group</option>
+          </select>
+          <label class="toggle"><input type="checkbox" id="tm-errors"><span class="dot"></span>errors only</label>
+        </div>
+      </div>
       <button id="tm-prev" class="btn tm-nav" title="previous episode">↑</button>
       <button id="tm-next" class="btn tm-nav" title="next episode">↓</button>
     </div>

--- a/src/prime_rl/dashboard/static/index.html
+++ b/src/prime_rl/dashboard/static/index.html
@@ -71,16 +71,6 @@
       <span id="step-label" class="t-label"></span>
     </div>
     <div class="controls">
-      <div class="seg" id="trace-kind">
-        <button data-kind="train" class="active">Train</button>
-        <button data-kind="eval">Eval</button>
-      </div>
-      <div class="seg" id="trace-subset">
-        <button data-subset="all">All</button>
-        <button data-subset="effective" class="active">Effective</button>
-      </div>
-      <span id="trace-status" class="muted"></span>
-      <div class="spacer"></div>
       <div id="trace-filter-wrap" class="dd-wrap">
         <button id="trace-filter-btn" class="btn dd-btn" title="filter &amp; sort">
           <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 5h18l-7 8v6l-4-2v-4L3 5z"></path></svg>
@@ -102,6 +92,15 @@
           <label class="toggle"><input type="checkbox" id="trace-errors"><span class="dot"></span>errors only</label>
         </div>
       </div>
+      <div class="seg" id="trace-kind">
+        <button data-kind="train" class="active">Train</button>
+        <button data-kind="eval">Eval</button>
+      </div>
+      <div class="seg" id="trace-subset">
+        <button data-subset="all">All</button>
+        <button data-subset="effective" class="active">Effective</button>
+      </div>
+      <span id="trace-status" class="muted"></span>
     </div>
     <div id="episode-table-wrap">
       <table id="episode-table">
@@ -146,20 +145,7 @@
       <span id="tm-step-label"></span>
       <button id="tm-step-next" class="btn tm-nav" title="next step">›</button>
     </div>
-    <div class="tm-head tm-filterhead">
-      <div class="seg" id="tm-kind">
-        <button data-kind="train">Train</button>
-        <button data-kind="eval">Eval</button>
-      </div>
-      <div class="seg" id="tm-subset">
-        <button data-subset="all">All</button>
-        <button data-subset="effective">Effective</button>
-      </div>
-    </div>
-    <div class="tm-head">
-      <span class="t-label">episodes</span>
-      <span id="tm-count" class="badge"></span>
-      <div class="spacer"></div>
+    <div class="tm-head tm-ctlrow">
       <div id="tm-filter-wrap" class="dd-wrap">
         <button id="tm-filter-btn" class="btn dd-btn" title="filter &amp; sort">
           <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 5h18l-7 8v6l-4-2v-4L3 5z"></path></svg>
@@ -181,6 +167,22 @@
           <label class="toggle"><input type="checkbox" id="tm-errors"><span class="dot"></span>errors only</label>
         </div>
       </div>
+    </div>
+    <div class="tm-head tm-ctlrow" id="tm-kind-row">
+      <div class="seg" id="tm-kind">
+        <button data-kind="train">Train</button>
+        <button data-kind="eval">Eval</button>
+      </div>
+    </div>
+    <div class="tm-head tm-ctlrow" id="tm-subset-row">
+      <div class="seg" id="tm-subset">
+        <button data-subset="all">All</button>
+        <button data-subset="effective">Effective</button>
+      </div>
+    </div>
+    <div class="tm-head">
+      <span class="t-label">episodes</span>
+      <span id="tm-count" class="badge"></span>
     </div>
     <div id="tm-list"></div>
   </aside>

--- a/src/prime_rl/dashboard/static/index.html
+++ b/src/prime_rl/dashboard/static/index.html
@@ -181,8 +181,6 @@
           <label class="toggle"><input type="checkbox" id="tm-errors"><span class="dot"></span>errors only</label>
         </div>
       </div>
-      <button id="tm-prev" class="btn tm-nav" title="previous episode">↑</button>
-      <button id="tm-next" class="btn tm-nav" title="next episode">↓</button>
     </div>
     <div id="tm-list"></div>
   </aside>

--- a/src/prime_rl/dashboard/static/style.css
+++ b/src/prime_rl/dashboard/static/style.css
@@ -682,6 +682,33 @@ mark.hit {
 #tm-right { border-left: 1px solid var(--hairline); overflow-y: auto; min-height: 0; }
 #tm-meta { padding: 12px 14px; }
 
+.trace-error-banner {
+  border: 1px solid var(--negative);
+  background: rgba(255, 69, 57, 0.08);
+  margin-bottom: 12px;
+  color: var(--grey-6);
+}
+.trace-error-head {
+  display: flex;
+  gap: 10px;
+  padding: 7px 12px;
+  border-bottom: 1px solid rgba(255, 69, 57, 0.35);
+  color: var(--negative);
+  font-size: 10px;
+  letter-spacing: var(--track-caps);
+  text-transform: uppercase;
+}
+.trace-error-message { padding: 10px 12px; white-space: pre-wrap; word-break: break-word; }
+.trace-error-banner pre {
+  margin: 0;
+  padding: 10px 12px;
+  border-top: 1px solid rgba(255, 69, 57, 0.2);
+  color: var(--grey-5);
+  font: 400 11px/1.5 var(--font-mono);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* numbered collapsible message entries */
 details.entry { border: 1px solid var(--hairline); margin-bottom: 8px; }
 details.entry > summary {

--- a/src/prime_rl/dashboard/static/style.css
+++ b/src/prime_rl/dashboard/static/style.css
@@ -659,6 +659,8 @@ mark.hit {
 .tm-item .tm-reward { flex-shrink: 0; }
 .tm-item:hover { background: var(--grey-2); }
 .tm-item.active { background: var(--grey-2); border-color: var(--grey-3); color: var(--grey-6); }
+.tm-item.err { background: rgba(255, 69, 57, 0.08); border-color: var(--negative); }
+.tm-item.err:hover, .tm-item.err.active { background: rgba(255, 69, 57, 0.16); }
 .tm-item .tm-reward { margin-left: auto; }
 .tm-nav { padding: 0 8px; height: 24px; }
 .tm-stephead { justify-content: space-between; background: var(--grey-2); min-height: 40px; }

--- a/src/prime_rl/dashboard/static/style.css
+++ b/src/prime_rl/dashboard/static/style.css
@@ -570,6 +570,8 @@ mark.hit {
 #step-blocks { flex: 1; display: flex; gap: 2px; height: 16px; min-width: 0; margin-bottom: 4px; }
 .sb-cell { position: relative; flex: 1; min-width: 0; background: var(--grey-2); border: 1px solid var(--hairline); cursor: pointer; }
 .sb-cell:hover { border-color: var(--grey-6); }
+.sb-cell.placeholder { cursor: default; }
+.sb-cell.placeholder:hover { border-color: var(--hairline); }
 .sb-cell.on { background: var(--accent); border-color: var(--accent); }
 /* eval steps carry a small dot under the block (same mark as the step label) */
 .sb-cell.eval::after {
@@ -613,6 +615,9 @@ mark.hit {
 #episode-table td { padding: 5px 10px; border-bottom: 1px solid var(--hairline-faint); white-space: nowrap; }
 #episode-table tbody tr { cursor: pointer; }
 #episode-table tbody tr:hover { background: var(--grey-2); }
+#episode-table tr.empty { cursor: default; }
+#episode-table tr.empty:hover { background: none; }
+#episode-table tr.empty td { border-bottom: 0; }
 .r-pos { color: var(--positive); }
 .r-neg { color: var(--negative); }
 .r-zero { color: var(--grey-4); }
@@ -668,6 +673,8 @@ mark.hit {
 #tm-step-label { color: var(--grey-6); }
 .tm-filterhead { gap: 8px; }
 .tm-filterhead .seg button { height: 22px; padding: 0 9px; font-size: 10px; }
+#tm-filter-btn { height: 22px; padding: 0 9px; font-size: 10px; }
+#tm-filter-wrap .dd-menu { top: 28px; right: 0; }
 #tm-step-label {
   font-size: 11px;
   letter-spacing: var(--track-caps);

--- a/src/prime_rl/dashboard/static/style.css
+++ b/src/prime_rl/dashboard/static/style.css
@@ -690,18 +690,22 @@ mark.hit {
   color: var(--grey-6);
 }
 .trace-error-banner + .trace-error-banner { margin-top: 8px; }
-.trace-error-head {
+.trace-error-message { padding: 10px 12px; font-size: 12px; white-space: pre-wrap; word-break: break-word; }
+.trace-error-type { font-weight: 500; color: var(--negative); }
+.trace-error-tb > summary {
   display: flex;
+  align-items: center;
   gap: 10px;
-  padding: 7px 12px;
-  border-bottom: 1px solid rgba(255, 69, 57, 0.35);
-  color: var(--negative);
+  padding: 6px 12px;
+  border-top: 1px solid rgba(255, 69, 57, 0.2);
+  color: var(--grey-4);
   font-size: 10px;
   letter-spacing: var(--track-caps);
   text-transform: uppercase;
 }
-.trace-error-message { padding: 10px 12px; white-space: pre-wrap; word-break: break-word; }
-.trace-error-banner pre {
+.trace-error-tb > summary:hover { color: var(--grey-6); }
+.trace-error-tb[open] .entry-chev { transform: rotate(90deg); }
+.trace-error-tb > pre {
   margin: 0;
   padding: 10px 12px;
   border-top: 1px solid rgba(255, 69, 57, 0.2);

--- a/src/prime_rl/dashboard/static/style.css
+++ b/src/prime_rl/dashboard/static/style.css
@@ -671,10 +671,7 @@ mark.hit {
 .tm-stephead { justify-content: space-between; background: var(--grey-2); min-height: 40px; }
 #step-label, #tm-step-label { white-space: nowrap; }
 #tm-step-label { color: var(--grey-6); }
-.tm-filterhead { gap: 8px; }
-.tm-filterhead .seg button { height: 22px; padding: 0 9px; font-size: 10px; }
-#tm-filter-btn { height: 22px; padding: 0 9px; font-size: 10px; }
-#tm-filter-wrap .dd-menu { top: 28px; right: 0; }
+.tm-ctlrow { min-height: 0; padding: 8px 14px; }
 #tm-step-label {
   font-size: 11px;
   letter-spacing: var(--track-caps);

--- a/src/prime_rl/dashboard/static/style.css
+++ b/src/prime_rl/dashboard/static/style.css
@@ -678,16 +678,18 @@ mark.hit {
 #tm-step-label .muted { text-transform: none; letter-spacing: var(--track-mono); }
 
 #tm-main { display: flex; flex-direction: column; min-height: 0; min-width: 0; }
-#tm-messages { flex: 1; overflow-y: auto; padding: 14px 16px; }
+#tm-messages { display: flex; flex: 1; flex-direction: column; overflow-y: auto; padding: 14px 16px; }
+#tm-messages > * { flex-shrink: 0; }
 #tm-right { border-left: 1px solid var(--hairline); overflow-y: auto; min-height: 0; }
 #tm-meta { padding: 12px 14px; }
 
+.trace-errors { margin-top: auto; padding-top: 12px; }
 .trace-error-banner {
   border: 1px solid var(--negative);
   background: rgba(255, 69, 57, 0.08);
-  margin-bottom: 12px;
   color: var(--grey-6);
 }
+.trace-error-banner + .trace-error-banner { margin-top: 8px; }
 .trace-error-head {
   display: flex;
   gap: 10px;


### PR DESCRIPTION
## Summary

- refresh live metrics and trace rows on the same five-second cadence
- better `no data yet` for unavailable overview data
- show episode and trace errors at the bottom of the trace viewer
- add the task key as `task ID` to the identity section of the trace overview pane
- use `n/a` for missing value uniformly; some spots showed an en dash.
- allow filter from trace viewer

## Verification

### Overview empty state

<img width="1608" height="1045" alt="Screenshot 2026-08-24 at 3 54 20 PM" src="https://github.com/user-attachments/assets/02e06087-5286-435e-9776-52ec9502f7f5" />

### Errors

<img width="1608" height="1045" alt="Screenshot 2026-08-24 at 3 52 29 PM" src="https://github.com/user-attachments/assets/b39a28cc-c50d-467c-b7f7-39c354a5e008" />

### Task ID

<img width="318" height="151" alt="Screenshot 2026-08-24 at 3 52 42 PM" src="https://github.com/user-attachments/assets/f12f50b5-685d-4ca5-8b80-5c89877cab43" />

### Checks

- `node --check src/prime_rl/dashboard/static/app.js`
- `git diff --check`
- dashboard browser smoke against `outputs/reverse-text-rl`
- live append browser repro for metrics, trace rows, and new trace steps
- fake inference URL eval and browser layout check with a full traceback
- headless browser render of a synthetic `ProviderError` episode: collapsed and expanded traceback, `task ID` row, consistent `n/a` placeholders, red-marked error rows in the sidebar

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only dashboard static assets; no API or training-path changes. Risk is limited to UI regressions in metrics/traces polling and the trace modal.
> 
> **Overview**
> This PR tightens **live updates** and **trace UX** in the static dashboard (`app.js`, `index.html`, `style.css`).
> 
> **Polling & loading:** Poll interval moves to **5s**; metrics and traces refresh when switching tabs with live on, on tab visibility, and when re-enabling live. Metrics streaming stops retrying the same offset when a partial JSONL line sits at EOF; `fetching` guards avoid overlapping metrics/trace loads.
> 
> **Traces:** Step selection **follows the latest preferred step** while you’re on the tail (historical picks and an open modal stay put). Empty trace/metrics states use shorter labels and the episode table keeps its chrome with an in-table empty row to avoid layout shift. Overview panels show **“no data yet”** for configured eval sections before data lands.
> 
> **Trace viewer:** Episode/trace **errors render as banners** at the bottom of the message column (with expandable tracebacks); **task ID** appears in the identity pane. The modal gets the same **filter/sort/env/errors** controls as the traces tab, synced through shared state. Error episodes are highlighted in the sidebar list.
> 
> **Polish:** Missing numeric/overview fields use **`n/a`** instead of en dashes (empty eval env list still shows **–**). Run overview merges the full run record from the runs list on refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 239dc7797d996fb0b17badb9dd60b640474b431d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->