### PR TITLE
feat: add Geo-Mask, Seq-TIS, Seq-MIS and MIS-PO loss types (sequence-level IS ablations)

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -276,6 +276,28 @@ Because the coefficient is detached, the gradient is the score function scaled b
 
 Reported metrics: `pmd_squared_error` (half the squared residual), `pmd_residual`, `pmd_abs_residual`, `sequence_log_ratio`, and `target_log_ratio`.
 
+### Geo-Mask Loss
+
+`[trainer.loss] type = "geo_mask"` replaces the `rl` component with sequence-level importance sampling behind a geometric trust region, from [RL collapse, part 3](https://richardli.xyz/post/rl-collapse-part3/). The rollout's importance ratio is the *geometric mean* of its per-token ratios, and the rollout contributes gradient only if that ratio lies inside the trust region:
+
+$$
+\rho_{\text{geo}}^{(j)} = \Big( \prod_t \rho_t^{(j)} \Big)^{1/|y^{(j)}|}, \qquad
+\mathcal{L} = -\sum_{j,t} \mathbb{I}\big(C_{\text{low}} \le \rho_{\text{geo}}^{(j)} \le C_{\text{high}}\big)\, \hat{A}_t^{(j)} \log \pi(y_t^{(j)}).
+$$
+
+The geometric mean is what makes the trust region length-invariant. A sequence-level mask on the *product* of per-token ratios rejects by cumulative divergence, which random-walks with length — past a critical length every rollout is rejected regardless of quality. The geometric mean is the average per-token log-ratio (an estimate of the per-token KL to the sampling policy), so the same bounds apply uniformly to short and long rollouts, and a rollout is judged by how far it drifted per token, not how long it is.
+
+Two properties distinguish it from the token-level trust regions above. The mask is all-or-nothing per rollout — a single divergent token never drops just itself, and an on-average-divergent rollout is dropped wholesale. And accepted rollouts use the plain score function with no importance weighting: inside the trust region the ratio is close to one, so the correction it would apply is dropped rather than carried as variance. Setting `token_clip` restores it as the Geo-Mask-Token-TIS hybrid, which weights each token's score function by its detached importance ratio clipped from above.
+
+| Knob | Default | What it does |
+|---|---|---|
+| `geo_mask_low` | 0.5 | Lower bound $C_{\text{low}}$ on the geometric-mean importance ratio. |
+| `geo_mask_high` | 2.0 | Upper bound $C_{\text{high}}$ on the geometric-mean importance ratio. The defaults accept rollouts whose mean absolute per-token log-ratio is within $\log 2 \approx 0.69$. |
+| `adv_tau` | 1.0 | Temperature on the advantage term. |
+| `token_clip` | None | Per-token importance-ratio ceiling for the Geo-Mask-Token-TIS hybrid ($\min(\rho_t, C)$, detached). None keeps the base estimator's plain score function. |
+
+Reported metrics: `masked_mismatch_kl` / `unmasked_mismatch_kl` (trainer/inference mismatch KL over dropped and kept tokens), `is_masked` (fraction of trainable tokens in rejected rollouts), and `geo_log_ratio` (the per-rollout mean log-ratio, $\log \rho_{\text{geo}}$).
+
 ### Custom Loss
 
 `[trainer.loss] type = "custom"` replaces the `rl` component. The loss is computed **per sequence**: you write a function that takes one sequence's tensors and returns a scalar loss. The trainer iterates and aggregates. `inputs.loss_mask` selects exactly the rl member tokens (for a plain GRPO run, all trainable tokens).

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -298,29 +298,42 @@ Two properties distinguish it from the token-level trust regions above. The mask
 
 Reported metrics: `masked_mismatch_kl` / `unmasked_mismatch_kl` (trainer/inference mismatch KL over dropped and kept tokens), `is_masked` (fraction of trainable tokens in rejected rollouts), and `geo_log_ratio` (the per-rollout mean log-ratio, $\log \rho_{\text{geo}}$).
 
-### Seq-IS Loss
+### Seq-TIS Loss
 
-`[trainer.loss] type = "seq_is"` replaces the `rl` component with sequence-level importance sampling: the rollout's full product importance ratio, detached, weights the score function of every token. This is the unbiased off-policy gradient — [the estimator that scales with batch size under policy lag](https://luk-huang.github.io/personal-website/blog/is-frontier-asynchronous-rl-solved.html) — whose price is a weight variance that compounds with length:
+`[trainer.loss] type = "seq_tis"` replaces the `rl` component with truncated sequence-level importance sampling: the rollout's full product importance ratio, capped at `seq_clip` and detached, weights the score function of every token ([the estimator family that scales with batch size under policy lag](https://luk-huang.github.io/personal-website/blog/is-frontier-asynchronous-rl-solved.html)):
 
 $$
 w^{(j)} = \prod_t \rho_t^{(j)}, \qquad
-\mathcal{L} = -\sum_{j,t} \mathbb{I}\big(C_{\text{low}} \le (w^{(j)})^{1/|y^{(j)}|} \le C_{\text{high}}\big)\, \min\big(w^{(j)}, C_{\text{seq}}\big)\, \hat{A}_t^{(j)} \log \pi(y_t^{(j)}),
+\mathcal{L} = -\sum_{j,t} \min\big(w^{(j)}, C\big)\, \hat{A}_t^{(j)} \log \pi(y_t^{(j)}).
 $$
 
-with the weight and mask detached. Two independent, composable controls trade bias for variance in different ways:
-
-- `seq_clip` truncates the weight from above (Seq-TIS): a small one-sided bias in exchange for a bounded weight. On by default — plain Seq-IS leans entirely on batch size to average its variance down, so drop the clip (`seq_clip = "None"`) only at large batch.
-- `geo_mask_low` / `geo_mask_high` put a trust region on the *geometric mean* of the per-token ratios and drop the rollout wholesale outside it. Unlike masking on the product (whose threshold rejects by cumulative divergence and so rejects long rollouts systematically), the geometric criterion is length-invariant; unlike the `geo_mask` loss type, accepted rollouts here keep their untempered product weight, so the estimator stays exactly unbiased on the accepted region. Off by default.
-
-The 2×2 of these knobs spans plain Seq-IS, Seq-TIS, geo-masked Seq-IS, and geo-masked Seq-TIS.
+Every rollout keeps a gradient contribution: a divergent rollout is damped to the ceiling rather than dropped, so its gradient direction is retained and the bias is one-sided (the region where the true weight would exceed $C$ is underweighted). Because the weight is detached, clipping does not zero the gradient of clipped rollouts. The complementary masking alternative is `seq_mis` below: truncation mis-weights the divergent tail but never discards data; masking discards it outright.
 
 | Knob | Default | What it does |
 |---|---|---|
-| `seq_clip` | 2.0 | Ceiling $C_{\text{seq}}$ on the sequence weight. None disables truncation (up to a numerics guard at $e^{40}$). |
-| `geo_mask_low` / `geo_mask_high` | None | Trust-region bounds on the geometric-mean importance ratio; each side is optional. |
+| `seq_clip` | 2.0 | Ceiling $C$ on the sequence weight. |
 | `adv_tau` | 1.0 | Temperature on the advantage term. |
 
-Reported metrics: `masked_mismatch_kl` / `unmasked_mismatch_kl`, `is_masked` (fraction of trainable tokens in geo-rejected rollouts), `is_clipped` (fraction of rollouts at the weight ceiling), `seq_log_ratio` ($\log w$), `geo_log_ratio` ($\frac{1}{T}\log w$), and `seq_weight` (the applied weight, post-clip).
+Reported metrics: `mismatch_kl`, `is_clipped` (fraction of rollouts at the ceiling), `seq_log_ratio` ($\log w$), `geo_log_ratio` ($\frac{1}{T}\log w$), and `seq_weight` (the applied weight, post-clip).
+
+### Seq-MIS Loss
+
+`[trainer.loss] type = "seq_mis"` replaces the `rl` component with masked sequence-level importance sampling: the rollout is dropped wholesale unless the *geometric mean* of its per-token ratios lies within `[geo_mask_low, geo_mask_high]`, and accepted rollouts keep their untempered product importance ratio (detached) on the score function of every token:
+
+$$
+\mathcal{L} = -\sum_{j,t} \mathbb{I}\big(C_{\text{low}} \le (w^{(j)})^{1/|y^{(j)}|} \le C_{\text{high}}\big)\, w^{(j)} \hat{A}_t^{(j)} \log \pi(y_t^{(j)}).
+$$
+
+The masking criterion is deliberately the geometric mean rather than the product: a threshold on the product rejects by cumulative divergence, which random-walks with length until every long rollout is rejected, while [the geometric mean judges rollouts by their average per-token drift](https://richardli.xyz/post/rl-collapse-part3/), so the same bounds apply to short and long rollouts. Unlike the `geo_mask` loss type (same acceptance rule, weight dropped) the accepted rollouts here keep the full product weight, so the estimator is exactly unbiased on the accepted region — at the price of a weight whose spread still compounds with length inside the trust region (a numerics guard caps it at $e^{40}$).
+
+Against `seq_tis`, this is the mask-vs-truncate trade: no mis-weighted gradients from the divergent tail, but the effective batch shrinks as the policies drift apart — watch `is_masked`.
+
+| Knob | Default | What it does |
+|---|---|---|
+| `geo_mask_low` / `geo_mask_high` | 0.5 / 2.0 | Trust-region bounds $C_{\text{low}}, C_{\text{high}}$ on the geometric-mean importance ratio. |
+| `adv_tau` | 1.0 | Temperature on the advantage term. |
+
+Reported metrics: `masked_mismatch_kl` / `unmasked_mismatch_kl`, `is_masked` (fraction of trainable tokens in rejected rollouts), `seq_log_ratio` ($\log w$), `geo_log_ratio` ($\frac{1}{T}\log w$), and `seq_weight` (the applied weight).
 
 ### Custom Loss
 

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -298,6 +298,30 @@ Two properties distinguish it from the token-level trust regions above. The mask
 
 Reported metrics: `masked_mismatch_kl` / `unmasked_mismatch_kl` (trainer/inference mismatch KL over dropped and kept tokens), `is_masked` (fraction of trainable tokens in rejected rollouts), and `geo_log_ratio` (the per-rollout mean log-ratio, $\log \rho_{\text{geo}}$).
 
+### Seq-IS Loss
+
+`[trainer.loss] type = "seq_is"` replaces the `rl` component with sequence-level importance sampling: the rollout's full product importance ratio, detached, weights the score function of every token. This is the unbiased off-policy gradient — [the estimator that scales with batch size under policy lag](https://luk-huang.github.io/personal-website/blog/is-frontier-asynchronous-rl-solved.html) — whose price is a weight variance that compounds with length:
+
+$$
+w^{(j)} = \prod_t \rho_t^{(j)}, \qquad
+\mathcal{L} = -\sum_{j,t} \mathbb{I}\big(C_{\text{low}} \le (w^{(j)})^{1/|y^{(j)}|} \le C_{\text{high}}\big)\, \min\big(w^{(j)}, C_{\text{seq}}\big)\, \hat{A}_t^{(j)} \log \pi(y_t^{(j)}),
+$$
+
+with the weight and mask detached. Two independent, composable controls trade bias for variance in different ways:
+
+- `seq_clip` truncates the weight from above (Seq-TIS): a small one-sided bias in exchange for a bounded weight. On by default — plain Seq-IS leans entirely on batch size to average its variance down, so drop the clip (`seq_clip = "None"`) only at large batch.
+- `geo_mask_low` / `geo_mask_high` put a trust region on the *geometric mean* of the per-token ratios and drop the rollout wholesale outside it. Unlike masking on the product (whose threshold rejects by cumulative divergence and so rejects long rollouts systematically), the geometric criterion is length-invariant; unlike the `geo_mask` loss type, accepted rollouts here keep their untempered product weight, so the estimator stays exactly unbiased on the accepted region. Off by default.
+
+The 2×2 of these knobs spans plain Seq-IS, Seq-TIS, geo-masked Seq-IS, and geo-masked Seq-TIS.
+
+| Knob | Default | What it does |
+|---|---|---|
+| `seq_clip` | 2.0 | Ceiling $C_{\text{seq}}$ on the sequence weight. None disables truncation (up to a numerics guard at $e^{40}$). |
+| `geo_mask_low` / `geo_mask_high` | None | Trust-region bounds on the geometric-mean importance ratio; each side is optional. |
+| `adv_tau` | 1.0 | Temperature on the advantage term. |
+
+Reported metrics: `masked_mismatch_kl` / `unmasked_mismatch_kl`, `is_masked` (fraction of trainable tokens in geo-rejected rollouts), `is_clipped` (fraction of rollouts at the weight ceiling), `seq_log_ratio` ($\log w$), `geo_log_ratio` ($\frac{1}{T}\log w$), and `seq_weight` (the applied weight, post-clip).
+
 ### Custom Loss
 
 `[trainer.loss] type = "custom"` replaces the `rl` component. The loss is computed **per sequence**: you write a function that takes one sequence's tensors and returns a scalar loss. The trainer iterates and aggregates. `inputs.loss_mask` selects exactly the rl member tokens (for a plain GRPO run, all trainable tokens).

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -335,6 +335,26 @@ Against `seq_tis`, this is the mask-vs-truncate trade: no mis-weighted gradients
 
 Reported metrics: `masked_mismatch_kl` / `unmasked_mismatch_kl`, `is_masked` (fraction of trainable tokens in rejected rollouts), `seq_log_ratio` ($\log w$), `geo_log_ratio` ($\frac{1}{T}\log w$), and `seq_weight` (the applied weight).
 
+### MIS-PO Loss
+
+`[trainer.loss] type = "mis_po"` replaces the `rl` component with the Metropolis-Independence-Sampling-filtered objective from [Step 3.5 Flash](https://arxiv.org/abs/2602.10604) (eq. 2): the plain score function behind dual-level binary masking, with no importance weighting anywhere. The inference policy is treated as a proposal distribution — samples close enough to the trainer are kept as effectively on-policy, everything else is dropped:
+
+$$
+\mathcal{L} = -\sum_{j,t} \mathbb{I}\big(\rho_{\text{tok,low}} \le \rho_t^{(j)} \le \rho_{\text{tok,high}}\big)\, \mathbb{I}\big(\rho_{\text{geo,low}} \le \bar\rho^{(j)} \le \rho_{\text{geo,high}}\big)\, \hat{A}_t^{(j)} \log \pi(y_t^{(j)}), \qquad \bar\rho = \Big(\prod_t \rho_t\Big)^{1/T}.
+$$
+
+The token-level indicator drops individually mismatched tokens even inside accepted rollouts; the trajectory-level indicator drops the rollout wholesale when its geometric-mean ratio drifts. Against the neighbouring loss types: it is `geo_mask`'s trajectory filter plus a token-level mismatch filter (and a far tighter trajectory band), and it is the pure-filtering counterpoint to the token trust regions above (`default`, `ipo`, `kpop`), which weight kept tokens by the importance ratio — MIS-PO deliberately does not.
+
+One calibration note: the paper's ratio numerator is the pre-update policy snapshot, so its ratios measure pure train/inference mismatch, whose geometric mean concentrates near one at long context — hence the very tight default trajectory band. Here the numerator is the live trainer policy (identical on the first pass over a batch); under real policy lag the geometric mean drifts further, so widen `geo_mask_low`/`geo_mask_high` accordingly (watch `is_traj_masked`).
+
+| Knob | Default | What it does |
+|---|---|---|
+| `token_mask_low` / `token_mask_high` | 0.5 / 2.0 | Token-level band on the trainer/inference importance ratio (paper values). |
+| `geo_mask_low` / `geo_mask_high` | 0.996 / 1.001 | Trajectory-level band on the geometric-mean importance ratio (paper values). |
+| `adv_tau` | 1.0 | Temperature on the advantage term. |
+
+Reported metrics: `masked_mismatch_kl` / `unmasked_mismatch_kl`, `is_masked` (fraction of trainable tokens dropped by either level), `is_token_masked`, `is_traj_masked`, and `geo_log_ratio`.
+
 ### Custom Loss
 
 `[trainer.loss] type = "custom"` replaces the `rl` component. The loss is computed **per sequence**: you write a function that takes one sequence's tensors and returns a scalar loss. The trainer iterates and aggregates. `inputs.loss_mask` selects exactly the rl member tokens (for a plain GRPO run, all trainable tokens).

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -580,6 +580,28 @@ class GeoMaskLossConfig(BaseConfig):
     function with no importance weighting."""
 
 
+class SeqISLossConfig(BaseConfig):
+    type: Literal["seq_is"] = "seq_is"
+
+    seq_clip: float | None = Field(2.0, gt=0)
+    """Ceiling on the sequence-level importance weight (Seq-TIS). None disables
+    truncation, leaving the unbiased Seq-IS weight (up to a numerics guard at
+    ``exp(40)``)."""
+
+    geo_mask_low: float | None = Field(None, gt=0)
+    """Optional lower bound of a trust region on the geometric-mean importance
+    ratio: rollouts whose ratio falls below it contribute no gradient. None
+    (the default) disables the bound."""
+
+    geo_mask_high: float | None = Field(None, gt=0)
+    """Optional upper bound of a trust region on the geometric-mean importance
+    ratio: rollouts whose ratio rises above it contribute no gradient. None
+    (the default) disables the bound."""
+
+    adv_tau: float = Field(1.0, ge=0)
+    """Temperature for the advantage term."""
+
+
 class CustomLossConfig(BaseConfig):
     type: Literal["custom"] = "custom"
 
@@ -597,6 +619,7 @@ LossConfig: TypeAlias = Annotated[
     | KimiK15LossConfig
     | PMDMeanLossConfig
     | GeoMaskLossConfig
+    | SeqISLossConfig
     | CustomLossConfig,
     Field(discriminator="type"),
 ]

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -559,6 +559,27 @@ class PMDMeanLossConfig(BaseConfig):
     (``advantage / pmd_tau``). Must be positive; the loss divides by it."""
 
 
+class GeoMaskLossConfig(BaseConfig):
+    type: Literal["geo_mask"] = "geo_mask"
+
+    geo_mask_low: float = Field(0.5, gt=0)
+    """Lower bound of the trust region on the geometric-mean importance ratio.
+    Sequences whose ratio falls below it contribute no gradient."""
+
+    geo_mask_high: float = Field(2.0, gt=0)
+    """Upper bound of the trust region on the geometric-mean importance ratio.
+    Sequences whose ratio rises above it contribute no gradient."""
+
+    adv_tau: float = Field(1.0, ge=0)
+    """Temperature for the advantage term."""
+
+    token_clip: float | None = Field(None, gt=0)
+    """Per-token importance-ratio ceiling for the Geo-Mask-Token-TIS hybrid:
+    accepted sequences weight the score function by ``min(ratio, token_clip)``
+    (detached). None (the default) is the base estimator — the plain score
+    function with no importance weighting."""
+
+
 class CustomLossConfig(BaseConfig):
     type: Literal["custom"] = "custom"
 
@@ -570,7 +591,13 @@ class CustomLossConfig(BaseConfig):
 
 
 LossConfig: TypeAlias = Annotated[
-    DefaultLossConfig | IPOLossConfig | KPopLossConfig | KimiK15LossConfig | PMDMeanLossConfig | CustomLossConfig,
+    DefaultLossConfig
+    | IPOLossConfig
+    | KPopLossConfig
+    | KimiK15LossConfig
+    | PMDMeanLossConfig
+    | GeoMaskLossConfig
+    | CustomLossConfig,
     Field(discriminator="type"),
 ]
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -606,6 +606,31 @@ class SeqMISLossConfig(BaseConfig):
     """Temperature for the advantage term."""
 
 
+class MISPOLossConfig(BaseConfig):
+    type: Literal["mis_po"] = "mis_po"
+
+    token_mask_low: float = Field(0.5, gt=0)
+    """Lower bound of the token-level band on the trainer/inference importance
+    ratio. Tokens outside the band are dropped individually."""
+
+    token_mask_high: float = Field(2.0, gt=0)
+    """Upper bound of the token-level band on the trainer/inference importance
+    ratio. Tokens outside the band are dropped individually."""
+
+    geo_mask_low: float = Field(0.996, gt=0)
+    """Lower bound of the trajectory-level band on the geometric-mean importance
+    ratio. Rollouts outside the band are dropped wholesale. The tight default is
+    the paper's, calibrated for near-on-policy train/inference mismatch at 128k
+    context; widen it under real policy lag."""
+
+    geo_mask_high: float = Field(1.001, gt=0)
+    """Upper bound of the trajectory-level band on the geometric-mean importance
+    ratio. Rollouts outside the band are dropped wholesale."""
+
+    adv_tau: float = Field(1.0, ge=0)
+    """Temperature for the advantage term."""
+
+
 class CustomLossConfig(BaseConfig):
     type: Literal["custom"] = "custom"
 
@@ -625,6 +650,7 @@ LossConfig: TypeAlias = Annotated[
     | GeoMaskLossConfig
     | SeqTISLossConfig
     | SeqMISLossConfig
+    | MISPOLossConfig
     | CustomLossConfig,
     Field(discriminator="type"),
 ]

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -580,23 +580,27 @@ class GeoMaskLossConfig(BaseConfig):
     function with no importance weighting."""
 
 
-class SeqISLossConfig(BaseConfig):
-    type: Literal["seq_is"] = "seq_is"
+class SeqTISLossConfig(BaseConfig):
+    type: Literal["seq_tis"] = "seq_tis"
 
-    seq_clip: float | None = Field(2.0, gt=0)
-    """Ceiling on the sequence-level importance weight (Seq-TIS). None disables
-    truncation, leaving the unbiased Seq-IS weight (up to a numerics guard at
-    ``exp(40)``)."""
+    seq_clip: float = Field(2.0, gt=0)
+    """Ceiling on the sequence-level importance weight. Every rollout keeps a
+    (possibly damped) gradient contribution; the bias is one-sided."""
 
-    geo_mask_low: float | None = Field(None, gt=0)
-    """Optional lower bound of a trust region on the geometric-mean importance
-    ratio: rollouts whose ratio falls below it contribute no gradient. None
-    (the default) disables the bound."""
+    adv_tau: float = Field(1.0, ge=0)
+    """Temperature for the advantage term."""
 
-    geo_mask_high: float | None = Field(None, gt=0)
-    """Optional upper bound of a trust region on the geometric-mean importance
-    ratio: rollouts whose ratio rises above it contribute no gradient. None
-    (the default) disables the bound."""
+
+class SeqMISLossConfig(BaseConfig):
+    type: Literal["seq_mis"] = "seq_mis"
+
+    geo_mask_low: float = Field(0.5, gt=0)
+    """Lower bound of the trust region on the geometric-mean importance ratio.
+    Rollouts whose ratio falls below it contribute no gradient."""
+
+    geo_mask_high: float = Field(2.0, gt=0)
+    """Upper bound of the trust region on the geometric-mean importance ratio.
+    Rollouts whose ratio rises above it contribute no gradient."""
 
     adv_tau: float = Field(1.0, ge=0)
     """Temperature for the advantage term."""
@@ -619,7 +623,8 @@ LossConfig: TypeAlias = Annotated[
     | KimiK15LossConfig
     | PMDMeanLossConfig
     | GeoMaskLossConfig
-    | SeqISLossConfig
+    | SeqTISLossConfig
+    | SeqMISLossConfig
     | CustomLossConfig,
     Field(discriminator="type"),
 ]

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
@@ -9,6 +10,7 @@ from torch import Tensor
 from prime_rl.configs.trainer import (
     CustomLossConfig,
     DefaultLossConfig,
+    GeoMaskLossConfig,
     IPOLossConfig,
     KimiK15LossConfig,
     KPopLossConfig,
@@ -419,12 +421,67 @@ def pmd_mean_loss_fn(
     return LossOutputs(loss=loss, metrics=metrics)
 
 
+@jaxtyped(typechecker=typechecker)
+def geo_mask_loss_fn(inputs: LossInputs, loss_config: GeoMaskLossConfig) -> LossOutputs:
+    """Geo-Mask loss type (https://richardli.xyz/post/rl-collapse-part3/):
+    sequence-level importance sampling behind a geometric trust region. The
+    rollout's importance ratio is the geometric mean of its per-token ratios —
+    an intensive quantity that stays comparable across lengths, where the
+    product of per-token ratios grows with length and ends up rejecting long
+    rollouts wholesale. A rollout contributes gradient only if that ratio lies
+    within ``[geo_mask_low, geo_mask_high]``; the mask is all-or-nothing per
+    rollout, never per token.
+
+    Accepted rollouts use the plain score function: inside the trust region
+    the ratio is close to one, so the correction it would apply is dropped
+    rather than carried as variance. ``token_clip`` switches to the
+    Geo-Mask-Token-TIS hybrid, which weights each token's score function by
+    its detached importance ratio clipped from above.
+    """
+    trainer_logprobs = inputs.trainer_logprobs
+    inference_logprobs = inputs.inference_logprobs
+    advantages = inputs.advantages
+    loss_mask = inputs.loss_mask
+
+    log_importance_ratio, importance_ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
+        trainer_logprobs, inference_logprobs
+    )
+
+    num_tokens = loss_mask.sum().clamp_min(1)
+    geo_log_ratio = (loss_mask * log_importance_ratio).sum() / num_tokens
+    is_masked = (geo_log_ratio < math.log(loss_config.geo_mask_low)) | (
+        geo_log_ratio > math.log(loss_config.geo_mask_high)
+    )
+    keep_mask = loss_mask & ~is_masked
+
+    advantages = loss_config.adv_tau * advantages
+    if loss_config.token_clip is None:
+        token_weight = 1.0
+    else:
+        token_weight = importance_ratio.detach().clamp(max=loss_config.token_clip)
+    pg_loss = keep_mask * advantages * token_weight * trainer_logprobs
+    per_token_loss = -pg_loss
+    if inputs.loss_weights is not None:
+        per_token_loss = per_token_loss * inputs.loss_weights
+    loss = per_token_loss.sum()
+
+    metrics = {
+        "masked_mismatch_kl": _safe_mean(mismatch_kl, loss_mask & is_masked),  # all trainable, masked tokens
+        "unmasked_mismatch_kl": _safe_mean(mismatch_kl, keep_mask),  # all trainable, unmasked tokens
+        "is_masked": _safe_mean(is_masked.expand(loss_mask.shape), loss_mask),
+        "geo_log_ratio": geo_log_ratio.detach(),
+    }
+
+    return LossOutputs(loss=loss, metrics=metrics)
+
+
 def setup_rl_loss_fn(loss_config: LossConfig) -> LossFn:
     """Build the loss fn for the rl component from ``trainer.loss``:
     ``default_loss_fn`` (``DefaultLossConfig``), ``ipo_loss_fn``
     (``IPOLossConfig``), ``kpop_loss_fn`` (``KPopLossConfig``),
     ``kimi_k15_loss_fn`` (``KimiK15LossConfig``),
-    ``pmd_mean_loss_fn`` (``PMDMeanLossConfig``), or the imported
+    ``pmd_mean_loss_fn`` (``PMDMeanLossConfig``),
+    ``geo_mask_loss_fn`` (``GeoMaskLossConfig``), or the imported
     function (``CustomLossConfig``).
     The ce / ref_kl loss types are fixed and unaffected by ``trainer.loss``."""
     if isinstance(loss_config, CustomLossConfig):
@@ -449,6 +506,10 @@ def setup_rl_loss_fn(loss_config: LossConfig) -> LossFn:
 
         def rl_fn(inputs: LossInputs) -> LossOutputs:
             return pmd_mean_loss_fn(inputs, loss_config)
+    elif isinstance(loss_config, GeoMaskLossConfig):
+
+        def rl_fn(inputs: LossInputs) -> LossOutputs:
+            return geo_mask_loss_fn(inputs, loss_config)
     else:
 
         def rl_fn(inputs: LossInputs) -> LossOutputs:

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -16,6 +16,7 @@ from prime_rl.configs.trainer import (
     KPopLossConfig,
     LossConfig,
     PMDMeanLossConfig,
+    SeqISLossConfig,
 )
 from prime_rl.utils.utils import import_object
 
@@ -475,13 +476,81 @@ def geo_mask_loss_fn(inputs: LossInputs, loss_config: GeoMaskLossConfig) -> Loss
     return LossOutputs(loss=loss, metrics=metrics)
 
 
+@jaxtyped(typechecker=typechecker)
+def seq_is_loss_fn(inputs: LossInputs, loss_config: SeqISLossConfig) -> LossOutputs:
+    """Seq-IS loss type: sequence-level importance sampling — the rollout's
+    full product importance ratio, detached, weights the score function of
+    every token. This is the unbiased off-policy gradient, whose weight
+    variance compounds with length; the two optional controls trade bias for
+    variance in different ways.
+
+    ``seq_clip`` truncates the weight from above (Seq-TIS): a small one-sided
+    bias in exchange for a bounded weight. ``geo_mask_low`` / ``geo_mask_high``
+    put a trust region on the *geometric mean* of the per-token ratios and drop
+    the rollout wholesale outside it — a length-invariant acceptance rule
+    (bias only from the rejected region), leaving the weight of accepted
+    rollouts untempered. The controls compose; with neither, this is plain
+    Seq-IS, which leans entirely on batch size to average the variance down
+    (https://luk-huang.github.io/personal-website/blog/is-frontier-asynchronous-rl-solved.html).
+    """
+    trainer_logprobs = inputs.trainer_logprobs
+    inference_logprobs = inputs.inference_logprobs
+    advantages = inputs.advantages
+    loss_mask = inputs.loss_mask
+
+    log_importance_ratio, _, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
+        trainer_logprobs, inference_logprobs
+    )
+
+    seq_log_ratio = (loss_mask * log_importance_ratio).sum().detach()
+    num_tokens = loss_mask.sum().clamp_min(1)
+    geo_log_ratio = seq_log_ratio / num_tokens
+
+    is_masked = torch.zeros((), dtype=torch.bool, device=loss_mask.device)
+    if loss_config.geo_mask_low is not None:
+        is_masked = is_masked | (geo_log_ratio < math.log(loss_config.geo_mask_low))
+    if loss_config.geo_mask_high is not None:
+        is_masked = is_masked | (geo_log_ratio > math.log(loss_config.geo_mask_high))
+    keep_mask = loss_mask & ~is_masked
+
+    log_weight = seq_log_ratio
+    if loss_config.seq_clip is not None:
+        log_weight = log_weight.clamp(max=math.log(loss_config.seq_clip))
+    # An unclipped long rollout's summed log-ratio overflows exp() well before
+    # the weight is meaningful; keep the loss finite rather than poisoning the
+    # step with inf. Only reachable with seq_clip=None.
+    seq_weight = log_weight.clamp(max=40.0).exp()
+
+    advantages = loss_config.adv_tau * advantages
+    pg_loss = keep_mask * seq_weight * advantages * trainer_logprobs
+    per_token_loss = -pg_loss
+    if inputs.loss_weights is not None:
+        per_token_loss = per_token_loss * inputs.loss_weights
+    loss = per_token_loss.sum()
+
+    is_clipped = seq_log_ratio > log_weight
+
+    metrics = {
+        "masked_mismatch_kl": _safe_mean(mismatch_kl, loss_mask & is_masked),  # all trainable, masked tokens
+        "unmasked_mismatch_kl": _safe_mean(mismatch_kl, keep_mask),  # all trainable, unmasked tokens
+        "is_masked": _safe_mean(is_masked.expand(loss_mask.shape), loss_mask),
+        "is_clipped": is_clipped.float(),
+        "seq_log_ratio": seq_log_ratio,
+        "geo_log_ratio": geo_log_ratio,
+        "seq_weight": seq_weight,
+    }
+
+    return LossOutputs(loss=loss, metrics=metrics)
+
+
 def setup_rl_loss_fn(loss_config: LossConfig) -> LossFn:
     """Build the loss fn for the rl component from ``trainer.loss``:
     ``default_loss_fn`` (``DefaultLossConfig``), ``ipo_loss_fn``
     (``IPOLossConfig``), ``kpop_loss_fn`` (``KPopLossConfig``),
     ``kimi_k15_loss_fn`` (``KimiK15LossConfig``),
     ``pmd_mean_loss_fn`` (``PMDMeanLossConfig``),
-    ``geo_mask_loss_fn`` (``GeoMaskLossConfig``), or the imported
+    ``geo_mask_loss_fn`` (``GeoMaskLossConfig``),
+    ``seq_is_loss_fn`` (``SeqISLossConfig``), or the imported
     function (``CustomLossConfig``).
     The ce / ref_kl loss types are fixed and unaffected by ``trainer.loss``."""
     if isinstance(loss_config, CustomLossConfig):
@@ -510,6 +579,10 @@ def setup_rl_loss_fn(loss_config: LossConfig) -> LossFn:
 
         def rl_fn(inputs: LossInputs) -> LossOutputs:
             return geo_mask_loss_fn(inputs, loss_config)
+    elif isinstance(loss_config, SeqISLossConfig):
+
+        def rl_fn(inputs: LossInputs) -> LossOutputs:
+            return seq_is_loss_fn(inputs, loss_config)
     else:
 
         def rl_fn(inputs: LossInputs) -> LossOutputs:

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -15,6 +15,7 @@ from prime_rl.configs.trainer import (
     KimiK15LossConfig,
     KPopLossConfig,
     LossConfig,
+    MISPOLossConfig,
     PMDMeanLossConfig,
     SeqMISLossConfig,
     SeqTISLossConfig,
@@ -583,6 +584,64 @@ def seq_mis_loss_fn(inputs: LossInputs, loss_config: SeqMISLossConfig) -> LossOu
     return LossOutputs(loss=loss, metrics=metrics)
 
 
+@jaxtyped(typechecker=typechecker)
+def mis_po_loss_fn(inputs: LossInputs, loss_config: MISPOLossConfig) -> LossOutputs:
+    """MIS-PO loss type (Step 3.5 Flash, https://arxiv.org/abs/2602.10604,
+    eq. 2): Metropolis-Independence-Sampling-filtered policy optimization —
+    the plain score function behind dual-level binary masking, with no
+    importance weighting anywhere. The inference policy is treated as a
+    proposal distribution: samples close enough to the trainer are kept as
+    effectively on-policy, everything else is dropped.
+
+    Token level: tokens whose trainer/inference ratio leaves
+    ``[token_mask_low, token_mask_high]`` are dropped individually.
+    Trajectory level: the rollout is dropped wholesale when the geometric
+    mean of its per-token ratios leaves ``[geo_mask_low, geo_mask_high]``.
+    The paper's trajectory band ([0.996, 1.001]) is far tighter than
+    ``geo_mask``'s: the ratio in the paper measures train/inference mismatch
+    of a pre-update snapshot, whose geometric mean concentrates near one at
+    long context. Here the numerator is the live trainer policy (identical on
+    the first pass over a batch), so widen the band under real policy lag.
+    """
+    trainer_logprobs = inputs.trainer_logprobs
+    inference_logprobs = inputs.inference_logprobs
+    advantages = inputs.advantages
+    loss_mask = inputs.loss_mask
+
+    log_importance_ratio, importance_ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
+        trainer_logprobs, inference_logprobs
+    )
+
+    is_token_masked = (importance_ratio < loss_config.token_mask_low) | (importance_ratio > loss_config.token_mask_high)
+
+    num_tokens = loss_mask.sum().clamp_min(1)
+    geo_log_ratio = (loss_mask * log_importance_ratio).sum().detach() / num_tokens
+    is_traj_masked = (geo_log_ratio < math.log(loss_config.geo_mask_low)) | (
+        geo_log_ratio > math.log(loss_config.geo_mask_high)
+    )
+
+    is_masked = is_token_masked | is_traj_masked
+    keep_mask = loss_mask & ~is_masked
+
+    advantages = loss_config.adv_tau * advantages
+    pg_loss = keep_mask * advantages * trainer_logprobs
+    per_token_loss = -pg_loss
+    if inputs.loss_weights is not None:
+        per_token_loss = per_token_loss * inputs.loss_weights
+    loss = per_token_loss.sum()
+
+    metrics = {
+        "masked_mismatch_kl": _safe_mean(mismatch_kl, loss_mask & is_masked),  # all trainable, masked tokens
+        "unmasked_mismatch_kl": _safe_mean(mismatch_kl, keep_mask),  # all trainable, unmasked tokens
+        "is_masked": _safe_mean(is_masked, loss_mask),
+        "is_token_masked": _safe_mean(is_token_masked, loss_mask),
+        "is_traj_masked": _safe_mean(is_traj_masked.expand(loss_mask.shape), loss_mask),
+        "geo_log_ratio": geo_log_ratio,
+    }
+
+    return LossOutputs(loss=loss, metrics=metrics)
+
+
 def setup_rl_loss_fn(loss_config: LossConfig) -> LossFn:
     """Build the loss fn for the rl component from ``trainer.loss``:
     ``default_loss_fn`` (``DefaultLossConfig``), ``ipo_loss_fn``
@@ -591,7 +650,8 @@ def setup_rl_loss_fn(loss_config: LossConfig) -> LossFn:
     ``pmd_mean_loss_fn`` (``PMDMeanLossConfig``),
     ``geo_mask_loss_fn`` (``GeoMaskLossConfig``),
     ``seq_tis_loss_fn`` (``SeqTISLossConfig``),
-    ``seq_mis_loss_fn`` (``SeqMISLossConfig``), or the imported
+    ``seq_mis_loss_fn`` (``SeqMISLossConfig``),
+    ``mis_po_loss_fn`` (``MISPOLossConfig``), or the imported
     function (``CustomLossConfig``).
     The ce / ref_kl loss types are fixed and unaffected by ``trainer.loss``."""
     if isinstance(loss_config, CustomLossConfig):
@@ -628,6 +688,10 @@ def setup_rl_loss_fn(loss_config: LossConfig) -> LossFn:
 
         def rl_fn(inputs: LossInputs) -> LossOutputs:
             return seq_mis_loss_fn(inputs, loss_config)
+    elif isinstance(loss_config, MISPOLossConfig):
+
+        def rl_fn(inputs: LossInputs) -> LossOutputs:
+            return mis_po_loss_fn(inputs, loss_config)
     else:
 
         def rl_fn(inputs: LossInputs) -> LossOutputs:

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -16,7 +16,8 @@ from prime_rl.configs.trainer import (
     KPopLossConfig,
     LossConfig,
     PMDMeanLossConfig,
-    SeqISLossConfig,
+    SeqMISLossConfig,
+    SeqTISLossConfig,
 )
 from prime_rl.utils.utils import import_object
 
@@ -477,21 +478,16 @@ def geo_mask_loss_fn(inputs: LossInputs, loss_config: GeoMaskLossConfig) -> Loss
 
 
 @jaxtyped(typechecker=typechecker)
-def seq_is_loss_fn(inputs: LossInputs, loss_config: SeqISLossConfig) -> LossOutputs:
-    """Seq-IS loss type: sequence-level importance sampling — the rollout's
-    full product importance ratio, detached, weights the score function of
-    every token. This is the unbiased off-policy gradient, whose weight
-    variance compounds with length; the two optional controls trade bias for
-    variance in different ways.
-
-    ``seq_clip`` truncates the weight from above (Seq-TIS): a small one-sided
-    bias in exchange for a bounded weight. ``geo_mask_low`` / ``geo_mask_high``
-    put a trust region on the *geometric mean* of the per-token ratios and drop
-    the rollout wholesale outside it — a length-invariant acceptance rule
-    (bias only from the rejected region), leaving the weight of accepted
-    rollouts untempered. The controls compose; with neither, this is plain
-    Seq-IS, which leans entirely on batch size to average the variance down
+def seq_tis_loss_fn(inputs: LossInputs, loss_config: SeqTISLossConfig) -> LossOutputs:
+    """Seq-TIS loss type: truncated sequence-level importance sampling — the
+    rollout's full product importance ratio, capped at ``seq_clip`` and
+    detached, weights the score function of every token
     (https://luk-huang.github.io/personal-website/blog/is-frontier-asynchronous-rl-solved.html).
+
+    Every rollout keeps a gradient contribution: divergent rollouts are damped
+    to the ceiling rather than dropped, so the bias is one-sided (the region
+    where the weight would exceed the ceiling is underweighted, but its
+    gradient direction is retained).
     """
     trainer_logprobs = inputs.trainer_logprobs
     inference_logprobs = inputs.inference_logprobs
@@ -506,20 +502,67 @@ def seq_is_loss_fn(inputs: LossInputs, loss_config: SeqISLossConfig) -> LossOutp
     num_tokens = loss_mask.sum().clamp_min(1)
     geo_log_ratio = seq_log_ratio / num_tokens
 
-    is_masked = torch.zeros((), dtype=torch.bool, device=loss_mask.device)
-    if loss_config.geo_mask_low is not None:
-        is_masked = is_masked | (geo_log_ratio < math.log(loss_config.geo_mask_low))
-    if loss_config.geo_mask_high is not None:
-        is_masked = is_masked | (geo_log_ratio > math.log(loss_config.geo_mask_high))
+    seq_weight = seq_log_ratio.clamp(max=math.log(loss_config.seq_clip)).exp()
+    is_clipped = seq_log_ratio > math.log(loss_config.seq_clip)
+
+    advantages = loss_config.adv_tau * advantages
+    pg_loss = loss_mask * seq_weight * advantages * trainer_logprobs
+    per_token_loss = -pg_loss
+    if inputs.loss_weights is not None:
+        per_token_loss = per_token_loss * inputs.loss_weights
+    loss = per_token_loss.sum()
+
+    metrics = {
+        "mismatch_kl": _safe_mean(mismatch_kl, loss_mask),
+        "is_clipped": is_clipped.float(),
+        "seq_log_ratio": seq_log_ratio,
+        "geo_log_ratio": geo_log_ratio,
+        "seq_weight": seq_weight,
+    }
+
+    return LossOutputs(loss=loss, metrics=metrics)
+
+
+@jaxtyped(typechecker=typechecker)
+def seq_mis_loss_fn(inputs: LossInputs, loss_config: SeqMISLossConfig) -> LossOutputs:
+    """Seq-MIS loss type: masked sequence-level importance sampling — the
+    rollout is dropped wholesale unless the *geometric mean* of its per-token
+    ratios lies within ``[geo_mask_low, geo_mask_high]``; accepted rollouts
+    keep the untempered product importance ratio (detached) on the score
+    function of every token, so the estimator is exactly unbiased on the
+    accepted region.
+
+    The masking criterion is deliberately the geometric mean rather than the
+    product: a threshold on the product rejects by cumulative divergence,
+    which grows with length until every long rollout is rejected, while the
+    geometric mean judges rollouts by their average per-token drift
+    (https://richardli.xyz/post/rl-collapse-part3/). The complementary
+    trade-off to ``seq_tis``: masking discards the divergent tail entirely
+    (no mis-weighted gradients, but the effective batch shrinks as policies
+    drift apart), truncation keeps it damped.
+    """
+    trainer_logprobs = inputs.trainer_logprobs
+    inference_logprobs = inputs.inference_logprobs
+    advantages = inputs.advantages
+    loss_mask = inputs.loss_mask
+
+    log_importance_ratio, _, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
+        trainer_logprobs, inference_logprobs
+    )
+
+    seq_log_ratio = (loss_mask * log_importance_ratio).sum().detach()
+    num_tokens = loss_mask.sum().clamp_min(1)
+    geo_log_ratio = seq_log_ratio / num_tokens
+
+    is_masked = (geo_log_ratio < math.log(loss_config.geo_mask_low)) | (
+        geo_log_ratio > math.log(loss_config.geo_mask_high)
+    )
     keep_mask = loss_mask & ~is_masked
 
-    log_weight = seq_log_ratio
-    if loss_config.seq_clip is not None:
-        log_weight = log_weight.clamp(max=math.log(loss_config.seq_clip))
-    # An unclipped long rollout's summed log-ratio overflows exp() well before
-    # the weight is meaningful; keep the loss finite rather than poisoning the
-    # step with inf. Only reachable with seq_clip=None.
-    seq_weight = log_weight.clamp(max=40.0).exp()
+    # Within the geo trust region a long rollout's product ratio can still
+    # overflow exp(); keep the weight finite rather than poisoning the step
+    # with inf.
+    seq_weight = seq_log_ratio.clamp(max=40.0).exp()
 
     advantages = loss_config.adv_tau * advantages
     pg_loss = keep_mask * seq_weight * advantages * trainer_logprobs
@@ -528,13 +571,10 @@ def seq_is_loss_fn(inputs: LossInputs, loss_config: SeqISLossConfig) -> LossOutp
         per_token_loss = per_token_loss * inputs.loss_weights
     loss = per_token_loss.sum()
 
-    is_clipped = seq_log_ratio > log_weight
-
     metrics = {
         "masked_mismatch_kl": _safe_mean(mismatch_kl, loss_mask & is_masked),  # all trainable, masked tokens
         "unmasked_mismatch_kl": _safe_mean(mismatch_kl, keep_mask),  # all trainable, unmasked tokens
         "is_masked": _safe_mean(is_masked.expand(loss_mask.shape), loss_mask),
-        "is_clipped": is_clipped.float(),
         "seq_log_ratio": seq_log_ratio,
         "geo_log_ratio": geo_log_ratio,
         "seq_weight": seq_weight,
@@ -550,7 +590,8 @@ def setup_rl_loss_fn(loss_config: LossConfig) -> LossFn:
     ``kimi_k15_loss_fn`` (``KimiK15LossConfig``),
     ``pmd_mean_loss_fn`` (``PMDMeanLossConfig``),
     ``geo_mask_loss_fn`` (``GeoMaskLossConfig``),
-    ``seq_is_loss_fn`` (``SeqISLossConfig``), or the imported
+    ``seq_tis_loss_fn`` (``SeqTISLossConfig``),
+    ``seq_mis_loss_fn`` (``SeqMISLossConfig``), or the imported
     function (``CustomLossConfig``).
     The ce / ref_kl loss types are fixed and unaffected by ``trainer.loss``."""
     if isinstance(loss_config, CustomLossConfig):
@@ -579,10 +620,14 @@ def setup_rl_loss_fn(loss_config: LossConfig) -> LossFn:
 
         def rl_fn(inputs: LossInputs) -> LossOutputs:
             return geo_mask_loss_fn(inputs, loss_config)
-    elif isinstance(loss_config, SeqISLossConfig):
+    elif isinstance(loss_config, SeqTISLossConfig):
 
         def rl_fn(inputs: LossInputs) -> LossOutputs:
-            return seq_is_loss_fn(inputs, loss_config)
+            return seq_tis_loss_fn(inputs, loss_config)
+    elif isinstance(loss_config, SeqMISLossConfig):
+
+        def rl_fn(inputs: LossInputs) -> LossOutputs:
+            return seq_mis_loss_fn(inputs, loss_config)
     else:
 
         def rl_fn(inputs: LossInputs) -> LossOutputs:


### PR DESCRIPTION
Adds four loss types to the algo-ablations set (#3381), drawing on [RL collapse, part 3](https://richardli.xyz/post/rl-collapse-part3/) (Li) and [Is Frontier Asynchronous RL Solved?](https://luk-huang.github.io/personal-website/blog/is-frontier-asynchronous-rl-solved.html) (Huang). `seq_tis` and `seq_mis` are the truncate-vs-mask pair for sequence-level IS; `geo_mask` is Li's pure-filter estimator.

All three compute the rollout's summed log-ratio; they differ in what they do with it. Weights are always detached (score-function surrogates), so clipping/masking never silently zeroes gradients through the ratio.

## `seq_tis` — truncated sequence-level IS (Huang)

$$
w = \prod_t \rho_t, \qquad \mathcal{L} = -\sum_{j,t} \min\big(w^{(j)}, C\big)\, \hat{A}_t^{(j)} \log \pi(y_t^{(j)})
$$

Every rollout keeps a (possibly damped) gradient contribution; bias is one-sided. The estimator Huang's K=12 lag experiments found most durable.

| Knob | Default |
|---|---|
| `seq_clip` | 2.0 |
| `adv_tau` | 1.0 |

Metrics: `mismatch_kl`, `is_clipped`, `seq_log_ratio`, `geo_log_ratio`, `seq_weight`.

## `seq_mis` — masked sequence-level IS, geometric criterion (Li × Huang)

$$
\mathcal{L} = -\sum_{j,t} \mathbb{I}\big(C_{\text{low}} \le (w^{(j)})^{1/T_j} \le C_{\text{high}}\big)\, w^{(j)} \hat{A}_t^{(j)} \log \pi(y_t^{(j)})
$$

Drops the rollout wholesale unless the **geometric mean** of its per-token ratios is in the trust region; accepted rollouts keep the untempered product weight, so the estimator is exactly unbiased on the accepted region. The criterion is deliberately geometric rather than a product threshold (which rejects by cumulative divergence and kills all long rollouts); the weight is deliberately untempered (tempering to $w^{1/T}$ is the bias Huang shows makes GeoMean-IS track token-IS). Numerics guard caps the weight at $e^{40}$. The mask-vs-truncate contrast with `seq_tis`: no mis-weighted gradients from the divergent tail, but effective batch shrinks as policies drift (watch `is_masked`).

| Knob | Default |
|---|---|
| `geo_mask_low` / `geo_mask_high` | 0.5 / 2.0 |
| `adv_tau` | 1.0 |

Metrics: `masked/unmasked_mismatch_kl`, `is_masked`, `seq_log_ratio`, `geo_log_ratio`, `seq_weight`.

## `geo_mask` — geometric trust region, pure filter (Li)

$$
\mathcal{L} = -\sum_{j,t} \mathbb{I}\big(C_{\text{low}} \le \rho_{\text{geo}}^{(j)} \le C_{\text{high}}\big)\, \hat{A}_t^{(j)} \log \pi(y_t^{(j)}), \qquad \rho_{\text{geo}} = \Big(\prod_t \rho_t\Big)^{1/T}
$$

Same length-invariant acceptance rule as `seq_mis`, but accepted rollouts use the plain score function with no importance weighting (the post's pure-filter design: inside the trust region the ratio is ~1). `token_clip` enables the post's Geo-Mask-Token-TIS hybrid (score function weighted by the detached, upper-clipped per-token ratio) for full per-token IS correction.

| Knob | Default |
|---|---|
| `geo_mask_low` / `geo_mask_high` | 0.5 / 2.0 |
| `adv_tau` | 1.0 |
| `token_clip` | None |

Metrics: `masked/unmasked_mismatch_kl`, `is_masked`, `geo_log_ratio`.


## `mis_po` — dual-level binary masking, pure score function (Step 3.5 Flash)

From [Step 3.5 Flash](https://arxiv.org/abs/2602.10604) (eq. 2), "Metropolis Independence Sampling-filtered Policy Optimization": treat the inference policy as a proposal distribution and keep only samples close enough to the trainer, as effectively on-policy — no importance weighting anywhere:

$$
\mathcal{L} = -\sum_{j,t} \mathbb{I}\big(\rho_{\text{tok,low}} \le \rho_t^{(j)} \le \rho_{\text{tok,high}}\big)\, \mathbb{I}\big(\rho_{\text{geo,low}} \le \bar\rho^{(j)} \le \rho_{\text{geo,high}}\big)\, \hat{A}_t^{(j)} \log \pi(y_t^{(j)})
$$

Token-level indicator drops individually mismatched tokens; trajectory-level indicator drops the rollout when its geometric-mean ratio drifts. Structurally it is `geo_mask`'s trajectory filter + a token-level mismatch filter, with the paper's much tighter trajectory band (their ratios measure pre-update-snapshot/vLLM mismatch, which concentrates near 1 at 128k context — under real policy lag the band should be widened; docs note this).

| Knob | Default |
|---|---|
| `token_mask_low` / `token_mask_high` | 0.5 / 2.0 (paper) |
| `geo_mask_low` / `geo_mask_high` | 0.996 / 1.001 (paper) |
| `adv_tau` | 1.0 |

Metrics: `masked/unmasked_mismatch_kl`, `is_masked`, `is_token_masked`, `is_traj_masked`, `geo_log_ratio`.

## Test plan

Smoke-tested all four loss fns directly (no test files added, per repo convention): exact gradients in every regime (score function with per-token drops for mis_po; score function `-adv`; clipped weight `-2·adv`; untempered in-region weight `-e^{0.8}·adv`; `token_clip` hybrid's detached weight), both-sided geo rejection with zero gradient while staying backward-able, masks computed only over loss-masked tokens, the $e^{40}$ overflow guard (finite loss/grads at summed log-ratio 800), and clean zero loss on empty masks. `ruff check` / `ruff format` clean; all configs parse through the `LossConfig` discriminated union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
