### PR TITLE
Allow the shared-data PVC to survive helm uninstall

### DIFF
--- a/k8s/prime-rl/templates/pvc.yaml
+++ b/k8s/prime-rl/templates/pvc.yaml
@@ -6,6 +6,17 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "prime-rl.labels" . | nindent 4 }}
+  {{- if .Values.storage.retainOnUninstall }}
+  annotations:
+    # Tells Helm to leave this resource behind on `helm uninstall`
+    # instead of deleting it with the rest of the release -- opt-in,
+    # not the default, since most dedicated-run teardowns should still
+    # reclaim their PVC. Full-finetuning run storage is the one case
+    # that needs to survive the run's own compute lifecycle (checkpoints
+    # stay browsable after the run finalizes); the platform sets this
+    # value specifically for FFT dispatches.
+    helm.sh/resource-policy: keep
+  {{- end }}
 spec:
   accessModes:
     {{- toYaml .Values.storage.accessModes | nindent 4 }}

--- a/k8s/prime-rl/values.yaml
+++ b/k8s/prime-rl/values.yaml
@@ -20,6 +20,12 @@ storage:
     - ReadWriteMany
   size: 1Ti
   mountPath: /data
+  # When true, the PVC survives `helm uninstall` instead of being torn
+  # down with the rest of the release (see templates/pvc.yaml). Off by
+  # default -- most dedicated-run teardowns should still reclaim their
+  # PVC; the platform overrides this per-dispatch for full-finetuning
+  # runs, whose checkpoints need to stay browsable after the run ends.
+  retainOnUninstall: false
 
 # Orchestrator component
 orchestrator:


### PR DESCRIPTION
Adds an opt-in `storage.retainOnUninstall` value. When set, the shared-data PVC gets `helm.sh/resource-policy: keep`, so `helm uninstall` leaves it behind instead of deleting it with the rest of the release.

- Off by default — every other dedicated-run teardown keeps reclaiming its PVC exactly as before.
- Needed for full-finetuning runs (ENG-5456/ENG-5570): checkpoints need to stay browsable after a run finalizes, not just while it's running.
- Verified with `helm lint` and `helm template` (default and `retainOnUninstall=true`) — the annotation only renders when explicitly set.

Companion platform-side change (stop deleting the run's namespace on auto-teardown) tracked separately.
