### PR TITLE
refactor(cp): collapse ring attention paths into one implementation

### DIFF
--- a/src/prime_rl/trainer/models/layers/attn.py
+++ b/src/prime_rl/trainer/models/layers/attn.py
@@ -189,22 +189,22 @@ ATTN_IMPL2CLASS = {
 }
 
 
+ATTN_IMPL2FLASH_VERSION = {
+    "flash_attention_2": 2,
+    "flash_attention_3": 3,
+    "flash_attention_4": 4,
+}
+
+
 def substitute_ring_attn(
     process_group: torch.distributed.ProcessGroup,
     heads_k_stride: int,
     attn_impl: str = "flash_attention_2",
 ) -> None:
     """Patch _compute_attention on FlashAttention variants to use ring attention."""
-    from ring_flash_attn import llama3_flash_attn_varlen_func
+    from .ring_attn import ring_flash_attn_varlen_func
 
-    from .ring_attn import ring_fa3_varlen_func, ring_fa4_varlen_func
-
-    if attn_impl == "flash_attention_4":
-        ring_func = ring_fa4_varlen_func
-    elif attn_impl == "flash_attention_3":
-        ring_func = ring_fa3_varlen_func
-    else:
-        ring_func = llama3_flash_attn_varlen_func
+    flash_attn_version = ATTN_IMPL2FLASH_VERSION[attn_impl]
 
     def _ring_compute_attention(self, q, k, v, cu_seqlens, max_seqlen):
         from ring_flash_attn.adapters.hf_adapter import DATA_PARAMS
