### PR TITLE
feat(cp): add attention sink support to ring and ulysses context parallelism

### DIFF
--- a/src/prime_rl/trainer/models/layers/flash_varlen.py
+++ b/src/prime_rl/trainer/models/layers/flash_varlen.py
@@ -313,11 +313,12 @@ class _SinkVarlen(torch.autograd.Function):
         max_seqlen_k: int,
         causal: bool,
         flash_attn_version: int,
+        softmax_scale: float | None = None,
         window_size_left: int = -1,
         window_size_right: int = -1,
     ) -> torch.Tensor:
         window_size = (window_size_left, window_size_right)
-        softmax_scale = q.shape[-1] ** (-0.5)
+        softmax_scale = q.shape[-1] ** (-0.5) if softmax_scale is None else softmax_scale
         out, lse = VARLEN_FORWARD[flash_attn_version](
             q=q,
             k=k,
@@ -365,8 +366,8 @@ class _SinkVarlen(torch.autograd.Function):
         )
         dsink = sink_grad(out, lse, dout, sink)
         # Grads for: q, k, v, sink, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
-        #            causal, flash_attn_version, window_size_left, window_size_right
-        return dq, dk, dv, dsink, None, None, None, None, None, None, None, None
+        #            causal, flash_attn_version, softmax_scale, window_size_left, window_size_right
+        return dq, dk, dv, dsink, None, None, None, None, None, None, None, None, None
 
 
 def sink_flash_attn_varlen_func(
@@ -380,6 +381,7 @@ def sink_flash_attn_varlen_func(
     max_seqlen_k: int,
     causal: bool,
     flash_attn_version: int,
+    softmax_scale: float | None = None,
     window_size: tuple[int, int] = (-1, -1),
 ) -> torch.Tensor:
     return _SinkVarlen.apply(
@@ -393,6 +395,7 @@ def sink_flash_attn_varlen_func(
         max_seqlen_k,
         causal,
         flash_attn_version,
+        softmax_scale,
         window_size[0],
         window_size[1],
     )

--- a/src/prime_rl/trainer/models/layers/flash_varlen.py
+++ b/src/prime_rl/trainer/models/layers/flash_varlen.py
@@ -258,3 +258,141 @@ def _fa4_varlen_backward(
 
 VARLEN_FORWARD = {2: _fa2_varlen_forward, 3: _fa3_varlen_forward, 4: _fa4_varlen_forward}
 VARLEN_BACKWARD = {2: _fa2_varlen_backward, 3: _fa3_varlen_backward, 4: _fa4_varlen_backward}
+
+
+def apply_sink(out: torch.Tensor, lse: torch.Tensor, sink: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fold a per-head additive sink logit into a sink-unaware kernel's output and LSE.
+
+    A sink is a virtual softmax column whose value vector is zero, so it contributes nothing to
+    the numerator and only enlarges the denominator. Writing `Z = exp(lse)` for the sink-free
+    denominator, the sink-inclusive output is `out * Z / (Z + exp(sink))`, i.e.
+    `out * sigmoid(lse - sink)`, and the new LSE is `logaddexp(lse, sink)`.
+
+    `out` is `[total_q, nheads, head_dim]`, `lse` is `[nheads, total_q]`, `sink` is `[nheads]`.
+    """
+    sink = sink.to(lse.dtype).unsqueeze(-1)
+    scale = torch.sigmoid(lse - sink)
+    out = (out.float() * scale.transpose(0, 1).unsqueeze(-1)).to(out.dtype)
+    return out, torch.logaddexp(lse, sink.expand_as(lse))
+
+
+def sink_grad(out: torch.Tensor, lse: torch.Tensor, dout: torch.Tensor, sink: torch.Tensor) -> torch.Tensor:
+    """Gradient of the loss with respect to the per-head sink logit.
+
+    The sink column's softmax weight is `p = exp(sink - lse)` and its value vector is zero, so its
+    contribution to the usual `dscore = p * (dot(dout, v) - D)` reduces to `-p * D`, where
+    `D[q,h] = sum_d out[q,h,d] * dout[q,h,d]`. Summing over queries gives the whole gradient.
+
+    `out` and `lse` must both already include the sink (see `apply_sink`).
+    """
+    D = (out.float() * dout.float()).sum(-1).transpose(0, 1)
+    p = torch.exp(sink.to(lse.dtype).unsqueeze(-1) - lse)
+    return -(p * D).sum(-1).to(sink.dtype)
+
+
+class _SinkVarlen(torch.autograd.Function):
+    """Varlen flash attention with a per-head additive sink logit, on one device.
+
+    No flash-attention backward kernel differentiates its own sink argument, so the sink is
+    applied outside the kernel instead (`apply_sink`), which also makes this work with FA2, whose
+    forward has no sink argument at all. `dq`/`dk`/`dv` still come straight from the ordinary
+    backward kernel: fed the sink-inclusive `out` and `lse`, its `D = rowsum(dout * out)` term is
+    already the sink-inclusive one, since the sink column contributes zero to it.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        sink: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        causal: bool,
+        flash_attn_version: int,
+        window_size_left: int = -1,
+        window_size_right: int = -1,
+    ) -> torch.Tensor:
+        window_size = (window_size_left, window_size_right)
+        softmax_scale = q.shape[-1] ** (-0.5)
+        out, lse = VARLEN_FORWARD[flash_attn_version](
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size=window_size,
+        )
+        out, lse = apply_sink(out, lse, sink)
+
+        ctx.save_for_backward(q, k, v, sink, out, lse, cu_seqlens_q, cu_seqlens_k)
+        ctx.softmax_scale = softmax_scale
+        ctx.max_seqlen_q = max_seqlen_q
+        ctx.max_seqlen_k = max_seqlen_k
+        ctx.causal = causal
+        ctx.flash_attn_version = flash_attn_version
+        ctx.window_size = window_size
+        return out
+
+    @staticmethod
+    def backward(ctx, dout: torch.Tensor):
+        q, k, v, sink, out, lse, cu_seqlens_q, cu_seqlens_k = ctx.saved_tensors
+        dq, dk, dv = torch.empty_like(q), torch.empty_like(k), torch.empty_like(v)
+        VARLEN_BACKWARD[ctx.flash_attn_version](
+            dout=dout,
+            q=q,
+            k=k,
+            v=v,
+            out=out,
+            softmax_lse=lse,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=ctx.max_seqlen_q,
+            max_seqlen_k=ctx.max_seqlen_k,
+            dq=dq,
+            dk=dk,
+            dv=dv,
+            softmax_scale=ctx.softmax_scale,
+            causal=ctx.causal,
+            window_size=ctx.window_size,
+        )
+        dsink = sink_grad(out, lse, dout, sink)
+        # Grads for: q, k, v, sink, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
+        #            causal, flash_attn_version, window_size_left, window_size_right
+        return dq, dk, dv, dsink, None, None, None, None, None, None, None, None
+
+
+def sink_flash_attn_varlen_func(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    sink: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    causal: bool,
+    flash_attn_version: int,
+    window_size: tuple[int, int] = (-1, -1),
+) -> torch.Tensor:
+    return _SinkVarlen.apply(
+        q,
+        k,
+        v,
+        sink,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        causal,
+        flash_attn_version,
+        window_size[0],
+        window_size[1],
+    )

--- a/src/prime_rl/trainer/models/layers/ring_attn.py
+++ b/src/prime_rl/trainer/models/layers/ring_attn.py
@@ -7,7 +7,7 @@ import torch
 import torch.distributed as dist
 from ring_flash_attn.utils import AllGatherComm
 
-from .flash_varlen import VARLEN_BACKWARD, VARLEN_FORWARD, apply_sink
+from .flash_varlen import VARLEN_BACKWARD, VARLEN_FORWARD, apply_sink, sink_grad
 
 
 def _resolve_group(group_name: str) -> dist.ProcessGroup:
@@ -107,7 +107,7 @@ class _RingVarlen(torch.autograd.Function):
         out = torch.cat(out_list, dim=1)
         lse = torch.cat(lse_list, dim=-2)
 
-        ctx.save_for_backward(q, k, v, out, lse, cu_seqlens_q, cu_seqlens_k)
+        ctx.save_for_backward(q, k, v, sink, out, lse, cu_seqlens_q, cu_seqlens_k)
         ctx.softmax_scale = softmax_scale
         ctx.max_seqlen_q = max_seqlen_q
         ctx.max_seqlen_k = max_seqlen_k
@@ -121,7 +121,7 @@ class _RingVarlen(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dout: torch.Tensor):
-        q, k, v, out, softmax_lse, cu_seqlens_q, cu_seqlens_k = ctx.saved_tensors
+        q, k, v, sink, out, softmax_lse, cu_seqlens_q, cu_seqlens_k = ctx.saved_tensors
         heads_k_stride = ctx.heads_k_stride
         local_k_slice = ctx.local_k_slice
         causal = ctx.causal
@@ -144,6 +144,7 @@ class _RingVarlen(torch.autograd.Function):
         dq = torch.empty_like(q)
         dk = torch.empty_like(k)
         dv = torch.empty_like(v)
+        dsink = None if sink is None else torch.empty_like(sink)
 
         comm = AllGatherComm(group)
         comm.all_gather(kv_buffer_copy[0], k[:, :heads_k_stride].contiguous())
@@ -190,6 +191,11 @@ class _RingVarlen(torch.autograd.Function):
                 window_size=ctx.window_size,
             )
 
+            if sink is not None:
+                # This rank's queries only. The sink is replicated across the CP group, so the
+                # gradient reduction that FSDP already does over dp_shard_cp completes the sum.
+                dsink[q_slice] = sink_grad(out_i, lse_i, dout_i, sink[q_slice])
+
             if heads_k_stride != nheads_k:
                 dk_i = kv_contiguous_buffer[0]
                 dv_i = kv_contiguous_buffer[1]
@@ -206,7 +212,7 @@ class _RingVarlen(torch.autograd.Function):
         # Grads for: q, k, v, sink, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
         #            local_k_slice_start, local_k_slice_stop, heads_k_stride, causal, group_name,
         #            flash_attn_version, window_size_left, window_size_right
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None
+        return dq, dk, dv, dsink, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 def ring_flash_attn_varlen_func(

--- a/src/prime_rl/trainer/models/layers/ring_attn.py
+++ b/src/prime_rl/trainer/models/layers/ring_attn.py
@@ -7,7 +7,7 @@ import torch
 import torch.distributed as dist
 from ring_flash_attn.utils import AllGatherComm
 
-from .flash_varlen import VARLEN_BACKWARD, VARLEN_FORWARD
+from .flash_varlen import VARLEN_BACKWARD, VARLEN_FORWARD, apply_sink
 
 
 def _resolve_group(group_name: str) -> dist.ProcessGroup:
@@ -35,6 +35,7 @@ class _RingVarlen(torch.autograd.Function):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
+        sink: torch.Tensor | None,
         cu_seqlens_q: torch.Tensor,
         cu_seqlens_k: torch.Tensor,
         max_seqlen_q: int,
@@ -78,7 +79,8 @@ class _RingVarlen(torch.autograd.Function):
                 comm.all_gather(kv_buffer_copy[0], k[:, left:right].contiguous())
                 comm.all_gather(kv_buffer_copy[1], v[:, left:right].contiguous())
 
-            q_i = q[:, i * nheads // nheads_k : (i + heads_k_stride) * nheads // nheads_k]
+            q_slice = slice(i * nheads // nheads_k, (i + heads_k_stride) * nheads // nheads_k)
+            q_i = q[:, q_slice]
             k_i = kv_buffer[0][local_k_slice]
             v_i = kv_buffer[1][local_k_slice]
             out_i, lse_i = flash_forward(
@@ -93,6 +95,12 @@ class _RingVarlen(torch.autograd.Function):
                 causal=causal,
                 window_size=window_size,
             )
+            if sink is not None:
+                # Every head is visited by exactly one iteration, so the sink lands on each query
+                # exactly once. This is also the only place it can land: the all-gathered key range
+                # makes each rank's softmax complete over its queries, so there is no partial
+                # denominator for a sink term to be folded into later.
+                out_i, lse_i = apply_sink(out_i, lse_i, sink[q_slice])
             out_list.append(out_i)
             lse_list.append(lse_i)
 
@@ -195,10 +203,10 @@ class _RingVarlen(torch.autograd.Function):
                 dk[:, i : i + heads_k_stride] = dk_i
                 dv[:, i : i + heads_k_stride] = dv_i
 
-        # Grads for: q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
+        # Grads for: q, k, v, sink, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
         #            local_k_slice_start, local_k_slice_stop, heads_k_stride, causal, group_name,
         #            flash_attn_version, window_size_left, window_size_right
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 def ring_flash_attn_varlen_func(
@@ -214,12 +222,14 @@ def ring_flash_attn_varlen_func(
     heads_k_stride: int,
     group: dist.ProcessGroup,
     flash_attn_version: int,
+    sink: torch.Tensor | None = None,
     window_size: tuple[int, int] = (-1, -1),
 ) -> torch.Tensor:
     return _RingVarlen.apply(
         q,
         k,
         v,
+        sink,
         cu_seqlens_q,
         cu_seqlens_k,
         max_seqlen_q,

--- a/src/prime_rl/trainer/models/layers/ulysses_attn.py
+++ b/src/prime_rl/trainer/models/layers/ulysses_attn.py
@@ -39,6 +39,8 @@ import torch
 import torch.distributed as dist
 import torch.distributed.nn.functional as dist_nn
 
+from .flash_varlen import sink_flash_attn_varlen_func
+
 # Populated by `update_ulysses_params` before each forward pass. Mirrors
 # ring_flash_attn's DATA_PARAMS pattern so the patched attention path can
 # reach the *full* (un-sharded) cu_seqlens / max_seqlen at call time.
@@ -129,6 +131,7 @@ def ulysses_flash_attn_varlen_func(
     softmax_scale: float | None = None,
     dropout_p: float = 0.0,
     deterministic: bool | None = None,
+    sink: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Run varlen flash attention under Ulysses CP.
 
@@ -138,6 +141,10 @@ def ulysses_flash_attn_varlen_func(
     GQA with num_key_value_heads < cp_size: K/V heads are replicated up to
     cp_size before the all-to-all (see `_replicate_kv_heads`), so each rank runs
     grouped attention on its query-head slice with the single matching KV head.
+
+    `sink` is a per-head additive sink logit over the *full* head count; each rank
+    applies the slice belonging to its own query heads, so its gradient comes back
+    zero-filled elsewhere and the CP-group sum reassembles it.
     """
     q = _all_to_all_seq_to_head(q, cp_size, cp_group)
     if k.shape[1] < cp_size:
@@ -156,7 +163,27 @@ def ulysses_flash_attn_varlen_func(
     if deterministic is not None:
         kwargs["deterministic"] = deterministic
 
-    if flash_attn_version == 4:
+    if sink is not None:
+        assert not dropout_p, "ulysses CP with an attention sink does not support dropout"
+        assert not deterministic, "ulysses CP with an attention sink does not support deterministic mode"
+        # After the all-to-all this rank holds query heads [rank * h_local, (rank + 1) * h_local).
+        h_local = q.shape[1]
+        rank = dist.get_rank(cp_group)
+        out = sink_flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            sink[rank * h_local : (rank + 1) * h_local],
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            causal=causal,
+            flash_attn_version=flash_attn_version,
+            softmax_scale=softmax_scale,
+            window_size=window_size,
+        )
+    elif flash_attn_version == 4:
         # FA4 takes cu_seqlens as keyword args (qv positional collides otherwise).
         kwargs["cu_seqlens_q"] = cu_seqlens_q
         kwargs["cu_seqlens_k"] = cu_seqlens_k

--- a/tests/distributed/test_cp.py
+++ b/tests/distributed/test_cp.py
@@ -11,6 +11,7 @@ from tests.dtest import DTest
 
 from ring_flash_attn.llama3_flash_attn_varlen import llama3_flash_attn_prepare_cu_seqlens
 
+from prime_rl.trainer.models.layers.flash_varlen import sink_flash_attn_varlen_func
 from prime_rl.trainer.models.layers.ring_attn import ring_flash_attn_varlen_func
 from prime_rl.trainer.models.layers.ulysses_attn import ulysses_flash_attn_varlen_func
 
@@ -47,6 +48,12 @@ def _build_inputs(
     v = torch.randn(total, nheads_k, HEAD_DIM, device=device, dtype=torch.bfloat16)
 
     return q, k, v, cu_seqlens, max_seqlen
+
+
+def _build_sink(device: torch.device) -> torch.Tensor:
+    """A per-head additive sink logit, standing in for GPT-OSS's `GptOssAttention.sinks`."""
+    torch.manual_seed(7)
+    return torch.randn(NHEADS, device=device, dtype=torch.bfloat16)
 
 
 def _build_dout(q: torch.Tensor) -> torch.Tensor:
@@ -111,6 +118,19 @@ def _assert_shard_matches_reference(
             )
         else:
             assert torch.equal(got.grad, expected), f"{name} is not bitwise equal to the reference"
+
+
+def _assert_sink_grad_matches_reference(ref_sink: torch.Tensor, cp_sink: torch.Tensor) -> None:
+    assert cp_sink.grad is not None, "the sink received no gradient"
+    # The sink is replicated, not sharded, and its gradient sums over queries (ring) or over a
+    # head slice (ulysses), so each rank holds a partial. FSDP shards parameters over dp_shard_cp,
+    # which includes the CP dimension, so its gradient reduction already sums these; emulate that
+    # here rather than making the attention wrapper communicate.
+    dsink = cp_sink.grad.clone()
+    dist.all_reduce(dsink)
+    torch.testing.assert_close(
+        dsink, ref_sink.grad, rtol=2e-2, atol=_bf16_ulp(ref_sink.grad), msg=lambda m: f"dsink: {m}"
+    )
 
 
 class TestRingAttnCP(DTest):
@@ -180,6 +200,62 @@ class TestRingAttnCP(DTest):
 
         self._check(flash_attn_varlen_func, flash_attn_version=4)
 
+    def _check_sink(self, flash_attn_version: int) -> None:
+        q, k, v, cu_seqlens, max_seqlen = _build_inputs(self.device)
+        sink = _build_sink(self.device)
+        dout = _build_dout(q)
+        cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, local_k_slice = llama3_flash_attn_prepare_cu_seqlens(
+            cu_seqlens, causal=True, rank=self.rank, world_size=self.world_size
+        )
+
+        *ref_qkv, ref_sink = _leaves(q, k, v, sink)
+        ref_out = sink_flash_attn_varlen_func(
+            *ref_qkv,
+            ref_sink,
+            cu_seqlens,
+            cu_seqlens,
+            max_seqlen,
+            max_seqlen,
+            causal=True,
+            flash_attn_version=flash_attn_version,
+        )
+        ref_out.backward(dout)
+
+        *cp_qkv, cp_sink = _leaves(*(_shard(t, self.rank, self.world_size) for t in (q, k, v)), sink)
+        out = ring_flash_attn_varlen_func(
+            *cp_qkv,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            local_k_slice,
+            causal=True,
+            heads_k_stride=1,
+            group=dist.group.WORLD,
+            flash_attn_version=flash_attn_version,
+            sink=cp_sink,
+        )
+        out.backward(_shard(dout, self.rank, self.world_size))
+
+        _assert_shard_matches_reference(
+            ref_out, out, ref_qkv, cp_qkv, self.rank, self.world_size, summed_across_ranks=("dk", "dv")
+        )
+        _assert_sink_grad_matches_reference(ref_sink, cp_sink)
+
+    @pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
+    def test_fa2_sink_correctness(self) -> None:
+        self._check_sink(flash_attn_version=2)
+
+    @pytest.mark.skipif(_NOT_HOPPER, reason=f"FA3 requires Hopper (SM90); found SM{_SM_MAJOR}{_SM_MINOR}")
+    @pytest.mark.skipif(not _HAS_FLASH_ATTN_3, reason="flash_attn_interface not installed")
+    def test_fa3_sink_correctness(self) -> None:
+        self._check_sink(flash_attn_version=3)
+
+    @pytest.mark.skipif(_NOT_SM100, reason=f"FA4 requires SM100 (datacenter Blackwell); found SM{_SM_MAJOR}{_SM_MINOR}")
+    @pytest.mark.skipif(not _HAS_FLASH_ATTN_4, reason="flash_attn.cute not installed")
+    def test_fa4_sink_correctness(self) -> None:
+        self._check_sink(flash_attn_version=4)
+
 
 class TestUlyssesCP(DTest):
     """Ulysses CP must match the single-GPU reference bit for bit.
@@ -244,6 +320,63 @@ class TestUlyssesCP(DTest):
         from flash_attn.cute import flash_attn_varlen_func
 
         self._check(flash_attn_varlen_func, flash_attn_version=4)
+
+    def _check_sink(self, flash_fn, flash_attn_version: int) -> None:
+        q, k, v, cu_seqlens, max_seqlen = _build_inputs(self.device)
+        sink = _build_sink(self.device)
+        dout = _build_dout(q)
+
+        *ref_qkv, ref_sink = _leaves(q, k, v, sink)
+        ref_out = sink_flash_attn_varlen_func(
+            *ref_qkv,
+            ref_sink,
+            cu_seqlens,
+            cu_seqlens,
+            max_seqlen,
+            max_seqlen,
+            causal=True,
+            flash_attn_version=flash_attn_version,
+        )
+        ref_out.backward(dout)
+
+        *cp_qkv, cp_sink = _leaves(*(_shard(t, self.rank, self.world_size) for t in (q, k, v)), sink)
+        out = ulysses_flash_attn_varlen_func(
+            flash_fn,
+            *cp_qkv,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_k=max_seqlen,
+            causal=True,
+            cp_group=dist.group.WORLD,
+            cp_size=self.world_size,
+            flash_attn_version=flash_attn_version,
+            sink=cp_sink,
+        )
+        out.backward(_shard(dout, self.rank, self.world_size))
+
+        _assert_shard_matches_reference(ref_out, out, ref_qkv, cp_qkv, self.rank, self.world_size)
+        _assert_sink_grad_matches_reference(ref_sink, cp_sink)
+
+    @pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
+    def test_fa2_sink_correctness(self) -> None:
+        from flash_attn import flash_attn_varlen_func
+
+        self._check_sink(flash_attn_varlen_func, flash_attn_version=2)
+
+    @pytest.mark.skipif(_NOT_HOPPER, reason=f"FA3 requires Hopper (SM90); found SM{_SM_MAJOR}{_SM_MINOR}")
+    @pytest.mark.skipif(not _HAS_FLASH_ATTN_3, reason="flash_attn_interface not installed")
+    def test_fa3_sink_correctness(self) -> None:
+        from flash_attn_interface import flash_attn_varlen_func
+
+        self._check_sink(flash_attn_varlen_func, flash_attn_version=3)
+
+    @pytest.mark.skipif(_NOT_SM100, reason=f"FA4 requires SM100 (datacenter Blackwell); found SM{_SM_MAJOR}{_SM_MINOR}")
+    @pytest.mark.skipif(not _HAS_FLASH_ATTN_4, reason="flash_attn.cute not installed")
+    def test_fa4_sink_correctness(self) -> None:
+        from flash_attn.cute import flash_attn_varlen_func
+
+        self._check_sink(flash_attn_varlen_func, flash_attn_version=4)
 
     @pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
     def test_fa2_gqa_kv_head_replication_correctness(self) -> None:

--- a/tests/distributed/test_cp.py
+++ b/tests/distributed/test_cp.py
@@ -22,6 +22,14 @@ HEAD_DIM = 64
 # rank 0's shard spans into the second document and rank 1's shard sits fully inside it.
 SEQLENS = (48, 80)
 
+# Tolerances for gradients whose defining sum CP re-partitions across ranks: each rank rounds its
+# partial to bf16 before the sum, where the single-GPU reference rounds the whole sum once. Measured
+# at the shapes above (FA2, world_size=2), the absolute slack needed beyond rtol is 1.5e-2 for ring
+# dv, 5.8e-3 for ring dk, 5.6e-3 and 3.9e-3 for the KV-replicated ulysses dv/dk, and 0 for ring
+# dsink, whose error rtol absorbs on its own. Backstop at 2x the largest of those.
+REDUCED_GRAD_RTOL = 2e-2
+REDUCED_GRAD_ATOL = 3e-2
+
 _HAS_FLASH_ATTN = importlib.util.find_spec("flash_attn") is not None
 _HAS_FLASH_ATTN_3 = importlib.util.find_spec("flash_attn_interface") is not None
 _HAS_FLASH_ATTN_4 = importlib.util.find_spec("flash_attn.cute") is not None
@@ -89,48 +97,35 @@ def _reference_attn(
     return out[0] if isinstance(out, tuple) else out
 
 
-def _bf16_ulp(t: torch.Tensor) -> float:
-    """One bfloat16 ulp at the tensor's peak magnitude (bf16 carries an 8-bit significand)."""
-    return 2**-8 * t.abs().max().item()
+def _assert_reference_is_meaningful(expected: torch.Tensor, what: str) -> None:
+    # Two all-zero tensors compare equal, which would read as a pass while proving nothing.
+    assert expected.abs().max().item() > 0, f"{what}: the reference is all zeros, the comparison is vacuous"
 
 
-def _assert_shard_matches_reference(
-    ref_out: torch.Tensor,
-    out: torch.Tensor,
-    ref_inputs: tuple[torch.Tensor, ...],
-    cp_inputs: tuple[torch.Tensor, ...],
-    rank: int,
-    world_size: int,
-    summed_across_ranks: tuple[str, ...] = (),
-) -> None:
-    """Compare this rank's output and input gradients against the single-GPU reference.
+def _assert_equal(actual: torch.Tensor, expected: torch.Tensor, what: str) -> None:
+    """Exact equality, for quantities CP computes with the reference's own arithmetic."""
+    _assert_reference_is_meaningful(expected, what)
+    assert torch.equal(actual, expected), f"{what} is not bitwise equal to the reference"
 
-    Everything is bitwise except gradients named in `summed_across_ranks`: those are accumulated in
-    bf16 across ranks, whereas the reference rounds the whole sum once, so they land within a
-    bf16 ulp of it rather than on it.
+
+def _assert_close(actual: torch.Tensor, expected: torch.Tensor, what: str, *, rtol: float, atol: float) -> None:
+    """Approximate equality, for quantities whose defining sum CP re-partitions across ranks."""
+    _assert_reference_is_meaningful(expected, what)
+    torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol, msg=lambda m: f"{what}: {m}")
+
+
+def _all_reduced_grad(leaf: torch.Tensor) -> torch.Tensor:
+    """This rank's gradient for a replicated parameter, summed over the CP group.
+
+    The sink is replicated rather than sharded, so each rank only holds a partial: a sum over its
+    own queries under ring, over its own head slice under ulysses. FSDP shards parameters over
+    dp_shard_cp, which includes the CP dimension, so its gradient reduction already sums these.
+    Emulate that here rather than making the attention wrapper communicate.
     """
-    assert torch.equal(out, _shard(ref_out, rank, world_size))
-    for name, ref, got in zip(("dq", "dk", "dv"), ref_inputs, cp_inputs):
-        expected = _shard(ref.grad, rank, world_size)
-        if name in summed_across_ranks:
-            torch.testing.assert_close(
-                got.grad, expected, rtol=2e-2, atol=_bf16_ulp(expected), msg=lambda m: f"{name}: {m}"
-            )
-        else:
-            assert torch.equal(got.grad, expected), f"{name} is not bitwise equal to the reference"
-
-
-def _assert_sink_grad_matches_reference(ref_sink: torch.Tensor, cp_sink: torch.Tensor) -> None:
-    assert cp_sink.grad is not None, "the sink received no gradient"
-    # The sink is replicated, not sharded, and its gradient sums over queries (ring) or over a
-    # head slice (ulysses), so each rank holds a partial. FSDP shards parameters over dp_shard_cp,
-    # which includes the CP dimension, so its gradient reduction already sums these; emulate that
-    # here rather than making the attention wrapper communicate.
-    dsink = cp_sink.grad.clone()
-    dist.all_reduce(dsink)
-    torch.testing.assert_close(
-        dsink, ref_sink.grad, rtol=2e-2, atol=_bf16_ulp(ref_sink.grad), msg=lambda m: f"dsink: {m}"
-    )
+    assert leaf.grad is not None, "the sink received no gradient"
+    grad = leaf.grad.clone()
+    dist.all_reduce(grad)
+    return grad
 
 
 class TestRingAttnCP(DTest):
@@ -155,13 +150,17 @@ class TestRingAttnCP(DTest):
             cu_seqlens, causal=True, rank=self.rank, world_size=self.world_size
         )
 
-        ref_inputs = _leaves(q, k, v)
-        ref_out = _reference_attn(flash_fn, *ref_inputs, cu_seqlens, max_seqlen, flash_attn_version)
+        shard = (self.rank, self.world_size)
+
+        ref_q, ref_k, ref_v = _leaves(q, k, v)
+        ref_out = _reference_attn(flash_fn, ref_q, ref_k, ref_v, cu_seqlens, max_seqlen, flash_attn_version)
         ref_out.backward(dout)
 
-        cp_inputs = _leaves(*(_shard(t, self.rank, self.world_size) for t in (q, k, v)))
+        cp_q, cp_k, cp_v = _leaves(*(_shard(t, *shard) for t in (q, k, v)))
         out = ring_flash_attn_varlen_func(
-            *cp_inputs,
+            cp_q,
+            cp_k,
+            cp_v,
             cu_seqlens_q,
             cu_seqlens_k,
             max_seqlen_q,
@@ -172,13 +171,14 @@ class TestRingAttnCP(DTest):
             group=dist.group.WORLD,
             flash_attn_version=flash_attn_version,
         )
-        out.backward(_shard(dout, self.rank, self.world_size))
+        out.backward(_shard(dout, *shard))
 
+        _assert_equal(out, _shard(ref_out, *shard), "out")
+        _assert_equal(cp_q.grad, _shard(ref_q.grad, *shard), "dq")
         # dk/dv are the only reduced quantities: every rank holds every key, so each contributes a
         # partial that a reduce-scatter sums.
-        _assert_shard_matches_reference(
-            ref_out, out, ref_inputs, cp_inputs, self.rank, self.world_size, summed_across_ranks=("dk", "dv")
-        )
+        _assert_close(cp_k.grad, _shard(ref_k.grad, *shard), "dk", rtol=REDUCED_GRAD_RTOL, atol=REDUCED_GRAD_ATOL)
+        _assert_close(cp_v.grad, _shard(ref_v.grad, *shard), "dv", rtol=REDUCED_GRAD_RTOL, atol=REDUCED_GRAD_ATOL)
 
     @pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
     def test_fa2_correctness(self) -> None:
@@ -208,9 +208,13 @@ class TestRingAttnCP(DTest):
             cu_seqlens, causal=True, rank=self.rank, world_size=self.world_size
         )
 
-        *ref_qkv, ref_sink = _leaves(q, k, v, sink)
+        shard = (self.rank, self.world_size)
+
+        ref_q, ref_k, ref_v, ref_sink = _leaves(q, k, v, sink)
         ref_out = sink_flash_attn_varlen_func(
-            *ref_qkv,
+            ref_q,
+            ref_k,
+            ref_v,
             ref_sink,
             cu_seqlens,
             cu_seqlens,
@@ -221,9 +225,11 @@ class TestRingAttnCP(DTest):
         )
         ref_out.backward(dout)
 
-        *cp_qkv, cp_sink = _leaves(*(_shard(t, self.rank, self.world_size) for t in (q, k, v)), sink)
+        cp_q, cp_k, cp_v, cp_sink = _leaves(*(_shard(t, *shard) for t in (q, k, v)), sink)
         out = ring_flash_attn_varlen_func(
-            *cp_qkv,
+            cp_q,
+            cp_k,
+            cp_v,
             cu_seqlens_q,
             cu_seqlens_k,
             max_seqlen_q,
@@ -235,12 +241,17 @@ class TestRingAttnCP(DTest):
             flash_attn_version=flash_attn_version,
             sink=cp_sink,
         )
-        out.backward(_shard(dout, self.rank, self.world_size))
+        out.backward(_shard(dout, *shard))
 
-        _assert_shard_matches_reference(
-            ref_out, out, ref_qkv, cp_qkv, self.rank, self.world_size, summed_across_ranks=("dk", "dv")
-        )
-        _assert_sink_grad_matches_reference(ref_sink, cp_sink)
+        _assert_equal(out, _shard(ref_out, *shard), "out")
+        _assert_equal(cp_q.grad, _shard(ref_q.grad, *shard), "dq")
+        # dk/dv are the only reduced quantities: every rank holds every key, so each contributes a
+        # partial that a reduce-scatter sums.
+        _assert_close(cp_k.grad, _shard(ref_k.grad, *shard), "dk", rtol=REDUCED_GRAD_RTOL, atol=REDUCED_GRAD_ATOL)
+        _assert_close(cp_v.grad, _shard(ref_v.grad, *shard), "dv", rtol=REDUCED_GRAD_RTOL, atol=REDUCED_GRAD_ATOL)
+        # dsink sums over this rank's queries, so it is reduced for the same reason dk/dv are.
+        dsink = _all_reduced_grad(cp_sink)
+        _assert_close(dsink, ref_sink.grad, "dsink", rtol=REDUCED_GRAD_RTOL, atol=REDUCED_GRAD_ATOL)
 
     @pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
     def test_fa2_sink_correctness(self) -> None:
@@ -265,24 +276,30 @@ class TestUlyssesCP(DTest):
     a subset of heads over the full sequence produces exactly the same per-head arithmetic as
     running it on all heads together. No rounding-order difference is introduced anywhere in the
     pipeline, so, like ring attention, a mismatch means the reshaping is wrong, not that rounding
-    drifted. Unlike ring attention this covers the backward pass with no exceptions: nothing is
-    summed across ranks, so dq, dk, and dv are all bitwise equal to the reference.
+    drifted. Unlike ring attention that extends to the whole backward pass: nothing is summed across
+    ranks, so dq, dk, dv and dsink are all bitwise equal too. The one exception is GQA with fewer KV
+    heads than the CP size, where `_replicate_kv_heads` copies a KV head to several ranks and its
+    backward sums their partials, putting dk and dv back in the same position as ring attention's.
     """
 
     default_world_size = 2
 
-    def _check(self, flash_fn, flash_attn_version: int, nheads_k: int = NHEADS_K) -> None:
+    def _run(
+        self, flash_fn, flash_attn_version: int, nheads_k: int = NHEADS_K
+    ) -> tuple[torch.Tensor, torch.Tensor, tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]:
+        """Run the reference and the CP path, backward included, and hand back what to compare."""
         q, k, v, cu_seqlens, max_seqlen = _build_inputs(self.device, nheads_k=nheads_k)
         dout = _build_dout(q)
+        shard = (self.rank, self.world_size)
 
-        ref_inputs = _leaves(q, k, v)
-        ref_out = _reference_attn(flash_fn, *ref_inputs, cu_seqlens, max_seqlen, flash_attn_version)
+        ref_leaves = _leaves(q, k, v)
+        ref_out = _reference_attn(flash_fn, *ref_leaves, cu_seqlens, max_seqlen, flash_attn_version)
         ref_out.backward(dout)
 
-        cp_inputs = _leaves(*(_shard(t, self.rank, self.world_size) for t in (q, k, v)))
+        cp_leaves = _leaves(*(_shard(t, *shard) for t in (q, k, v)))
         out = ulysses_flash_attn_varlen_func(
             flash_fn,
-            *cp_inputs,
+            *cp_leaves,
             cu_seqlens_q=cu_seqlens,
             cu_seqlens_k=cu_seqlens,
             max_seqlen_q=max_seqlen,
@@ -292,14 +309,31 @@ class TestUlyssesCP(DTest):
             cp_size=self.world_size,
             flash_attn_version=flash_attn_version,
         )
-        out.backward(_shard(dout, self.rank, self.world_size))
+        out.backward(_shard(dout, *shard))
+        return out, ref_out, ref_leaves, cp_leaves
 
-        # Nothing is summed across ranks, except when `_replicate_kv_heads` kicks in: then each
-        # replica of a KV head produces a partial dk/dv that its backward sums.
-        summed = ("dk", "dv") if nheads_k < self.world_size else ()
-        _assert_shard_matches_reference(
-            ref_out, out, ref_inputs, cp_inputs, self.rank, self.world_size, summed_across_ranks=summed
-        )
+    def _check(self, flash_fn, flash_attn_version: int) -> None:
+        shard = (self.rank, self.world_size)
+        out, ref_out, (ref_q, ref_k, ref_v), (cp_q, cp_k, cp_v) = self._run(flash_fn, flash_attn_version)
+
+        # Nothing is summed across ranks, so every quantity is the reference's own arithmetic.
+        _assert_equal(out, _shard(ref_out, *shard), "out")
+        _assert_equal(cp_q.grad, _shard(ref_q.grad, *shard), "dq")
+        _assert_equal(cp_k.grad, _shard(ref_k.grad, *shard), "dk")
+        _assert_equal(cp_v.grad, _shard(ref_v.grad, *shard), "dv")
+
+    def _check_replicated_kv(self, flash_fn, flash_attn_version: int) -> None:
+        # nheads_k=1 < cp_size=2 forces _replicate_kv_heads, unlike the other tests
+        # (nheads_k=2 == cp_size never triggers it).
+        shard = (self.rank, self.world_size)
+        out, ref_out, (ref_q, ref_k, ref_v), (cp_q, cp_k, cp_v) = self._run(flash_fn, flash_attn_version, nheads_k=1)
+
+        _assert_equal(out, _shard(ref_out, *shard), "out")
+        _assert_equal(cp_q.grad, _shard(ref_q.grad, *shard), "dq")
+        # Each replica of the single KV head produces a partial dk/dv that `_replicate_kv_heads`'
+        # backward sums, so unlike the plain case these two are reduced.
+        _assert_close(cp_k.grad, _shard(ref_k.grad, *shard), "dk", rtol=REDUCED_GRAD_RTOL, atol=REDUCED_GRAD_ATOL)
+        _assert_close(cp_v.grad, _shard(ref_v.grad, *shard), "dv", rtol=REDUCED_GRAD_RTOL, atol=REDUCED_GRAD_ATOL)
 
     @pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
     def test_fa2_correctness(self) -> None:
@@ -326,9 +360,13 @@ class TestUlyssesCP(DTest):
         sink = _build_sink(self.device)
         dout = _build_dout(q)
 
-        *ref_qkv, ref_sink = _leaves(q, k, v, sink)
+        shard = (self.rank, self.world_size)
+
+        ref_q, ref_k, ref_v, ref_sink = _leaves(q, k, v, sink)
         ref_out = sink_flash_attn_varlen_func(
-            *ref_qkv,
+            ref_q,
+            ref_k,
+            ref_v,
             ref_sink,
             cu_seqlens,
             cu_seqlens,
@@ -339,10 +377,12 @@ class TestUlyssesCP(DTest):
         )
         ref_out.backward(dout)
 
-        *cp_qkv, cp_sink = _leaves(*(_shard(t, self.rank, self.world_size) for t in (q, k, v)), sink)
+        cp_q, cp_k, cp_v, cp_sink = _leaves(*(_shard(t, *shard) for t in (q, k, v)), sink)
         out = ulysses_flash_attn_varlen_func(
             flash_fn,
-            *cp_qkv,
+            cp_q,
+            cp_k,
+            cp_v,
             cu_seqlens_q=cu_seqlens,
             cu_seqlens_k=cu_seqlens,
             max_seqlen_q=max_seqlen,
@@ -353,10 +393,16 @@ class TestUlyssesCP(DTest):
             flash_attn_version=flash_attn_version,
             sink=cp_sink,
         )
-        out.backward(_shard(dout, self.rank, self.world_size))
+        out.backward(_shard(dout, *shard))
 
-        _assert_shard_matches_reference(ref_out, out, ref_qkv, cp_qkv, self.rank, self.world_size)
-        _assert_sink_grad_matches_reference(ref_sink, cp_sink)
+        # Nothing is summed across ranks, so every quantity is the reference's own arithmetic.
+        # dsink included: this rank's partial is zero outside its own heads, and adding zero is
+        # exact, so the all-reduce that reassembles it changes no bits.
+        _assert_equal(out, _shard(ref_out, *shard), "out")
+        _assert_equal(cp_q.grad, _shard(ref_q.grad, *shard), "dq")
+        _assert_equal(cp_k.grad, _shard(ref_k.grad, *shard), "dk")
+        _assert_equal(cp_v.grad, _shard(ref_v.grad, *shard), "dv")
+        _assert_equal(_all_reduced_grad(cp_sink), ref_sink.grad, "dsink")
 
     @pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
     def test_fa2_sink_correctness(self) -> None:
@@ -380,8 +426,6 @@ class TestUlyssesCP(DTest):
 
     @pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
     def test_fa2_gqa_kv_head_replication_correctness(self) -> None:
-        # nheads_k=1 < cp_size=2 forces _replicate_kv_heads, unlike the other tests above
-        # (nheads_k=2 == cp_size never triggers it).
         from flash_attn import flash_attn_varlen_func
 
-        self._check(flash_attn_varlen_func, flash_attn_version=2, nheads_k=1)
+        self._check_replicated_kv(flash_attn_varlen_func, flash_attn_version=2)

--- a/tests/unit/train/models/test_flash_varlen.py
+++ b/tests/unit/train/models/test_flash_varlen.py
@@ -1,0 +1,136 @@
+"""Sink-aware varlen attention against an fp32 reference with an explicit sink column."""
+
+import importlib.util
+
+import pytest
+import torch
+
+from prime_rl.trainer.models.layers.flash_varlen import sink_flash_attn_varlen_func
+
+pytestmark = [pytest.mark.gpu]
+
+NHEADS = 4
+NHEADS_K = 2
+HEAD_DIM = 64
+SEQLENS = (48, 80)
+
+# Measured below: every bf16 quantity lands at 1.7e-3..3.4e-3 against fp32, which is bf16's own
+# 3.9e-3 resolution. A backstop at ~3x that; the sharper check is the ratio against what
+# sink-free flash attention already costs, which needs no constant.
+BF16_TOL = 1e-2
+# Gradients come out at 1.00x..1.03x the sink-free path's own fp32 error: the sink costs them
+# nothing. The forward sits at 1.40x, which is rounding bookkeeping rather than lost precision:
+# rescaling by the sink rounds the output to bf16 a second time, and shrinks it, so the same
+# absolute error is divided by a smaller reference norm. One extra rounding caps that at 2x.
+SINK_COST_RATIO = 2.0
+
+_HAS_FLASH_ATTN = importlib.util.find_spec("flash_attn") is not None
+
+
+def _rel_err(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    expected = expected.float()
+    return ((actual.float() - expected).norm() / expected.norm().clamp_min(1e-12)).item()
+
+
+def _assert_close(actual: torch.Tensor, expected: torch.Tensor, label: str) -> None:
+    err = _rel_err(actual, expected)
+    print(f"{label}: rel_err={err:.3e} tol={BF16_TOL:.1e} margin={BF16_TOL / max(err, 1e-12):.1f}x")
+    assert err < BF16_TOL, f"{label}: relative error {err:.3e} exceeds {BF16_TOL:.1e}"
+
+
+def _fp32_attention(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, sink: torch.Tensor | None) -> torch.Tensor:
+    """Causal varlen attention in fp32, with the sink as a literal extra softmax column.
+
+    This is the definition the kernel path is supposed to implement: append one column of logits
+    equal to `sink[h]`, softmax over the widened row, then drop that column. Its value vector is
+    zero, so dropping it after the softmax is the whole of its effect.
+    """
+    starts = (0, *torch.tensor(SEQLENS).cumsum(0).tolist())
+    outs = []
+    for start, stop in zip(starts, starts[1:]):
+        q_d = q[start:stop].transpose(0, 1)
+        repeats = q.shape[1] // k.shape[1]
+        k_d = k[start:stop].transpose(0, 1).repeat_interleave(repeats, dim=0)
+        v_d = v[start:stop].transpose(0, 1).repeat_interleave(repeats, dim=0)
+
+        seqlen = stop - start
+        logits = (q_d @ k_d.transpose(-1, -2)) * HEAD_DIM**-0.5
+        causal = torch.ones(seqlen, seqlen, device=q.device, dtype=torch.bool).tril()
+        logits = logits.masked_fill(~causal, float("-inf"))
+
+        if sink is not None:
+            sink_column = sink[:, None, None].expand(q.shape[1], seqlen, 1)
+            probs = torch.cat([logits, sink_column], dim=-1).softmax(-1)[..., :-1]
+        else:
+            probs = logits.softmax(-1)
+        outs.append((probs @ v_d).transpose(0, 1))
+    return torch.cat(outs, dim=0)
+
+
+@pytest.fixture
+def inputs() -> tuple[torch.Tensor, ...]:
+    torch.manual_seed(0)
+    total = sum(SEQLENS)
+    randn = lambda *shape: torch.randn(*shape, device="cuda", dtype=torch.bfloat16)  # noqa: E731
+    q, k, v = randn(total, NHEADS, HEAD_DIM), randn(total, NHEADS_K, HEAD_DIM), randn(total, NHEADS_K, HEAD_DIM)
+    sink = randn(NHEADS)
+    dout = randn(total, NHEADS, HEAD_DIM)
+    cu_seqlens = torch.tensor([0, *torch.tensor(SEQLENS).cumsum(0).tolist()], dtype=torch.int32, device="cuda")
+    return q, k, v, sink, dout, cu_seqlens
+
+
+def _backward(out: torch.Tensor, dout: torch.Tensor, leaves: tuple[torch.Tensor, ...]) -> list[torch.Tensor]:
+    out.backward(dout)
+    return [leaf.grad for leaf in leaves]
+
+
+@pytest.mark.skipif(not _HAS_FLASH_ATTN, reason="flash_attn not installed")
+def test_sink_attention_matches_fp32_reference(inputs):
+    """The sink path must reproduce the explicit-sink-column definition, gradients included.
+
+    A tolerance alone would only say "close enough". The ratio against sink-free flash attention's
+    own fp32 error says the sink costs no accuracy beyond what bf16 attention already costs, which
+    is the claim that matters and needs no magic number.
+    """
+    from flash_attn import flash_attn_varlen_func
+
+    q, k, v, sink, dout, cu_seqlens = inputs
+    max_seqlen = max(SEQLENS)
+
+    leaves = tuple(t.clone().requires_grad_() for t in (q, k, v, sink))
+    out = sink_flash_attn_varlen_func(
+        *leaves, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen, causal=True, flash_attn_version=2
+    )
+    grads = _backward(out, dout, leaves)
+
+    truth_leaves = tuple(t.float().clone().requires_grad_() for t in (q, k, v, sink))
+    truth = _fp32_attention(*truth_leaves)
+    truth_grads = _backward(truth, dout.float(), truth_leaves)
+
+    # Sink-free flash attention against its own fp32 truth: the accuracy floor bf16 already costs.
+    free_leaves = tuple(t.clone().requires_grad_() for t in (q, k, v))
+    free_out = flash_attn_varlen_func(*free_leaves, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen, causal=True)
+    free_grads = _backward(free_out, dout, free_leaves)
+    free_truth_leaves = tuple(t.float().clone().requires_grad_() for t in (q, k, v))
+    free_truth = _fp32_attention(*free_truth_leaves, sink=None)
+    free_truth_grads = _backward(free_truth, dout.float(), free_truth_leaves)
+
+    assert _rel_err(out, free_out) > 0.1, "the sink barely moved the output; it is being ignored"
+
+    for name, got, want, free, free_want in zip(
+        ("out", "dq", "dk", "dv"),
+        (out, *grads[:3]),
+        (truth, *truth_grads[:3]),
+        (free_out, *free_grads),
+        (free_truth, *free_truth_grads),
+    ):
+        _assert_close(got, want, name)
+        floor, err = _rel_err(free, free_want), _rel_err(got, want)
+        print(f"{name}: sink-free floor={floor:.3e} sink={err:.3e} ratio={err / max(floor, 1e-12):.2f}x")
+        assert err <= SINK_COST_RATIO * floor, (
+            f"{name}: sink path errs {err:.3e} against fp32, over {SINK_COST_RATIO}x the "
+            f"{floor:.3e} that sink-free flash attention already costs"
+        )
+
+    assert grads[3] is not None, "the sink received no gradient"
+    _assert_close(grads[3], truth_grads[3], "dsink")


### PR DESCRIPTION
Fourth of four stacked PRs, builds on #3396. Adds attention-sink support to both context-parallel attention implementations.

Attention sinks are currently dropped under CP. `substitute_hf_ulysses_attn` installs an attention forward whose signature ends in `**kwargs`, and HuggingFace's gpt-oss attention passes its sinks as `s_aux=self.sinks`. That kwarg is swallowed and never applied, so training gpt-oss with CP enabled produces numerically wrong attention with no error and no warning.

This PR builds the missing machinery: sinks are threaded through the varlen implementation from #3396, applied in the ring CP forward pass, backpropagated under ring CP, and supported under Ulysses. Tests cover both CP strategies against a single-rank reference, plus an fp32 explicit-sink-column reference for the sink softmax itself.

**Not yet wired end to end.** No production caller passes `sink=` yet: the substitution wrappers in `ulysses_attn.py` and `attn.py` still drop `s_aux`. Connecting gpt-oss to this machinery is follow-up work, so merging this PR alone does not yet change training behavior for any model.
