### PR TITLE
fix: hide unused SFT validation plots

### DIFF
--- a/src/prime_rl/dashboard/server.py
+++ b/src/prime_rl/dashboard/server.py
@@ -278,6 +278,7 @@ def run_meta(run_dir: Path) -> dict:
         "type": run_type,
         "model": model_name(config),
         "dataset": (config.get("data") or {}).get("name"),
+        "has_validation": run_type == "sft" and config.get("val") is not None,
         "env": ((config.get("env") or {}).get("taskset") or {}).get("id"),
         "total_episodes": (config.get("num_tasks") or 0) * (config.get("num_rollouts") or 0) or None,
         "max_steps": config.get("max_steps"),

--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -574,7 +574,10 @@ function buildSections(meta) {
   const sections = [];
   const evalEnvs = meta.eval_envs || [];
   if (meta.type === "sft") {
-    sections.push({ name: "train", panels: SFT_TRAIN_METRICS.map((m) => ({ metric: m })) });
+    const trainMetrics = meta.has_validation
+      ? SFT_TRAIN_METRICS
+      : SFT_TRAIN_METRICS.filter((m) => !m.startsWith("val/"));
+    sections.push({ name: "train", panels: trainMetrics.map((m) => ({ metric: m })) });
     if (evalEnvs.length) sections.push(...evalEnvs.map((e) => evalSection(`eval/${e}`, escRe(e), true)));
     else sections.push(evalSection("eval", ".*"));
     sections.push({ name: "stability", panels: SFT_STABILITY_METRICS.map((m) => ({ metric: m })) });


### PR DESCRIPTION
## Summary

- Expose whether an SFT run has a validation dataset in dashboard metadata.
- Hide `val/loss` and `val/perplexity` plots when validation is not configured.
- Keep both validation plots when the resolved SFT config includes `val.data`.

## Verification

Before: `dashboard-sft-no-val-1-step` showed empty `val/loss` and `val/perplexity` plots.

After:

- `dashboard-sft-no-val-1-step` shows only training loss, perplexity, and epoch plots.

<img width="1607" height="1045" alt="Screenshot 2026-08-26 at 12 15 49 AM" src="https://github.com/user-attachments/assets/d4ebe5bf-48fa-4f07-a626-0cb9f369dfa1" />

- `dashboard-sft-with-val-1-step` shows both validation plots and reports `val/loss = 5.811`.

<img width="1607" height="1045" alt="Screenshot 2026-08-26 at 12 15 32 AM" src="https://github.com/user-attachments/assets/4746e568-dea3-4660-9692-545bf2dfa5dd" />

Both runs completed one SFT step. A browser check confirmed the expected plot titles and rendered validation data.

- Ran `node --check src/prime_rl/dashboard/static/app.js`.
- Ran `uv run --no-sync ruff check src/prime_rl/dashboard/server.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only metadata and client-side panel filtering; no training, auth, or data-path changes.
> 
> **Overview**
> SFT runs without a validation dataset no longer show empty **val/loss** and **val/perplexity** charts on the metrics overview.
> 
> The runs API now exposes **`has_validation`** for SFT runs (true when resolved config has a **`val`** section). The metrics UI uses that flag to omit **`val/*`** panels from the train section while still showing training loss, perplexity, and epoch progress; runs with validation configured keep all panels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0ae1cc23e89f0cb7264f1b8538179e72e9fe387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->