### PR TITLE
fix: repair mini_moe.py presets and verify on production settings

### DIFF
--- a/scripts/mini_moe.py
+++ b/scripts/mini_moe.py
@@ -1,7 +1,8 @@
 """Create and verify a mini MoE model for testing.
 
-Creates a small MoE model with random weights, saves it with a tokenizer,
-and verifies the HF <-> PrimeRL weight conversion roundtrip.
+Creates a small MoE model with random weights, saves it with a tokenizer, and verifies the HF <->
+PrimeRL weight conversion roundtrip. Compares KL divergences between prime-rl and HF
+implementations, and top-1 agreement (a noisy metric for random-init models).
 
 How this mirrors production:
   1. bf16 weights, fp32 buffers (inv_freq, expert_bias, ...): the prod forward under FSDP mixed precision
@@ -10,13 +11,6 @@ How this mirrors production:
   4. flash_attention_2 on both models, so a logits gap means the port, not two kernels
   5. Prime LM head injected, as setup_model does
   6. seq_lens passed explicitly, but as one document, so packed boundaries stay untested
-
-Never use model.to(dtype=...) here: it casts buffers too, quantizing the rope table irrecoverably.
-Flash attention constrains only the q/k/v activations, so nothing forces buffers to bf16.
-
-Not covered: FSDP (no fp32 masters, no gradient reduction), backward, EP/CP, activation
-checkpointing, torch.compile, quantization, the fused MoE kernel, long context (one 64-token
-sequence), and real checkpoints (weights are random).
 
 Usage:
     # Create and verify
@@ -30,6 +24,7 @@ import argparse
 from pathlib import Path
 
 import torch
+import torch.nn.functional as F
 import transformers.utils.generic
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from transformers import Glm4MoeForCausalLM as HFGlm4MoeForCausalLM
@@ -111,7 +106,7 @@ def _qwen3_5_moe_vlm_config():
     tc.linear_num_value_heads = 8
     tc.layer_types = ["full_attention", "linear_attention"]
     tc.use_cache = False
-    # head_dim shrinks to 64, so the rotary dim is 16 and mrope_section must sum to 8
+    # mrope sections must sum to head_dim * partial_rotary_factor / 2 = 8, for head_dim = 64
     tc.rope_parameters["mrope_section"] = [3, 3, 2]
 
     vc = config.vision_config
@@ -273,17 +268,11 @@ def _create_hf_model_from_config(preset, config):
 
 
 def _compare_distributions(hf_logits: torch.Tensor, prime_logits: torch.Tensor) -> tuple[float, float, float]:
-    """Report full-vocab KL and top-1 agreement, and return the three gated quantities.
-
-    KL is the informative number. Max logits diff is a tail statistic over millions of entries, and
-    bf16 error concentrates on near-zero logits that carry almost no probability mass.
-
-    Both the mean and the max KL are gated: averaging over the sequence dilutes a single divergent
-    token by the sequence length, so a localized error can hide behind a healthy mean.
-    """
+    "Report and return full-vocab KL mean, KL max, and top-1 agreement."
     hf_logprobs = hf_logits.float().log_softmax(-1)
     prime_logprobs = prime_logits.float().log_softmax(-1)
-    kl = (hf_logprobs.exp() * (hf_logprobs - prime_logprobs)).sum(-1)
+    # F.kl_div computes KL(target || input), so the arguments read in the opposite order to the name
+    kl = F.kl_div(input=prime_logprobs, target=hf_logprobs, reduction="none", log_target=True).sum(-1)
     top1 = (hf_logits.argmax(-1) == prime_logits.argmax(-1)).float().mean()
     print(f"  HF vs PrimeRL KL(HF || PrimeRL) per token: mean {kl.mean().item():.3e}, max {kl.max().item():.3e}")
     print(f"  HF vs PrimeRL top-1 agreement: {top1.item():.1%}")
@@ -353,9 +342,8 @@ def verify(arch: str, model_dir: Path) -> None:
 
     # Use tokens in safe range (avoid special VLM token IDs)
     max_token = min(vocab_size, 200) if is_vlm else vocab_size
-    with torch.device("cuda"), default_dtype(torch.bfloat16):
-        input_ids = torch.randint(0, max_token, (1, 64))
-        position_ids = torch.arange(1, 65).unsqueeze(0)
+    input_ids = torch.randint(0, max_token, (1, 64), device="cuda")
+    position_ids = torch.arange(1, 65, device="cuda").unsqueeze(0)
 
     seq_lens = torch.tensor([input_ids.shape[1]], device=input_ids.device)
     hf_output = hf_model(input_ids=input_ids, position_ids=position_ids)

--- a/scripts/mini_moe.py
+++ b/scripts/mini_moe.py
@@ -12,6 +12,10 @@ How this mirrors production:
   5. Prime LM head injected, as setup_model does
   6. seq_lens passed explicitly, but as one document, so packed boundaries stay untested
 
+NOTE: should be taken as a very coarse sanity check against catastrophic incorrectness. Thresholds
+are loose and may pass even with moderate correctness bugs. Not a replacement for robust unit
+testing.
+
 Usage:
     # Create and verify
     uv run python scripts/mini_moe.py --arch glm4_moe --output-dir ./mini-glm-moe

--- a/scripts/mini_moe.py
+++ b/scripts/mini_moe.py
@@ -3,6 +3,21 @@
 Creates a small MoE model with random weights, saves it with a tokenizer,
 and verifies the HF <-> PrimeRL weight conversion roundtrip.
 
+How this mirrors production:
+  1. bf16 weights, fp32 buffers (inv_freq, expert_bias, ...): the prod forward under FSDP mixed precision
+  2. fp32 MoE router gate, per the moe_router_dtype="float32" default
+  3. Grouped-mm experts, per the use_grouped_mm=True default (needs a recent GPU arch)
+  4. flash_attention_2 on both models, so a logits gap means the port, not two kernels
+  5. Prime LM head injected, as setup_model does
+  6. seq_lens passed explicitly, the packed-sample boundary contract
+
+Never use model.to(dtype=...) here: it casts buffers too, quantizing the rope table irrecoverably.
+Flash attention constrains only the q/k/v activations, so nothing forces buffers to bf16.
+
+Not covered: FSDP (no fp32 masters, no gradient reduction), backward, EP/CP, activation
+checkpointing, torch.compile, quantization, the fused MoE kernel, long context (one 64-token
+sequence), and real checkpoints (weights are random).
+
 Usage:
     # Create and verify
     uv run python scripts/mini_moe.py --arch glm4_moe --output-dir ./mini-glm-moe
@@ -30,6 +45,7 @@ from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
 )
 from transformers.utils.output_capturing import OutputRecorder
 
+from prime_rl.trainer.model import apply_fp32_moe_router
 from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig
 from prime_rl.trainer.models.glm4_moe import Glm4MoeForCausalLM as PrimeRLGlm4MoeForCausalLM
 from prime_rl.trainer.models.laguna import LagunaConfig
@@ -138,7 +154,6 @@ ARCH_PRESETS = {
             first_k_dense_replace=1,
             norm_topk_prob=True,
             use_qk_norm=False,
-            use_grouped_mm=False,
             pad_token_id=151329,
             eos_token_id=[151329, 151336, 151338],
         ),
@@ -167,7 +182,6 @@ ARCH_PRESETS = {
             use_routing_bias=True,
             use_qk_norm=True,
             qk_norm_type="per_layer",
-            use_grouped_mm=False,
             auto_map={"AutoModelForCausalLM": f"{MINIMAX_M2_REPO}--modeling_minimax_m2.MiniMaxM2ForCausalLM"},
         ),
         "hf_model_class": None,  # uses AutoModelForCausalLM with trust_remote_code
@@ -213,7 +227,6 @@ ARCH_PRESETS = {
             num_experts_per_tok=4,
             mlp_layer_types=["dense"] + ["sparse"] * 11,
             moe_routed_scaling_factor=2.5,
-            use_grouped_mm=False,
             pad_token_id=9,
             bos_token_id=2,
             eos_token_id=[2, 24],
@@ -260,6 +273,21 @@ def _create_hf_model_from_config(preset, config):
     if hf_cls is not None:
         return hf_cls._from_config(config)
     return AutoModelForCausalLM.from_config(config, trust_remote_code=True)
+
+
+def _compare_distributions(hf_logits: torch.Tensor, prime_logits: torch.Tensor) -> tuple[float, float]:
+    """Report full-vocab KL and top-1 agreement, and return the two gated quantities.
+
+    KL is the informative number. Max logits diff is a tail statistic over millions of entries, and
+    bf16 error concentrates on near-zero logits that carry almost no probability mass.
+    """
+    hf_logprobs = hf_logits.float().log_softmax(-1)
+    prime_logprobs = prime_logits.float().log_softmax(-1)
+    kl = (hf_logprobs.exp() * (hf_logprobs - prime_logprobs)).sum(-1)
+    top1 = (hf_logits.argmax(-1) == prime_logits.argmax(-1)).float().mean()
+    print(f"  HF vs PrimeRL KL per token: mean {kl.mean().item():.3e}, max {kl.max().item():.3e}")
+    print(f"  HF vs PrimeRL top-1 agreement: {top1.item():.1%}")
+    return kl.mean().item(), top1.item()
 
 
 def _build_config(preset):
@@ -309,7 +337,9 @@ def verify(arch: str, model_dir: Path) -> None:
     text_config = getattr(config, "text_config", config)
     vocab_size = text_config.vocab_size
 
-    hf_model = _load_hf_model(preset, model_dir, config).to(device="cuda", dtype=torch.bfloat16)
+    # `config.dtype` above already builds bf16 weights. Casting with `.to(dtype=...)` would also cast
+    # buffers, quantizing inv_freq and the routing bias that PrimeRL keeps in fp32.
+    hf_model = _load_hf_model(preset, model_dir, config).to(device="cuda")
     with torch.device("cuda"), default_dtype(torch.bfloat16):
         prime_model = preset["prime_model_class"]._from_config(config)
 
@@ -319,6 +349,7 @@ def verify(arch: str, model_dir: Path) -> None:
         prime_model.load_state_dict(state_dict)
 
     inject_prime_lm_head(prime_model, chunk_size=None)
+    apply_fp32_moe_router(prime_model)
 
     # Use tokens in safe range (avoid special VLM token IDs)
     max_token = min(vocab_size, 200) if is_vlm else vocab_size
@@ -337,6 +368,9 @@ def verify(arch: str, model_dir: Path) -> None:
     logits_diff = prime_output["logits"] - hf_output.logits
     max_diff = logits_diff.abs().max().item()
     print(f"  HF vs PrimeRL max logits diff: {max_diff:.6f}")
+    mean_kl, top1 = _compare_distributions(hf_output.logits, prime_output["logits"])
+    assert mean_kl < 1e-3, f"HF vs PrimeRL distribution mismatch: mean KL {mean_kl}"
+    assert top1 >= 0.75, f"HF vs PrimeRL top-1 agreement too low: {top1}"
     assert max_diff < 1.0, f"HF vs PrimeRL logits mismatch: max diff {max_diff}"
 
     # Roundtrip weight conversion: HF -> PrimeRL -> HF

--- a/scripts/mini_moe.py
+++ b/scripts/mini_moe.py
@@ -9,7 +9,7 @@ How this mirrors production:
   3. Grouped-mm experts, per the use_grouped_mm=True default (needs a recent GPU arch)
   4. flash_attention_2 on both models, so a logits gap means the port, not two kernels
   5. Prime LM head injected, as setup_model does
-  6. seq_lens passed explicitly, the packed-sample boundary contract
+  6. seq_lens passed explicitly, but as one document, so packed boundaries stay untested
 
 Never use model.to(dtype=...) here: it casts buffers too, quantizing the rope table irrecoverably.
 Flash attention constrains only the q/k/v activations, so nothing forces buffers to bf16.
@@ -34,9 +34,6 @@ import transformers.utils.generic
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from transformers import Glm4MoeForCausalLM as HFGlm4MoeForCausalLM
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
-from transformers.models.minimax_m2.modeling_minimax_m2 import (
-    MiniMaxM2ForCausalLM as NativeMiniMaxM2ForCausalLM,
-)
 from transformers.models.minimax_m2.modeling_minimax_m2 import (
     MiniMaxM2RotaryEmbedding as NativeMiniMaxM2RotaryEmbedding,
 )
@@ -69,7 +66,7 @@ def _patch_minimax_m2_hub_code() -> None:
     out of `utils.generic`, turning `compute_default_rope_parameters` into a per-class method on the
     rotary embedding, and respelling `_tied_weights_keys` as a tied-key -> source mapping. Without
     these the module fails to import, then to initialize its weights, then to save. The two
-    modernized attributes are borrowed from transformers' own MiniMax-M2 classes.
+    modernized attributes are borrowed from the native transformers and PrimeRL MiniMax-M2 classes.
 
     The hub code, not transformers' native MiniMaxM2ForCausalLM, is the reference we want: real
     MiniMax-M2.1 checkpoints use `block_sparse_moe.experts.{j}.w1/w2/w3`, which
@@ -84,7 +81,7 @@ def _patch_minimax_m2_hub_code() -> None:
     hub_class("MiniMaxM2RotaryEmbedding").compute_default_rope_parameters = staticmethod(
         NativeMiniMaxM2RotaryEmbedding.compute_default_rope_parameters
     )
-    hub_class("MiniMaxM2ForCausalLM")._tied_weights_keys = NativeMiniMaxM2ForCausalLM._tied_weights_keys
+    hub_class("MiniMaxM2ForCausalLM")._tied_weights_keys = PrimeRLMiniMaxM2ForCausalLM._tied_weights_keys
 
 
 def _qwen3_5_moe_vlm_config():
@@ -275,19 +272,22 @@ def _create_hf_model_from_config(preset, config):
     return AutoModelForCausalLM.from_config(config, trust_remote_code=True)
 
 
-def _compare_distributions(hf_logits: torch.Tensor, prime_logits: torch.Tensor) -> tuple[float, float]:
-    """Report full-vocab KL and top-1 agreement, and return the two gated quantities.
+def _compare_distributions(hf_logits: torch.Tensor, prime_logits: torch.Tensor) -> tuple[float, float, float]:
+    """Report full-vocab KL and top-1 agreement, and return the three gated quantities.
 
     KL is the informative number. Max logits diff is a tail statistic over millions of entries, and
     bf16 error concentrates on near-zero logits that carry almost no probability mass.
+
+    Both the mean and the max KL are gated: averaging over the sequence dilutes a single divergent
+    token by the sequence length, so a localized error can hide behind a healthy mean.
     """
     hf_logprobs = hf_logits.float().log_softmax(-1)
     prime_logprobs = prime_logits.float().log_softmax(-1)
     kl = (hf_logprobs.exp() * (hf_logprobs - prime_logprobs)).sum(-1)
     top1 = (hf_logits.argmax(-1) == prime_logits.argmax(-1)).float().mean()
