### PR TITLE
feat(configs): add PRL_OUTPUT_DIR env var for default output_dir

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -77,7 +77,7 @@ A condensed view of the knobs you'll most often tune. For trainer-side paralleli
 
 | Knob | What it does |
 |---|---|
-| `--output-dir outputs` | Directory that groups related runs. Each run writes its artifacts to its own run directory `<output_dir>/<run_name>` (`<run_dir>` below). |
+| `--output-dir outputs` | Directory that groups related runs. Each run writes its artifacts to its own run directory `<output_dir>/<run_name>` (`<run_dir>` below). Defaults to `$PRL_OUTPUT_DIR` if set, else `outputs`. |
 | `--run.name <name>` | Run name, also the run directory name under `<output_dir>` (override the directory separately via `--run.dir`). Auto-generated as `<envs>--<model>--<short-id>` when unset, so every launch gets a fresh, readable run directory. Set an explicit name for a predictable path — required to resume the run later. |
 | `--clean` | Wipe the run directory before starting. Useful when re-running a named run during iteration. |
 | `--max-steps N` | Stop after `N` trainer steps. Overrides the config value. |

--- a/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 
 import verifiers.v1 as vf
-from pydantic import SerializeAsAny, model_validator
+from pydantic import Field, SerializeAsAny, model_validator
 
 from prime_rl.configs.shared import LogConfig
-from prime_rl.utils.config import BaseConfig
+from prime_rl.utils.config import BaseConfig, default_output_dir
 
 
 class EnvServerConfig(BaseConfig):
@@ -20,8 +20,8 @@ class EnvServerConfig(BaseConfig):
 
     log: LogConfig = LogConfig()
 
-    output_dir: Path = Path("outputs")
-    """Directory to write outputs to — logs and any generated artifacts are written as subdirectories."""
+    output_dir: Path = Field(default_factory=default_output_dir)
+    """Directory to write outputs to — logs and any generated artifacts are written as subdirectories. Defaults to ``$PRL_OUTPUT_DIR`` if set, else ``outputs``."""
 
     @model_validator(mode="before")
     @classmethod

--- a/packages/prime-rl-configs/src/prime_rl/configs/evals.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/evals.py
@@ -6,7 +6,7 @@ from prime_rl.configs.monitors import MonitorsConfig
 from prime_rl.configs.orchestrator import ConcurrencyConfig, EvalConfig
 from prime_rl.configs.shared import ClientConfig, LogConfig
 from prime_rl.configs.trainer import WeightBroadcastConfig
-from prime_rl.utils.config import BaseConfig
+from prime_rl.utils.config import BaseConfig, default_output_dir
 
 
 class EvalsEvalConfig(EvalConfig):
@@ -86,9 +86,9 @@ class EvalsConfig(BaseConfig):
     """Weight transport for online evals. The ``sft`` launcher fills this from its
     resolved trainer transport. None uses filesystem reloads."""
 
-    output_dir: Path = Path("outputs")
+    output_dir: Path = Field(default_factory=default_output_dir)
     """Directory to write outputs to — rollout traces and logs are written as
-    subdirectories. Shared with the trainer for online evals."""
+    subdirectories. Shared with the trainer for online evals. Defaults to ``$PRL_OUTPUT_DIR`` if set, else ``outputs``."""
 
     log: LogConfig = LogConfig()
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -7,7 +7,7 @@ from pydantic import ConfigDict, Field, model_validator
 from pydantic_config import BaseConfig
 
 from prime_rl.configs.shared import EnvVars, LogConfig, SlurmConfig
-from prime_rl.utils.config import find_package_resource
+from prime_rl.utils.config import default_output_dir, find_package_resource
 from prime_rl.utils.parsers import resolve_reasoning_parser, resolve_tool_call_parser
 
 # TODO: Set thinking/ solution budget
@@ -471,8 +471,8 @@ class InferenceConfig(BaseConfig):
     slurm: SlurmConfig | None = None
     """SLURM configuration. When set, the run is submitted as a SLURM job instead of running locally."""
 
-    output_dir: Path = Path("outputs")
-    """Directory for SLURM logs and generated scripts."""
+    output_dir: Path = Field(default_factory=default_output_dir)
+    """Directory for SLURM logs and generated scripts. Defaults to ``$PRL_OUTPUT_DIR`` if set, else ``outputs``."""
 
     dry_run: bool = False
     """Only validate and dump resolved configs, then exit early."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -22,7 +22,7 @@ from prime_rl.configs.shared import (
     ZMQTransportConfig,
 )
 from prime_rl.configs.trainer import TokenizerConfig
