### PR TITLE
feat(sft): native verifiers-trace data source — train straight off traces.jsonl

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -144,7 +144,25 @@ class SFTValConfig(BaseConfig):
     data: SFTDataConfig
 
 
-DataConfig: TypeAlias = Annotated[FakeDataConfig | SFTDataConfig, Field(discriminator="type")]
+class VerifiersDataConfig(BaseDataConfig):
+    type: Literal["verifiers"] = "verifiers"
+
+    path: str
+    """Path to a verifiers `traces.jsonl` — one episode record per line, as the
+    eval CLI (and any `write_episode` producer) emits. Bare-trace lines (a
+    message graph at top level) are accepted too."""
+
+    shuffle: bool = True
+    """Shuffle the expanded samples at the start of each epoch."""
+
+    seed: int = 0
+    """Random seed for shuffling. Re-shuffled per epoch by adding the epoch count to the seed."""
+
+    loss_mask: LossMaskConfig = LossMaskConfig()
+    """Which message types contribute to the loss."""
+
+
+DataConfig: TypeAlias = Annotated[FakeDataConfig | SFTDataConfig | VerifiersDataConfig, Field(discriminator="type")]
 
 
 class BaseDeploymentConfig(BaseConfig):

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -638,6 +638,85 @@ def load_sft_dataset(config: SFTDataConfig) -> Dataset:
         )
 
 