-    print(f"  HF vs PrimeRL KL per token: mean {kl.mean().item():.3e}, max {kl.max().item():.3e}")
+    print(f"  HF vs PrimeRL KL(HF || PrimeRL) per token: mean {kl.mean().item():.3e}, max {kl.max().item():.3e}")
     print(f"  HF vs PrimeRL top-1 agreement: {top1.item():.1%}")
-    return kl.mean().item(), top1.item()
+    return kl.mean().item(), kl.max().item(), top1.item()
 
 
 def _build_config(preset):
@@ -368,8 +368,9 @@ def verify(arch: str, model_dir: Path) -> None:
     logits_diff = prime_output["logits"] - hf_output.logits
     max_diff = logits_diff.abs().max().item()
     print(f"  HF vs PrimeRL max logits diff: {max_diff:.6f}")
-    mean_kl, top1 = _compare_distributions(hf_output.logits, prime_output["logits"])
+    mean_kl, max_kl, top1 = _compare_distributions(hf_output.logits, prime_output["logits"])
     assert mean_kl < 1e-3, f"HF vs PrimeRL distribution mismatch: mean KL {mean_kl}"
+    assert max_kl < 1e-2, f"HF vs PrimeRL distribution mismatch on one token: max KL {max_kl}"
     assert top1 >= 0.75, f"HF vs PrimeRL top-1 agreement too low: {top1}"
     assert max_diff < 1.0, f"HF vs PrimeRL logits mismatch: max diff {max_diff}"
 

