### PR TITLE
fix: silence W&B Weave advertisement on wandb.init

### DIFF
--- a/src/prime_rl/monitors/wandb/monitor.py
+++ b/src/prime_rl/monitors/wandb/monitor.py
@@ -42,6 +42,9 @@ class WandbMonitor(Monitor):
             self.logger.debug(f"Found WANDB_ARGS in environment variables {wandb_args}")
             sys.argv = json.loads(wandb_args)
 
+        # W&B advertises Weave on every init when it sees openai/verifiers imported.
+        os.environ.setdefault("WANDB_DISABLE_WEAVE", "1")
+
         # WANDB_MODE=disabled/offline takes precedence over shared mode — shared mode
         # requires a server connection and can't work offline.
         shared_mode = os.environ.get("WANDB_SHARED_MODE") == "1" and os.environ.get("WANDB_MODE") not in (


### PR DESCRIPTION
Every process that initializes W&B currently prints:

```
wandb: Detected [anthropic, mcp, openai, verifiers] in use.
wandb: Use W&B Weave for improved LLM call tracing. Install Weave with `pip install weave` then add `import weave` to the top of your script.
wandb: For more information, check out the docs at: https://weave-docs.wandb.ai
```

`wandb.init()` calls `wandb.integration.weave.setup()`, which scans `sys.modules` for a hardcoded list of LLM libraries (`openai` and `verifiers` are on it) and advertises Weave when it isn't imported. The integration has an official opt-out: any non-empty `WANDB_DISABLE_WEAVE`.

This sets `WANDB_DISABLE_WEAVE=1` via `os.environ.setdefault` in `WandbMonitor.init` right before `wandb.init`, so it covers every entrypoint (rl/sft/eval, all subprocesses) while leaving a user who explicitly unsets it (`WANDB_DISABLE_WEAVE=`) free to opt back in.

Verified: offline `wandb.init` with `openai`/`verifiers` imported prints zero Weave lines with the var set in-process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only environment default with no auth, data, or training logic changes; low blast radius.
> 
> **Overview**
> **Silences the recurring W&B Weave promotion** when `openai` or `verifiers` are loaded and `WandbMonitor` calls `wandb.init`.
> 
> `WandbMonitor.init` now sets `WANDB_DISABLE_WEAVE=1` with `os.environ.setdefault` immediately before W&B initialization, using the SDK’s documented opt-out. Because all `wandb.init` usage goes through this monitor, RL/SFT/eval subprocesses get the same behavior without touching each entrypoint. A user who explicitly clears the variable can still enable Weave.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9511d02f1e65b9586802d686a916ee9f6c81b4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->