### PR TITLE
chore: release v0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prime-rl"
-version = "0.8.0"
+version = "0.9.0"
 description = "Async RL Training at Scale"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/uv.lock
+++ b/uv.lock
@@ -4964,7 +4964,7 @@ dev = [
 
 [[package]]
 name = "prime-rl"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
## Summary

- bump the prime-rl project version from 0.8.0 to 0.9.0
- update the matching prime-rl entry in uv.lock
- prepare the [draft v0.9.0 GitHub release](https://github.com/PrimeIntellect-ai/prime-rl/releases/tag/untagged-6fdfe34d2c7a47da166a) with notes for 105 commits since v0.8.0
- include the latest dashboard, SLURM teardown, weight synchronization, and eval policy fixes in the release notes

## Verification

- uv lock --check
- git diff --check origin/main...HEAD