-from prime_rl.utils.config import BaseConfig
+from prime_rl.utils.config import BaseConfig, default_output_dir
 
 
 class LoRAConfig(BaseConfig):
@@ -491,8 +491,8 @@ class OrchestratorConfig(BaseConfig):
     rollout_transport: TransportConfig = ZMQTransportConfig()
     """Transport used to ship rollouts from orchestrator to trainer."""
 
-    output_dir: Path = Path("outputs")
-    """Directory to write outputs to — checkpoints, weights, rollouts, and logs are written as subdirectories. Shared with the trainer; should be a persistent directory with enough disk space and unique per experiment running on a single node."""
+    output_dir: Path = Field(default_factory=default_output_dir)
+    """Directory to write outputs to — checkpoints, weights, rollouts, and logs are written as subdirectories. Shared with the trainer; should be a persistent directory with enough disk space and unique per experiment running on a single node. Defaults to ``$PRL_OUTPUT_DIR`` if set, else ``outputs``."""
 
     tasks_per_minute: int | None = Field(None, ge=1)
     """Global rate limit on task dispatch, in tasks per minute. Recommended for sandbox-backed environments to prevent sandbox-not-ready errors during autoscaling. None disables rate limiting."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -41,7 +41,7 @@ from prime_rl.configs.trainer import (
     TokenizerConfig,
     TrainerConfig,
 )
-from prime_rl.utils.config import BaseConfig, find_package_resource
+from prime_rl.utils.config import BaseConfig, default_output_dir, find_package_resource
 from prime_rl.utils.validation import (
     propagate_shared_fields,
     validate_shared_ckpt_config,
@@ -243,8 +243,8 @@ class RLConfig(BaseConfig):
     run: RunConfig = Field(default_factory=RunConfig)
     """Run metadata. ``run.name`` names the run directory under ``output_dir``."""
 
-    output_dir: Path = Path("outputs")
-    """Directory that groups related runs. Each run writes its artifacts to ``output_dir / run.name``."""
+    output_dir: Path = Field(default_factory=default_output_dir)
+    """Directory that groups related runs. Each run writes its artifacts to ``output_dir / run.name``. Defaults to ``$PRL_OUTPUT_DIR`` if set, else ``outputs``."""
 
     clean: bool = False
     """Delete the run directory (``output_dir / run.name``) before starting training. Required to overwrite a run directory that contains artifacts from a previous run when not resuming."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -33,7 +33,7 @@ from prime_rl.configs.trainer import (
     WeightBroadcastConfig,
     validate_scheduler,
 )
-from prime_rl.utils.config import BaseConfig, find_package_resource
+from prime_rl.utils.config import BaseConfig, default_output_dir, find_package_resource
 
 
 class BaseDataConfig(BaseConfig):
@@ -233,8 +233,8 @@ class SFTConfig(BaseConfig):
     run: RunConfig = Field(default_factory=RunConfig)
     """Run metadata. ``run.name`` names the run directory under ``output_dir``."""
 