--- a/scripts/mini_moe.py
+++ b/scripts/mini_moe.py
@@ -110,8 +110,6 @@ def _qwen3_5_moe_vlm_config():
     tc.linear_num_value_heads = 8
     tc.layer_types = ["full_attention", "linear_attention"]
     tc.use_cache = False
-    # mrope sections must sum to head_dim * partial_rotary_factor / 2 = 8, for head_dim = 64
-    tc.rope_parameters["mrope_section"] = [3, 3, 2]
 
     vc = config.vision_config
     vc.depth = 2

--- a/scripts/mini_moe.py
+++ b/scripts/mini_moe.py
@@ -15,11 +15,20 @@ import argparse
 from pathlib import Path
 
 import torch
+import transformers.utils.generic
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from transformers import Glm4MoeForCausalLM as HFGlm4MoeForCausalLM
+from transformers.dynamic_module_utils import get_class_from_dynamic_module
+from transformers.models.minimax_m2.modeling_minimax_m2 import (
+    MiniMaxM2ForCausalLM as NativeMiniMaxM2ForCausalLM,
+)
+from transformers.models.minimax_m2.modeling_minimax_m2 import (
+    MiniMaxM2RotaryEmbedding as NativeMiniMaxM2RotaryEmbedding,
+)
 from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
     Qwen3_5MoeForConditionalGeneration as HFQwen3_5MoeVLM,
 )
