### PR TITLE
fix(orchestrator): pre-seed datasets' tqdm lock to avoid concurrent-load crash

### DIFF
--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -179,6 +179,13 @@ class Envs(Generic[EnvT]):
     async def start(self) -> None:
         """Connect to all env servers in parallel — every address is known up front,
         so there's nothing to serialize on."""
+        # When several env.start()s load_dataset() concurrently, datasets' parallel arrow read
+        # (tqdm thread_map) races in ensure_lock's `del tqdm_class._lock` and crashes with
+        # `AttributeError: type object 'tqdm' has no attribute '_lock'`. Pre-seed the lock so it
+        # isn't created-and-deleted per call.
+        from datasets.utils import tqdm as hf_tqdm
+
+        hf_tqdm.set_lock(hf_tqdm.get_lock())
         await asyncio.gather(*(env.start() for env in self))
 
 


### PR DESCRIPTION
## Problem

`Envs.start()` starts every source concurrently (`asyncio.gather(env.start() for env in self)`), and each `env.start()` materializes its taskset via `load_dataset()` in a worker thread (`asyncio.to_thread(lambda: list(taskset))`). HuggingFace `datasets` reads cached arrow shards through `tqdm.contrib.concurrent.thread_map(tqdm_class=hf_tqdm)`, whose `ensure_lock()` is:

```python
old_lock = getattr(tqdm_class, "_lock", None)
lock = old_lock or tqdm_class.get_lock()
...
yield lock                       # the (slow) arrow read happens here
if old_lock is None:
    del tqdm_class._lock         # <-- racing line
else:
    tqdm_class.set_lock(old_lock)
```

When two of these run concurrently with the class lock unset, both observe `old_lock is None`, both reach `del tqdm_class._lock` on exit, and the second raises:

```
AttributeError: type object 'tqdm' has no attribute '_lock'
```

That kills the orchestrator during `setup()` ("Fatal error in run_orchestrator"), and the trainer then hangs waiting for rollouts that never come.

**When it triggers:** ≥2 sources load datasets concurrently at startup (e.g. multiple train sources over the same taskset). The race window is the arrow read, so more sources / colder caches make it more likely — 3 concurrent loads hit it essentially every run, 2 intermittently, 1 never. It is **not** caught by `--dry-run`, which never calls `load_dataset()`.

Root cause is a tqdm thread-safety gap (`ensure_lock` isn't safe for concurrent use on a single class), exposed by `datasets`' `thread_map` plus concurrent taskset loading here.

## Fix

Pre-seed the `datasets` tqdm class lock once, before the concurrent gather, so `old_lock` is never `None` and every `ensure_lock` takes the non-deleting `else` branch — the same state tqdm is in whenever a progress bar is active:

```python
from datasets.utils import tqdm as _hf_tqdm
_hf_tqdm.set_lock(_hf_tqdm.get_lock())
```

This targets the exact class `datasets` passes to `thread_map` (`datasets.utils.tqdm.tqdm`, the same object `arrow_reader` imports). It only stops the lock object from being created-and-deleted per call; no change to progress-bar display, dataset contents, or ordering.

## Reproduction

Hammering the failing primitive directly (16 threads, window widened to mimic the slow arrow read):

- **without** the fix: consistent `AttributeError: type object 'tqdm' has no attribute '_lock'`
- **with** the fix: clean, 0 failures

Also observed live: a 3-train-source run crashed here every time; after the fix all three arms load cleanly.

## Alternative considered

Loading sources sequentially in `Envs.start()` also avoids the race, at the cost of startup parallelism. The pre-seed keeps the parallel load.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line lock initialization before existing parallel env startup; no auth, data, or algorithm changes.
> 
> **Overview**
> **Fixes a startup crash** when multiple train/eval sources load HuggingFace datasets in parallel during `Envs.start()`.
> 
> Concurrent `load_dataset()` paths use `datasets`' `thread_map` with tqdm's `ensure_lock()`, which can race on `del tqdm_class._lock` and raise `AttributeError`—fatal during orchestrator `setup()` and leaving the trainer waiting on rollouts.
> 
> Before `asyncio.gather` on `env.start()`, the change **pre-seeds** the lock on `datasets.utils.tqdm` via `set_lock(get_lock())` so concurrent readers never hit the delete branch. Parallel startup is preserved; no change to dataset contents or progress display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1007d2d9cc0b8e15a2df959cec54cf3b366fce3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->