### PR TITLE
exp(weight-transfer): add sparse filesystem updates

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -209,7 +209,7 @@ class VllmConfig(BaseConfig):
 
 
 class WeightBroadcastConfig(BaseConfig):
-    type: Literal["nccl", "filesystem", "nixl"] = "filesystem"
+    type: Literal["nccl", "filesystem", "sparse_filesystem", "nixl"] = "filesystem"
     """Weight broadcast transport."""
 
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -378,6 +378,10 @@ class FileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
     type: Literal["filesystem"] = "filesystem"
 
 
+class SparseFileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
+    type: Literal["sparse_filesystem"] = "sparse_filesystem"
+
+
 class InMemoryWeightBroadcastConfig(BaseWeightBroadcastConfig):
     host: str = "localhost"
     """Weight transfer host."""
@@ -410,7 +414,10 @@ class NIXLWeightBroadcastConfig(InMemoryWeightBroadcastConfig):
 
 
 WeightBroadcastConfig: TypeAlias = Annotated[
-    FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig | NIXLWeightBroadcastConfig,
+    FileSystemWeightBroadcastConfig
+    | SparseFileSystemWeightBroadcastConfig
+    | NCCLWeightBroadcastConfig
+    | NIXLWeightBroadcastConfig,
     Field(discriminator="type"),
 ]
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -20,6 +20,9 @@ from prime_rl.configs.orchestrator import (
 from prime_rl.configs.orchestrator import (
     OrchestratorConfig,
 )
+from prime_rl.configs.orchestrator import (
+    SparseFileSystemWeightBroadcastConfig as OrchestratorSparseFileSystemWeightBroadcastConfig,
+)
 from prime_rl.configs.shared import (
     EnvVars,
     ResumeConfig,
@@ -36,6 +39,9 @@ from prime_rl.configs.trainer import (
 )
 from prime_rl.configs.trainer import (
     NIXLWeightBroadcastConfig as TrainerNIXLWeightBroadcastConfig,
+)
+from prime_rl.configs.trainer import (
+    SparseFileSystemWeightBroadcastConfig as TrainerSparseFileSystemWeightBroadcastConfig,
 )
 from prime_rl.configs.trainer import (
     TokenizerConfig,
@@ -166,8 +172,18 @@ class SharedFileSystemWeightBroadcastConfig(BaseConfig):
     """Timeout in seconds for the broadcast handshake and transfer."""
 
 
+class SharedSparseFileSystemWeightBroadcastConfig(BaseConfig):
+    type: Literal["sparse_filesystem"] = "sparse_filesystem"
+
+    timeout: int = 1200
+    """Timeout in seconds for the broadcast handshake and transfer."""
+
+
 SharedWeightBroadcastConfig: TypeAlias = Annotated[
-    SharedFileSystemWeightBroadcastConfig | SharedNCCLWeightBroadcastConfig | SharedNIXLWeightBroadcastConfig,
+    SharedFileSystemWeightBroadcastConfig
+    | SharedSparseFileSystemWeightBroadcastConfig
+    | SharedNCCLWeightBroadcastConfig
+    | SharedNIXLWeightBroadcastConfig,
     Field(discriminator="type"),
 ]
 
@@ -504,6 +520,13 @@ class RLConfig(BaseConfig):
                 timeout=self.weight_broadcast.timeout, broadcast_final=broadcast_final
             )
             self.orchestrator.weight_broadcast = OrchestratorFileSystemWeightBroadcastConfig(
+                timeout=self.weight_broadcast.timeout, broadcast_final=broadcast_final
+            )
+        elif self.weight_broadcast.type == "sparse_filesystem":
+            self.trainer.weight_broadcast = TrainerSparseFileSystemWeightBroadcastConfig(
+                timeout=self.weight_broadcast.timeout, broadcast_final=broadcast_final
+            )
+            self.orchestrator.weight_broadcast = OrchestratorSparseFileSystemWeightBroadcastConfig(
                 timeout=self.weight_broadcast.timeout, broadcast_final=broadcast_final
             )
         if self.inference is not None:

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -550,6 +550,11 @@ class FileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
     type: Literal["filesystem"] = "filesystem"
 
 
+class SparseFileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
+    type: Literal["sparse_filesystem"] = "sparse_filesystem"
+    """Experimental per-rank sorted-index/absolute-value filesystem updates."""
+
+
 class InMemoryWeightBroadcastConfig(BaseWeightBroadcastConfig):
     host: str = "localhost"
     """Weight transfer host."""
@@ -583,7 +588,10 @@ class NIXLWeightBroadcastConfig(InMemoryWeightBroadcastConfig):
 
 
 WeightBroadcastConfig: TypeAlias = Annotated[
-    FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig | NIXLWeightBroadcastConfig,
+    FileSystemWeightBroadcastConfig
+    | SparseFileSystemWeightBroadcastConfig
+    | NCCLWeightBroadcastConfig
+    | NIXLWeightBroadcastConfig,
     Field(discriminator="type"),
 ]
 

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -63,6 +63,7 @@ def models(request: Request) -> OpenAIServingModels:
 WORKER_EXTENSION_CLS = {
     "nccl": "prime_rl.inference.vllm.worker.nccl.NCCLWeightUpdateWorker",
     "filesystem": "prime_rl.inference.vllm.worker.filesystem.FileSystemWeightUpdateWorker",
+    "sparse_filesystem": "prime_rl.inference.vllm.worker.filesystem.FileSystemWeightUpdateWorker",
     "nixl": "prime_rl.inference.vllm.worker.nixl.NIXLWeightUpdateWorker",
 }
 

--- a/src/prime_rl/inference/vllm/worker/filesystem.py
+++ b/src/prime_rl/inference/vllm/worker/filesystem.py
@@ -1,9 +1,12 @@
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+import torch
 from torch.nn import Module
 from vllm.model_executor.model_loader import DefaultModelLoader, get_model_loader
 
 from prime_rl.inference.vllm.worker.weight_transfer import load_weights_checkpoint_layerwise
+from prime_rl.trainer.sparse_update import apply_sparse_update
 
 # This is to get type hints for the Worker class but not actually extend it at runtime as this is required by vLLM worker extension
 if TYPE_CHECKING:
@@ -18,38 +21,82 @@ class FileSystemWeightUpdateWorker(Worker):
     """vLLM worker extension for updating weights in-place using shared filesystem."""
 
     def init_broadcaster(self) -> None:
-        """Initialize the broadcaster."""
-        ...
+        """Initialize sparse-update receiver state."""
+        self._sparse_state_dict: dict[str, torch.Tensor] | None = None
+        self._sparse_step = 0
+        self._sparse_base_path: str | None = None
 
     def liveness_probe(self) -> None:
         """No-op RPC used by the API server liveness endpoint."""
         return None
 
     def update_weights_from_path(self, weight_path: str) -> None:
-        """Update weights from a specified path in shared filesystem containing a HF-compatible checkpoint."""
-        # Get vLLM model runner and model
-        # When enforce_eager=True, model isn't wrapped by torch.compile so no .runnable attr
-        model_runner = self.model_runner
-        if hasattr(model_runner.model, "runnable"):
-            model = model_runner.model.runnable
-        else:
-            model = model_runner.model
-        assert isinstance(model, Module)
+        """Load a full checkpoint or apply a sparse HF patch chain."""
+        if not hasattr(self, "_sparse_step"):
+            self.init_broadcaster()
+        path = Path(weight_path)
+        if (path / "sparse_manifest.json").exists():
+            self._ensure_sparse_cache()
+            self._sparse_step = apply_sparse_update(self._sparse_state_dict, path, expected_base_step=self._sparse_step)
+            model = (
+                self.model_runner.model.runnable
+                if hasattr(self.model_runner.model, "runnable")
+                else self.model_runner.model
+            )
+            load_weights_checkpoint_layerwise(
+                model,
+                self._sparse_state_dict.items(),
+                self.model_runner.model_config,
+                self.vllm_config,
+            )
+            return
 
-        # Get vLLM model loader
+        model = (
+            self.model_runner.model.runnable
+            if hasattr(self.model_runner.model, "runnable")
+            else self.model_runner.model
+        )
+        assert isinstance(model, Module)
+        weights_iterator = self._weights_iterator(model, path)
+        load_weights_checkpoint_layerwise(model, weights_iterator, self.model_runner.model_config, self.vllm_config)
+        self._sparse_state_dict = None
+        self._sparse_base_path = weight_path
+        self._sparse_step = self._extract_step(path) or 0
+
+    def _weights_iterator(self, model: Module, path: Path):
         model_loader = get_model_loader(self.load_config)
         assert isinstance(model_loader, DefaultModelLoader)
-        local_source = DefaultModelLoader.Source(
-            weight_path,
-            revision=None,  # TODO: Check that this is correct or if we should use the default (model_config.revision)
+        source = DefaultModelLoader.Source(
+            str(path),
+            revision=None,
             prefix="",
             fall_back_to_pt=getattr(model, "fall_back_to_pt_during_load", True),
             allow_patterns_overrides=getattr(model, "allow_patterns_overrides", None),
         )
-        weights_iterator = model_loader._get_weights_iterator(local_source)
-        load_weights_checkpoint_layerwise(
-            model,
-            weights_iterator,
-            self.model_runner.model_config,
-            self.vllm_config,
+        return model_loader._get_weights_iterator(source)
+
+    def _ensure_sparse_cache(self) -> None:
+        if self._sparse_state_dict is not None:
+            return
+        model = (
+            self.model_runner.model.runnable
+            if hasattr(self.model_runner.model, "runnable")
+            else self.model_runner.model
         )
+        source = Path(self._sparse_base_path or self.model_runner.model_config.model)
+        self._sparse_state_dict = {
+            name: tensor.detach().to("cpu", dtype=torch.bfloat16).contiguous()
+            for name, tensor in self._weights_iterator(model, source)
+        }
+        if "lm_head.weight" not in self._sparse_state_dict and "model.embed_tokens.weight" in self._sparse_state_dict:
+            self._sparse_state_dict["lm_head.weight"] = self._sparse_state_dict["model.embed_tokens.weight"].clone()
+
+    @staticmethod
+    def _extract_step(path: Path) -> int | None:
+        for parent in (path, *path.parents):
+            if parent.name.startswith("step_"):
+                try:
+                    return int(parent.name.removeprefix("step_"))
+                except ValueError:
+                    return None
+        return None

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -243,6 +243,30 @@ def train(config: TrainerConfig):
     else:
         logger.info("Starting from scratch")
 
+    if config.weight_broadcast.type == "sparse_filesystem" and weight_sender is not None:
+        from prime_rl.trainer.models import PreTrainedModelPrimeRL
+        from prime_rl.trainer.sparse_update import OptimizerSparseUpdateHook, SparseUpdateWriter
+
+        if checkpoint_step is not None:
+            raise ValueError("Sparse filesystem weight updates do not support checkpoint resume in this POC")
+        state_dict = model.state_dict()
+        if isinstance(model, PreTrainedModelPrimeRL) and model.is_prime_state_dict(state_dict):
+            raise ValueError(
+                "Sparse filesystem updates currently require trainer state-dict names/shapes to match HF format."
+            )
+        sparse_writer = SparseUpdateWriter(
+            config.output_dir / ".sparse_weight_updates",
+            rank=world.rank,
+        )
+        sparse_writer.initialize(state_dict, base_step=0)
+        sparse_writer.write(state_dict, target_step=0)
+        OptimizerSparseUpdateHook(
+            optimizer,
+            sparse_writer,
+            model.state_dict,
+            lambda: progress.step,
+        )
+
     # Set up the data loader (Optionally, use a fake data loader for debugging)
     logger.info(f"Initializing data loader ({config.data})")
     t0 = time.perf_counter()

--- a/src/prime_rl/trainer/sparse_update.py
+++ b/src/prime_rl/trainer/sparse_update.py
@@ -1,0 +1,210 @@
+"""Experimental sparse filesystem policy updates in HF checkpoint coordinates."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import uuid
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors.torch import load_file, save_file
+from torch.distributed.tensor import DTensor, Partial, Replicate
+from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
+from torch.optim import Optimizer
+
+FORMAT = "prime-rl-sparse-hf-v1"
+
+
+@dataclass(frozen=True)
+class TensorPatch:
+    name: str
+    global_shape: tuple[int, ...]
+    dtype: str
+    indices_key: str
+    values_key: str
+    changed: int
+
+
+@dataclass(frozen=True)
+class RankPatch:
+    rank: int
+    base_step: int
+    target_step: int
+    file: str
+    tensors: tuple[TensorPatch, ...]
+
+
+def _atomic_json(path: Path, value: Any) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+    os.replace(temporary, path)
+
+
+def _global_indices(
+    local_indices: torch.Tensor, local_shape: tuple[int, ...], global_shape: tuple[int, ...], offset: tuple[int, ...]
+) -> torch.Tensor:
+    coordinates = torch.unravel_index(local_indices, local_shape)
+    global_coordinates = tuple(coordinate + start for coordinate, start in zip(coordinates, offset))
+    strides = [math.prod(global_shape[index + 1 :]) for index in range(len(global_shape))]
+    result = torch.zeros_like(local_indices, dtype=torch.int64)
+    for coordinate, stride in zip(global_coordinates, strides):
+        result += coordinate * stride
+    return result
+
+
+def _local_tensor(value: torch.Tensor) -> tuple[torch.Tensor, tuple[int, ...], tuple[int, ...], int, int]:
+    if not isinstance(value, DTensor):
+        return value.detach(), tuple(value.shape), (0,) * value.ndim, 0, 1
+    if any(isinstance(placement, Partial) for placement in value.placements):
+        raise ValueError("Partial DTensors cannot be sparsely published")
+    shape, offset = compute_local_shape_and_global_offset(value.shape, value.device_mesh, value.placements)
+    coordinate = value.device_mesh.get_coordinate()
+    replica_dims = [index for index, placement in enumerate(value.placements) if isinstance(placement, Replicate)]
+    replica_index, replica_count = 0, 1
+    for dimension in replica_dims:
+        replica_index = replica_index * value.device_mesh.shape[dimension] + coordinate[dimension]
+        replica_count *= value.device_mesh.shape[dimension]
+    local = value.to_local().detach()
+    if tuple(local.shape) != tuple(shape):
+        local = local[tuple(slice(size) for size in shape)]
+    return local, tuple(value.shape), tuple(offset), replica_index, replica_count
+
+
+class SparseUpdateWriter:
+    """Keep one BF16 local-shard baseline and emit sorted global indices/new values."""
+
+    def __init__(self, root: Path, *, rank: int, serving_dtype: torch.dtype = torch.bfloat16) -> None:
+        self.root, self.rank, self.serving_dtype = root, rank, serving_dtype
+        self._baseline: dict[str, torch.Tensor] = {}
+        self._initialized = False
+        self.base_step = 0
+
+    def initialize(self, state_dict: Mapping[str, torch.Tensor], *, base_step: int = 0) -> None:
+        self._baseline = {}
+        for name, value in state_dict.items():
+            if isinstance(value, torch.Tensor) and value.is_floating_point():
+                local, _, _, replica_index, _ = _local_tensor(value)
+                if replica_index == 0:
+                    self._baseline[name] = local.to("cpu", dtype=self.serving_dtype, copy=True).contiguous()
+        self.base_step = base_step
+        self._initialized = True
+
+    def write(self, state_dict: Mapping[str, torch.Tensor], *, target_step: int) -> RankPatch:
+        if not self._initialized:
+            raise RuntimeError("initialize sparse baseline before optimizer.step")
+        directory = self.root / f"step_{target_step}"
+        directory.mkdir(parents=True, exist_ok=True)
+        payload: dict[str, torch.Tensor] = {}
+        entries: list[TensorPatch] = []
+        for tensor_index, (name, value) in enumerate(state_dict.items()):
+            if name not in self._baseline:
+                continue
+            local, global_shape, offset, replica_index, _ = _local_tensor(value)
+            if replica_index != 0:
+                continue
+            current = local.to("cpu", dtype=self.serving_dtype, copy=True).contiguous()
+            baseline = self._baseline[name]
+            if tuple(current.shape) != tuple(baseline.shape):
+                raise ValueError(f"local shape changed for {name}")
+            changed_local = current.view(-1).ne(baseline.view(-1)).nonzero().view(-1)
+            if not changed_local.numel():
+                baseline.copy_(current)
+                continue
+            indices = _global_indices(changed_local, tuple(current.shape), global_shape, offset)
+            if math.prod(global_shape) < 2**31:
+                indices = indices.to(torch.int32)
+            indices, order = indices.sort()
+            values = current.view(-1).index_select(0, changed_local).index_select(0, order).contiguous()
+            indices_key, values_key = f"t{tensor_index}_indices", f"t{tensor_index}_values"
+            payload[indices_key], payload[values_key] = indices, values
+            entries.append(
+                TensorPatch(
+                    name,
+                    global_shape,
+                    str(self.serving_dtype).removeprefix("torch."),
+                    indices_key,
+                    values_key,
+                    indices.numel(),
+                )
+            )
+            baseline.copy_(current)
+        file = f"rank_{self.rank}.safetensors"
+        if payload:
+            save_file(payload, directory / file)
+        patch = RankPatch(self.rank, self.base_step, target_step, file, tuple(entries))
+        _atomic_json(directory / f"rank_{self.rank}.json", asdict(patch))
+        self.base_step = target_step
+        return patch
+
+
+def commit_sparse_update(root: Path, *, target_step: int, base_step: int, world_size: int) -> Path:
+    directory = root / f"step_{target_step}"
+    ranks = []
+    for rank in range(world_size):
+        data = json.loads((directory / f"rank_{rank}.json").read_text())
+        if data["base_step"] != base_step or data["target_step"] != target_step:
+            raise ValueError("sparse patch chain mismatch")
+        ranks.append(data)
+    changed = sum(tensor["changed"] for rank in ranks for tensor in rank["tensors"])
+    payload_bytes = sum((directory / rank["file"]).stat().st_size for rank in ranks if rank["tensors"])
+    manifest = {
+        "format": FORMAT,
+        "base_step": base_step,
+        "target_step": target_step,
+        "changed": changed,
+        "payload_bytes": payload_bytes,
+        "ranks": ranks,
+    }
+    manifest["sha256"] = hashlib.sha256(json.dumps(manifest, sort_keys=True).encode()).hexdigest()
+    path = directory / "sparse_manifest.json"
+    _atomic_json(path, manifest)
+    (directory / "STABLE").touch()
+    return path
+
+
+def apply_sparse_update(state_dict: dict[str, torch.Tensor], directory: Path, *, expected_base_step: int) -> int:
+    manifest = json.loads((directory / "sparse_manifest.json").read_text())
+    checksum = manifest.pop("sha256", None)
+    actual = hashlib.sha256(json.dumps(manifest, sort_keys=True).encode()).hexdigest()
+    if checksum != actual:
+        raise ValueError("sparse patch manifest checksum mismatch")
+    if manifest["format"] != FORMAT or manifest["base_step"] != expected_base_step:
+        raise ValueError("sparse patch base mismatch")
+    for rank in manifest["ranks"]:
+        tensors = load_file(directory / rank["file"]) if rank["tensors"] else {}
+        for entry in rank["tensors"]:
+            target = state_dict[entry["name"]]
+            if tuple(target.shape) != tuple(entry["global_shape"]):
+                raise ValueError(f"shape mismatch for {entry['name']}")
+            indices = tensors[entry["indices_key"]].long()
+            if indices.numel() and (indices[0] < 0 or indices[-1] >= target.numel()):
+                raise ValueError(f"index out of bounds for {entry['name']}")
+            if indices.numel() > 1 and not bool(torch.all(indices[1:] > indices[:-1])):
+                raise ValueError(f"indices are not strictly sorted for {entry['name']}")
+            values = tensors[entry["values_key"]].to(target.dtype)
+            target.view(-1).index_copy_(0, indices, values)
+    return manifest["target_step"]
+
+
+class OptimizerSparseUpdateHook:
+    def __init__(
+        self,
+        optimizer: Optimizer | Any,
+        writer: SparseUpdateWriter,
+        state_dict: Callable[[], Mapping[str, torch.Tensor]],
+        step: Callable[[], int],
+    ) -> None:
+        self.writer, self.state_dict, self.step = writer, state_dict, step
+        self.handle = getattr(optimizer, "base_optimizer", optimizer).register_step_post_hook(self._after_step)
+
+    def _after_step(self, optimizer, args, kwargs) -> None:
+        self.writer.write(self.state_dict(), target_step=self.step())
+
+    def remove(self) -> None:
+        self.handle.remove()

--- a/src/prime_rl/transports/weights/__init__.py
+++ b/src/prime_rl/transports/weights/__init__.py
@@ -9,6 +9,7 @@ from prime_rl.transports.weights.base import WeightReceiver, WeightSender, prune
 from prime_rl.transports.weights.filesystem import FileSystemWeightReceiver, FileSystemWeightSender
 from prime_rl.transports.weights.nccl import NCCLWeightReceiver, NCCLWeightSender
 from prime_rl.transports.weights.nixl import NIXLWeightReceiver, NIXLWeightSender
+from prime_rl.transports.weights.sparse_filesystem import SparseFileSystemWeightSender
 
 __all__ = [
     "WeightReceiver",
@@ -29,6 +30,8 @@ def setup_weight_sender(
         return NCCLWeightSender(output_dir, config, torch.cuda.current_device())
     elif config.type == "filesystem":
         return FileSystemWeightSender(output_dir, config, lora_config)
+    elif config.type == "sparse_filesystem":
+        return SparseFileSystemWeightSender(output_dir, config, lora_config)
     elif config.type == "nixl":
         return NIXLWeightSender(output_dir, config, parallel_dims)
     else:
@@ -44,6 +47,8 @@ def setup_weight_receiver(
     if config.type == "nccl":
         return NCCLWeightReceiver(broadcast_dir, config, admin_clients, model_name)
     elif config.type == "filesystem":
+        return FileSystemWeightReceiver(broadcast_dir, config, admin_clients, model_name)
+    elif config.type == "sparse_filesystem":
         return FileSystemWeightReceiver(broadcast_dir, config, admin_clients, model_name)
     elif config.type == "nixl":
         return NIXLWeightReceiver(broadcast_dir, config, admin_clients, model_name)

--- a/src/prime_rl/transports/weights/sparse_filesystem.py
+++ b/src/prime_rl/transports/weights/sparse_filesystem.py
@@ -1,0 +1,49 @@
+import json
+import shutil
+import time
+from pathlib import Path
+
+import torch.distributed as dist
+import torch.nn as nn
+
+from prime_rl.configs.trainer import LoRAConfig, SparseFileSystemWeightBroadcastConfig
+from prime_rl.trainer.sparse_update import commit_sparse_update
+from prime_rl.transports.weights.base import WeightSender
+
+
+class SparseFileSystemWeightSender(WeightSender):
+    """Publish rank-local sparse patches captured after the optimizer step."""
+
+    def __init__(
+        self,
+        output_dir: Path,
+        config: SparseFileSystemWeightBroadcastConfig,
+        lora_config: LoRAConfig | None = None,
+    ) -> None:
+        super().__init__(output_dir, config.timeout)
+        if lora_config is not None:
+            raise ValueError("Sparse filesystem updates do not support LoRA")
+        self.staging_dir = output_dir / ".sparse_weight_updates"
+
+    def _broadcast(self, model: nn.Module, step: int, step_dir: Path) -> None:
+        started = time.perf_counter()
+        if dist.is_initialized():
+            dist.barrier()
+        if self.world.is_master:
+            staged_step_dir = self.staging_dir / f"step_{step}"
+            manifest_path = commit_sparse_update(
+                self.staging_dir,
+                target_step=step,
+                base_step=max(0, step - 1),
+                world_size=self.world.world_size,
+            )
+            manifest = json.loads(manifest_path.read_text())
+            for source in staged_step_dir.iterdir():
+                shutil.move(str(source), step_dir / source.name)
+            staged_step_dir.rmdir()
+            self.logger.info(
+                f"Published distributed sparse policy v{step}: {manifest['changed']:,} changed values, "
+                f"{manifest['payload_bytes'] / 1024**2:.2f} MiB in {time.perf_counter() - started:.2f}s"
+            )
+        if dist.is_initialized():
+            dist.barrier()

--- a/tests/unit/train/test_sparse_update.py
+++ b/tests/unit/train/test_sparse_update.py
@@ -1,0 +1,64 @@
+import json
+
+import pytest
+import torch
+
+from prime_rl.trainer.sparse_update import (
+    OptimizerSparseUpdateHook,
+    SparseUpdateWriter,
+    _global_indices,
+    apply_sparse_update,
+    commit_sparse_update,
+)
+
+
+def test_global_indices_for_column_shard():
+    local = torch.tensor([0, 1, 2, 3])
+    assert _global_indices(local, (2, 2), (2, 4), (0, 1)).tolist() == [1, 2, 5, 6]
+
+
+def test_sparse_update_roundtrip_and_chain(tmp_path):
+    weight = torch.arange(8, dtype=torch.bfloat16)
+    writer = SparseUpdateWriter(tmp_path, rank=0)
+    writer.initialize({"weight": weight}, base_step=0)
+
+    weight[[1, 6]] = torch.tensor([-2, -3], dtype=torch.bfloat16)
+    patch = writer.write({"weight": weight}, target_step=1)
+    commit_sparse_update(tmp_path, target_step=1, base_step=0, world_size=1)
+
+    assert patch.tensors[0].changed == 2
+    from safetensors.torch import load_file
+
+    assert load_file(tmp_path / "step_1" / "rank_0.safetensors")["t0_indices"].dtype == torch.int32
+    payload = json.loads((tmp_path / "step_1" / "rank_0.json").read_text())
+    assert payload["tensors"][0]["changed"] == 2
+    receiver = {"weight": torch.arange(8, dtype=torch.bfloat16)}
+    assert apply_sparse_update(receiver, tmp_path / "step_1", expected_base_step=0) == 1
+    torch.testing.assert_close(receiver["weight"], weight)
+
+    weight[3] = -4
+    writer.write({"weight": weight}, target_step=2)
+    commit_sparse_update(tmp_path, target_step=2, base_step=1, world_size=1)
+    assert apply_sparse_update(receiver, tmp_path / "step_2", expected_base_step=1) == 2
+    torch.testing.assert_close(receiver["weight"], weight)
+
+    with pytest.raises(ValueError, match="base mismatch"):
+        apply_sparse_update(receiver, tmp_path / "step_2", expected_base_step=0)
+
+
+def test_optimizer_hook_captures_post_step_values(tmp_path):
+    parameter = torch.nn.Parameter(torch.tensor([1.0, 2.0], dtype=torch.bfloat16))
+    optimizer = torch.optim.SGD([parameter], lr=0.5)
+    writer = SparseUpdateWriter(tmp_path, rank=0)
+    writer.initialize({"weight": parameter}, base_step=0)
+    step = 1
+    hook = OptimizerSparseUpdateHook(optimizer, writer, lambda: {"weight": parameter}, lambda: step)
+
+    parameter.grad = torch.ones_like(parameter)
+    optimizer.step()
+    hook.remove()
+    commit_sparse_update(tmp_path, target_step=1, base_step=0, world_size=1)
+
+    receiver = {"weight": torch.tensor([1.0, 2.0], dtype=torch.bfloat16)}
+    apply_sparse_update(receiver, tmp_path / "step_1", expected_base_step=0)
+    torch.testing.assert_close(receiver["weight"], parameter)


### PR DESCRIPTION
## Summary

Experimental sparse filesystem policy publication for RL runs where most serving-precision weights remain unchanged.

- captures rank-local BF16 changes after optimizer steps without gathering the full model
- publishes sorted global flat indices with absolute BF16 replacement values
- supports DTensor shard offsets and selects one owner for replicated placements
- reconstructs an HF-format CPU state on vLLM workers, then uses vLLM's normal layerwise reload path
- validates an explicit `base_step -> target_step` sparse chain
- integrates with the shared weight transport sender/receiver handshake

Configure it with:

```toml
[weight_broadcast]
type = "sparse_filesystem"
```

## Scope

This is a proof of concept. It currently requires trainer state-dict names and shapes to already match HF checkpoint coordinates. It rejects LoRA, checkpoint resume, and `Partial` DTensors. It also requires the inference base checkpoint to match the trainer's initial sparse baseline.

The inference worker retains a full BF16 HF state cache in CPU memory. Sparse publication reduces filesystem/network bytes, but vLLM still performs normal layerwise processing across the logical model.

A remaining correctness hardening item is commit-aware baseline promotion: local writer baselines currently advance when rank artifacts are written, before global publication acknowledgement.

## Results

A Qwen3-0.6B two-GPU PrimeRL/vLLM smoke run completed through startup and multiple chained sparse reloads.

Observed update artifacts:

| Update | Changed BF16 values | Sparse artifact |
|---|---:|---:|
| v3 | 17,729,393 | 169.25 MiB |
| v4 | 15,076,716 | 143.95 MiB |

The dense model weights were about 2,273.78 MiB, making these artifacts about 13.4x and 15.8x smaller. The sparse format is not compressed yet.

## Validation

- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run pytest -q tests/unit/train/test_sparse_update.py tests/unit/test_configs.py` — 125 passed
- `uv run pytest -q tests/unit/train -m 'not gpu'` — 77 passed, 85 deselected
- four-GPU 2x2 `[Replicate(), Shard(1)]` DTensor reconstruction smoke test
- two-GPU Qwen3-0.6B PrimeRL/vLLM chained sparse reload smoke test