-    output_dir: Path = Path("outputs")
-    """Directory that groups related runs. Each run writes its artifacts (checkpoints, logs, ...) to ``output_dir / run.name``. Should be a persistent directory with enough disk space."""
+    output_dir: Path = Field(default_factory=default_output_dir)
+    """Directory that groups related runs. Each run writes its artifacts (checkpoints, logs, ...) to ``output_dir / run.name``. Should be a persistent directory with enough disk space. Defaults to ``$PRL_OUTPUT_DIR`` if set, else ``outputs``."""
 
     clean: bool = False
     """Delete the run directory (``output_dir / run.name``) before starting training. Required to overwrite a run directory that contains artifacts from a previous run when not resuming."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -16,7 +16,7 @@ from prime_rl.configs.shared import (
     TransportConfig,
     ZMQTransportConfig,
 )
-from prime_rl.utils.config import BaseConfig
+from prime_rl.utils.config import BaseConfig, default_output_dir
 
 # -- Shared trainer configs (used by both SFT and RL trainers) --
 
@@ -619,8 +619,8 @@ class TrainerConfig(BaseConfig):
     monitors: MonitorsConfig = MonitorsConfig()
     """Metric monitors (``monitors.wandb``, ``monitors.file``)."""
 
-    output_dir: Path = Path("outputs")
-    """Directory to write outputs to — checkpoints, weights, rollouts, and logs are written as subdirectories. Should be a persistent directory with enough disk space and unique per experiment running on a single node."""
+    output_dir: Path = Field(default_factory=default_output_dir)
+    """Directory to write outputs to — checkpoints, weights, rollouts, and logs are written as subdirectories. Should be a persistent directory with enough disk space and unique per experiment running on a single node. Defaults to ``$PRL_OUTPUT_DIR`` if set, else ``outputs``."""
 
     matmul_precision: Literal["highest", "high", "medium"] = "high"
     """Precision for float32 matrix multiplications. ``highest`` is full FP32 (required on ROCm/AMD GPUs to avoid catastrophic precision loss in softmax over large vocabularies). ``high`` enables TF32 on NVIDIA GPUs for a speedup with minor precision tradeoff. See ``torch.set_float32_matmul_precision``."""

--- a/packages/prime-rl-configs/src/prime_rl/utils/config.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/config.py
@@ -1,9 +1,15 @@
+import os
 from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel
 from pydantic_config import BaseConfig as BaseConfig  # noqa: F401
 from pydantic_config import cli  # noqa: F401
+
+
+def default_output_dir() -> Path:
+    """Default output directory: ``$PRL_OUTPUT_DIR`` if set, else ``outputs``."""
+    return Path(os.environ.get("PRL_OUTPUT_DIR", "outputs"))
 
 
 def dump_resolved_config(config: BaseModel, exclude: set[str] | None = None) -> dict:

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -17,7 +17,7 @@ uv run rl --model @ model.toml --data @ data.toml                          # nes
 uv run rl @ base.toml --trainer @ trainer.toml --trainer.lr 1e-3           # mixed
 ```
 
-Resolution order: CLI > config files (left-to-right) > class defaults. Merging is deep — unset fields in an overlay are preserved from the base.
+Resolution order: CLI > config files (left-to-right) > class defaults. Merging is deep — unset fields in an overlay are preserved from the base. `output_dir` has one extra fallback: CLI > config files > `$PRL_OUTPUT_DIR` > `"outputs"`.
 
 Naming: CLI uses kebab-case (`--vllm.max-model-len`); TOML uses snake_case (`max_model_len`).
 

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -6,7 +6,7 @@ description: Find, start, use, and stop the local run dashboard — the web UI f
 # Run dashboard
 
 `uv sync --extra dashboard && uv run dashboard [output_dir ...]` (default
-`outputs/`) serves a web UI at `http://localhost:7788`. It only reads run
+`outputs/`, or `$PRL_OUTPUT_DIR` if set) serves a web UI at `http://localhost:7788`. It only reads run
 dirs — safe against live runs — and installs anywhere (cluster head node,
 laptop against a mounted outputs dir): GPU dependencies live behind the
 `gpu` extra.

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -54,7 +54,7 @@ In W&B, each project auto-gets an **"overview" saved view** (train / eval / stab
 
 ### Dashboard
 
-`uv run dashboard [output_dir ...]` (default `outputs/`; several dirs can be tracked at
+`uv run dashboard [output_dir ...]` (default `outputs/`, or `$PRL_OUTPUT_DIR` if set; several dirs can be tracked at
 once) serves a local web dashboard at `http://localhost:7788` with four views per run:
 metrics (the W&B overview sections, read from `metrics.jsonl`), the resolved config
 files, a rollout trace viewer with a per-token advantage/logprob view, and merged

--- a/src/prime_rl/dashboard/server.py
+++ b/src/prime_rl/dashboard/server.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import orjson
 
 from prime_rl.entrypoints.dashboard import DAEMON_FILE, DIRS_FILE, STATE_DIR, registry_lock
+from prime_rl.utils.config import default_output_dir
 from prime_rl.utils.process import set_proc_title
 
 try:
@@ -37,7 +38,7 @@ MASTER_LOGS = {"trainer.log", "orchestrator.log", "inference.log", "evals.log"}
 MAX_LOG_CHUNK = 2_000_000
 
 app = FastAPI()
-output_dirs: list[Path] = [Path("outputs")]
+output_dirs: list[Path] = [default_output_dir()]
 
 # run id -> run dir, rebuilt on every /api/runs poll; ids are the run name,
 # qualified with the output dir's basename when two dirs hold the same name
@@ -888,7 +889,7 @@ def release_daemon() -> None:
 def main() -> None:
     global output_dirs, isolated
     parser = argparse.ArgumentParser(description="prime-rl run dashboard")
-    parser.add_argument("output_dirs", nargs="*", default=[Path("outputs")], type=Path, metavar="output_dir")
+    parser.add_argument("output_dirs", nargs="*", default=[default_output_dir()], type=Path, metavar="output_dir")
     parser.add_argument("--port", type=int, default=7788)
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument(


### PR DESCRIPTION
Lets a user set a persistent default output location for all runs without repeating --output-dir on every launch. Precedence stays class default ("outputs") < PRL_OUTPUT_DIR < TOML < CLI, since the new default_factory only fires when output_dir is untouched by TOML/CLI merge.

Also respected by the dashboard UI. 