### PR TITLE
feat: record run invocation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -251,4 +251,11 @@ ls /tmp/reverse-dry/check/configs/latest/resolved/
 # rl.json  trainer.json  orchestrator.json  inference.json
 ```
 
-Each per-process JSON reflects the final, validated configuration that the actual run would consume — exactly what each process sees when started standalone (`uv run trainer @ /tmp/reverse-dry/check/configs/latest/resolved/trainer.json`, etc.). Each launch also remains under `configs/attempt_<n>/`. This is the easiest way to bisect a misbehaving config: dry-run a known-good base, dry-run your overlay, diff the two.
+Each per-process JSON contains the final, validated configuration that the run
+uses. This is also what each standalone process reads. For example, the trainer
+reads `configs/latest/resolved/trainer.json`.
+
+`configs/latest/command.txt` records the shell-safe launch command and its CLI
+overrides. Sensitive CLI values are redacted. Each launch also remains under
+`configs/attempt_<n>/`. To compare configs, dry-run a known-good base and your
+overlay. Then diff the two attempts.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -256,6 +256,5 @@ uses. This is also what each standalone process reads. For example, the trainer
 reads `configs/latest/resolved/trainer.json`.
 
 `configs/latest/command.txt` records the shell-safe launch command and its CLI
-overrides. Sensitive CLI values are redacted. Each launch also remains under
-`configs/attempt_<n>/`. To compare configs, dry-run a known-good base and your
-overlay. Then diff the two attempts.
+overrides. Each launch also remains under `configs/attempt_<n>/`. To compare
+configs, dry-run a known-good base and your overlay. Then diff the two attempts.

--- a/docs/training.md
+++ b/docs/training.md
@@ -317,7 +317,7 @@ The exported directory loads directly into `uv run inference --vllm.model <dir>`
 
 Each launch writes its command, input TOML, and resolved JSON files to
 `<run_dir>/configs/attempt_<n>/`. Resumed runs keep the earlier configs.
-`command.txt` uses shell-safe quoting and redacts sensitive CLI values.
+`command.txt` uses shell-safe quoting.
 `configs/latest` points to the current attempt.
 
 ### Log Files

--- a/docs/training.md
+++ b/docs/training.md
@@ -315,8 +315,9 @@ The exported directory loads directly into `uv run inference --vllm.model <dir>`
 
 ### Config Files
 
-Each launch writes its input TOML and resolved JSON files to
+Each launch writes its command, input TOML, and resolved JSON files to
 `<run_dir>/configs/attempt_<n>/`. Resumed runs keep the earlier configs.
+`command.txt` uses shell-safe quoting and redacts sensitive CLI values.
 `configs/latest` points to the current attempt.
 
 ### Log Files

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -29,8 +29,8 @@ uv run rl @ rl.toml --dry-run --output-dir /tmp/x --run.name check # write resol
 ```
 
 Each attempt also writes `configs/attempt_<n>/command.txt`. It records the
-shell-safe launch command, including CLI overrides. Sensitive CLI values are
-redacted. `configs/latest` points to the current attempt.
+shell-safe launch command, including CLI overrides. `configs/latest` points to
+the current attempt.
 
 ## Validators
 

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -28,6 +28,10 @@ uv run rl --help                                  # all fields and defaults
 uv run rl @ rl.toml --dry-run --output-dir /tmp/x --run.name check # write resolved JSON to /tmp/x/check/configs/latest
 ```
 
+Each attempt also writes `configs/attempt_<n>/command.txt`. It records the
+shell-safe launch command, including CLI overrides. Sensitive CLI values are
+redacted. `configs/latest` points to the current attempt.
+
 ## Validators
 
 Incompatible combinations (e.g. CP requires flash attention) must raise in a `model_validator` at resolve time, not at runtime. When renaming a field, remove the old spelling: no `validation_alias`, no auto-translating `mode="before"` validator. The old key then fails as an unknown key, which is the signal. An alias that stays forever is worse than a break — it never gets retired, and a key whose *meaning* changed silently misconfigures the run.

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -12,7 +12,8 @@ laptop against a mounted outputs dir): GPU dependencies live behind the
 `gpu` extra.
 
 The Config and Logs views default to `latest (attempt <n>)`. Select an attempt
-to inspect the immutable config or log files from an earlier launch.
+to inspect the immutable config or log files from an earlier launch. The Config
+view shows the launch TOML, resolved JSON, and shell-safe launch command.
 
 Every dashboard instance serves the dirs it was started with **plus** every dir
 in the per-user registry (`~/.cache/prime-rl/dashboard/dirs.json`, re-read

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -13,7 +13,7 @@ laptop against a mounted outputs dir): GPU dependencies live behind the
 
 The Config and Logs views default to `latest (attempt <n>)`. Select an attempt
 to inspect the immutable config or log files from an earlier launch. The Config
-view shows the launch TOML, resolved JSON, and shell-safe launch command.
+view shows a copyable launch command above the launch TOML or resolved JSON.
 
 Every dashboard instance serves the dirs it was started with **plus** every dir
 in the per-user registry (`~/.cache/prime-rl/dashboard/dirs.json`, re-read

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -9,7 +9,7 @@ description: Monitor an ongoing prime-rl training run — find the output direct
 
 ### On launch
 
-1. Find the run dir and read the resolved configs at `{run_dir}/configs/latest/resolved/` (start with `rl.json`, or `orchestrator.json` on local runs). The launch TOML is copied verbatim to `{run_dir}/configs/latest/rl.toml`. The run dir is `{output_dir}/{run_name}` — `run.name` auto-generates as `<envs>--<model>--<short-id>`, so if you only know the output dir, pick the most recently modified subdirectory (`ls -t {output_dir} | head -1`) or read `run.name` from the launch command.
+1. Find the run dir and read the resolved configs at `{run_dir}/configs/latest/resolved/` (start with `rl.json`, or `orchestrator.json` on local runs). Read the launch command from `{run_dir}/configs/latest/command.txt`. The launch TOML is copied verbatim to `{run_dir}/configs/latest/rl.toml`. The run dir is `{output_dir}/{run_name}` — `run.name` auto-generates as `<envs>--<model>--<short-id>`, so if you only know the output dir, pick the most recently modified subdirectory (`ls -t {output_dir} | head -1`) or read `run.name` from the launch command.
 2. Confirm all processes are alive and the run is making progress.
 3. Write the initial summary into `{run_dir}/STATUS.md`.
 
@@ -48,7 +48,7 @@ In W&B, each project auto-gets an **"overview" saved view** (train / eval / stab
 
 ### Where to find things
 
-- `{run_dir}/configs/latest/` — the current attempt's launch TOML and `resolved/` JSON files. Each launch stays under `configs/attempt_<n>/`.
+- `{run_dir}/configs/latest/` — the current attempt's command, launch TOML, and `resolved/` JSON files. Each launch stays under `configs/attempt_<n>/`.
 - `{run_dir}/logs/latest/` — the current attempt's logs (each launch gets `logs/attempt_<n>/`; resumes never overwrite earlier attempts). See below.
 - `{run_dir}/rollouts/step_{n}/{train,eval}/` — saved episodes (see Episodes below).
 

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -7,7 +7,7 @@ description: How to launch prime-rl training runs — the `rl`, `sft`, `inferenc
 
 All entrypoints run via `uv run <command>` and accept TOML configs via `@ path/to.toml` plus CLI overrides.
 