+from transformers.utils.output_capturing import OutputRecorder
 
 from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig
 from prime_rl.trainer.models.glm4_moe import Glm4MoeForCausalLM as PrimeRLGlm4MoeForCausalLM
@@ -34,10 +43,39 @@ from prime_rl.utils.utils import default_dtype
 
 setup_logger("info")
 
+MINIMAX_M2_REPO = "MiniMaxAI/MiniMax-M2.1"
+
+
+def _patch_minimax_m2_hub_code() -> None:
+    """Backport three transformers refactors into the MiniMax-M2.1 hub modeling code.
+
+    The hub code has not changed since 2026-02-13 and predates transformers moving OutputRecorder
+    out of `utils.generic`, turning `compute_default_rope_parameters` into a per-class method on the
+    rotary embedding, and respelling `_tied_weights_keys` as a tied-key -> source mapping. Without
+    these the module fails to import, then to initialize its weights, then to save. The two
+    modernized attributes are borrowed from transformers' own MiniMax-M2 classes.
+
+    The hub code, not transformers' native MiniMaxM2ForCausalLM, is the reference we want: real
+    MiniMax-M2.1 checkpoints use `block_sparse_moe.experts.{j}.w1/w2/w3`, which
+    `converting_minimax_m2.py` targets, whereas the native class uses fused
+    `mlp.experts.gate_up_proj`.
+    """
+    transformers.utils.generic.OutputRecorder = OutputRecorder
+
+    def hub_class(name: str) -> type:
+        return get_class_from_dynamic_module(f"{MINIMAX_M2_REPO}--modeling_minimax_m2.{name}", MINIMAX_M2_REPO)
+
+    hub_class("MiniMaxM2RotaryEmbedding").compute_default_rope_parameters = staticmethod(
+        NativeMiniMaxM2RotaryEmbedding.compute_default_rope_parameters
+    )
+    hub_class("MiniMaxM2ForCausalLM")._tied_weights_keys = NativeMiniMaxM2ForCausalLM._tied_weights_keys
+
 
 def _qwen3_5_moe_vlm_config():
     """Build a tiny composite VLM config for Qwen3.5 MoE."""
