### PR TITLE
Add unit tests

### DIFF
--- a/tests/unit/train/models/test_quantization_numerics.py
+++ b/tests/unit/train/models/test_quantization_numerics.py
@@ -1,0 +1,313 @@
+"""Numerics of the FP8 / MXFP8 GEMM paths against the BF16 path they replace.
+
+Both backends are *supposed* to be less accurate than BF16 — quantizing to e4m3 costs
+accuracy no kernel can avoid. So a hand-picked tolerance would either be loose enough to
+hide a wrong scale or tight enough to flake on a new kernel version. Instead every check
+compares against the **quantization floor**: the same operands rounded to e4m3 with the
+same block layout, multiplied in fp32. Anything the kernel adds on top of that floor is
+the kernel's own error, and that ratio is what these tests bound.
+
+The floor is computed in plain torch here, deliberately duplicating the recipe rather than
+calling the Triton casts, so a bug in the casts cannot cancel itself out of the comparison.
+
+`pytest -s` prints every measured error and its margin.
+"""
+
+import pytest
+import torch
+from torch import Tensor, nn
+
+from prime_rl.trainer.models.layers.moe import GroupedExperts
+
+_CAPABILITY = torch.cuda.get_device_capability() if torch.cuda.is_available() else None
+
+# DeepGEMM ships kernels for Hopper (SM90) and Blackwell datacenter (SM100) only. On
+# other GPUs — SM120 consumer Blackwell included — it aborts with "Unknown recipe".
+FP8_UNAVAILABLE = (
+    None
+    if _CAPABILITY is not None and _CAPABILITY[0] in (9, 10)
+    else f"FP8 blockwise needs DeepGEMM (SM90 or SM100), got {_CAPABILITY}"
+)
+MXFP8_UNAVAILABLE = (
+    None if _CAPABILITY is not None and _CAPABILITY >= (10, 0) else f"MXFP8 needs SM100+, got {_CAPABILITY}"
+)
+# torchao's MoE grouped-GEMM kernels are built for SM100/SM100a only. The dense MXFP8
+# linear path runs on consumer Blackwell (SM120) too, so the two guards differ.
+MXFP8_GROUPED_UNAVAILABLE = (
+    None
+    if _CAPABILITY is not None and _CAPABILITY[0] == 10
+    else f"torchao MXFP8 grouped GEMM needs SM100, got {_CAPABILITY}"
+)
+
+requires_fp8 = pytest.mark.skipif(FP8_UNAVAILABLE is not None, reason=str(FP8_UNAVAILABLE))
+requires_mxfp8 = pytest.mark.skipif(MXFP8_UNAVAILABLE is not None, reason=str(MXFP8_UNAVAILABLE))
+requires_mxfp8_grouped = pytest.mark.skipif(
+    MXFP8_GROUPED_UNAVAILABLE is not None, reason=str(MXFP8_GROUPED_UNAVAILABLE)
+)
+
+pytestmark = [pytest.mark.gpu]
+
+FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
+FP8_BLOCK = 128
+MX_BLOCK = 32
+
+# How much error the kernel may add on top of the floor. A correct kernel differs from the
+# floor only by accumulation order (fp32 tensor-core reduction vs one fp32 matmul), which
+# lands just above 1.0; a swapped scale or a transposed operand lands an order of magnitude
+# out. 2x leaves room for the layout details the floor does not model.
+FLOOR_RATIO = 2.0
+
+
+def _rel_err(actual: Tensor, expected: Tensor) -> float:
+    """Relative Frobenius error — the scale-free way to compare two GEMM paths."""
+    expected = expected.float()
+    return ((actual.float() - expected).norm() / expected.norm().clamp_min(1e-12)).item()
+
+
+def _qdq(t: Tensor, block: tuple[int, int], power_of_two_scale: bool) -> Tensor:
+    """Round `t` to e4m3 with one scale per `block`, then back to fp32.
+
+    This is the accuracy the arithmetic can reach at best — the floor every kernel below is
+    measured against.
+    """
+    rows, cols = t.shape
+    block_rows, block_cols = block
+    assert rows % block_rows == 0 and cols % block_cols == 0, f"{t.shape} not tileable by {block}"
+
+    blocks = t.float().reshape(rows // block_rows, block_rows, cols // block_cols, block_cols)
+    scale = blocks.abs().amax(dim=(1, 3), keepdim=True).clamp_min(1e-12) / FP8_MAX
+    if power_of_two_scale:
+        scale = torch.exp2(torch.ceil(torch.log2(scale)))
+    quantized = (blocks / scale).clamp(-FP8_MAX, FP8_MAX).to(torch.float8_e4m3fn)
+    return (quantized.float() * scale).reshape(rows, cols)
+
+
+def _assert_near_floor(actual: Tensor, reference: Tensor, floor: Tensor, label: str) -> None:
+    """The kernel may be no worse than `FLOOR_RATIO` times the cost of quantizing alone."""
+    kernel_err = _rel_err(actual, reference)
+    floor_err = _rel_err(floor, reference)
+    assert floor_err > 0, f"{label}: floor is exact, the comparison would be vacuous"
+    # A kernel that silently fell back to BF16 would score a perfect zero here, which must
+    # read as a failure, not as the best possible result.
+    assert kernel_err > 0, f"{label}: output is bit-identical to BF16 — the quantized path did not run"
+    ratio = kernel_err / floor_err
+    print(f"{label}: kernel={kernel_err:.3e} floor={floor_err:.3e} ratio={ratio:.2f}x (limit {FLOOR_RATIO:.1f}x)")
+    assert ratio < FLOOR_RATIO, f"{label}: {kernel_err:.3e} is {ratio:.2f}x the quantization floor {floor_err:.3e}"
+
+
+def _linear_inputs(m: int, k: int, n: int, seed: int = 0) -> tuple[Tensor, Tensor, Tensor]:
+    torch.manual_seed(seed)
+    randn = lambda *shape: torch.randn(*shape, device="cuda", dtype=torch.bfloat16) * 0.3
+    return randn(m, k), randn(n, k), randn(m, n)
+
+
+def _run_linear(module: nn.Module, x: Tensor, grad_out: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+    """Forward and backward through `module`, returning (out, dx, dw)."""
+    x = x.clone().requires_grad_(True)
+    out = module(x)
+    # Note the explicit grad tensor: `out.sum().backward()` feeds an *expanded* ones tensor,
+    # and torchao's MXFP8 backward asserts on non-contiguous grad_output.
+    out.backward(grad_out)
+    return out, x.grad, module.weight.grad
+
+
+@requires_fp8
+@pytest.mark.parametrize("m,k,n", [(512, 512, 256), (256, 1024, 512), (384, 256, 128)])
+def test_fp8_linear_matches_quantization_floor(m, k, n):
+    """FP8 blockwise linear: 1x128 scales on activations, 128x128 on weights."""
+    from prime_rl.trainer.models.kernels.fp8_utils import ue8m0_for_device
+    from prime_rl.trainer.models.layers.fp8_linear import Float8BlockwiseLinear
+
+    x, w, grad_out = _linear_inputs(m, k, n)
+    reference = nn.Linear(k, n, bias=False, device="cuda", dtype=torch.bfloat16)
+    with torch.no_grad():
+        reference.weight.copy_(w)
+    quantized = Float8BlockwiseLinear.from_linear(nn.Linear(k, n, bias=False, device="cuda", dtype=torch.bfloat16))
+    with torch.no_grad():
+        quantized.weight.copy_(w)
+
+    ref_out, ref_dx, ref_dw = _run_linear(reference, x, grad_out)
+    out, dx, dw = _run_linear(quantized, x, grad_out)
+
+    ue8m0 = ue8m0_for_device(x.device)
+    x_q = _qdq(x, (1, FP8_BLOCK), ue8m0)
+    w_q = _qdq(w, (FP8_BLOCK, FP8_BLOCK), ue8m0)
+    grad_q = _qdq(grad_out, (1, FP8_BLOCK), ue8m0)
+
+    _assert_near_floor(out, ref_out, x_q @ w_q.T, f"fp8 fwd {m}x{k}x{n}")
+    _assert_near_floor(dx, ref_dx, grad_q @ w_q, f"fp8 dx {m}x{k}x{n}")
+    # The wgrad reduces over tokens, so both operands are quantized along M (1x128 blocks
+    # of the transposed tensors) — the axis the forward does not exercise.
+    _assert_near_floor(
+        dw,
+        ref_dw,
+        _qdq(grad_out.T.contiguous(), (1, FP8_BLOCK), ue8m0) @ _qdq(x.T.contiguous(), (1, FP8_BLOCK), ue8m0).T,
+        f"fp8 dw {m}x{k}x{n}",
+    )
+
+
+@requires_fp8
+@pytest.mark.parametrize(
+    "tokens_per_expert",
+    [
+        pytest.param([128, 128, 128, 128], id="aligned"),
+        # Sequence packing hands the experts group sizes that are not multiples of the
+        # 128-token GEMM alignment; the padding and unpack path is where they break.
+        pytest.param([112, 144, 96, 160], id="unaligned"),
+        pytest.param([0, 256, 128, 128], id="empty-expert"),
+    ],
+)
+def test_fp8_grouped_gemm_matches_grouped_mm(tokens_per_expert):
+    """The FP8 grouped GEMM is a drop-in for `torch._grouped_mm` over expert weights."""
+    from prime_rl.trainer.models.layers.fp8_grouped_gemm import grouped_fp8_gemm
+
+    torch.manual_seed(0)
+    num_experts, k, n = len(tokens_per_expert), 256, 128
+    total_m = sum(tokens_per_expert)
+    x = torch.randn(total_m, k, device="cuda", dtype=torch.bfloat16) * 0.3
+    w = torch.randn(num_experts, k, n, device="cuda", dtype=torch.bfloat16) * 0.3
+    grad_out = torch.randn(total_m, n, device="cuda", dtype=torch.bfloat16) * 0.3
+    offs = torch.tensor(tokens_per_expert, device="cuda", dtype=torch.int32).cumsum(0).to(torch.int32)
+
+    def run(fn) -> tuple[Tensor, Tensor, Tensor]:
+        xg, wg = x.clone().requires_grad_(True), w.clone().requires_grad_(True)
+        out = fn(xg, wg, offs)
+        out.backward(grad_out)
+        return out, xg.grad, wg.grad
+
+    ref_out, ref_dx, ref_dw = run(lambda xg, wg, o: torch._grouped_mm(xg, wg, offs=o))
+    out, dx, dw = run(grouped_fp8_gemm)
+
+    # Per-expert floors, concatenated back into the grouped layout.
+    ue8m0 = True  # both supported architectures use UE8M0 scales in the grouped kernels
+    starts = [0] + torch.tensor(tokens_per_expert).cumsum(0).tolist()
+    floor_out, floor_dx, floor_dw = [], [], []
+    for expert, (start, end) in enumerate(zip(starts[:-1], starts[1:])):
+        x_e, g_e = x[start:end], grad_out[start:end]
+        rows = end - start
+        if rows == 0:
+            floor_dw.append(torch.zeros_like(w[expert], dtype=torch.float32))
+            continue
+        pad = (-rows) % FP8_BLOCK  # the kernel zero-pads the token axis before the wgrad
+        x_p = torch.nn.functional.pad(x_e, (0, 0, 0, pad))
+        g_p = torch.nn.functional.pad(g_e, (0, 0, 0, pad))
+        w_q = _qdq(w[expert], (FP8_BLOCK, FP8_BLOCK), ue8m0)
+        floor_out.append(_qdq(x_e, (1, FP8_BLOCK), ue8m0) @ w_q)
+        floor_dx.append(_qdq(g_e, (1, FP8_BLOCK), ue8m0) @ w_q.T)
+        floor_dw.append(
+            _qdq(x_p.T.contiguous(), (1, FP8_BLOCK), ue8m0) @ _qdq(g_p.T.contiguous(), (1, FP8_BLOCK), ue8m0).T
+        )
+
+    label = "-".join(str(t) for t in tokens_per_expert)
+    _assert_near_floor(out, ref_out, torch.cat(floor_out), f"fp8 grouped fwd [{label}]")
+    _assert_near_floor(dx, ref_dx, torch.cat(floor_dx), f"fp8 grouped dx [{label}]")
+    _assert_near_floor(dw, ref_dw, torch.stack(floor_dw), f"fp8 grouped dw [{label}]")
+
+
+@requires_mxfp8
+@pytest.mark.parametrize("recipe", ["mxfp8_rceil", "mxfp8_rceil_wgrad_with_hp"])
+@pytest.mark.parametrize("m,k,n", [(512, 512, 256), (256, 1024, 512), (128, 256, 128)])
+def test_mxfp8_linear_matches_quantization_floor(recipe, m, k, n):
+    """MXFP8 linear: one power-of-two scale per 32 elements along the reduction axis."""
+    from prime_rl.trainer.models.layers.mxfp8_linear import MXFP8Linear
+
+    x, w, grad_out = _linear_inputs(m, k, n)
+    reference = nn.Linear(k, n, bias=False, device="cuda", dtype=torch.bfloat16)
+    with torch.no_grad():
+        reference.weight.copy_(w)
+    quantized = MXFP8Linear.from_linear(
+        nn.Linear(k, n, bias=False, device="cuda", dtype=torch.bfloat16),
+        wgrad_with_hp=recipe == "mxfp8_rceil_wgrad_with_hp",
+    )
+    with torch.no_grad():
+        quantized.weight.copy_(w)
+
+    ref_out, ref_dx, ref_dw = _run_linear(reference, x, grad_out)
+    out, dx, dw = _run_linear(quantized, x, grad_out)
+
+    # Every operand is quantized along the axis it is reduced over.
+    _assert_near_floor(
+        out, ref_out, _qdq(x, (1, MX_BLOCK), True) @ _qdq(w, (1, MX_BLOCK), True).T, f"mxfp8/{recipe} fwd {m}x{k}x{n}"
+    )
+    _assert_near_floor(
+        dx,
+        ref_dx,
+        _qdq(grad_out, (1, MX_BLOCK), True) @ _qdq(w.T.contiguous(), (1, MX_BLOCK), True).T,
+        f"mxfp8/{recipe} dx {m}x{k}x{n}",
+    )
+    if recipe == "mxfp8_rceil_wgrad_with_hp":
+        # The point of this recipe is that the weight gradient skips quantization entirely.
+        wgrad_err = _rel_err(dw, ref_dw)
+        print(f"mxfp8/{recipe} dw {m}x{k}x{n}: rel_err={wgrad_err:.3e} (high-precision wgrad)")
+        assert wgrad_err < _rel_err(_qdq(grad_out.T.contiguous(), (1, MX_BLOCK), True), grad_out.T.contiguous()), (
+            "wgrad_with_hp should be more accurate than an MXFP8-quantized wgrad"
+        )
+    else:
+        _assert_near_floor(
+            dw,
+            ref_dw,
+            _qdq(grad_out.T.contiguous(), (1, MX_BLOCK), True) @ _qdq(x.T.contiguous(), (1, MX_BLOCK), True).T,
+            f"mxfp8/{recipe} dw {m}x{k}x{n}",
+        )
+
+
+@requires_mxfp8
+def test_mxfp8_linear_applies_bias():
+    """`from_linear` carries the bias over, and the forward must actually add it."""
+    from prime_rl.trainer.models.layers.mxfp8_linear import MXFP8Linear
+
+    torch.manual_seed(0)
+    x = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+    linear = nn.Linear(128, 64, bias=True, device="cuda", dtype=torch.bfloat16)
+    quantized = MXFP8Linear.from_linear(linear)
+
+    assert quantized.bias is linear.bias
+    with torch.no_grad():
+        # A bias far above the matmul's own scale, so the shift it produces is unambiguous
+        # in bfloat16 — subtracting a small bias back out would drown in rounding.
+        quantized.bias.fill_(100.0)
+        biased = quantized(x)
+        quantized.bias.zero_()
+        shift = (biased - quantized(x)).float()
+
+    torch.testing.assert_close(shift, torch.full_like(shift, 100.0), rtol=2e-2, atol=0.0)
+
+
+@requires_mxfp8_grouped
+@pytest.mark.parametrize("recipe", ["mxfp8_rceil", "mxfp8_rceil_wgrad_with_hp"])
+def test_mxfp8_grouped_experts_match_bf16(recipe):
+    """`apply_mxfp8_moe_grouped_gemm` swaps the expert GEMMs, not the routing around them."""
+    from prime_rl.trainer.models.layers.mxfp8_grouped_gemm import apply_mxfp8_moe_grouped_gemm
+
+    torch.manual_seed(0)
+    dim, hidden_dim, num_experts = 256, 128, 4
+    tokens_per_expert = torch.tensor([64, 96, 32, 64], device="cuda", dtype=torch.int32)
+    x = torch.randn(int(tokens_per_expert.sum()), dim, device="cuda", dtype=torch.bfloat16) * 0.3
+    grad_out = torch.randn_like(x) * 0.3
+
+    def build() -> GroupedExperts:
+        torch.manual_seed(1)
+        experts = GroupedExperts(dim, hidden_dim, num_experts, use_grouped_mm=True).to("cuda", torch.bfloat16)
+        experts.init_weights(0.02)
+        return experts.to(torch.bfloat16)
+
+    def run(experts: GroupedExperts) -> tuple[Tensor, Tensor, Tensor]:
+        xg = x.clone().requires_grad_(True)
+        out = experts(xg, tokens_per_expert)
+        out.backward(grad_out)
+        return out, xg.grad, experts.w1.grad
+
+    reference = build()
+    quantized = build()
+    apply_mxfp8_moe_grouped_gemm(quantized, recipe)
+
+    ref_out, ref_dx, ref_dw1 = run(reference)
+    out, dx, dw1 = run(quantized)
+
+    for label, actual, expected in (("fwd", out, ref_out), ("dx", dx, ref_dx), ("dw1", dw1, ref_dw1)):
+        err = _rel_err(actual, expected)
+        print(f"mxfp8/{recipe} experts {label}: rel_err={err:.3e}")
+        assert err > 0, f"experts {label}: bit-identical to BF16 — the MXFP8 grouped GEMM did not run"
+        # Three chained quantized GEMMs (w1, w3, then w2), so the per-GEMM ~4e-2 floor
+        # compounds; this bounds the whole expert stack, not one matmul.
+        assert err < 0.2, f"experts {label}: relative error {err:.3e} too large for an MXFP8 expert stack"

--- a/tests/unit/train/models/test_quantization_swap.py
+++ b/tests/unit/train/models/test_quantization_swap.py
@@ -1,0 +1,201 @@
+"""Module-swap logic for the FP8 / MXFP8 dense-linear paths.
+
+The swap decides *which* layers train in low precision, and it fails silently in both
+directions: an ignore pattern that is too broad leaves a layer in BF16 (drift against an
+FP8 inference engine), one that is too narrow quantizes a layer that must stay high
+precision (routers, LM head). Neither shows up as an error — only as worse numerics — so
+the mapping from module name and shape to swap decision is pinned here.
+
+No GPU needed: the replacement functions only build modules, they never launch a kernel.
+"""
+
+import pytest
+import torch
+from torch import nn
+
+from prime_rl.configs.trainer import FP8Config, ModelConfig, MXFP8Config
+from prime_rl.trainer.model import apply_quantization
+from prime_rl.trainer.models.layers.fp8_linear import (
+    Float8BlockwiseLinear,
+    replace_linear_with_fp8_blockwise_linear,
+)
+from prime_rl.trainer.models.layers.mxfp8_linear import MXFP8Linear, replace_linear_with_mxfp8_linear
+
+DIM, HIDDEN, NUM_EXPERTS = 256, 512, 8
+
+# Divisible by 32 but not by 128: MXFP8 takes it, FP8 leaves it in BF16.
+MX_ONLY_DIM = 96
+# Divisible by neither: both backends leave it in BF16.
+UNALIGNED_DIM = 48
+
+
+class _Attention(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.q_proj = nn.Linear(DIM, DIM, bias=False)
+        self.k_proj = nn.Linear(DIM, HIDDEN, bias=False)
+        self.o_proj = nn.Linear(DIM, DIM, bias=False)
+
+
+class _DenseMLP(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.gate_proj = nn.Linear(DIM, HIDDEN, bias=False)
+        self.up_proj = nn.Linear(DIM, HIDDEN, bias=False)
+        self.down_proj = nn.Linear(HIDDEN, DIM, bias=False)
+
+
+class _Router(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.gate = nn.Linear(DIM, NUM_EXPERTS, bias=False)
+
+
+class _MoEMLP(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.router = _Router()
+        self.shared_expert_gate = nn.Linear(DIM, 1, bias=False)
+        self.mx_only = nn.Linear(DIM, MX_ONLY_DIM, bias=False)
+        self.unaligned = nn.Linear(DIM, UNALIGNED_DIM, bias=False)
+
+
+class _Layer(nn.Module):
+    def __init__(self, moe: bool) -> None:
+        super().__init__()
+        self.self_attn = _Attention()
+        self.mlp = _MoEMLP() if moe else _DenseMLP()
+
+
+class _Model(nn.Module):
+    """Module tree with the fully-qualified names the ignore patterns are written against."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([_Layer(moe=False), _Layer(moe=True)])
+        self.lm_head = nn.Linear(DIM, HIDDEN, bias=False)
+
+
+ALWAYS_REPLACED = [
+    "layers.0.self_attn.q_proj",
+    "layers.0.self_attn.k_proj",
+    "layers.0.self_attn.o_proj",
+    "layers.1.self_attn.q_proj",
+    # `mlp.gate_proj` is a dense MLP projection, not a router gate. The ignore pattern is
+    # written `mlp\.gate\.` precisely so it does not match here — an unescaped `mlp.gate.`
+    # matched `mlp.gate_proj` and left it in BF16 while inference quantized it.
+    "layers.0.mlp.gate_proj",
+    "layers.0.mlp.up_proj",
+    "layers.0.mlp.down_proj",
+]
+
+ALWAYS_SKIPPED = [
+    "lm_head",
+    "layers.1.mlp.router.gate",
+    "layers.1.mlp.shared_expert_gate",
+    "layers.1.mlp.unaligned",
+]
+
+
+@pytest.fixture
+def model() -> _Model:
+    return _Model()
+
+
+def _module_types(model: nn.Module) -> dict[str, type]:
+    return {name: type(module) for name, module in model.named_modules()}
+
+
+def test_fp8_swap_replaces_aligned_layers(model: _Model):
+    replace_linear_with_fp8_blockwise_linear(model, ignore_modules=FP8Config().ignore_patterns)
+    types = _module_types(model)
+
+    for name in ALWAYS_REPLACED:
+        assert types[name] is Float8BlockwiseLinear, f"{name} should train in FP8"
+    for name in ALWAYS_SKIPPED + ["layers.1.mlp.mx_only"]:
+        assert types[name] is nn.Linear, f"{name} should stay in BF16"
+
+
+def test_mxfp8_swap_replaces_aligned_layers(model: _Model):
+    replace_linear_with_mxfp8_linear(model, recipe="mxfp8_rceil", ignore_modules=MXFP8Config().ignore_patterns)
+    types = _module_types(model)
+
+    for name in ALWAYS_REPLACED:
+        assert types[name] is MXFP8Linear, f"{name} should train in MXFP8"
+    # MXFP8 scales over blocks of 32, so it takes shapes FP8 blockwise (128) has to skip.
+    assert types["layers.1.mlp.mx_only"] is MXFP8Linear
+    for name in ALWAYS_SKIPPED:
+        assert types[name] is nn.Linear, f"{name} should stay in BF16"
+
+
+@pytest.mark.parametrize(
+    "replace",
+    [
+        pytest.param(
+            lambda m: replace_linear_with_fp8_blockwise_linear(m, ignore_modules=FP8Config().ignore_patterns),
+            id="fp8",
+        ),
+        pytest.param(
+            lambda m: replace_linear_with_mxfp8_linear(
+                m, recipe="mxfp8_rceil", ignore_modules=MXFP8Config().ignore_patterns
+            ),
+            id="mxfp8",
+        ),
+    ],
+)
+def test_swap_keeps_the_same_parameter_objects(model: _Model, replace):
+    """The swap must rebind the existing parameters, not re-initialize the model.
+
+    Weights are loaded from a checkpoint before quantization is applied, and the swapped
+    modules are what FSDP later shards — a copy here would train from random init.
+    """
+    before = {name: param for name, param in model.named_parameters()}
+    replace(model)
+    after = {name: param for name, param in model.named_parameters()}
+
+    assert before.keys() == after.keys()
+    for name, param in before.items():
+        assert after[name] is param, f"{name} was rebound to a different parameter"
+
+
+def test_ignore_patterns_are_regexes_not_substrings(model: _Model):
+    """`ignore_patterns` go through `re.search`, so callers can pass anchors and alternation."""
+    replace_linear_with_mxfp8_linear(model, recipe="mxfp8_rceil", ignore_modules=[r"^layers\.0\.", "q_proj$"])
+    types = _module_types(model)
+
+    assert types["layers.0.self_attn.q_proj"] is nn.Linear
+    assert types["layers.0.mlp.up_proj"] is nn.Linear
+    assert types["layers.1.self_attn.q_proj"] is nn.Linear
+    assert types["layers.1.self_attn.k_proj"] is MXFP8Linear
+
+
+def test_empty_ignore_patterns_quantize_everything_aligned(model: _Model):
+    replace_linear_with_mxfp8_linear(model, recipe="mxfp8_rceil", ignore_modules=[])
+    types = _module_types(model)
+
+    assert types["lm_head"] is MXFP8Linear
+    assert types["layers.1.mlp.router.gate"] is nn.Linear  # 256 -> 8, not 32-divisible
+    assert types["layers.1.mlp.unaligned"] is nn.Linear
+
+
+def test_apply_quantization_without_config_is_a_noop(model: _Model):
+    before = _module_types(model)
+    apply_quantization(model, ModelConfig(quantization=None))
+
+    assert _module_types(model) == before
+
+
+def test_apply_quantization_dispatches_fp8(model: _Model):
+    apply_quantization(model, ModelConfig(quantization=FP8Config()))
+
+    assert _module_types(model)["layers.0.self_attn.q_proj"] is Float8BlockwiseLinear
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() >= (10, 0),
+    reason="checks the pre-Blackwell rejection, so it needs a GPU older than SM100",
+)
+def test_apply_quantization_rejects_mxfp8_below_blackwell(model: _Model):
+    with pytest.raises(ValueError, match="MXFP8 quantization requires SM100"):
+        apply_quantization(model, ModelConfig(quantization=MXFP8Config()))

--- a/tests/unit/train/models/test_quantization_training.py
+++ b/tests/unit/train/models/test_quantization_training.py
@@ -1,0 +1,219 @@
+"""A tiny training run per quantization backend, checked against the BF16 path.
+
+The numerics tests cover single GEMMs. This covers the glue: that the swapped modules stay
+in the autograd graph, that gradients reach every parameter, that the optimizer makes
+progress, and that nothing goes non-finite over a sequence of steps.
+
+Comparing two independent loss curves does *not* work here: overfitting a fixed batch is a
+chaotic trajectory, so two runs that differ only by rounding drift apart on their own, and
+a threshold loose enough not to flake is loose enough to pass a broken backward. So the
+comparison keeps both models on the **same weights** — the BF16 model trains, the quantized
+model is synced to it every step — and checks the gradient it produces there. That isolates
+the quantization error from the trajectory divergence it would otherwise compound into.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+from prime_rl.configs.trainer import FP8Config, ModelConfig, MXFP8Config, QuantizationConfig
+from prime_rl.trainer.model import apply_quantization
+from prime_rl.trainer.models.layers.fp8_linear import Float8BlockwiseLinear
+from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
+from prime_rl.trainer.models.layers.moe import GroupedExperts
+from prime_rl.trainer.models.layers.mxfp8_linear import MXFP8Linear
+from prime_rl.trainer.models.qwen3_moe import Qwen3MoeConfig
+from prime_rl.trainer.models.qwen3_moe import Qwen3MoeForCausalLM as Qwen3Moe
+from prime_rl.utils.utils import default_dtype
+from tests.unit.train.models.test_quantization_numerics import (
+    FP8_UNAVAILABLE,
+    MXFP8_GROUPED_UNAVAILABLE,
+    MXFP8_UNAVAILABLE,
+)
+
+pytestmark = [pytest.mark.gpu]
+
+SEQ_LEN, VOCAB_SIZE = 256, 512
+LEARNING_RATE = 5e-3
+# At initialization the gradient is dominated by near-degenerate structure (a router that
+# routes at random, an untrained LM head), and the two paths agree only to ~0.95 cosine
+# there — through no fault of the kernels. A couple of optimizer steps settle it.
+WARMUP_STEPS, COMPARE_STEPS = 2, 6
+CONVERGENCE_STEPS = 60
+
+# Every hidden size is a multiple of 128 so the FP8 blockwise swap accepts each projection —
+# on a model with unaligned dims the layers would silently stay in BF16 and these tests
+# would be comparing BF16 against BF16.
+MODEL_CONFIG = dict(
+    vocab_size=VOCAB_SIZE,
+    hidden_size=256,
+    intermediate_size=512,
+    moe_intermediate_size=128,
+    num_hidden_layers=2,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=64,
+    num_experts=4,
+    num_experts_per_tok=2,
+    max_position_embeddings=SEQ_LEN,
+    mlp_only_layers=[0],  # layer 0 dense, layer 1 MoE: both dense and expert GEMMs run
+    use_grouped_mm=True,
+    norm_topk_prob=True,
+    rms_norm_eps=1e-6,
+)
+
+QUANTIZED_LINEARS = (Float8BlockwiseLinear, MXFP8Linear)
+
+BACKENDS = [
+    pytest.param(
+        FP8Config(),
+        id="fp8",
+        marks=pytest.mark.skipif(FP8_UNAVAILABLE is not None, reason=str(FP8_UNAVAILABLE)),
+    ),
+    pytest.param(
+        MXFP8Config(enable_grouped_gemm=False),
+        id="mxfp8-dense",
+        marks=pytest.mark.skipif(MXFP8_UNAVAILABLE is not None, reason=str(MXFP8_UNAVAILABLE)),
+    ),
+    pytest.param(
+        MXFP8Config(),
+        id="mxfp8-grouped",
+        marks=pytest.mark.skipif(MXFP8_GROUPED_UNAVAILABLE is not None, reason=str(MXFP8_GROUPED_UNAVAILABLE)),
+    ),
+]
+
+# Measured for MXFP8 (the looser of the two backends) over the compared steps: cosine
+# similarity stays above 0.999 and the relative gradient error tracks the ~4e-2 e4m3
+# quantization floor. The bounds sit an order of magnitude out from that in (1 - cos) terms.
+MIN_GRADIENT_COSINE = 0.99
+MAX_GRADIENT_ERROR = 0.15
+MAX_LOSS_DEVIATION = 1e-2
+
+
+def _build_model(quantization: QuantizationConfig | None) -> Qwen3Moe:
+    """Build the same tiny model every call, quantized the way `get_model` would."""
+    config = Qwen3MoeConfig(**MODEL_CONFIG)
+    config._attn_implementation = "flash_attention_2"
+    # Mirrors `get_model`: the MoE expert GEMM reads FP8 off the model config, while the
+    # dense-linear swap (and the MXFP8 expert wrapping) go through `apply_quantization`.
+    config.fp8 = isinstance(quantization, FP8Config) and quantization.enable_grouped_gemm
+
+    torch.manual_seed(0)
+    with torch.device("cuda"), default_dtype(torch.bfloat16):
+        model = Qwen3Moe._from_config(config)
+        # `_from_config` leaves the fused expert weights at zero — HF's initializer does not
+        # reach them. Without this the expert GEMMs compute nothing and the tests would be
+        # judging the dense layers alone, whatever the grouped path did.
+        for module in model.modules():
+            if isinstance(module, GroupedExperts):
+                module.init_weights(0.02)
+    assert model.model.layers[1].mlp.experts.w1.any(), "expert weights are zero, the MoE GEMM path would be dead"
+
+    inject_prime_lm_head(model, chunk_size=None)
+    apply_quantization(model, ModelConfig(quantization=quantization))
+    return model
+
+
+def _backward(model: Qwen3Moe, input_ids: Tensor) -> float:
+    """One forward + backward on the fixed batch; returns the loss."""
+    logits = model(
+        input_ids=input_ids,
+        position_ids=torch.arange(SEQ_LEN, device="cuda").unsqueeze(0),
+        seq_lens=torch.tensor([SEQ_LEN], device="cuda"),
+    )["logits"]
+    loss = F.cross_entropy(logits[:, :-1].reshape(-1, VOCAB_SIZE).float(), input_ids[:, 1:].reshape(-1))
+    loss.backward()
+    return loss.item()
+
+
+def _sync_weights(target: nn.Module, source: nn.Module) -> None:
+    with torch.no_grad():
+        source_params = dict(source.named_parameters())
+        for name, param in target.named_parameters():
+            param.copy_(source_params[name])
+
+
+def _flat_gradient(model: nn.Module, order: list[str]) -> Tensor:
+    params = dict(model.named_parameters())
+    return torch.cat([params[name].grad.float().flatten() for name in order])
+
+
+@pytest.fixture(scope="module")
+def input_ids() -> Tensor:
+    torch.manual_seed(0)
+    return torch.randint(0, VOCAB_SIZE, (1, SEQ_LEN), device="cuda")
+
+
+@pytest.mark.parametrize("quantization", BACKENDS)
+def test_gradients_track_bf16_along_a_training_trajectory(quantization: QuantizationConfig, input_ids: Tensor):
+    """At every step of a real BF16 run, the quantized backward must point the same way."""
+    reference, quantized = _build_model(None), _build_model(quantization)
+    assert [name for name, mod in quantized.named_modules() if isinstance(mod, QUANTIZED_LINEARS)], (
+        "no linear was swapped — this would compare BF16 against BF16"
+    )
+    optimizer = torch.optim.AdamW(reference.parameters(), lr=LEARNING_RATE)
+    order = [name for name, _ in reference.named_parameters()]
+
+    for step in range(WARMUP_STEPS + COMPARE_STEPS):
+        _sync_weights(quantized, reference)
+        reference_loss = _backward(reference, input_ids)
+        quantized_loss = _backward(quantized, input_ids)
+
+        if step >= WARMUP_STEPS:
+            reference_grad, quantized_grad = _flat_gradient(reference, order), _flat_gradient(quantized, order)
+            cosine = F.cosine_similarity(quantized_grad, reference_grad, dim=0).item()
+            grad_error = ((quantized_grad - reference_grad).norm() / reference_grad.norm()).item()
+            loss_deviation = abs(quantized_loss - reference_loss) / reference_loss
+            print(
+                f"{quantization.type} step {step}: loss {reference_loss:.4f} vs {quantized_loss:.4f} "
+                f"(dev={loss_deviation:.2e}) grad cos={cosine:.5f} rel_err={grad_error:.3e}"
+            )
+
+            assert quantized_grad.isfinite().all(), f"step {step}: non-finite gradient"
+            # A silent fallback to BF16 would score a perfect 1.0 cosine and zero error.
+            assert grad_error > 0, f"step {step}: gradient is bit-identical to BF16, the quantized path did not run"
+            assert cosine > MIN_GRADIENT_COSINE, f"step {step}: gradient cosine {cosine:.5f} — the backward is off"
+            assert grad_error < MAX_GRADIENT_ERROR, f"step {step}: gradient relative error {grad_error:.3e}"
+            assert loss_deviation < MAX_LOSS_DEVIATION, f"step {step}: loss deviates {loss_deviation:.2%} from BF16"
+
+        optimizer.step()
+        optimizer.zero_grad()
+        quantized.zero_grad()
+
+
+@pytest.mark.parametrize("quantization", BACKENDS)
+def test_quantized_run_converges(quantization: QuantizationConfig, input_ids: Tensor):
+    """The backend trains on its own: a long run stays finite and drives the loss down.
+
+    Judged on its own trajectory, not against BF16's — the point here is that repeated
+    quantized updates neither stall nor blow up, which no single-step check can show.
+    """
+    model = _build_model(quantization)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=LEARNING_RATE)
+
+    losses = []
+    for step in range(CONVERGENCE_STEPS):
+        losses.append(_backward(model, input_ids))
+        for name, param in model.named_parameters():
+            assert param.grad is None or param.grad.isfinite().all(), f"step {step}: non-finite gradient in {name}"
+        optimizer.step()
+        optimizer.zero_grad()
+
+    print(f"{quantization.type}: {losses[0]:.4f} -> {losses[-1]:.4f} over {CONVERGENCE_STEPS} steps")
+    assert all(loss == loss for loss in losses), f"non-finite loss: {losses}"
+    assert losses[-1] < 0.5 * losses[0], f"training stalled ({losses[0]:.4f} -> {losses[-1]:.4f})"
+    for name, param in model.named_parameters():
+        assert param.isfinite().all(), f"non-finite weights in {name} after {CONVERGENCE_STEPS} steps"
+
+
+@pytest.mark.parametrize("quantization", BACKENDS)
+def test_every_parameter_receives_a_gradient(quantization: QuantizationConfig, input_ids: Tensor):
+    """A quantized layer that drops out of the graph trains at its initial weights forever."""
+    model = _build_model(quantization)
+    _backward(model, input_ids)
+
+    missing = [name for name, param in model.named_parameters() if param.requires_grad and param.grad is None]
+    assert not missing, f"parameters left out of the backward pass: {missing}"
+    dead = [name for name, param in model.named_parameters() if param.grad is not None and not param.grad.any()]
+    assert not dead, f"parameters received an all-zero gradient: {dead}"


### PR DESCRIPTION
This PR add unit tests for MXFP8 and FP8 to prime-rl.
Some tests require a GPU supporting those formats, some can run on the CPU.
We test quantization precision, layer replacing and a tiny mini-model run to make sure we catch regressions with those low precison types as we will use them more and more from now on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modifications; GPU tests may skip on unsupported hardware.
> 
> **Overview**
> Adds **three new unit test modules** for FP8 blockwise and MXFP8 training paths so numerics, layer swapping, and short training runs can catch regressions as low-precision training expands.
> 
> **Numerics** (`test_quantization_numerics.py`, GPU): Compares quantized linear and grouped GEMM outputs (forward, activation grad, weight grad) against BF16 references using a **quantization floor**—operands rounded to e4m3 with the same block layout, multiplied in fp32—rather than fixed tolerances. Checks also fail if outputs are bit-identical to BF16 (silent fallback). Coverage includes FP8 linear/grouped MoE (aligned, unaligned, empty expert), MXFP8 linear recipes (including high-precision wgrad), bias, and MXFP8 grouped experts. Tests skip or gate on **SM90/SM100** capability where kernels are unavailable.
> 
> **Module swap** (`test_quantization_swap.py`, mostly CPU): Pins which `nn.Linear` layers become `Float8BlockwiseLinear` / `MXFP8Linear` under default ignore patterns (routers, `lm_head`, unaligned dims, `mlp.gate` vs `gate_proj`), verifies **parameter object identity** after swap, regex ignore behavior, and `apply_quantization` dispatch/no-op; one GPU test asserts MXFP8 is rejected below SM100.
> 
> **Training glue** (`test_quantization_training.py`, GPU): Runs a tiny **Qwen3 MoE** model per backend (FP8, MXFP8 dense, MXFP8 grouped) to ensure gradients stay finite, reach every parameter, and track BF16 when weights are synced each step; plus a standalone convergence check on a fixed batch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eeeedfc64fdd4678b94dc939011608de19f370e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->