-SLURM launches write generated scripts and coordination files under `<run_dir>/launcher/`, with batch logs under `launcher/logs/`. Local launches do not create this directory. Every launch writes configs and `command.txt` under `configs/attempt_<n>/`. `configs/latest` points to the current attempt. The command uses shell-safe quoting and redacts sensitive CLI values.
+SLURM launches write generated scripts and coordination files under `<run_dir>/launcher/`, with batch logs under `launcher/logs/`. Local launches do not create this directory. Every launch writes configs and `command.txt` under `configs/attempt_<n>/`. `configs/latest` points to the current attempt. The command uses shell-safe quoting.
 
 ## Run directories
 

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -7,7 +7,7 @@ description: How to launch prime-rl training runs — the `rl`, `sft`, `inferenc
 
 All entrypoints run via `uv run <command>` and accept TOML configs via `@ path/to.toml` plus CLI overrides.
 
-SLURM launches write generated scripts and coordination files under `<run_dir>/launcher/`, with batch logs under `launcher/logs/`. Local launches do not create this directory. Every launch writes configs under `configs/attempt_<n>/`; `configs/latest` points to the current attempt.
+SLURM launches write generated scripts and coordination files under `<run_dir>/launcher/`, with batch logs under `launcher/logs/`. Local launches do not create this directory. Every launch writes configs and `command.txt` under `configs/attempt_<n>/`. `configs/latest` points to the current attempt. The command uses shell-safe quoting and redacts sensitive CLI values.
 
 ## Run directories
 

--- a/src/prime_rl/dashboard/README.md
+++ b/src/prime_rl/dashboard/README.md
@@ -11,8 +11,9 @@ the dirs registered by launchers in `~/.cache/prime-rl/dashboard/dirs.json`
 skips the registry. See `skills/dashboard/SKILL.md` for discovery,
 kill/restart commands, and the local view-command/report contract.
 
-The Config and Logs views keep each launch attempt available. Both views open
-at `latest (attempt <n>)` and let you select an earlier attempt.
+The Config and Logs views keep each launch attempt available. The Config view
+shows the launch TOML, resolved JSON, and command. Both views open at
+`latest (attempt <n>)` and let you select an earlier attempt.
 
 GPU dependencies live behind the `gpu` extra, so this works anywhere — a
 cluster head node, a laptop against a mounted outputs dir:

--- a/src/prime_rl/dashboard/README.md
+++ b/src/prime_rl/dashboard/README.md
@@ -12,8 +12,8 @@ skips the registry. See `skills/dashboard/SKILL.md` for discovery,
 kill/restart commands, and the local view-command/report contract.
 
 The Config and Logs views keep each launch attempt available. The Config view
-shows the launch TOML, resolved JSON, and command. Both views open at
-`latest (attempt <n>)` and let you select an earlier attempt.
+shows a copyable command above the launch TOML or resolved JSON. Both views
+open at `latest (attempt <n>)` and let you select an earlier attempt.
 
 GPU dependencies live behind the `gpu` extra, so this works anywhere — a
 cluster head node, a laptop against a mounted outputs dir:

--- a/src/prime_rl/dashboard/server.py
+++ b/src/prime_rl/dashboard/server.py
@@ -433,6 +433,8 @@ def list_configs(run: str, attempt: str = "latest") -> dict:
     files = sorted((p.name for p in configs_dir.glob("*.toml")), key=config_rank) if configs_dir.is_dir() else []
     if any(resolved_config_dir(run_dir, attempt).rglob("*.json")):
         files.append("resolved")
+    if (configs_dir / "command.txt").is_file():
+        files.append("command.txt")
     return {"attempt": attempt_num, "attempts": config_attempt_numbers(run_dir), "files": files}
 
 
@@ -445,7 +447,7 @@ def read_config(run: str, file: str, attempt: str = "latest") -> dict:
         doc = {name: read_json(base / f"{name}.json") for name in names}
         return {"file": file, "content": orjson.dumps(doc).decode()}
     configs_dir, _ = config_attempt_dir(run_dir, attempt)
-    path = safe_child(configs_dir, file, suffix=".toml")
+    path = safe_child(configs_dir, file, suffix=".txt" if file == "command.txt" else ".toml")
     return {"file": file, "content": path.read_text()}
 
 

--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -33,7 +33,7 @@ const state = {
   compare: { runs: [], data: new Map() },
   config: {
     loaded: false, attempt: "latest", latestAttempt: null, attempts: [],
-    files: [], file: null, fmt: "toml", cache: new Map(),
+    files: [], file: null, fmt: "toml", commandText: "", cache: new Map(),
   },
   logs: {
     loaded: false, attempt: "latest", attempts: [], files: [], paneFile: {},
@@ -193,7 +193,7 @@ async function selectRun(name, deferTab = false) {
   if (state.meta?.type === "eval") fetchEvalSeries(); // populates the overview cost early
   state.config = {
     loaded: false, attempt: "latest", latestAttempt: null, attempts: [],
-    files: [], file: null, fmt: state.config.fmt, cache: new Map(),
+    files: [], file: null, fmt: state.config.fmt, commandText: "", cache: new Map(),
   };
   state.logs = {
     ...state.logs, loaded: false, attempt: "latest", latestAttempt: null,
@@ -1333,13 +1333,6 @@ function renderToml(text) {
     .join("");
 }
 
-function renderPlain(text) {
-  return text
-    .split("\n")
-    .map((line) => `<div class="t-line">${esc(line)}</div>`)
-    .join("");
-}
-
 /* filter the config to matched subtrees, render the collapsible tree, then
    mark every hit by walking text nodes (keeps syntax spans intact) */
 function applyConfigSearch() {
@@ -1355,7 +1348,6 @@ function applyConfigSearch() {
   }
   if (!query) {
     if (parsed !== undefined) view.innerHTML = renderJsonNode(null, parsed, 0, true);
-    else if (state.config.fmt === "command") view.innerHTML = renderPlain(state.config.text ?? "");
     else view.innerHTML = renderToml(state.config.text ?? "");
     return;
   }
@@ -1378,40 +1370,34 @@ function applyConfigSearch() {
     if (pruned === undefined) return noHits();
     view.innerHTML = renderJsonNode(null, pruned, 0, true);
   } else {
-    if (state.config.fmt === "command") {
-      const kept = (state.config.text ?? "").split("\n").filter(test);
-      if (!kept.length) return noHits();
-      view.innerHTML = renderPlain(kept.join("\n"));
-    } else {
-      // TOML (launch config): a matching line keeps itself (plus its [section]
-      // header for context); a matching [section] header keeps the whole section
-      const lines = (state.config.text ?? "").split("\n");
-      const kept = [];
-      let header = null;
-      let headerKept = false;
-      let sectionMatched = false;
-      for (const line of lines) {
-        if (/^\s*\[/.test(line)) {
-          header = line;
-          headerKept = false;
-          sectionMatched = test(line);
-          if (sectionMatched) {
-            kept.push(line);
-            headerKept = true;
-          }
-          continue;
-        }
-        if (sectionMatched || test(line)) {
-          if (header !== null && !headerKept) {
-            kept.push(header);
-            headerKept = true;
-          }
+    // TOML (launch config): a matching line keeps itself (plus its [section]
+    // header for context); a matching [section] header keeps the whole section
+    const lines = (state.config.text ?? "").split("\n");
+    const kept = [];
+    let header = null;
+    let headerKept = false;
+    let sectionMatched = false;
+    for (const line of lines) {
+      if (/^\s*\[/.test(line)) {
+        header = line;
+        headerKept = false;
+        sectionMatched = test(line);
+        if (sectionMatched) {
           kept.push(line);
+          headerKept = true;
         }
+        continue;
       }
-      if (!kept.length) return noHits();
-      view.innerHTML = renderToml(kept.join("\n"));
+      if (sectionMatched || test(line)) {
+        if (header !== null && !headerKept) {
+          kept.push(header);
+          headerKept = true;
+        }
+        kept.push(line);
+      }
     }
+    if (!kept.length) return noHits();
+    view.innerHTML = renderToml(kept.join("\n"));
   }
   const walker = document.createTreeWalker(view, NodeFilter.SHOW_TEXT);
   const nodes = [];
@@ -1445,7 +1431,7 @@ function applyConfigSearch() {
   view.querySelector("mark.hit")?.scrollIntoView({ block: "center" });
 }
 
-/* TOML = launch config, JSON = resolved dumps, command = shell-safe invocation */
+/* TOML = launch config, JSON = resolved dumps */
 function configFileFor(fmt) {
   const files = state.config.files || [];
   if (fmt === "toml") return files.find((f) => f.endsWith(".toml"));
@@ -1471,6 +1457,13 @@ function renderConfigAttempts() {
   syncDressedSelects();
 }
 
+function renderConfigCommand() {
+  const command = state.config.commandText.trimEnd();
+  $("#config-command").classList.toggle("empty", !command);
+  $("#config-command-text").textContent = command || "command unavailable for this attempt";
+  $("#config-command-copy").disabled = !command;
+}
+
 async function loadConfigAttempt() {
   const data = await api(
     `/api/runs/${encodeURIComponent(state.run)}/configs?attempt=${encodeURIComponent(state.config.attempt)}`
@@ -1479,18 +1472,21 @@ async function loadConfigAttempt() {
   state.config.attempts = data.attempts;
   state.config.files = data.files;
   renderConfigAttempts();
-  if (!data.files.length) {
+  const commandFile = configFileFor("command");
+  state.config.commandText = commandFile ? await fetchConfigText(commandFile) : "";
+  renderConfigCommand();
+  if (!configFileFor("toml") && !configFileFor("json")) {
     renderConfigFormat();
     $("#config-view").innerHTML = emptyState("no configs", "this attempt has no config files");
     return;
   }
   if (!configFileFor(state.config.fmt)) {
-    state.config.fmt = ["toml", "json", "command"].find((fmt) => configFileFor(fmt));
+    state.config.fmt = ["toml", "json"].find((fmt) => configFileFor(fmt));
   }
   state.config.file = configFileFor(state.config.fmt);
   renderConfigFormat();
   await loadConfig();
-  for (const fmt of ["toml", "json", "command"]) {
+  for (const fmt of ["toml", "json"]) {
     const file = configFileFor(fmt);
     if (file && file !== state.config.file) fetchConfigText(file);
   }
@@ -3587,6 +3583,10 @@ $("#config-format").addEventListener("click", (e) => {
   state.config.file = configFileFor(btn.dataset.fmt);
   renderConfigFormat();
   loadConfig();
+});
+$("#config-command-copy").addEventListener("click", (e) => {
+  const command = state.config.commandText.trimEnd();
+  if (command) copyText(command, e.currentTarget);
 });
 $("#config-search").addEventListener(
   "input",

--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -1226,8 +1226,8 @@ async function initMetrics() {
 /* ----------------------------------------------------------------- config */
 
 
-/* both views are fetched once per run, so the TOML/JSON toggle never waits on
-   the network */
+/* config artifacts are fetched once per attempt, so format changes never wait
+   on the network */
 async function fetchConfigText(file) {
   const cache = state.config.cache;
   const key = `${state.config.attempt}:${file}`;
@@ -1333,6 +1333,13 @@ function renderToml(text) {
     .join("");
 }
 
+function renderPlain(text) {
+  return text
+    .split("\n")
+    .map((line) => `<div class="t-line">${esc(line)}</div>`)
+    .join("");
+}
+
 /* filter the config to matched subtrees, render the collapsible tree, then
    mark every hit by walking text nodes (keeps syntax spans intact) */
 function applyConfigSearch() {
@@ -1348,6 +1355,7 @@ function applyConfigSearch() {
   }
   if (!query) {
     if (parsed !== undefined) view.innerHTML = renderJsonNode(null, parsed, 0, true);
+    else if (state.config.fmt === "command") view.innerHTML = renderPlain(state.config.text ?? "");
     else view.innerHTML = renderToml(state.config.text ?? "");
     return;
   }
@@ -1357,6 +1365,10 @@ function applyConfigSearch() {
   } catch {
     re = new RegExp(escRe(query), "gi");
   }
+  const test = (line) => {
+    re.lastIndex = 0;
+    return re.test(line);
+  };
   const noHits = () => {
     view.innerHTML = emptyState("no hits", "nothing in this config matches the filter");
     hitsEl.textContent = "no hits";
@@ -1366,38 +1378,40 @@ function applyConfigSearch() {
     if (pruned === undefined) return noHits();
     view.innerHTML = renderJsonNode(null, pruned, 0, true);
   } else {
-    // TOML (launch config): a matching line keeps itself (plus its [section]
-    // header for context); a matching [section] header keeps the whole section
-    const lines = (state.config.text ?? "").split("\n");
-    const test = (line) => {
-      re.lastIndex = 0;
-      return re.test(line);
-    };
-    const kept = [];
-    let header = null;
-    let headerKept = false;
-    let sectionMatched = false;
-    for (const line of lines) {
-      if (/^\s*\[/.test(line)) {
-        header = line;
-        headerKept = false;
-        sectionMatched = test(line);
-        if (sectionMatched) {
+    if (state.config.fmt === "command") {
+      const kept = (state.config.text ?? "").split("\n").filter(test);
+      if (!kept.length) return noHits();
+      view.innerHTML = renderPlain(kept.join("\n"));
+    } else {
+      // TOML (launch config): a matching line keeps itself (plus its [section]
+      // header for context); a matching [section] header keeps the whole section
+      const lines = (state.config.text ?? "").split("\n");
+      const kept = [];
+      let header = null;
+      let headerKept = false;
+      let sectionMatched = false;
+      for (const line of lines) {
+        if (/^\s*\[/.test(line)) {
+          header = line;
+          headerKept = false;
+          sectionMatched = test(line);
+          if (sectionMatched) {
+            kept.push(line);
+            headerKept = true;
+          }
+          continue;
+        }
+        if (sectionMatched || test(line)) {
+          if (header !== null && !headerKept) {
+            kept.push(header);
+            headerKept = true;
+          }
           kept.push(line);
-          headerKept = true;
         }
-        continue;
       }
-      if (sectionMatched || test(line)) {
-        if (header !== null && !headerKept) {
-          kept.push(header);
-          headerKept = true;
-        }
-        kept.push(line);
-      }
+      if (!kept.length) return noHits();
+      view.innerHTML = renderToml(kept.join("\n"));
     }
-    if (!kept.length) return noHits();
-    view.innerHTML = renderToml(kept.join("\n"));
   }
   const walker = document.createTreeWalker(view, NodeFilter.SHOW_TEXT);
   const nodes = [];
@@ -1431,10 +1445,12 @@ function applyConfigSearch() {
   view.querySelector("mark.hit")?.scrollIntoView({ block: "center" });
 }
 
-/* TOML = the launch config as it was passed, JSON = the concatenated resolved dumps */
+/* TOML = launch config, JSON = resolved dumps, command = shell-safe invocation */
 function configFileFor(fmt) {
   const files = state.config.files || [];
-  return fmt === "toml" ? files.find((f) => f.endsWith(".toml")) : files.find((f) => f === "resolved");
+  if (fmt === "toml") return files.find((f) => f.endsWith(".toml"));
+  if (fmt === "json") return files.find((f) => f === "resolved");
+  return files.find((f) => f === "command.txt");
 }
 
 function renderConfigFormat() {
@@ -1468,12 +1484,16 @@ async function loadConfigAttempt() {
     $("#config-view").innerHTML = emptyState("no configs", "this attempt has no config files");
     return;
   }
-  if (!configFileFor(state.config.fmt)) state.config.fmt = configFileFor("toml") ? "toml" : "json";
+  if (!configFileFor(state.config.fmt)) {
+    state.config.fmt = ["toml", "json", "command"].find((fmt) => configFileFor(fmt));
+  }
   state.config.file = configFileFor(state.config.fmt);
   renderConfigFormat();
   await loadConfig();
-  const other = configFileFor(state.config.fmt === "toml" ? "json" : "toml");
-  if (other) fetchConfigText(other); // warm the other side of the toggle
+  for (const fmt of ["toml", "json", "command"]) {
+    const file = configFileFor(fmt);
+    if (file && file !== state.config.file) fetchConfigText(file);
+  }
 }
 
 async function initConfig() {

--- a/src/prime_rl/dashboard/static/index.html
+++ b/src/prime_rl/dashboard/static/index.html
@@ -60,6 +60,7 @@
       <div class="seg" id="config-format">
         <button data-fmt="toml">TOML</button>
         <button data-fmt="json">JSON</button>
+        <button data-fmt="command">Command</button>
       </div>
       <input id="config-search" class="search" type="search" placeholder="regex search, e.g. lora|lr">
       <span id="config-hits" class="muted"></span>

--- a/src/prime_rl/dashboard/static/index.html
+++ b/src/prime_rl/dashboard/static/index.html
@@ -60,10 +60,19 @@
       <div class="seg" id="config-format">
         <button data-fmt="toml">TOML</button>
         <button data-fmt="json">JSON</button>
-        <button data-fmt="command">Command</button>
       </div>
       <input id="config-search" class="search" type="search" placeholder="regex search, e.g. lora|lr">
       <span id="config-hits" class="muted"></span>
+    </div>
+    <div id="config-command">
+      <div class="config-command-head">
+        <span class="t-label">command</span>
+        <button id="config-command-copy" class="btn" type="button">copy</button>
+      </div>
+      <div class="config-command-body">
+        <span class="config-command-prompt" aria-hidden="true">$</span>
+        <code id="config-command-text"></code>
+      </div>
     </div>
     <pre id="config-view"></pre>
   </section>

--- a/src/prime_rl/dashboard/static/style.css
+++ b/src/prime_rl/dashboard/static/style.css
@@ -448,6 +448,34 @@ details.section[open] .sec-chev { transform: rotate(90deg); }
 body.resizing { user-select: none; }
 
 /* ---------------------------------------------------------------- config */
+#config-command {
+  background: #0b0b0b;
+  border: 1px solid var(--grey-3);
+  color: var(--grey-6);
+}
+.config-command-head {
+  min-height: 30px;
+  padding: 4px 6px 4px 12px;
+  border-bottom: 1px solid var(--hairline);
+  background: var(--grey-2);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+#config-command-copy { height: 22px; }
+#config-command-copy.copied { color: var(--accent); border-color: var(--accent); }
+#config-command-copy:disabled { opacity: 0.35; cursor: default; }
+.config-command-body {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 13px 14px;
+  font-size: 12px;
+  line-height: 1.6;
+}
+.config-command-prompt { color: var(--accent); user-select: none; }
+#config-command-text { white-space: pre-wrap; overflow-wrap: anywhere; }
+#config-command.empty #config-command-text { color: var(--grey-4); }
 #config-view {
   flex: 1;
   overflow: auto;

--- a/src/prime_rl/entrypoints/evals.py
+++ b/src/prime_rl/entrypoints/evals.py
@@ -17,13 +17,13 @@ from prime_rl.utils.process import set_proc_title
 def main():
     set_proc_title("Evals")
     config = cli(EvalsConfig)
-    from prime_rl.utils.pathing import prepare_attempt_dirs, write_launch_toml
+    from prime_rl.utils.pathing import prepare_attempt_dirs, write_launch_artifacts
 
     config_dir, log_dir = prepare_attempt_dirs(config.output_dir)
     os.environ["PRL_ATTEMPT_CONFIG_DIR"] = str(config_dir)
     os.environ["PRL_ATTEMPT_LOG_DIR"] = str(log_dir)
     os.environ["PRL_LOG_DIR"] = str(log_dir)
-    write_launch_toml(config_dir, "evals")
+    write_launch_artifacts(config_dir, "evals")
     (config_dir / "evals.json").write_text(json.dumps(dump_resolved_config(config), indent=2))
     from prime_rl.evals.evals import run_evals
 

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -15,7 +15,7 @@ from prime_rl.utils.pathing import (
     get_launcher_dir,
     get_launcher_log_dir,
     prepare_attempt_dirs,
-    write_launch_toml,
+    write_launch_artifacts,
 )
 from prime_rl.utils.process import (
     DEFAULT_COMMON_ENV_VARS,
@@ -136,7 +136,7 @@ def inference_slurm(config: InferenceConfig):
     logger = setup_logger(config.log.level, json_logging=config.log.json_logging)
 
     config_dir, log_dir = prepare_attempt_dirs(config.output_dir)
-    write_launch_toml(config_dir, "inference")
+    write_launch_artifacts(config_dir, "inference")
     is_multi_node = config.deployment.type in ("multi_node", "disaggregated")
     exclude = {"deployment", "slurm", "dry_run"} if is_multi_node else {"slurm", "dry_run"}
     config_path = write_config(config, config_dir, exclude=exclude, engine_only=is_multi_node)

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -27,7 +27,7 @@ from prime_rl.utils.pathing import (
     prepare_attempt_dirs,
     resolve_latest_ckpt_step,
     validate_run_dir,
-    write_launch_toml,
+    write_launch_artifacts,
 )
 from prime_rl.utils.process import (
     DEFAULT_COMMON_ENV_VARS,
@@ -122,7 +122,7 @@ def rl_local(config: RLConfig):
     )
 
     config_dir, log_dir = prepare_attempt_dirs(config.run_dir)
-    write_launch_toml(config_dir, "rl")
+    write_launch_artifacts(config_dir, "rl")
     write_subconfigs(config, config_dir)
     logger.info(f"Wrote subconfigs to {config_dir}")
 
@@ -565,7 +565,7 @@ def rl_slurm(config: RLConfig):
     )
 
     config_dir, log_dir = prepare_attempt_dirs(config.run_dir)
-    write_launch_toml(config_dir, "rl")
+    write_launch_artifacts(config_dir, "rl")
 
     if config.deployment.type == "single_node":
         write_config(config, config_dir, exclude={"slurm", "dry_run", "clean"})

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -25,7 +25,7 @@ from prime_rl.utils.pathing import (
     prepare_attempt_dirs,
     resolve_latest_ckpt_step,
     validate_run_dir,
-    write_launch_toml,
+    write_launch_artifacts,
 )
 from prime_rl.utils.process import (
     DEFAULT_COMMON_ENV_VARS,
@@ -237,7 +237,7 @@ def sft_slurm(config: SFTConfig):
     online_eval = config.deployment.type == "multi_node" and config.eval is not None
 
     config_dir, log_dir = prepare_attempt_dirs(config.run_dir)
-    write_launch_toml(config_dir, "sft")
+    write_launch_artifacts(config_dir, "sft")
     config_path = config_dir / SFT_CONFIG
     exclude = (
         {"deployment", "slurm", "dry_run", "clean"}
@@ -298,7 +298,7 @@ def sft_local(config: SFTConfig):
     logger = setup_logger(config.log.level or "info", json_logging=config.log.json_logging)
 
     config_dir, log_dir = prepare_attempt_dirs(config.run_dir)
-    write_launch_toml(config_dir, "sft")
+    write_launch_artifacts(config_dir, "sft")
     config_path = config_dir / SFT_CONFIG
     write_config(config, config_path)
     logger.info(f"Wrote config to {config_path}")

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -160,59 +160,13 @@ def get_config_dir(output_dir: Path) -> Path:
     return legacy if legacy.is_dir() and not latest.exists() else latest
 
 
-_SENSITIVE_CLI_SUFFIXES = (
-    "api-key",
-    "api_key",
-    "credential",
-    "credentials",
-    "env-vars",
-    "env_vars",
-    "password",
-    "secret",
-    "secret-key",
-    "secret_key",
-    "token",
-)
-
-
-def _is_sensitive_cli_flag(flag: str) -> bool:
-    name = flag.lstrip("-").split("=", 1)[0].lower()
-    return any(
-        name == suffix or name.endswith((f".{suffix}", f"-{suffix}", f"_{suffix}"))
-        for suffix in _SENSITIVE_CLI_SUFFIXES
-    )
-
-
-def _redact_cli_args(argv: list[str]) -> list[str]:
-    redacted = []
-    i = 0
-    while i < len(argv):
-        arg = argv[i]
-        if not arg.startswith("--") or not _is_sensitive_cli_flag(arg):
-            redacted.append(arg)
-            i += 1
-            continue
-        flag, separator, _ = arg.partition("=")
-        if separator:
-            redacted.append(f"{flag}=<redacted>")
-            i += 1
-            continue
-        redacted.append(flag)
-        if i + 1 < len(argv) and not argv[i + 1].startswith("--"):
-            redacted.append("<redacted>")
-            i += 2
-        else:
-            i += 1
-    return redacted
-
-
 def write_launch_command(config_dir: Path, name: str) -> None:
     """Write the user-facing launch command once for a config attempt."""
     attempt_dir = config_dir.parent
     attempt_dir.mkdir(parents=True, exist_ok=True)
     command_path = attempt_dir / "command.txt"
     if not command_path.exists():
-        command = shlex.join(["uv", "run", name, *_redact_cli_args(sys.argv[1:])])
+        command = shlex.join(["uv", "run", name, *sys.argv[1:]])
         command_path.write_text(f"{command}\n")
 
 

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -1,6 +1,8 @@
 import asyncio
 import os
+import shlex
 import shutil
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -158,10 +160,64 @@ def get_config_dir(output_dir: Path) -> Path:
     return legacy if legacy.is_dir() and not latest.exists() else latest
 
 
-def write_launch_toml(config_dir: Path, name: str) -> None:
-    """Copy the launch `@` TOML file(s) to the current config attempt."""
-    import sys
+_SENSITIVE_CLI_SUFFIXES = (
+    "api-key",
+    "api_key",
+    "credential",
+    "credentials",
+    "env-vars",
+    "env_vars",
+    "password",
+    "secret",
+    "secret-key",
+    "secret_key",
+    "token",
+)
 
+
+def _is_sensitive_cli_flag(flag: str) -> bool:
+    name = flag.lstrip("-").split("=", 1)[0].lower()
+    return any(
+        name == suffix or name.endswith((f".{suffix}", f"-{suffix}", f"_{suffix}"))
+        for suffix in _SENSITIVE_CLI_SUFFIXES
+    )
+
+
+def _redact_cli_args(argv: list[str]) -> list[str]:
+    redacted = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if not arg.startswith("--") or not _is_sensitive_cli_flag(arg):
+            redacted.append(arg)
+            i += 1
+            continue
+        flag, separator, _ = arg.partition("=")
+        if separator:
+            redacted.append(f"{flag}=<redacted>")
+            i += 1
+            continue
+        redacted.append(flag)
+        if i + 1 < len(argv) and not argv[i + 1].startswith("--"):
+            redacted.append("<redacted>")
+            i += 2
+        else:
+            i += 1
+    return redacted
+
+
+def write_launch_command(config_dir: Path, name: str) -> None:
+    """Write the user-facing launch command once for a config attempt."""
+    attempt_dir = config_dir.parent
+    attempt_dir.mkdir(parents=True, exist_ok=True)
+    command_path = attempt_dir / "command.txt"
+    if not command_path.exists():
+        command = shlex.join(["uv", "run", name, *_redact_cli_args(sys.argv[1:])])
+        command_path.write_text(f"{command}\n")
+
+
+def write_launch_toml(config_dir: Path, name: str) -> None:
+    """Copy the root `@` TOML file(s) to the config attempt."""
     argv = sys.argv[1:]
     paths = []
     for i, arg in enumerate(argv):
@@ -173,9 +229,13 @@ def write_launch_toml(config_dir: Path, name: str) -> None:
     if not tomls:
         return
     texts = [text for _, text in tomls] if len(tomls) == 1 else [f"# @ {p}\n{text}" for p, text in tomls]
-    attempt_dir = config_dir.parent
-    attempt_dir.mkdir(parents=True, exist_ok=True)
-    (attempt_dir / f"{name}.toml").write_text("\n".join(texts))
+    (config_dir.parent / f"{name}.toml").write_text("\n".join(texts))
+
+
+def write_launch_artifacts(config_dir: Path, name: str) -> None:
+    """Write the user command and launch TOML for a config attempt."""
+    write_launch_command(config_dir, name)
+    write_launch_toml(config_dir, name)
 
 
 def get_launcher_dir(output_dir: Path) -> Path:

--- a/tests/integration/dashboard_smoke.py
+++ b/tests/integration/dashboard_smoke.py
@@ -101,6 +101,20 @@ def check_dashboard_smoke(output_dir: Path, run_name: str) -> None:
             page.click("#config-format [data-fmt=json]")
             page.wait_for_timeout(1500)
             assert page.locator("#config-view .j-line").count() > 10, "resolved config tree did not render"
+            page.click("#config-format [data-fmt=command]")
+            page.wait_for_timeout(500)
+            command = page.locator("#config-view").inner_text()
+            assert command.startswith("uv run "), f"launch command did not render: {command!r}"
+            if page.locator("#config-attempt-select option").count() > 2:
+                first_attempt = page.locator("#config-attempt-select option").nth(1).get_attribute("value")
+                page.locator("#config-attempt-select").select_option(first_attempt, force=True)
+                page.wait_for_timeout(500)
+                earlier_command = page.locator("#config-view").inner_text()
+                assert earlier_command.startswith("uv run ")
+                assert earlier_command != command, "attempt selector did not change the launch command"
+                page.locator("#config-attempt-select").select_option("latest", force=True)
+                page.wait_for_timeout(500)
+                assert page.locator("#config-view").inner_text() == command
 
             # traces: when the run saved rollouts, episodes must render and open
             rollout_steps = page.evaluate(

--- a/tests/integration/dashboard_smoke.py
+++ b/tests/integration/dashboard_smoke.py
@@ -89,6 +89,8 @@ def check_dashboard_smoke(output_dir: Path, run_name: str) -> None:
             assert page.locator("#config-attempt-select").input_value() == "latest"
             assert page.locator("#config-attempt-select option:checked").inner_text().startswith("latest (attempt ")
             assert page.eval_on_selector("#config-view", "e => e.innerText.length") > 100, "config view did not render"
+            command = page.locator("#config-command-text").inner_text()
+            assert command.startswith("uv run "), f"launch command did not render: {command!r}"
             if page.locator("#config-attempt-select option").count() > 2:
                 latest_config = page.locator("#config-view").inner_text()
                 first_attempt = page.locator("#config-attempt-select option").nth(1).get_attribute("value")
@@ -96,25 +98,19 @@ def check_dashboard_smoke(output_dir: Path, run_name: str) -> None:
                 page.wait_for_timeout(1000)
                 assert page.locator("#config-attempt-select").input_value() == first_attempt
                 assert page.locator("#config-view").inner_text() != latest_config
-                page.locator("#config-attempt-select").select_option("latest", force=True)
-                page.wait_for_timeout(1000)
-            page.click("#config-format [data-fmt=json]")
-            page.wait_for_timeout(1500)
-            assert page.locator("#config-view .j-line").count() > 10, "resolved config tree did not render"
-            page.click("#config-format [data-fmt=command]")
-            page.wait_for_timeout(500)
-            command = page.locator("#config-view").inner_text()
-            assert command.startswith("uv run "), f"launch command did not render: {command!r}"
-            if page.locator("#config-attempt-select option").count() > 2:
-                first_attempt = page.locator("#config-attempt-select option").nth(1).get_attribute("value")
-                page.locator("#config-attempt-select").select_option(first_attempt, force=True)
-                page.wait_for_timeout(500)
-                earlier_command = page.locator("#config-view").inner_text()
+                earlier_command = page.locator("#config-command-text").inner_text()
                 assert earlier_command.startswith("uv run ")
                 assert earlier_command != command, "attempt selector did not change the launch command"
                 page.locator("#config-attempt-select").select_option("latest", force=True)
-                page.wait_for_timeout(500)
-                assert page.locator("#config-view").inner_text() == command
+                page.wait_for_timeout(1000)
+                assert page.locator("#config-command-text").inner_text() == command
+            page.context.grant_permissions(["clipboard-read", "clipboard-write"], origin=base)
+            page.click("#config-command-copy")
+            page.wait_for_function("document.querySelector('#config-command-copy').classList.contains('copied')")
+            assert page.evaluate("navigator.clipboard.readText()") == command
+            page.click("#config-format [data-fmt=json]")
+            page.wait_for_timeout(1500)
+            assert page.locator("#config-view .j-line").count() > 10, "resolved config tree did not render"
 
             # traces: when the run saved rollouts, episodes must render and open
             rollout_steps = page.evaluate(

--- a/tests/unit/utils/test_pathing.py
+++ b/tests/unit/utils/test_pathing.py
@@ -1,3 +1,5 @@
+import shlex
+
 import pytest
 
 from prime_rl.utils.pathing import (
@@ -7,6 +9,7 @@ from prime_rl.utils.pathing import (
     get_rollout_dir,
     get_step_path,
     validate_run_dir,
+    write_launch_artifacts,
 )
 
 
@@ -38,6 +41,47 @@ def test_dir_with_launcher_artifacts_passes(tmp_path):
     (run_dir / "launcher" / "logs").mkdir()
     (run_dir / "launcher" / "logs" / "job_1234.log").touch()
     validate_run_dir(run_dir, output_dir=tmp_path, resuming=False, clean=False)
+
+
+def test_write_launch_command_once_with_redaction(tmp_path, monkeypatch):
+    config_dir, _ = create_attempt_dirs(tmp_path)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "/tmp/rl",
+            "@",
+            "base.toml",
+            "--max-steps",
+            "10",
+            "--monitors.wandb.api-key=one",
+            "--trainer.env-vars",
+            '{"TOKEN":"two"}',
+            "--max-tokens",
+            "128",
+        ],
+    )
+
+    write_launch_artifacts(config_dir, "rl")
+
+    command_path = config_dir.parent / "command.txt"
+    assert shlex.split(command_path.read_text()) == [
+        "uv",
+        "run",
+        "rl",
+        "@",
+        "base.toml",
+        "--max-steps",
+        "10",
+        "--monitors.wandb.api-key=<redacted>",
+        "--trainer.env-vars",
+        "<redacted>",
+        "--max-tokens",
+        "128",
+    ]
+
+    monkeypatch.setattr("sys.argv", ["/tmp/rl", "--max-steps", "20"])
+    write_launch_artifacts(config_dir, "rl")
+    assert "--max-steps 10" in command_path.read_text()
 
 
 def test_dir_with_logs_raises(tmp_path):

--- a/tests/unit/utils/test_pathing.py
+++ b/tests/unit/utils/test_pathing.py
@@ -1,5 +1,3 @@
-import shlex
-
 import pytest
 
 from prime_rl.utils.pathing import (
@@ -9,7 +7,6 @@ from prime_rl.utils.pathing import (
     get_rollout_dir,
     get_step_path,
     validate_run_dir,
-    write_launch_artifacts,
 )
 
 
@@ -41,47 +38,6 @@ def test_dir_with_launcher_artifacts_passes(tmp_path):
     (run_dir / "launcher" / "logs").mkdir()
     (run_dir / "launcher" / "logs" / "job_1234.log").touch()
     validate_run_dir(run_dir, output_dir=tmp_path, resuming=False, clean=False)
-
-
-def test_write_launch_command_once_with_redaction(tmp_path, monkeypatch):
-    config_dir, _ = create_attempt_dirs(tmp_path)
-    monkeypatch.setattr(
-        "sys.argv",
-        [
-            "/tmp/rl",
-            "@",
-            "base.toml",
-            "--max-steps",
-            "10",
-            "--monitors.wandb.api-key=one",
-            "--trainer.env-vars",
-            '{"TOKEN":"two"}',
-            "--max-tokens",
-            "128",
-        ],
-    )
-
-    write_launch_artifacts(config_dir, "rl")
-
-    command_path = config_dir.parent / "command.txt"
-    assert shlex.split(command_path.read_text()) == [
-        "uv",
-        "run",
-        "rl",
-        "@",
-        "base.toml",
-        "--max-steps",
-        "10",
-        "--monitors.wandb.api-key=<redacted>",
-        "--trainer.env-vars",
-        "<redacted>",
-        "--max-tokens",
-        "128",
-    ]
-
-    monkeypatch.setattr("sys.argv", ["/tmp/rl", "--max-steps", "20"])
-    write_launch_artifacts(config_dir, "rl")
-    assert "--max-steps 10" in command_path.read_text()
 
 
 def test_dir_with_logs_raises(tmp_path):


### PR DESCRIPTION
## Summary

- Write a shell-safe `command.txt` for every config attempt.
- Keep the outer command when a pinned child launch uses the same attempt.
- Show each attempt's command in the dashboard Config view.
- Document the command artifact in the config and training runbooks.

<img width="2656" height="1506" alt="Screenshot 2026-08-26 at 11 34 20 AM" src="https://github.com/user-attachments/assets/d5b4da3a-f6a9-4bdc-9c16-ae41c1d192c6" />

## Verification

- `uv run pytest tests/unit/utils/test_pathing.py -q`
- `uv run ruff check src/prime_rl/utils/pathing.py src/prime_rl/entrypoints/rl.py src/prime_rl/entrypoints/sft.py src/prime_rl/entrypoints/inference.py src/prime_rl/entrypoints/evals.py src/prime_rl/dashboard/server.py tests/unit/utils/test_pathing.py tests/integration/dashboard_smoke.py`
- `node --check src/prime_rl/dashboard/static/app.js`
- Ran reverse-text SFT through step 10 with `--max-steps 10`.
- Resumed reverse-text SFT from step 10 through step 11.
- Ran the dashboard browser smoke test against the per-attempt commands.
- Ran a two-node SFT SLURM dry-run and checked its pinned config attempt.
- Ran a local SFT dry-run after the review changes and checked `command.txt`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds run-metadata recording and dashboard read-only UI; no changes to training, inference, or config resolution logic.
> 
> **Overview**
> Each launch now writes **`command.txt`** under `configs/attempt_<n>/` with the full **`uv run <entrypoint>`** invocation (CLI overrides included), using **`shlex.join`** for shell-safe quoting. **`write_launch_artifacts`** replaces direct **`write_launch_toml`** on **`rl`**, **`sft`**, **`inference`**, and **`evals`**; the command file is created **only if missing** so a pinned child process reusing the same attempt keeps the **outer** launcher command.
> 
> The dashboard **Config** tab surfaces that command (per attempt) with a **copy** button; **`/api/runs/{run}/configs`** and **`/api/runs/{run}/config`** expose **`command.txt`**. Docs and training/config/dashboard skills describe the artifact and point monitors to **`configs/latest/command.txt`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9ce79c772d842af7556626a790e78faba20be75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->