-    config = AutoConfig.from_pretrained("Qwen/Qwen3.5-35B-A3B", trust_remote_code=True, attn_implementation="sdpa")
+    config = AutoConfig.from_pretrained(
+        "Qwen/Qwen3.5-35B-A3B", trust_remote_code=True, attn_implementation="flash_attention_2"
+    )
     config.use_cache = False
 
     tc = config.text_config
@@ -60,6 +98,8 @@ def _qwen3_5_moe_vlm_config():
     tc.linear_num_value_heads = 8
     tc.layer_types = ["full_attention", "linear_attention"]
     tc.use_cache = False
+    # head_dim shrinks to 64, so the rotary dim is 16 and mrope_section must sum to 8
+    tc.rope_parameters["mrope_section"] = [3, 3, 2]
 
     vc = config.vision_config
     vc.depth = 2
@@ -128,11 +168,11 @@ ARCH_PRESETS = {
             use_qk_norm=True,
             qk_norm_type="per_layer",
             use_grouped_mm=False,
-            auto_map={"AutoModelForCausalLM": "MiniMaxAI/MiniMax-M2.1--modeling_minimax_m2.MiniMaxM2ForCausalLM"},
+            auto_map={"AutoModelForCausalLM": f"{MINIMAX_M2_REPO}--modeling_minimax_m2.MiniMaxM2ForCausalLM"},
         ),
         "hf_model_class": None,  # uses AutoModelForCausalLM with trust_remote_code
         "prime_model_class": PrimeRLMiniMaxM2ForCausalLM,