+
+
+def _trace_branches(nodes: list[dict]) -> list[list[dict]]:
+    """Every root-to-leaf message path of a trace's node graph, in leaf order —
+    one training sample per branch, so subagent side-threads and
+    pre-compaction histories all train (shared sampled prefixes are cheap
+    duplication offline; the online path dedups them by token mask)."""
+    parents = {i: n.get("parent") for i, n in enumerate(nodes)}
+    non_leaves = {p for p in parents.values() if p is not None}
+    branches = []
+    for leaf in range(len(nodes)):
+        if leaf in non_leaves:
+            continue
+        path, cur = [], leaf
+        while cur is not None:
+            path.append(cur)
+            cur = parents.get(cur)
+        branches.append([nodes[i]["message"] for i in reversed(path)])
+    return branches
+
+
+def _oai_message(msg: dict) -> dict:
+    out = {"role": msg["role"], "content": msg.get("content") or ""}
+    if msg.get("reasoning_content"):
+        out["reasoning_content"] = msg["reasoning_content"]
+    if msg.get("tool_calls"):
+        out["tool_calls"] = [
+            {"id": tc.get("id"), "type": "function",
+             "function": {"name": tc.get("name"), "arguments": tc.get("arguments") or "{}"}}
+            for tc in msg["tool_calls"]
+        ]
+    if msg["role"] == "tool":
+        out["tool_call_id"] = msg.get("tool_call_id")
+        if msg.get("name"):
+            out["name"] = msg["name"]
+    return out
+
+
+def load_verifiers_traces(config) -> Dataset:
+    """Expand a verifiers traces.jsonl into SFT message rows: every trace whose
+    agent stands trainable, every message-graph branch. Rows carry the same
+    `messages`/`tools` shape the SFT path consumes, so masking, rendering, and
+    packing reuse the proven pipeline; trace identity (agent name, episode ok,
+    branch bookkeeping) rides extra columns for provenance."""
+    rows = []
+    n_lines = n_untrainable = 0
+    with open(config.path, encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            n_lines += 1
+            record = json.loads(line)
+            # An episode line carries `traces`; a bare-trace line IS one trace.
+            traces = record.get("traces") if "traces" in record and "nodes" not in record else [record]
+            for trace in traces or []:
+                agent = trace.get("agent") or {}
+                if agent.get("trainable") is False:
+                    n_untrainable += 1
+                    continue
+                branches = [b for b in _trace_branches(trace.get("nodes") or []) if any(m.get("role") == "assistant" for m in b)]
+                for b_i, branch in enumerate(branches):
+                    rows.append(
+                        {
+                            "messages": [_oai_message(m) for m in branch],
+                            "tools": trace.get("tools") or [],
+                            "agent": agent.get("name") or "",
+                            "episode_ok": record.get("ok"),
+                            "branch": b_i,
+                            "n_branches": len(branches),
+                        }
+                    )
+    if not rows:
+        raise ValueError(f"no trainable samples in {config.path} ({n_lines} lines, {n_untrainable} untrainable traces)")
+    get_logger().info(
+        f"Expanded {config.path}: {n_lines} lines -> {len(rows)} samples ({n_untrainable} untrainable traces skipped)"
+    )
+    return Dataset.from_list(rows)
+
+
 def setup_dataset(
     tokenizer: PreTrainedTokenizer,
     config: DataConfig,
@@ -655,6 +734,20 @@ def setup_dataset(
             length=config.length,
             input_ids=config.input_ids,
             seed=config.seed,
+        )
+    elif config.type == "verifiers":
+        if renderer is None:
+            raise ValueError("Verifiers trace data requires a renderer.")
+        return SFTDataset(
+            load_verifiers_traces(config),
+            renderer,
+            shuffle=config.shuffle,
+            seed=config.seed,
+            seq_len=config.seq_len,
+            loss_mask_config=config.loss_mask,
+            non_dp_size=non_dp_size,
+            max_epochs=max_epochs,
+            multimodal=multimodal,
         )
     elif config.type == "sft":
         if renderer is None:

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -638,8 +638,6 @@ def load_sft_dataset(config: SFTDataConfig) -> Dataset:
         )
 
 
-
-
 def _trace_branches(nodes: list[dict]) -> list[list[dict]]:
     """Every root-to-leaf message path of a trace's node graph, in leaf order —
     one training sample per branch, so subagent side-threads and
@@ -665,8 +663,11 @@ def _oai_message(msg: dict) -> dict:
         out["reasoning_content"] = msg["reasoning_content"]
     if msg.get("tool_calls"):
         out["tool_calls"] = [
-            {"id": tc.get("id"), "type": "function",
-             "function": {"name": tc.get("name"), "arguments": tc.get("arguments") or "{}"}}
+            {
+                "id": tc.get("id"),
+                "type": "function",
+                "function": {"name": tc.get("name"), "arguments": tc.get("arguments") or "{}"},
+            }
             for tc in msg["tool_calls"]
         ]
     if msg["role"] == "tool":
@@ -697,7 +698,9 @@ def load_verifiers_traces(config) -> Dataset:
                 if agent.get("trainable") is False:
                     n_untrainable += 1
                     continue
-                branches = [b for b in _trace_branches(trace.get("nodes") or []) if any(m.get("role") == "assistant" for m in b)]
+                branches = [
+                    b for b in _trace_branches(trace.get("nodes") or []) if any(m.get("role") == "assistant" for m in b)
+                ]
                 for b_i, branch in enumerate(branches):
                     rows.append(
                         {


### PR DESCRIPTION
Closes the loop for trace-collection envs (the swe factory's eval lane in prime-envs-private#113): `uv run eval` → `traces.jsonl` → `uv run sft`, no manual export step.

## What changed
- **`VerifiersDataConfig` (`type = "verifiers"`)**: `path` to a `traces.jsonl` — one episode record per line as the eval CLI (any `write_episode` producer) emits; bare-trace lines (a message graph at top level) are accepted too, matching verifiers' own `sniff_episode` convention.
- **`load_verifiers_traces`** expands the file at load: every trace whose `agent.trainable` stands (envs decide; the flag is honored, not policy'd here) yields **one sample per message-graph branch** — subagent side-threads and pre-compaction histories included, the same branch semantics the online path trains (offline, shared sampled prefixes are cheap duplication; branch/n_branches ride the row for de-weighting). Tool calls convert to OAI nested-function form; `agent` name and `episode_ok` ride extra columns for provenance.
- Rows land in the exact `messages`/`tools` shape `SFTDataset` already consumes, so **masking (`loss_mask`), rendering, and packing reuse the proven pipeline unchanged**; the typed-renderer requirement applies as for any real-sample run.

```toml
[data]
type = "verifiers"
path = "outputs/factory-run/traces.jsonl"
```

## Verified
- Loader logic exercised end-to-end on a synthetic file (episode line + bare-trace line + untrainable trace): 4 samples from 2 trainable traces × 2 branches, untrainable skipped, subagent branch present, OAI tool_calls shape.
- ruff clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SFT data path that reuses the existing SFTDataset pipeline; main risk is mis-expanded branches or OAI conversion affecting training data quality, not core training or security logic.
> 
> **Overview**
> Adds a **`verifiers`** SFT data type so training can read **`traces.jsonl`** directly (eval / `write_episode` output), skipping a manual export step.
> 
> **Config:** `VerifiersDataConfig` points at a JSONL file and exposes the same shuffle, seed, and **`loss_mask`** knobs as standard SFT data. The shared **`DataConfig`** discriminated union now includes this type.
> 
> **Loading:** `load_verifiers_traces` parses episode lines (`traces` array) and bare single-trace lines, skips traces with **`agent.trainable === false`**, walks each trace’s node graph to emit **one row per root-to-leaf branch** (branches without an assistant message are dropped), normalizes messages to OAI shape (including tool calls), and attaches provenance fields (`agent`, `episode_ok`, `branch`, `n_branches`). Rows feed the existing **`SFTDataset`** path in **`setup_dataset`**, so rendering, masking, and packing stay unchanged; a typed renderer is still required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fd0ddb618a37a6ed11b904e590c3e48bdd84ad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->