@@ -214,7 +214,7 @@ def substitute_ring_attn(
         if sliding_window is not None:
             window_size = (sliding_window - 1, 0)
 
-        out = ring_func(
+        out = ring_flash_attn_varlen_func(
             q,
             k,
             v,
@@ -227,6 +227,7 @@ def substitute_ring_attn(
             window_size=window_size,
             group=process_group,
             heads_k_stride=heads_k_stride,
+            flash_attn_version=flash_attn_version,
         )
         if isinstance(out, tuple):
             out = out[0]

--- a/src/prime_rl/trainer/models/layers/flash_varlen.py
+++ b/src/prime_rl/trainer/models/layers/flash_varlen.py
@@ -1,0 +1,260 @@
+"""Low-level varlen flash-attention forward/backward wrappers, one pair per FA version.
+
+Each pair exposes the same signature regardless of the kernel underneath, so callers that need
+raw `out`/`lse` access (ring CP in `ring_attn.py`, ulysses CP in `ulysses_attn.py`) can select a
+kernel by version number instead of branching on it.
+"""
+
+from __future__ import annotations
+
+# ruff: noqa: I001 (`prime_rl._compat` must run before the `ring_flash_attn` imports below)
+import prime_rl._compat  # noqa: F401
+
+import torch
+from ring_flash_attn.utils import get_default_args
+
+
+def _set_causal_and_window_params(params: dict, causal: bool, window_size: tuple[int, int]) -> None:
+    """Fill in the causal/window arguments, whose names differ across flash-attention builds."""
+    if "is_causal" in params:
+        params["is_causal"] = causal
+    else:
+        params["causal"] = causal
+
+    if "window_size" in params:
+        params["window_size"] = window_size
+    else:
+        params["window_size_left"] = window_size[0]
+        params["window_size_right"] = window_size[1]
+
+
+def _fa2_varlen_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float,
+    causal: bool,
+    window_size: tuple[int, int] = (-1, -1),
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from flash_attn.flash_attn_interface import _flash_attn_varlen_forward
+
+    params = get_default_args(_flash_attn_varlen_forward).copy()
+    params.update(
+        {
+            "q": q,
+            "k": k,
+            "v": v,
+            "cu_seqlens_q": cu_seqlens_q,
+            "cu_seqlens_k": cu_seqlens_k,
+            "max_seqlen_q": max_seqlen_q,
+            "max_seqlen_k": max_seqlen_k,
+            "dropout_p": 0.0,
+            "softmax_scale": softmax_scale,
+        }
+    )
+    _set_causal_and_window_params(params, causal, window_size)
+    out, lse, _, _ = _flash_attn_varlen_forward(**params)
+    return out, lse
+
+
+def _fa2_varlen_backward(
+    dout: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    out: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    dv: torch.Tensor,
+    softmax_scale: float,
+    causal: bool,
+    window_size: tuple[int, int] = (-1, -1),
+) -> None:
+    from flash_attn.flash_attn_interface import _flash_attn_varlen_backward
+
+    params = get_default_args(_flash_attn_varlen_backward).copy()
+    params.update(
+        {
+            "dout": dout,
+            "q": q,
+            "k": k,
+            "v": v,
+            "out": out,
+            "softmax_lse": softmax_lse,
+            "cu_seqlens_q": cu_seqlens_q,
+            "cu_seqlens_k": cu_seqlens_k,
+            "max_seqlen_q": max_seqlen_q,
+            "max_seqlen_k": max_seqlen_k,
+            "dq": dq,
+            "dk": dk,
+            "dv": dv,
+            "dropout_p": 0.0,
+            "softmax_scale": softmax_scale,
+        }
+    )
+    _set_causal_and_window_params(params, causal, window_size)
+    _flash_attn_varlen_backward(**params)
+
+
+def _fa3_varlen_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float,
+    causal: bool,
+    window_size: tuple[int, int] = (-1, -1),
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from flash_attn_interface import _flash_attn_forward
+
+    params = get_default_args(_flash_attn_forward).copy()
+    params.update(
+        {
+            "q": q,
+            "k": k,
+            "v": v,
+            "cu_seqlens_q": cu_seqlens_q,
+            "cu_seqlens_k": cu_seqlens_k,
+            "max_seqlen_q": max_seqlen_q,
+            "max_seqlen_k": max_seqlen_k,
+            "softmax_scale": softmax_scale,
+        }
+    )
+    _set_causal_and_window_params(params, causal, window_size)
+    out, lse, _, _ = _flash_attn_forward(**params)
+    return out, lse
+
+
+def _fa3_varlen_backward(
+    dout: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    out: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    dv: torch.Tensor,
+    softmax_scale: float,
+    causal: bool,
+    window_size: tuple[int, int] = (-1, -1),
+) -> None:
+    from flash_attn_interface import _flash_attn_backward
+
+    params = get_default_args(_flash_attn_backward).copy()
+    params.update(
+        {
+            "dout": dout,
+            "q": q,
+            "k": k,
+            "v": v,
+            "out": out,
+            "softmax_lse": softmax_lse,
+            "cu_seqlens_q": cu_seqlens_q,
+            "cu_seqlens_k": cu_seqlens_k,
+            "max_seqlen_q": max_seqlen_q,
+            "max_seqlen_k": max_seqlen_k,
+            "dq": dq,
+            "dk": dk,
+            "dv": dv,
+            "softmax_scale": softmax_scale,
+        }
+    )
+    _set_causal_and_window_params(params, causal, window_size)
+    _flash_attn_backward(**params)
+
+
+def _fa4_varlen_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float,
+    causal: bool,
+    window_size: tuple[int, int] = (-1, -1),
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from flash_attn.cute.interface import _flash_attn_fwd
+
+    wl = window_size[0] if window_size[0] != -1 else None
+    wr = window_size[1] if window_size[1] != -1 else None
+    out, lse = _flash_attn_fwd(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=wl,
+        window_size_right=wr,
+        return_lse=True,
+    )
+    return out, lse
+
+
+def _fa4_varlen_backward(
+    dout: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    out: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    dv: torch.Tensor,
+    softmax_scale: float,
+    causal: bool,
+    window_size: tuple[int, int] = (-1, -1),
+) -> None:
+    from flash_attn.cute.interface import _flash_attn_bwd
+
+    wl = window_size[0] if window_size[0] != -1 else None
+    wr = window_size[1] if window_size[1] != -1 else None
+    _flash_attn_bwd(
+        q,
+        k,
+        v,
+        out,
+        dout,
+        softmax_lse,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=wl,
+        window_size_right=wr,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        dq=dq,
+        dk=dk,
+        dv=dv,
+    )
+
+
+VARLEN_FORWARD = {2: _fa2_varlen_forward, 3: _fa3_varlen_forward, 4: _fa4_varlen_forward}
+VARLEN_BACKWARD = {2: _fa2_varlen_backward, 3: _fa3_varlen_backward, 4: _fa4_varlen_backward}

--- a/src/prime_rl/trainer/models/layers/ring_attn.py
+++ b/src/prime_rl/trainer/models/layers/ring_attn.py
@@ -1,106 +1,32 @@
 from __future__ import annotations
 
-# ruff: noqa: I001 — `prime_rl._compat` must run before `ring_flash_attn` imports below.
+# ruff: noqa: I001 (`prime_rl._compat` must run before the `ring_flash_attn` imports below)
 import prime_rl._compat  # noqa: F401
 
 import torch
 import torch.distributed as dist
-from ring_flash_attn.utils import AllGatherComm, get_default_args
+from ring_flash_attn.utils import AllGatherComm
+
+from .flash_varlen import VARLEN_BACKWARD, VARLEN_FORWARD
 
 
-def _set_fa3_signature_params(params: dict, causal: bool, window_size: tuple[int, int]) -> None:
-    if "is_causal" in params:
-        params["is_causal"] = causal
-    else:
-        params["causal"] = causal
-
-    if "window_size" in params:
-        params["window_size"] = window_size
-    else:
-        params["window_size_left"] = window_size[0]
-        params["window_size_right"] = window_size[1]
+def _resolve_group(group_name: str) -> dist.ProcessGroup:
+    for pg in dist.distributed_c10d._world.pg_map:
+        if pg.group_name == group_name:
+            return pg
+    return dist.group.WORLD
 
 
-def _fa3_varlen_forward(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cu_seqlens_q: torch.Tensor,
-    cu_seqlens_k: torch.Tensor,
-    max_seqlen_q: int,
-    max_seqlen_k: int,
-    softmax_scale: float,
-    causal: bool,
-    window_size: tuple[int, int] = (-1, -1),
-) -> tuple[torch.Tensor, torch.Tensor]:
-    from flash_attn_interface import _flash_attn_forward
+class _RingVarlen(torch.autograd.Function):
+    """Ring attention with all-gather communication, for any flash-attention version.
 
-    params = get_default_args(_flash_attn_forward).copy()
-    params.update(
-        {
-            "q": q,
-            "k": k,
-            "v": v,
-            "cu_seqlens_q": cu_seqlens_q,
-            "cu_seqlens_k": cu_seqlens_k,
-            "max_seqlen_q": max_seqlen_q,
-            "max_seqlen_k": max_seqlen_k,
-            "softmax_scale": softmax_scale,
-        }
-    )
-    _set_fa3_signature_params(params, causal, window_size)
-    out, lse, _, _ = _flash_attn_forward(**params)
-    return out, lse
+    Mirrors ring-flash-attn's `llama3_flash_attn_varlen` pattern: all-gather the whole K/V across
+    the CP group once, then make one ordinary varlen flash call per head group over this rank's
+    key range. Only the kernel pair (`VARLEN_FORWARD` / `VARLEN_BACKWARD`) varies by version; the
+    communication is identical, so all versions share this one implementation.
 
-
-def _fa3_varlen_backward(
-    dout: torch.Tensor,
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    out: torch.Tensor,
-    softmax_lse: torch.Tensor,
-    cu_seqlens_q: torch.Tensor,
-    cu_seqlens_k: torch.Tensor,
-    max_seqlen_q: int,
-    max_seqlen_k: int,
-    dq: torch.Tensor,
-    dk: torch.Tensor,
-    dv: torch.Tensor,
-    softmax_scale: float,
-    causal: bool,
-    window_size: tuple[int, int] = (-1, -1),
-) -> None:
-    from flash_attn_interface import _flash_attn_backward
-
-    params = get_default_args(_flash_attn_backward).copy()
-    params.update(
-        {
-            "dout": dout,
-            "q": q,
-            "k": k,
-            "v": v,
-            "out": out,
-            "softmax_lse": softmax_lse,
-            "cu_seqlens_q": cu_seqlens_q,
-            "cu_seqlens_k": cu_seqlens_k,
-            "max_seqlen_q": max_seqlen_q,
-            "max_seqlen_k": max_seqlen_k,
-            "dq": dq,
-            "dk": dk,
-            "dv": dv,
-            "softmax_scale": softmax_scale,
-        }
-    )
-    _set_fa3_signature_params(params, causal, window_size)
-    _flash_attn_backward(**params)
-
-
-class _RingFA3Varlen(torch.autograd.Function):
-    """Ring attention using FA3 kernels with all-gather communication.
-
-    Mirrors the llama3_flash_attn_varlen pattern from ring-flash-attn but
-    calls flash-attention-3 low-level forward/backward instead of FA2.
+    Non-tensor arguments are ints and strings rather than objects (`local_k_slice` as start/stop,
+    the process group by name) so the Function stays traceable.
     """
 
     @staticmethod
@@ -118,14 +44,12 @@ class _RingFA3Varlen(torch.autograd.Function):
         heads_k_stride: int,
         causal: bool,
         group_name: str,
+        flash_attn_version: int,
         window_size_left: int = -1,
         window_size_right: int = -1,
     ) -> torch.Tensor:
-        group = dist.group.WORLD
-        for pg in dist.distributed_c10d._world.pg_map:
-            if pg.group_name == group_name:
-                group = pg
-                break
+        group = _resolve_group(group_name)
+        flash_forward = VARLEN_FORWARD[flash_attn_version]
 
         local_k_slice = slice(local_k_slice_start, local_k_slice_stop)
         window_size = (window_size_left, window_size_right)
@@ -157,7 +81,7 @@ class _RingFA3Varlen(torch.autograd.Function):
             q_i = q[:, i * nheads // nheads_k : (i + heads_k_stride) * nheads // nheads_k]
             k_i = kv_buffer[0][local_k_slice]
             v_i = kv_buffer[1][local_k_slice]
-            out_i, lse_i = _fa3_varlen_forward(
+            out_i, lse_i = flash_forward(
                 q=q_i,
                 k=k_i,
                 v=v_i,
@@ -183,6 +107,7 @@ class _RingFA3Varlen(torch.autograd.Function):
         ctx.heads_k_stride = heads_k_stride
         ctx.causal = causal
         ctx.group_name = group_name
+        ctx.flash_attn_version = flash_attn_version
         ctx.window_size = window_size
         return out
 
@@ -193,11 +118,8 @@ class _RingFA3Varlen(torch.autograd.Function):
         local_k_slice = ctx.local_k_slice
         causal = ctx.causal
 
-        group = dist.group.WORLD
-        for pg in dist.distributed_c10d._world.pg_map:
-            if pg.group_name == ctx.group_name:
-                group = pg
-                break
+        group = _resolve_group(ctx.group_name)
+        flash_backward = VARLEN_BACKWARD[ctx.flash_attn_version]
 
         nheads = q.shape[1]
         total_k, nheads_k, head_dim = k.shape
@@ -241,7 +163,7 @@ class _RingFA3Varlen(torch.autograd.Function):
             dk_i = dkv_buffer[0][local_k_slice]
             dv_i = dkv_buffer[1][local_k_slice]
 
-            _fa3_varlen_backward(
+            flash_backward(
                 dout=dout_i,
                 q=q_i,
                 k=k_i,
@@ -275,11 +197,11 @@ class _RingFA3Varlen(torch.autograd.Function):
 
         # Grads for: q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
         #            local_k_slice_start, local_k_slice_stop, heads_k_stride, causal, group_name,
-        #            window_size_left, window_size_right
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None
+        #            flash_attn_version, window_size_left, window_size_right
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None
 
 
-def ring_fa3_varlen_func(
+def ring_flash_attn_varlen_func(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -291,9 +213,10 @@ def ring_fa3_varlen_func(
     causal: bool,
     heads_k_stride: int,
     group: dist.ProcessGroup,
+    flash_attn_version: int,
     window_size: tuple[int, int] = (-1, -1),
 ) -> torch.Tensor:
-    return _RingFA3Varlen.apply(
+    return _RingVarlen.apply(
         q,
         k,
         v,
@@ -306,301 +229,7 @@ def ring_fa3_varlen_func(
         heads_k_stride,
         causal,
         group.group_name,
-        window_size[0],
-        window_size[1],
-    )
-
-
-# ---------------------------------------------------------------------------
-# FA4 (flash_attn.cute) ring attention
-# ---------------------------------------------------------------------------
-
-
-def _fa4_varlen_forward(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cu_seqlens_q: torch.Tensor,
-    cu_seqlens_k: torch.Tensor,
-    max_seqlen_q: int,
-    max_seqlen_k: int,
-    softmax_scale: float,
-    causal: bool,
-    window_size: tuple[int, int] = (-1, -1),
-) -> tuple[torch.Tensor, torch.Tensor]:
-    from flash_attn.cute.interface import _flash_attn_fwd
-
-    wl = window_size[0] if window_size[0] != -1 else None
-    wr = window_size[1] if window_size[1] != -1 else None
-    out, lse = _flash_attn_fwd(
-        q,
-        k,
-        v,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=max_seqlen_q,
-        max_seqlen_k=max_seqlen_k,
-        softmax_scale=softmax_scale,
-        causal=causal,
-        window_size_left=wl,
-        window_size_right=wr,
-        return_lse=True,
-    )
-    return out, lse
-
-
-def _fa4_varlen_backward(
-    dout: torch.Tensor,
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    out: torch.Tensor,
-    softmax_lse: torch.Tensor,
-    cu_seqlens_q: torch.Tensor,
-    cu_seqlens_k: torch.Tensor,
-    max_seqlen_q: int,
-    max_seqlen_k: int,
-    dq: torch.Tensor,
-    dk: torch.Tensor,
-    dv: torch.Tensor,
-    softmax_scale: float,
-    causal: bool,
-    window_size: tuple[int, int] = (-1, -1),
-) -> None:
-    from flash_attn.cute.interface import _flash_attn_bwd
-
-    wl = window_size[0] if window_size[0] != -1 else None
-    wr = window_size[1] if window_size[1] != -1 else None
-    _flash_attn_bwd(
-        q,
-        k,
-        v,
-        out,
-        dout,
-        softmax_lse,
-        softmax_scale=softmax_scale,
-        causal=causal,
-        window_size_left=wl,
-        window_size_right=wr,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=max_seqlen_q,
-        max_seqlen_k=max_seqlen_k,
-        dq=dq,
-        dk=dk,
-        dv=dv,
-    )
-
-
-class _RingFA4Varlen(torch.autograd.Function):
-    """Ring attention using FA4 (flash_attn.cute) kernels with all-gather communication.
-
-    Mirrors _RingFA3Varlen but calls the FA4 low-level forward/backward.
-    """
-
-    @staticmethod
-    def forward(
-        ctx,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        cu_seqlens_q: torch.Tensor,
-        cu_seqlens_k: torch.Tensor,
-        max_seqlen_q: int,
-        max_seqlen_k: int,
-        local_k_slice_start: int,
-        local_k_slice_stop: int,
-        heads_k_stride: int,
-        causal: bool,
-        group_name: str,
-        window_size_left: int = -1,
-        window_size_right: int = -1,
-    ) -> torch.Tensor:
-        group = dist.group.WORLD
-        for pg in dist.distributed_c10d._world.pg_map:
-            if pg.group_name == group_name:
-                group = pg
-                break
-
-        local_k_slice = slice(local_k_slice_start, local_k_slice_stop)
-        window_size = (window_size_left, window_size_right)
-        softmax_scale = q.shape[-1] ** (-0.5)
-        out_list = []
-        lse_list = []
-
-        nheads = q.shape[1]
-        total_k, nheads_k, head_dim = k.shape
-        world_size = dist.get_world_size(group)
-
-        kv_buffer = torch.empty((2, total_k * world_size, heads_k_stride, head_dim), dtype=k.dtype, device=k.device)
-        kv_buffer_copy = torch.empty_like(kv_buffer)
-        comm = AllGatherComm(group)
-
-        comm.all_gather(kv_buffer_copy[0], k[:, :heads_k_stride].contiguous())
-        comm.all_gather(kv_buffer_copy[1], v[:, :heads_k_stride].contiguous())
-
-        for i in range(0, nheads_k, heads_k_stride):
-            comm.wait()
-            kv_buffer, kv_buffer_copy = kv_buffer_copy, kv_buffer
-
-            if i < nheads_k - heads_k_stride:
-                left = i + heads_k_stride
-                right = left + heads_k_stride
-                comm.all_gather(kv_buffer_copy[0], k[:, left:right].contiguous())
-                comm.all_gather(kv_buffer_copy[1], v[:, left:right].contiguous())
-
-            q_i = q[:, i * nheads // nheads_k : (i + heads_k_stride) * nheads // nheads_k]
-            k_i = kv_buffer[0][local_k_slice]
-            v_i = kv_buffer[1][local_k_slice]
-            out_i, lse_i = _fa4_varlen_forward(
-                q=q_i,
-                k=k_i,
-                v=v_i,
-                cu_seqlens_q=cu_seqlens_q,
-                cu_seqlens_k=cu_seqlens_k,
-                max_seqlen_q=max_seqlen_q,
-                max_seqlen_k=max_seqlen_k,
-                softmax_scale=softmax_scale,
-                causal=causal,
-                window_size=window_size,
-            )
-            out_list.append(out_i)
-            lse_list.append(lse_i)
-
-        out = torch.cat(out_list, dim=1)
-        lse = torch.cat(lse_list, dim=-2)
-
-        ctx.save_for_backward(q, k, v, out, lse, cu_seqlens_q, cu_seqlens_k)
-        ctx.softmax_scale = softmax_scale
-        ctx.max_seqlen_q = max_seqlen_q
-        ctx.max_seqlen_k = max_seqlen_k
-        ctx.local_k_slice = local_k_slice
-        ctx.heads_k_stride = heads_k_stride
-        ctx.causal = causal
-        ctx.group_name = group_name
-        ctx.window_size = window_size
-        return out
-
-    @staticmethod
-    def backward(ctx, dout: torch.Tensor):
-        q, k, v, out, softmax_lse, cu_seqlens_q, cu_seqlens_k = ctx.saved_tensors
-        heads_k_stride = ctx.heads_k_stride
-        local_k_slice = ctx.local_k_slice
-        causal = ctx.causal
-
-        group = dist.group.WORLD
-        for pg in dist.distributed_c10d._world.pg_map:
-            if pg.group_name == ctx.group_name:
-                group = pg
-                break
-
-        nheads = q.shape[1]
-        total_k, nheads_k, head_dim = k.shape
-        world_size = dist.get_world_size(group)
-
-        kv_buffer = torch.empty((2, total_k * world_size, heads_k_stride, head_dim), dtype=k.dtype, device=k.device)
-        kv_buffer_copy = torch.empty_like(kv_buffer)
-        dkv_buffer = torch.empty((2, total_k * world_size, heads_k_stride, head_dim), dtype=k.dtype, device=k.device)
-
-        kv_contiguous_buffer = None
-        if heads_k_stride != nheads_k:
-            kv_contiguous_buffer = torch.empty((2, total_k, heads_k_stride, head_dim), dtype=k.dtype, device=k.device)
-
-        dq = torch.empty_like(q)
-        dk = torch.empty_like(k)
-        dv = torch.empty_like(v)
-
-        comm = AllGatherComm(group)
-        comm.all_gather(kv_buffer_copy[0], k[:, :heads_k_stride].contiguous())
-        comm.all_gather(kv_buffer_copy[1], v[:, :heads_k_stride].contiguous())
-
-        for i in range(0, nheads_k, heads_k_stride):
-            dkv_buffer.zero_()
-            q_slice = slice(i * nheads // nheads_k, (i + heads_k_stride) * nheads // nheads_k)
-            q_i = q[:, q_slice]
-            dout_i = dout[:, q_slice]
-            out_i = out[:, q_slice]
-            dq_i = dq[:, q_slice]
-            lse_i = softmax_lse[q_slice].contiguous()
-
-            comm.wait()
-            kv_buffer, kv_buffer_copy = kv_buffer_copy, kv_buffer
-            if i < nheads_k - heads_k_stride:
-                left = i + heads_k_stride
-                right = left + heads_k_stride
-                comm.all_gather(kv_buffer_copy[0], k[:, left:right].contiguous())
-                comm.all_gather(kv_buffer_copy[1], v[:, left:right].contiguous())
-
-            k_i = kv_buffer[0][local_k_slice]
-            v_i = kv_buffer[1][local_k_slice]
-            dk_i = dkv_buffer[0][local_k_slice]
-            dv_i = dkv_buffer[1][local_k_slice]
-
-            _fa4_varlen_backward(
-                dout=dout_i,
-                q=q_i,
-                k=k_i,
-                v=v_i,
-                out=out_i,
-                softmax_lse=lse_i,
-                cu_seqlens_q=cu_seqlens_q,
-                cu_seqlens_k=cu_seqlens_k,
-                max_seqlen_q=ctx.max_seqlen_q,
-                max_seqlen_k=ctx.max_seqlen_k,
-                dq=dq_i,
-                dk=dk_i,
-                dv=dv_i,
-                softmax_scale=ctx.softmax_scale,
-                causal=causal,
-                window_size=ctx.window_size,
-            )
-
-            if heads_k_stride != nheads_k:
-                dk_i = kv_contiguous_buffer[0]
-                dv_i = kv_contiguous_buffer[1]
-            else:
-                dk_i = dk
-                dv_i = dv
-
-            dist.reduce_scatter_tensor(dk_i, dkv_buffer[0], group=group)
-            dist.reduce_scatter_tensor(dv_i, dkv_buffer[1], group=group)
-            if heads_k_stride != nheads_k:
-                dk[:, i : i + heads_k_stride] = dk_i
-                dv[:, i : i + heads_k_stride] = dv_i
-
-        # Grads for: q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
-        #            local_k_slice_start, local_k_slice_stop, heads_k_stride, causal, group_name,
-        #            window_size_left, window_size_right
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None
-
-
-def ring_fa4_varlen_func(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cu_seqlens_q: torch.Tensor,
-    cu_seqlens_k: torch.Tensor,
-    max_seqlen_q: int,
-    max_seqlen_k: int,
-    local_k_slice: slice,
-    causal: bool,
-    heads_k_stride: int,
-    group: dist.ProcessGroup,
-    window_size: tuple[int, int] = (-1, -1),
-) -> torch.Tensor:
-    return _RingFA4Varlen.apply(
-        q,
-        k,
-        v,
-        cu_seqlens_q,
-        cu_seqlens_k,
-        max_seqlen_q,
-        max_seqlen_k,
-        local_k_slice.start,
-        local_k_slice.stop,
-        heads_k_stride,
-        causal,
-        group.group_name,
+        flash_attn_version,
         window_size[0],
         window_size[1],
     )

--- a/tests/distributed/test_cp.py
+++ b/tests/distributed/test_cp.py
@@ -1,4 +1,4 @@
-# ruff: noqa: I001 — `prime_rl._compat` must run before `ring_flash_attn` imports below.
+# ruff: noqa: I001 (`prime_rl._compat` must run before the `ring_flash_attn` imports below)
 import prime_rl._compat  # noqa: F401
 
 import importlib.util
@@ -9,14 +9,9 @@ import torch.distributed as dist
 
 from tests.dtest import DTest
 
-from ring_flash_attn.llama3_flash_attn_varlen import llama3_flash_attn_prepare_cu_seqlens, llama3_flash_attn_varlen_func
+from ring_flash_attn.llama3_flash_attn_varlen import llama3_flash_attn_prepare_cu_seqlens
 
-from prime_rl.trainer.models.layers.ring_attn import (
-    _fa3_varlen_forward,
-    _fa4_varlen_forward,
-    ring_fa3_varlen_func,
-    ring_fa4_varlen_func,
-)
+from prime_rl.trainer.models.layers.ring_attn import ring_flash_attn_varlen_func
 from prime_rl.trainer.models.layers.ulysses_attn import ulysses_flash_attn_varlen_func
 
 NHEADS = 4
@@ -30,7 +25,7 @@ _HAS_FLASH_ATTN = importlib.util.find_spec("flash_attn") is not None
 _HAS_FLASH_ATTN_3 = importlib.util.find_spec("flash_attn_interface") is not None
 _HAS_FLASH_ATTN_4 = importlib.util.find_spec("flash_attn.cute") is not None
 
-# None when there's no CUDA device at all — DTest's own world_size check (`torch.cuda.device_count()
+# None when there's no CUDA device at all. DTest's own world_size check (`torch.cuda.device_count()
 # < world_size`) already reports that case with a clearer message, so the hardware skipif conditions
 # below stay False (never trigger) when there's no device, deferring to that check instead.
 _SM_MAJOR, _SM_MINOR = torch.cuda.get_device_capability() if torch.cuda.is_available() else (None, None)
@@ -40,124 +35,33 @@ _NOT_SM100 = _SM_MAJOR is not None and (_SM_MAJOR, _SM_MINOR) != (10, 0)
 
 def _build_inputs(
     device: torch.device, nheads_k: int = NHEADS_K
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, float]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
     # Every rank computes this identically from the same seed.
     torch.manual_seed(42)
     total = sum(SEQLENS)
     cu_seqlens = torch.tensor([0, *torch.tensor(SEQLENS).cumsum(0).tolist()], dtype=torch.int32, device=device)
     max_seqlen = max(SEQLENS)
-    softmax_scale = HEAD_DIM**-0.5
 
     q = torch.randn(total, NHEADS, HEAD_DIM, device=device, dtype=torch.bfloat16)
     k = torch.randn(total, nheads_k, HEAD_DIM, device=device, dtype=torch.bfloat16)
     v = torch.randn(total, nheads_k, HEAD_DIM, device=device, dtype=torch.bfloat16)
 
-    return q, k, v, cu_seqlens, max_seqlen, softmax_scale
+    return q, k, v, cu_seqlens, max_seqlen
 
 
-def _assert_shard_matches_reference(ref_out: torch.Tensor, out: torch.Tensor, rank: int, world_size: int) -> None:
-    expected = torch.chunk(ref_out, world_size, dim=0)[rank]
-    assert torch.equal(out, expected)
+def _build_dout(q: torch.Tensor) -> torch.Tensor:
+    # Seeded separately from `_build_inputs` so the upstream gradient doesn't depend on how many
+    # draws happened before it.
+    torch.manual_seed(1234)
+    return torch.randn_like(q)
 
 
-class TestRingAttnCP(DTest):
-    """Context-parallel attention must match the single-GPU reference bit for bit.
+def _leaves(*tensors: torch.Tensor) -> tuple[torch.Tensor, ...]:
+    return tuple(t.clone().requires_grad_() for t in tensors)
 
-    These wrappers all-gather K/V and then make ordinary varlen calls, rather than merging
-    per-step partial outputs and LSEs across ranks the way online ring attention does. Causality
-    forces each rank's key range to start at its document's start, so every output row reduces
-    over the same key blocks, in the same order, as the reference: identical arithmetic, hence
-    identical bits. A mismatch therefore means the reduction pattern changed, not that rounding
-    drifted.
-    """
 
-    default_world_size = 2
-
-    @pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
-    def test_fa2_correctness(self) -> None:
-        from flash_attn import flash_attn_varlen_func
-
-        q, k, v, cu_seqlens, max_seqlen, _softmax_scale = _build_inputs(self.device)
-        cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, local_k_slice = llama3_flash_attn_prepare_cu_seqlens(
-            cu_seqlens, causal=True, rank=self.rank, world_size=self.world_size
-        )
-        q_shard, k_shard, v_shard = (torch.chunk(t, self.world_size, dim=0)[self.rank] for t in (q, k, v))
-
-        ref_out = flash_attn_varlen_func(q, k, v, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen, causal=True)
-
-        out = llama3_flash_attn_varlen_func(
-            q_shard,
-            k_shard,
-            v_shard,
-            cu_seqlens_q,
-            cu_seqlens_k,
-            max_seqlen_q,
-            max_seqlen_k,
-            heads_k_stride=1,
-            local_k_slice=local_k_slice,
-            causal=True,
-            group=dist.group.WORLD,
-        )
-
-        _assert_shard_matches_reference(ref_out, out, self.rank, self.world_size)
-
-    @pytest.mark.skipif(_NOT_HOPPER, reason=f"FA3 requires Hopper (SM90); found SM{_SM_MAJOR}{_SM_MINOR}")
-    @pytest.mark.skipif(not _HAS_FLASH_ATTN_3, reason="flash_attn_interface not installed")
-    def test_fa3_correctness(self) -> None:
-        q, k, v, cu_seqlens, max_seqlen, softmax_scale = _build_inputs(self.device)
-        cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, local_k_slice = llama3_flash_attn_prepare_cu_seqlens(
-            cu_seqlens, causal=True, rank=self.rank, world_size=self.world_size
-        )
-        q_shard, k_shard, v_shard = (torch.chunk(t, self.world_size, dim=0)[self.rank] for t in (q, k, v))
-
-        ref_out, _ = _fa3_varlen_forward(
-            q, k, v, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen, softmax_scale, causal=True
-        )
-
-        out = ring_fa3_varlen_func(
-            q_shard,
-            k_shard,
-            v_shard,
-            cu_seqlens_q,
-            cu_seqlens_k,
-            max_seqlen_q,
-            max_seqlen_k,
-            local_k_slice,
-            causal=True,
-            heads_k_stride=1,
-            group=dist.group.WORLD,
-        )
-
-        _assert_shard_matches_reference(ref_out, out, self.rank, self.world_size)
-
-    @pytest.mark.skipif(_NOT_SM100, reason=f"FA4 requires SM100 (datacenter Blackwell); found SM{_SM_MAJOR}{_SM_MINOR}")
-    @pytest.mark.skipif(not _HAS_FLASH_ATTN_4, reason="flash_attn.cute not installed")
-    def test_fa4_correctness(self) -> None:
-        q, k, v, cu_seqlens, max_seqlen, softmax_scale = _build_inputs(self.device)
-        cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, local_k_slice = llama3_flash_attn_prepare_cu_seqlens(
-            cu_seqlens, causal=True, rank=self.rank, world_size=self.world_size
-        )
-        q_shard, k_shard, v_shard = (torch.chunk(t, self.world_size, dim=0)[self.rank] for t in (q, k, v))
-
-        ref_out, _ = _fa4_varlen_forward(
-            q, k, v, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen, softmax_scale, causal=True
-        )
-
-        out = ring_fa4_varlen_func(
-            q_shard,
-            k_shard,
-            v_shard,
-            cu_seqlens_q,
-            cu_seqlens_k,
-            max_seqlen_q,
-            max_seqlen_k,
-            local_k_slice,
-            causal=True,
-            heads_k_stride=1,
-            group=dist.group.WORLD,
-        )
-
-        _assert_shard_matches_reference(ref_out, out, self.rank, self.world_size)
+def _shard(t: torch.Tensor, rank: int, world_size: int) -> torch.Tensor:
+    return torch.chunk(t, world_size, dim=0)[rank]
 
 
 def _reference_attn(
@@ -178,6 +82,105 @@ def _reference_attn(
     return out[0] if isinstance(out, tuple) else out
 
 
+def _bf16_ulp(t: torch.Tensor) -> float:
+    """One bfloat16 ulp at the tensor's peak magnitude (bf16 carries an 8-bit significand)."""
+    return 2**-8 * t.abs().max().item()
+
+
+def _assert_shard_matches_reference(
+    ref_out: torch.Tensor,
+    out: torch.Tensor,
+    ref_inputs: tuple[torch.Tensor, ...],
+    cp_inputs: tuple[torch.Tensor, ...],
+    rank: int,
+    world_size: int,
+    summed_across_ranks: tuple[str, ...] = (),
+) -> None:
+    """Compare this rank's output and input gradients against the single-GPU reference.
+
+    Everything is bitwise except gradients named in `summed_across_ranks`: those are accumulated in
+    bf16 across ranks, whereas the reference rounds the whole sum once, so they land within a
+    bf16 ulp of it rather than on it.
+    """
+    assert torch.equal(out, _shard(ref_out, rank, world_size))
+    for name, ref, got in zip(("dq", "dk", "dv"), ref_inputs, cp_inputs):
+        expected = _shard(ref.grad, rank, world_size)
+        if name in summed_across_ranks:
+            torch.testing.assert_close(
+                got.grad, expected, rtol=2e-2, atol=_bf16_ulp(expected), msg=lambda m: f"{name}: {m}"
+            )
+        else:
+            assert torch.equal(got.grad, expected), f"{name} is not bitwise equal to the reference"
+
+
+class TestRingAttnCP(DTest):
+    """Context-parallel attention must match the single-GPU reference bit for bit.
+
+    These wrappers all-gather K/V and then make ordinary varlen calls, rather than merging
+    per-step partial outputs and LSEs across ranks the way online ring attention does. Causality
+    forces each rank's key range to start at its document's start, so every output row reduces
+    over the same key blocks, in the same order, as the reference: identical arithmetic, hence
+    identical bits. A mismatch therefore means the reduction pattern changed, not that rounding
+    drifted. The same holds for dq on the backward pass. dk and dv are the exception: every rank
+    computes a partial for every key, and the reduce-scatter that sums them rounds in bf16 twice
+    where the reference rounds once.
+    """
+
+    default_world_size = 2
+
+    def _check(self, flash_fn, flash_attn_version: int) -> None:
+        q, k, v, cu_seqlens, max_seqlen = _build_inputs(self.device)
+        dout = _build_dout(q)
+        cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, local_k_slice = llama3_flash_attn_prepare_cu_seqlens(
+            cu_seqlens, causal=True, rank=self.rank, world_size=self.world_size
+        )
+
+        ref_inputs = _leaves(q, k, v)
+        ref_out = _reference_attn(flash_fn, *ref_inputs, cu_seqlens, max_seqlen, flash_attn_version)
+        ref_out.backward(dout)
+
+        cp_inputs = _leaves(*(_shard(t, self.rank, self.world_size) for t in (q, k, v)))
+        out = ring_flash_attn_varlen_func(
+            *cp_inputs,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            local_k_slice,
+            causal=True,
+            heads_k_stride=1,
+            group=dist.group.WORLD,
+            flash_attn_version=flash_attn_version,
+        )
+        out.backward(_shard(dout, self.rank, self.world_size))
+
+        # dk/dv are the only reduced quantities: every rank holds every key, so each contributes a
+        # partial that a reduce-scatter sums.
+        _assert_shard_matches_reference(
+            ref_out, out, ref_inputs, cp_inputs, self.rank, self.world_size, summed_across_ranks=("dk", "dv")
+        )
+
+    @pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
+    def test_fa2_correctness(self) -> None:
+        from flash_attn import flash_attn_varlen_func
+
+        self._check(flash_attn_varlen_func, flash_attn_version=2)
+
+    @pytest.mark.skipif(_NOT_HOPPER, reason=f"FA3 requires Hopper (SM90); found SM{_SM_MAJOR}{_SM_MINOR}")
+    @pytest.mark.skipif(not _HAS_FLASH_ATTN_3, reason="flash_attn_interface not installed")
+    def test_fa3_correctness(self) -> None:
+        from flash_attn_interface import flash_attn_varlen_func
+
+        self._check(flash_attn_varlen_func, flash_attn_version=3)
+
+    @pytest.mark.skipif(_NOT_SM100, reason=f"FA4 requires SM100 (datacenter Blackwell); found SM{_SM_MAJOR}{_SM_MINOR}")
+    @pytest.mark.skipif(not _HAS_FLASH_ATTN_4, reason="flash_attn.cute not installed")
+    def test_fa4_correctness(self) -> None:
+        from flash_attn.cute import flash_attn_varlen_func
+
+        self._check(flash_attn_varlen_func, flash_attn_version=4)
+
+
 class TestUlyssesCP(DTest):
     """Ulysses CP must match the single-GPU reference bit for bit.
 
@@ -186,25 +189,24 @@ class TestUlyssesCP(DTest):
     a subset of heads over the full sequence produces exactly the same per-head arithmetic as
     running it on all heads together. No rounding-order difference is introduced anywhere in the
     pipeline, so, like ring attention, a mismatch means the reshaping is wrong, not that rounding
-    drifted.
+    drifted. Unlike ring attention this covers the backward pass with no exceptions: nothing is
+    summed across ranks, so dq, dk, and dv are all bitwise equal to the reference.
     """
 
     default_world_size = 2
 
-    @pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
-    def test_fa2_correctness(self) -> None:
-        from flash_attn import flash_attn_varlen_func
+    def _check(self, flash_fn, flash_attn_version: int, nheads_k: int = NHEADS_K) -> None:
+        q, k, v, cu_seqlens, max_seqlen = _build_inputs(self.device, nheads_k=nheads_k)
+        dout = _build_dout(q)
 
-        q, k, v, cu_seqlens, max_seqlen, _softmax_scale = _build_inputs(self.device, nheads_k=2)
-        q_shard, k_shard, v_shard = (torch.chunk(t, self.world_size, dim=0)[self.rank] for t in (q, k, v))
+        ref_inputs = _leaves(q, k, v)
+        ref_out = _reference_attn(flash_fn, *ref_inputs, cu_seqlens, max_seqlen, flash_attn_version)
+        ref_out.backward(dout)
 
-        ref_out = _reference_attn(flash_attn_varlen_func, q, k, v, cu_seqlens, max_seqlen, flash_attn_version=2)
-
+        cp_inputs = _leaves(*(_shard(t, self.rank, self.world_size) for t in (q, k, v)))
         out = ulysses_flash_attn_varlen_func(
-            flash_attn_varlen_func,
-            q_shard,
-            k_shard,
-            v_shard,
+            flash_fn,
+            *cp_inputs,
             cu_seqlens_q=cu_seqlens,
             cu_seqlens_k=cu_seqlens,
             max_seqlen_q=max_seqlen,
@@ -212,64 +214,36 @@ class TestUlyssesCP(DTest):
             causal=True,
             cp_group=dist.group.WORLD,
             cp_size=self.world_size,
-            flash_attn_version=2,
+            flash_attn_version=flash_attn_version,
+        )
+        out.backward(_shard(dout, self.rank, self.world_size))
+
+        # Nothing is summed across ranks, except when `_replicate_kv_heads` kicks in: then each
+        # replica of a KV head produces a partial dk/dv that its backward sums.
+        summed = ("dk", "dv") if nheads_k < self.world_size else ()
+        _assert_shard_matches_reference(
+            ref_out, out, ref_inputs, cp_inputs, self.rank, self.world_size, summed_across_ranks=summed
         )
 
-        _assert_shard_matches_reference(ref_out, out, self.rank, self.world_size)
+    @pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
+    def test_fa2_correctness(self) -> None:
+        from flash_attn import flash_attn_varlen_func
+
+        self._check(flash_attn_varlen_func, flash_attn_version=2)
 
     @pytest.mark.skipif(_NOT_HOPPER, reason=f"FA3 requires Hopper (SM90); found SM{_SM_MAJOR}{_SM_MINOR}")
     @pytest.mark.skipif(not _HAS_FLASH_ATTN_3, reason="flash_attn_interface not installed")
     def test_fa3_correctness(self) -> None:
         from flash_attn_interface import flash_attn_varlen_func
 
-        q, k, v, cu_seqlens, max_seqlen, _softmax_scale = _build_inputs(self.device, nheads_k=2)
-        q_shard, k_shard, v_shard = (torch.chunk(t, self.world_size, dim=0)[self.rank] for t in (q, k, v))
-
-        ref_out = _reference_attn(flash_attn_varlen_func, q, k, v, cu_seqlens, max_seqlen, flash_attn_version=3)
-
-        out = ulysses_flash_attn_varlen_func(
-            flash_attn_varlen_func,
-            q_shard,
-            k_shard,
-            v_shard,
-            cu_seqlens_q=cu_seqlens,
-            cu_seqlens_k=cu_seqlens,
-            max_seqlen_q=max_seqlen,
-            max_seqlen_k=max_seqlen,
-            causal=True,
-            cp_group=dist.group.WORLD,
-            cp_size=self.world_size,
-            flash_attn_version=3,
-        )
-
-        _assert_shard_matches_reference(ref_out, out, self.rank, self.world_size)
+        self._check(flash_attn_varlen_func, flash_attn_version=3)
 
     @pytest.mark.skipif(_NOT_SM100, reason=f"FA4 requires SM100 (datacenter Blackwell); found SM{_SM_MAJOR}{_SM_MINOR}")
     @pytest.mark.skipif(not _HAS_FLASH_ATTN_4, reason="flash_attn.cute not installed")
     def test_fa4_correctness(self) -> None:
         from flash_attn.cute import flash_attn_varlen_func
 
-        q, k, v, cu_seqlens, max_seqlen, _softmax_scale = _build_inputs(self.device, nheads_k=2)
-        q_shard, k_shard, v_shard = (torch.chunk(t, self.world_size, dim=0)[self.rank] for t in (q, k, v))
-
-        ref_out = _reference_attn(flash_attn_varlen_func, q, k, v, cu_seqlens, max_seqlen, flash_attn_version=4)
-
-        out = ulysses_flash_attn_varlen_func(
-            flash_attn_varlen_func,
-            q_shard,
-            k_shard,
-            v_shard,
-            cu_seqlens_q=cu_seqlens,
-            cu_seqlens_k=cu_seqlens,
-            max_seqlen_q=max_seqlen,
-            max_seqlen_k=max_seqlen,
-            causal=True,
-            cp_group=dist.group.WORLD,
-            cp_size=self.world_size,
-            flash_attn_version=4,
-        )
-
-        _assert_shard_matches_reference(ref_out, out, self.rank, self.world_size)
+        self._check(flash_attn_varlen_func, flash_attn_version=4)
 
     @pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
     def test_fa2_gqa_kv_head_replication_correctness(self) -> None:
@@ -277,24 +251,4 @@ class TestUlyssesCP(DTest):
         # (nheads_k=2 == cp_size never triggers it).
         from flash_attn import flash_attn_varlen_func
 
-        q, k, v, cu_seqlens, max_seqlen, _softmax_scale = _build_inputs(self.device, nheads_k=1)
-        q_shard, k_shard, v_shard = (torch.chunk(t, self.world_size, dim=0)[self.rank] for t in (q, k, v))
-
-        ref_out = _reference_attn(flash_attn_varlen_func, q, k, v, cu_seqlens, max_seqlen, flash_attn_version=2)
-
-        out = ulysses_flash_attn_varlen_func(
-            flash_attn_varlen_func,
-            q_shard,
-            k_shard,
-            v_shard,
-            cu_seqlens_q=cu_seqlens,
-            cu_seqlens_k=cu_seqlens,
-            max_seqlen_q=max_seqlen,
-            max_seqlen_k=max_seqlen,
-            causal=True,
-            cp_group=dist.group.WORLD,
-            cp_size=self.world_size,
-            flash_attn_version=2,
-        )
-
-        _assert_shard_matches_reference(ref_out, out, self.rank, self.world_size)
+        self._check(flash_attn_varlen_func, flash_attn_version=2, nheads_k=1)


### PR DESCRIPTION
Third of four stacked PRs, builds on #3395. Refactor which unifies and simplifies previous CP code paths and enables straightforward sink-token CP support in #3397.

Ring attention had accumulated several near-duplicate code paths across FA2/FA3/FA4. This collapses them into a single varlen implementation in the new `src/prime_rl/trainer/models/layers/flash_varlen.py` and reduces `ring_attn.py` to the ring-specific communication, dropping 431 lines. The tests from #3395 are what make that safe to do.

It is also what makes attention sinks possible on the FA2 ring path at all. That path previously dispatched to upstream `ring_flash_attn.llama3_flash_attn_varlen_func`, a third-party `autograd.Function`. A sink has to be folded into the per-head-group LSE inside the forward and returned as an extra `dsink` gradient slot from the backward, neither of which is reachable without owning that function. Bringing the implementation in-house reduces the sink change in #3397 to two call sites totalling 24 lines, instead of the same change in three places plus forking or vendoring a dependency.