-        "tokenizer_source": "MiniMaxAI/MiniMax-M2.1",
+        "tokenizer_source": MINIMAX_M2_REPO,
     },
     "laguna": {
         "config_class": LagunaConfig,
@@ -259,15 +299,18 @@ def verify(arch: str, model_dir: Path) -> None:
 
     trust_remote_code = preset["hf_model_class"] is None
     config = AutoConfig.from_pretrained(str(model_dir), trust_remote_code=trust_remote_code)
-    config._attn_implementation = "sdpa"
+    config._attn_implementation = "flash_attention_2"
     if hasattr(config, "text_config"):
-        config.text_config._attn_implementation = "sdpa"
+        config.text_config._attn_implementation = "flash_attention_2"
+    # The checkpoint is saved in float32, but flash attention only accepts fp16/bf16. `_from_config`
+    # reads `config.dtype`, which would otherwise override the ambient default dtype below.
+    config.dtype = torch.bfloat16
 
     text_config = getattr(config, "text_config", config)
     vocab_size = text_config.vocab_size
 
-    hf_model = _load_hf_model(preset, model_dir, config).to(device="cuda", dtype=torch.float32)
-    with torch.device("cuda"), default_dtype(torch.float32):
+    hf_model = _load_hf_model(preset, model_dir, config).to(device="cuda", dtype=torch.bfloat16)
+    with torch.device("cuda"), default_dtype(torch.bfloat16):
         prime_model = preset["prime_model_class"]._from_config(config)
 
     with torch.no_grad():
@@ -279,23 +322,22 @@ def verify(arch: str, model_dir: Path) -> None:
 
     # Use tokens in safe range (avoid special VLM token IDs)
     max_token = min(vocab_size, 200) if is_vlm else vocab_size
-    with torch.device("cuda"), default_dtype(torch.float32):
+    with torch.device("cuda"), default_dtype(torch.bfloat16):
         input_ids = torch.randint(0, max_token, (1, 64))
         position_ids = torch.arange(1, 65).unsqueeze(0)
 
+    seq_lens = torch.tensor([input_ids.shape[1]], device=input_ids.device)
     hf_output = hf_model(input_ids=input_ids, position_ids=position_ids)
-    prime_output = prime_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids, seq_lens=seq_lens)
 
     if is_vlm:
-        # HF GatedDeltaNet has a dtype bug in float32 mode; just verify non-NaN output
         assert not torch.isnan(prime_output["logits"]).any(), "PrimeRL VLM output contains NaN"
         assert prime_output["logits"].shape == hf_output.logits.shape
-        print("  VLM forward pass verified (shape match, no NaN)")
-    else:
-        logits_diff = prime_output["logits"] - hf_output.logits
-        max_diff = logits_diff.abs().max().item()
-        print(f"  HF vs PrimeRL max logits diff: {max_diff:.6f}")
-        assert max_diff < 0.1, f"HF vs PrimeRL logits mismatch: max diff {max_diff}"
+
+    logits_diff = prime_output["logits"] - hf_output.logits
+    max_diff = logits_diff.abs().max().item()
+    print(f"  HF vs PrimeRL max logits diff: {max_diff:.6f}")
+    assert max_diff < 1.0, f"HF vs PrimeRL logits mismatch: max diff {max_diff}"
 
     # Roundtrip weight conversion: HF -> PrimeRL -> HF
     # Normalize both through the same roundtrip to handle expert format differences
