### PR TITLE
docs: document orchestrator/eval concurrency config

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -208,6 +208,17 @@ The controller's idea is to treat the engines as ground truth and probe, instead
 
 The cap starts from a safe bound derived from the engines (KV capacity divided by the maximum context length), or from `initial_inflight` when a good value is known, and always stays within `[min_inflight, max_inflight]`.
 
+Configure it via `[orchestrator.concurrency]` (training episodes) or `[eval.concurrency]` (eval episodes):
+
+```toml
+[orchestrator.concurrency]
+initial_inflight = 512  # skip the ramp when a good value is known; omit to auto-derive one
+min_inflight = 1
+max_inflight = 1024     # hard ceiling, e.g. to bound external resources like sandboxes; default 1024, "None" removes it
+```
+
+Set `min_inflight = max_inflight` to pin a fixed concurrency instead of adapting.
+
 ## Advanced Configuration
 
 ### KV Cache Offload

--- a/docs/training.md
+++ b/docs/training.md
@@ -60,6 +60,7 @@ A condensed view of the knobs you'll most often tune. For trainer-side paralleli
 | `orchestrator.batch_size` | Tasks per trainer step. |
 | `orchestrator.group_size` | Rollouts generated per task. |
 | `orchestrator.max_off_policy_steps` | Maximum staleness of a trained rollout (default 8): the version a batch trains on minus the oldest version that generated the rollout, queue time included. Episodes past the bound are dropped; a group shares one dispatch version, so its episodes age out together. The main off-policy dial on long agentic rollouts — bump for throughput, lower for tighter on-policyness. Watch `off_policy/*` and `mismatch_kl/all/mean` when tuning. |
+| `[orchestrator.concurrency]` | Bounds (`min_inflight`/`max_inflight`) and optional seed (`initial_inflight`) for the adaptive in-flight episode cap. See [Adaptive Concurrency](inference.md#adaptive-concurrency). |
 | `[orchestrator.algo]` | Training algorithm — its `type` names it (`grpo` default, `max_rl`, `rae`, `hierarchical_grpo`, `opd`, `opsd`, `sft`, `echo`). See [Algorithms](#algorithms). |
 | `[[orchestrator.train.source]]` | Training sources. List multiple tables for multi-env training; weight them via `ratio`. See [Configuration § Training sources](configuration.md#training-sources-orchestratortrainsource). |
 | `[[orchestrator.eval.source]]` + `orchestrator.eval.interval` | Eval environments and cadence (default every 100 steps). |


### PR DESCRIPTION
## Summary
- Adaptive Concurrency was fully explained conceptually in `docs/inference.md` but never showed the actual TOML block to set it.
- Adds the `[orchestrator.concurrency]` / `[eval.concurrency]` example and cross-links it from the training knobs table.