### PR TITLE
Harden dashboard cited-report guidance

### DIFF
--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -93,10 +93,21 @@ The dip is provider errors, not policy regression [^err].
 [^err]: {"step": 4, "kind": "train", "subset": "all", "episode": "ep-...", "node": 0, "quote": "engine overloaded", "note": "The failed call that emptied this step's batch."}
 ```
 
+The frontmatter `title` is rendered as the report H1; do not repeat it with a
+Markdown `#` heading. The inline renderer supports only HTTP(S) and anchor
+links. Relative Markdown links render as literal text, so identify local source
+files with inline code paths or link to a supported HTTP endpoint.
+
 Each citation requires `step`, `kind`, `subset`, `episode`, `quote`, and `note`.
-Use the episode `id`, never `line`. Copy a short, distinctive quote exactly;
-matching is case-sensitive and whitespace-insensitive. Keep `note` to 1–2
-sentences explaining why the quote supports the claim.
+Use the top-level rollout record `id` returned by the dashboard episode-list
+API—not a nested `traces[*].id`, and never `line`. Copy a short, distinctive
+quote exactly; matching is case-sensitive and whitespace-insensitive. Keep
+`note` to 1–2 sentences explaining why the quote supports the claim.
+
+Cite major empirical, comparative, and diagnostic conclusions, but not routine
+explanation. Use exact trace citations for trajectory-level claims. For
+aggregate statistics, identify the run and source file; do not imply that one
+example trajectory proves the aggregate.
 
 Use adjacent markers (`[^a] [^b]`) only when one claim genuinely depends on
 distinct passages, such as a comparison or corroboration. Use one citation
@@ -108,3 +119,8 @@ parts. Use verbatim adjacent `prefix`/`suffix` only when a quote repeats.
 Ambiguous or mismatched citations remain broken and do not navigate.
 
 Use Markdown; raw HTML is escaped.
+
+Before handoff, reload the report and verify through the dashboard API that
+every referenced citation resolves uniquely to its episode, node, and quote.
+Confirm zero broken citations, one rendered title, and no unsupported relative
+links.


### PR DESCRIPTION
## Summary

- clarify that report citations use the top-level rollout episode ID, not a nested trace ID
- document title and link-rendering constraints
- add balanced citation-coverage guidance for trace and aggregate claims
- require a dashboard citation/rendering preflight before handoff

## Validation

- `uv run --with pyyaml python /Users/eli/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/dashboard`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to an agent skill file; no runtime or API behavior is modified.
> 
> **Overview**
> Updates the **dashboard** agent skill’s cited-report section so authors follow dashboard rendering and citation rules that were previously implicit or incomplete.
> 
> **Title and links:** The frontmatter `title` is the report H1—no duplicate `#` heading. Only HTTP(S) and anchor links render; relative Markdown links must be avoided (use inline code paths or HTTP URLs).
> 
> **Citation IDs:** Episode references must use the top-level rollout `id` from the episode-list API, explicitly **not** nested `traces[*].id` or `line`.
> 
> **Coverage:** Major empirical/comparative/diagnostic claims need citations; trajectory claims need exact trace citations; aggregate stats should cite run and source file without treating one example trajectory as proof of the aggregate.
> 
> **Preflight:** Before handoff, reload the report and verify via the dashboard API that every citation resolves uniquely, with zero broken citations, a single rendered title, and no unsupported relative links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8070a010a29458c0312232cd94b6d8fce0b72c10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->