@@ -319,6 +361,9 @@ def main():
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--verify-only", action="store_true", help="Skip creation, only verify an existing model")
     args = parser.parse_args()
+
+    if args.arch == "minimax_m2":
+        _patch_minimax_m2_hub_code()
 
     if not args.verify_only:
         create(args.arch, args.output_dir)

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -106,13 +106,17 @@ class LagunaFlashAttention(FlashAttention):
         self.attention_dropout = config.attention_dropout
         self.is_local_attention = config.layer_types[layer_idx] == "sliding_attention"
         self.sliding_window = config.sliding_window if self.is_local_attention else None
-        # Attention output gating, mirroring the upstream Laguna implementation:
-        #   True / "per-element" (Laguna M): one gate per (head, head_dim) channel
-        #   "per-head"           (Laguna S): one gate per head, broadcast across head_dim
-        #   False:                           no gating
+        # Attention output gating. Every current release states the mode explicitly ("per-head" for
+        # XS-2.1/S-2.1, "per-element" for M.1), so only the string selects per-element. Bare True
+        # appears only in the older XS.2, whose g_proj is [num_heads, hidden_size]; poolside
+        # re-released that same checkpoint as XS-2.1 with the field corrected to "per-head", so
+        # True means per-head.
+        #   "per-element":     one gate per (head, head_dim) channel
+        #   True / "per-head": one gate per head, broadcast across head_dim
+        #   False:             no gating
         gating = getattr(config, "gating", True)
         self.gating = bool(gating)
-        self.gate_per_head = gating == "per-head"
+        self.gate_per_head = gating != "per-element"
         if self.gating:
             gate_size = num_heads if self.gate_per_head else num_heads * self.head_dim
             self.g_proj = nn.Linear(config.hidden_size, gate_size, bias=False)


### PR DESCRIPTION
First of two stacked PRs; #3414 builds on it.

`scripts/mini_moe.py` is the smoke test [`docs/development.md`](docs/development.md) tells contributors to extend when they land a new architecture: it builds a tiny random-weight model per preset, saves it with a tokenizer, and checks that the HF and PrimeRL implementations agree and that the weight conversion roundtrips. Nothing in CI runs it, so it had rotted quietly, and all four presets failed. Repairing them surfaced a real production bug in the Laguna port, and exposed that the comparison had drifted away from the settings training actually uses. This branch does all three.

## The Laguna bug

`modeling_laguna.py` read a bare `gating: true` as per-element attention gating, sizing `g_proj` as `num_heads * head_dim`. Every current Laguna release states the mode explicitly (`"per-head"` for XS-2.1 and S-2.1, `"per-element"` for M.1), and the one checkpoint that still says bare `true`, `poolside/Laguna-XS.2`, has `g_proj` shaped `[num_heads, hidden_size]`; poolside re-released those same weights as XS-2.1 with the field corrected to `"per-head"`, and the XS.2 hub modeling code hardcodes `nn.Linear(hidden_size, num_heads)`. So PrimeRL could not load the only Laguna checkpoint [`docs/advanced.md`](docs/advanced.md) advertises. Now only the explicit string selects per-element.

## What was broken in the script

- `sdpa` was removed from the trainer's attention registry in #3057, so prime model construction raised `KeyError` / `ValueError` for three presets.
- `seq_lens` became a required keyword-only argument on the model forward in #3032 and was never passed.
- The MiniMax-M2.1 preset had never worked: it forces hub remote code that has not changed since 2026-02-13 and now trips three transformers refactors (`OutputRecorder` moved out of `utils.generic`, `compute_default_rope_parameters` became a per-class method, `_tied_weights_keys` became a mapping). All three are shimmed, with a comment explaining why the hub code rather than the native `MiniMaxM2ForCausalLM` is the right reference: real checkpoints use `block_sparse_moe.experts.{j}.w1/w2/w3`, which `converting_minimax_m2.py` targets.
- The VLM preset shrinks `head_dim` to 64, making the rotary dim 16, but inherited an `mrope_section` summing to 32.

Flash attention only accepts fp16/bf16, so the comparison also had to move off float32. Both models now share one `flash_attention_2` config in bfloat16, which means a logits gap is attributable to the port rather than to two different kernels.

## Making the comparison represent production

Three settings had drifted, each confirmed by measurement rather than inspection:

- **Buffers were being quantized.** `model.to(dtype=bfloat16)` casts floating-point *buffers*, not just parameters, so the reference ran with bf16 `inv_freq` and routing bias while PrimeRL keeps both fp32. Flash attention constrains only the q/k/v activations, so nothing required that. Dropping the cast improves Laguna's mean KL 5x, and since rope phase error grows linearly with position it would be far worse at the 4k-131k contexts these models train at.
- **The MoE router ran bf16.** Training pins it to fp32 (`apply_fp32_moe_router`, `moe_router_dtype="float32"`). The script now calls the same function.
- **The expert path was the slow one.** Three presets hardcoded `use_grouped_mm=False`, so they never touched the grouped-mm path production uses.

Verification also stopped relying on a single tail statistic. `max|Δ|` is uncorrelated with logit magnitude (measured correlation 0.00; the deviation at the peak-logit position is 0.0000 in three of four archs) and moves ~30% run to run from kernel nondeterminism alone. It is still printed and gated, but the binding checks are now full-vocab `KL(HF || PrimeRL)` per token, both mean and max, plus top-1 agreement. The max matters because averaging over the sequence dilutes a single divergent token by the sequence length.

## Results

Two passes, fresh random weights and fresh inputs each time. Gates are `mean KL < 1e-3`, `max KL < 1e-2`, `top-1 >= 0.75`, `max|Δ| < 1.0`.

| arch | pass | max abs logit diff | mean KL | max KL | top-1 |
| --- | --- | --- | --- | --- | --- |
| `glm4_moe` | 1 | 0.0625 | 3.4e-05 | 8.0e-05 | 98.4% |
| `glm4_moe` | 2 | 0.0957 | 3.7e-05 | 1.8e-04 | 96.9% |
| `minimax_m2` | 1 | 0.0547 | 1.2e-05 | 5.7e-05 | 100.0% |
| `minimax_m2` | 2 | 0.0449 | 1.1e-05 | 5.4e-05 | 95.3% |
| `laguna` | 1 | 0.2100 | 6.3e-05 | 9.9e-04 | 93.8% |
| `laguna` | 2 | 0.2012 | 3.5e-05 | 6.6e-04 | 96.9% |
| `qwen3_5_moe_vlm` | 1 | 0.0083 | 2.1e-06 | 4.3e-06 | 100.0% |
| `qwen3_5_moe_vlm` | 2 | 0.0080 | 2.1e-06 | 3.4e-06 | 100.0% |

All four presets print `Verification passed.` and exit 0. `tests/unit/train/models/{test_glm4_moe,test_qwen3_5_moe,test_qwen3_5_moe_vlm,test_qwen3_5_moe_mrope}.py` still pass (22 passed). Laguna carries the heaviest tail by an order of magnitude, mean 3.5e-05 against max 1e-03, so its disagreement is concentrated on a few tokens rather than spread; worth remembering if it ever starts failing.

## Worth knowing before merging

- `torch._grouped_mm` requires a recent GPU architecture, so presets that previously ran anywhere now need one. That was an explicit decision, not an oversight.
- End-to-end loading of the real 67 GB `poolside/Laguna-XS.2` checkpoint was **not** attempted. The production fix is argued from the checkpoint's own tensor shapes, its hub modeling code, and the mini-scale reproduction. `poolside/Laguna-tiny-per-element` exists as a cheap fixture if a reviewer wants the per-element path exercised.
- The fp32 router leaves an intentional asymmetry: PrimeRL's gate is fp32 while the HF reference's stays bf16. That is the configuration training runs, and it does not degrade the measurement (Laguna mean KL 5.96e-05 to 4.27e-05).
- `seq_lens` is passed as a single document, so packed-sequence boundaries remain untested. Adding that would need per-arch work for Laguna's sliding-window and the VLM's linear-attention layers.
- Still a manual developer script with no CI coverage, per the scope agreed for this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

