### PR TITLE
feat(evals): add resumable standalone runs

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/evals.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/evals.py
@@ -4,7 +4,7 @@ from pydantic import Field, model_validator
 
 from prime_rl.configs.monitors import MonitorsConfig
 from prime_rl.configs.orchestrator import ConcurrencyConfig, EvalConfig
-from prime_rl.configs.shared import ClientConfig, LogConfig
+from prime_rl.configs.shared import ClientConfig, LogConfig, ResumeConfig
 from prime_rl.configs.trainer import WeightBroadcastConfig
 from prime_rl.utils.config import BaseConfig, default_output_dir
 
@@ -66,6 +66,13 @@ class OnlineConfig(BaseConfig):
     this step."""
 
 
+class CheckpointConfig(BaseConfig):
+    """Checkpoint progress for an interruptible standalone eval run."""
+
+    interval: int = Field(1, ge=1)
+    """Save after every N completed task groups."""
+
+
 class EvalsConfig(BaseConfig):
     """``uv run evals``: run the configured evals against a live inference server.
     Standalone (no ``[online]``), one epoch of every eval source runs against the
@@ -95,6 +102,12 @@ class EvalsConfig(BaseConfig):
     """Directory to write outputs to — rollout traces and logs are written as
     subdirectories. Shared with the trainer for online evals. Defaults to ``$PRL_OUTPUT_DIR`` if set, else ``outputs``."""
 
+    ckpt: CheckpointConfig | None = None
+    """Checkpoint standalone eval progress. Checkpoint steps count completed task groups."""
+
+    resume: ResumeConfig | None = None
+    """Resume a standalone eval run from a group checkpoint. A bare block loads the latest checkpoint."""
+
     log: LogConfig = LogConfig()
 
     monitors: MonitorsConfig = MonitorsConfig()
@@ -115,5 +128,14 @@ class EvalsConfig(BaseConfig):
             raise ValueError(
                 "eval.skip_first_step only applies to online evals - a standalone run "
                 "would skip its only eval epoch. Remove it or add an [online] block."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_checkpointing_is_standalone_only(self):
+        if self.online is not None and (self.ckpt is not None or self.resume is not None):
+            raise ValueError(
+                "evals ckpt/resume only supports standalone evals - online evals are coordinated "
+                "with the trainer's live weight-broadcast lifecycle"
             )
         return self

--- a/packages/prime-rl-configs/src/prime_rl/configs/evals.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/evals.py
@@ -70,7 +70,7 @@ class CheckpointConfig(BaseConfig):
     """Checkpoint progress for an interruptible standalone eval run."""
 
     interval: int = Field(1, ge=1)
-    """Save after every N completed task groups."""
+    """Save after the task cursor advances by N completed groups."""
 
 
 class EvalsConfig(BaseConfig):
@@ -103,10 +103,10 @@ class EvalsConfig(BaseConfig):
     subdirectories. Shared with the trainer for online evals. Defaults to ``$PRL_OUTPUT_DIR`` if set, else ``outputs``."""
 
     ckpt: CheckpointConfig | None = None
-    """Checkpoint standalone eval progress. Checkpoint steps count completed task groups."""
+    """Checkpoint standalone eval progress. Checkpoint steps are task cursor positions."""
 
     resume: ResumeConfig | None = None
-    """Resume a standalone eval run from a group checkpoint. A bare block loads the latest checkpoint."""
+    """Resume a standalone eval run from a cursor checkpoint. A bare block loads the latest checkpoint."""
 
     log: LogConfig = LogConfig()
 

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -96,7 +96,7 @@ curl http://localhost:8000/v1/chat/completions \
 
 ## `evals` — multi-env evals
 
-Runs the configured eval sources against a live inference server. Standalone (no `[online]` block): one epoch of every source against the served weights, then exit. Add `[ckpt]` (`interval` counts completed task groups) to make the run interruptible, then use `--resume`, `--resume.step N`, or `--resume.dir path/to/checkpoints/step_N`; for standalone evals, checkpoint step N means N completed task groups. Partially completed groups are retried. Resume loads without `[ckpt]` but does not save new checkpoints. Checkpoint/resume is rejected with `[online]` because that process is coupled to the trainer's live broadcast handshake. With `[online]` (`broadcasts_dir`, `max_steps`, `resume_step`): watch the broadcasts dir for stable `step_{n}` weight broadcasts and evaluate each — the `sft` launcher writes this config for online evals. By default a newer checkpoint cancels unfinished episodes from the prior eval. Set `eval.cancel_on_new_checkpoint = false` to drain every epoch. The trainer can idle while it waits for slow evals. Launcher-managed SFT evals use NCCL weight broadcast by default, including multi-node SLURM deployments. LoRA and external inference use filesystem broadcast.
+Runs the configured eval sources against a live inference server. Standalone (no `[online]` block): one epoch of every source against the served weights, then exit. Add `[ckpt]` (`interval` counts completed task groups in the eval-source order) to make the run interruptible, then use `--resume`, `--resume.step N`, or `--resume.dir path/to/checkpoints/step_N`; for standalone evals, checkpoint step N means resume from task cursor N. Checkpoints store only the cursor, not generated episode records; partially completed groups and groups beyond the durable cursor are retried. Resume loads without `[ckpt]` but does not save new checkpoints. Checkpoint/resume is rejected with `[online]` because that process is coupled to the trainer's live broadcast handshake. With `[online]` (`broadcasts_dir`, `max_steps`, `resume_step`): watch the broadcasts dir for stable `step_{n}` weight broadcasts and evaluate each — the `sft` launcher writes this config for online evals. By default a newer checkpoint cancels unfinished episodes from the prior eval. Set `eval.cancel_on_new_checkpoint = false` to drain every epoch. The trainer can idle while it waits for slow evals. Launcher-managed SFT evals use NCCL weight broadcast by default, including multi-node SLURM deployments. LoRA and external inference use filesystem broadcast.
 
 ```bash
 uv run inference --vllm.model Qwen/Qwen3-4B   # start inference separately
@@ -123,7 +123,7 @@ env.agent.harness.id = "null"
 env.agent.runtime.type = "subprocess"
 
 [ckpt]               # optional: make a standalone eval resumable
-interval = 10        # completed task groups between saves
+interval = 10        # completed task groups between cursor saves
 ```
 
 - Env servers: spawned by the evals process, one per source without an explicit `serve.address`, at `tcp://127.0.0.1:<eval.env_server_base_port + index>`; logs at `{output_dir}/logs/latest/envs/eval/{name}.log`.

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -96,7 +96,7 @@ curl http://localhost:8000/v1/chat/completions \
 
 ## `evals` — multi-env evals
 
-Runs the configured eval sources against a live inference server. Standalone (no `[online]` block): one epoch of every source against the served weights, then exit. With `[online]` (`broadcasts_dir`, `max_steps`, `resume_step`): watch the broadcasts dir for stable `step_{n}` weight broadcasts and evaluate each — the `sft` launcher writes this config for online evals. By default a newer checkpoint cancels unfinished episodes from the prior eval. Set `eval.cancel_on_new_checkpoint = false` to drain every epoch. The trainer can idle while it waits for slow evals. Launcher-managed SFT evals use NCCL weight broadcast by default, including multi-node SLURM deployments. LoRA and external inference use filesystem broadcast.
+Runs the configured eval sources against a live inference server. Standalone (no `[online]` block): one epoch of every source against the served weights, then exit. Add `[ckpt]` (`interval` counts completed task groups) to make the run interruptible, then use `--resume`, `--resume.step N`, or `--resume.dir path/to/checkpoints/step_N`; for standalone evals, checkpoint step N means N completed task groups. Partially completed groups are retried. Resume loads without `[ckpt]` but does not save new checkpoints. Checkpoint/resume is rejected with `[online]` because that process is coupled to the trainer's live broadcast handshake. With `[online]` (`broadcasts_dir`, `max_steps`, `resume_step`): watch the broadcasts dir for stable `step_{n}` weight broadcasts and evaluate each — the `sft` launcher writes this config for online evals. By default a newer checkpoint cancels unfinished episodes from the prior eval. Set `eval.cancel_on_new_checkpoint = false` to drain every epoch. The trainer can idle while it waits for slow evals. Launcher-managed SFT evals use NCCL weight broadcast by default, including multi-node SLURM deployments. LoRA and external inference use filesystem broadcast.
 
 ```bash
 uv run inference --vllm.model Qwen/Qwen3-4B   # start inference separately
@@ -121,6 +121,9 @@ group_size = 4
 env.taskset.id = "aime25"
 env.agent.harness.id = "null"
 env.agent.runtime.type = "subprocess"
+
+[ckpt]               # optional: make a standalone eval resumable
+interval = 10        # completed task groups between saves
 ```
 
 - Env servers: spawned by the evals process, one per source without an explicit `serve.address`, at `tcp://127.0.0.1:<eval.env_server_base_port + index>`; logs at `{output_dir}/logs/latest/envs/eval/{name}.log`.

--- a/src/prime_rl/evals/ckpt.py
+++ b/src/prime_rl/evals/ckpt.py
@@ -1,4 +1,4 @@
-"""Checkpoint standalone eval progress and completed task-group results."""
+"""Checkpoint standalone eval progress cursor."""
 
 from __future__ import annotations
 
@@ -8,14 +8,10 @@ import pickle
 import tempfile
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
 
+from prime_rl.orchestrator.eval_source import EvalSource
 from prime_rl.utils.logger import format_time, get_logger
 from prime_rl.utils.pathing import get_all_ckpt_steps, get_ckpt_dir, get_step_path
-
-if TYPE_CHECKING:
-    from prime_rl.orchestrator.eval_sink import EvalSink
-    from prime_rl.orchestrator.eval_source import EvalSource
 
 
 class CheckpointManager:
@@ -33,33 +29,29 @@ class CheckpointManager:
             raise FileNotFoundError(f"No evals checkpoints found in {self.ckpt_dir}")
         return steps[-1]
 
-    def save(self, step: int, eval_source: EvalSource, eval_sink: EvalSink) -> None:
-        ckpt_path = self.get_ckpt_path(step)
+    def save(self, eval_source: EvalSource) -> None:
+        cursor = eval_source.cursor
+        ckpt_path = self.get_ckpt_path(cursor)
         ckpt_path.mkdir(parents=True, exist_ok=True)
         start = time.perf_counter()
+        # Keep the last complete checkpoint readable if the process dies mid-write.
         fd, tmp_name = tempfile.mkstemp(dir=ckpt_path, prefix="progress.pt.", suffix=".tmp")
         try:
             with os.fdopen(fd, "wb") as f:
-                pickle.dump(
-                    {
-                        "completed_groups": step,
-                        "eval_source": eval_source.state_dict(),
-                        "eval_sink": eval_sink.state_dict(),
-                    },
-                    f,
-                )
+                pickle.dump(eval_source.state_dict(), f)
             os.replace(tmp_name, ckpt_path / "progress.pt")
         except BaseException:
             with contextlib.suppress(OSError):
                 os.unlink(tmp_name)
             raise
-        get_logger().debug(f"Evals checkpoint saved to {ckpt_path} in {format_time(time.perf_counter() - start)}")
+        get_logger().debug(
+            f"Evals checkpoint saved to {ckpt_path} (cursor={cursor}) in {format_time(time.perf_counter() - start)}"
+        )
 
     def load(
         self,
         step: int,
         eval_source: EvalSource,
-        eval_sink: EvalSink,
         path: Path | None = None,
     ) -> None:
         ckpt_path = path if path is not None else self.get_ckpt_path(step)
@@ -69,9 +61,6 @@ class CheckpointManager:
         get_logger().info(f"Loading evals checkpoint from {state_file}")
         with open(state_file, "rb") as f:
             state = pickle.load(f)
-        if state["completed_groups"] != step:
-            raise ValueError(
-                f"Evals checkpoint contains {state['completed_groups']} completed groups, expected step {step}"
-            )
-        eval_source.load_state_dict(state["eval_source"])
-        eval_sink.load_state_dict(state["eval_sink"])
+        if state["cursor"] != step:
+            raise ValueError(f"Evals checkpoint contains cursor {state['cursor']}, expected step {step}")
+        eval_source.load_state_dict(state)

--- a/src/prime_rl/evals/ckpt.py
+++ b/src/prime_rl/evals/ckpt.py
@@ -34,7 +34,7 @@ class CheckpointManager:
         ckpt_path = self.get_ckpt_path(cursor)
         ckpt_path.mkdir(parents=True, exist_ok=True)
         start = time.perf_counter()
-        # Keep the last complete checkpoint readable if the process dies mid-write.
+        # Replace atomically so resume never observes a partially written pickle.
         fd, tmp_name = tempfile.mkstemp(dir=ckpt_path, prefix="progress.pt.", suffix=".tmp")
         try:
             with os.fdopen(fd, "wb") as f:

--- a/src/prime_rl/evals/ckpt.py
+++ b/src/prime_rl/evals/ckpt.py
@@ -1,0 +1,77 @@
+"""Checkpoint standalone eval progress and completed task-group results."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import pickle
+import tempfile
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from prime_rl.utils.logger import format_time, get_logger
+from prime_rl.utils.pathing import get_all_ckpt_steps, get_ckpt_dir, get_step_path
+
+if TYPE_CHECKING:
+    from prime_rl.orchestrator.eval_sink import EvalSink
+    from prime_rl.orchestrator.eval_source import EvalSource
+
+
+class CheckpointManager:
+    def __init__(self, output_dir: Path) -> None:
+        self.ckpt_dir = get_ckpt_dir(output_dir)
+
+    def get_ckpt_path(self, step: int) -> Path:
+        return get_step_path(self.ckpt_dir, step) / "evals"
+
+    def latest_step(self) -> int:
+        steps = [
+            step for step in get_all_ckpt_steps(self.ckpt_dir) if (self.get_ckpt_path(step) / "progress.pt").is_file()
+        ]
+        if not steps:
+            raise FileNotFoundError(f"No evals checkpoints found in {self.ckpt_dir}")
+        return steps[-1]
+
+    def save(self, step: int, eval_source: EvalSource, eval_sink: EvalSink) -> None:
+        ckpt_path = self.get_ckpt_path(step)
+        ckpt_path.mkdir(parents=True, exist_ok=True)
+        start = time.perf_counter()
+        fd, tmp_name = tempfile.mkstemp(dir=ckpt_path, prefix="progress.pt.", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                pickle.dump(
+                    {
+                        "completed_groups": step,
+                        "eval_source": eval_source.state_dict(),
+                        "eval_sink": eval_sink.state_dict(),
+                    },
+                    f,
+                )
+            os.replace(tmp_name, ckpt_path / "progress.pt")
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name)
+            raise
+        get_logger().debug(f"Evals checkpoint saved to {ckpt_path} in {format_time(time.perf_counter() - start)}")
+
+    def load(
+        self,
+        step: int,
+        eval_source: EvalSource,
+        eval_sink: EvalSink,
+        path: Path | None = None,
+    ) -> None:
+        ckpt_path = path if path is not None else self.get_ckpt_path(step)
+        state_file = ckpt_path / "progress.pt"
+        if not state_file.is_file():
+            raise FileNotFoundError(f"Evals checkpoint not found at {state_file}")
+        get_logger().info(f"Loading evals checkpoint from {state_file}")
+        with open(state_file, "rb") as f:
+            state = pickle.load(f)
+        if state["completed_groups"] != step:
+            raise ValueError(
+                f"Evals checkpoint contains {state['completed_groups']} completed groups, expected step {step}"
+            )
+        eval_source.load_state_dict(state["eval_source"])
+        eval_sink.load_state_dict(state["eval_sink"])

--- a/src/prime_rl/evals/evals.py
+++ b/src/prime_rl/evals/evals.py
@@ -35,6 +35,7 @@ from subprocess import Popen
 from prime_rl import monitors
 from prime_rl.configs.evals import EvalsConfig
 from prime_rl.configs.trainer import FileSystemWeightBroadcastConfig
+from prime_rl.evals.ckpt import CheckpointManager
 from prime_rl.orchestrator.clients import AdminClients, InferenceClient
 from prime_rl.orchestrator.concurrency import ConcurrencyController
 from prime_rl.orchestrator.dispatcher import Dispatcher, DispatcherMetrics, DispatcherMode
@@ -49,7 +50,13 @@ from prime_rl.orchestrator.patches import (
 )
 from prime_rl.orchestrator.periodic_logger import PeriodicLogger
 from prime_rl.orchestrator.types import DispatchFailure, EvalBatch, GroupCancellation, Policy
-from prime_rl.orchestrator.utils import eval_work, intercept_vf_logging, set_default_executor
+from prime_rl.orchestrator.utils import (
+    episode_env_name,
+    episode_group_id,
+    eval_work,
+    intercept_vf_logging,
+    set_default_executor,
+)
 from prime_rl.transports.weights import WeightReceiver, setup_weight_receiver
 from prime_rl.utils.config import dump_resolved_config
 from prime_rl.utils.logger import format_time, get_logger, setup_logger
@@ -84,6 +91,8 @@ class Evals:
         # The last weight-checkpoint step already handled (evaluated or skipped).
         self.last_step = (config.online.resume_step if config.online is not None else None) or 0
         self.eval_triggered_at: dict[tuple[str, int], float] = {}
+        self.ckpt_manager = CheckpointManager(config.output_dir)
+        self.completed_groups = 0
         self.env_server_procs: list[Popen] = []
         self.dispatcher_task: asyncio.Task | None = None
 
@@ -147,6 +156,21 @@ class Evals:
         is_resumed = config.online is not None and config.online.resume_step is not None
         self.eval_source = EvalSource(self.eval_envs, config.eval, is_resumed=is_resumed)
         self.eval_sink = EvalSink(eval_envs=self.eval_envs)
+        if config.resume is not None:
+            if config.resume.dir is not None:
+                resume_step = config.resume.dir_step
+                resume_path = config.resume.dir / "evals"
+            else:
+                resume_step = config.resume.step or self.ckpt_manager.latest_step()
+                resume_path = None
+            self.ckpt_manager.load(
+                resume_step,
+                self.eval_source,
+                self.eval_sink,
+                path=resume_path,
+            )
+            self.completed_groups = resume_step
+            get_logger().info(f"Resuming evals after {self.completed_groups} completed task groups")
         self.policy = Policy(version=0, model_name=config.model)
 
         # Pessimistic per-episode token cost for the controller's starting cap,
@@ -252,6 +276,9 @@ class Evals:
             await self.maybe_run_evals(step=0)
         else:
             await self.watch()
+
+        if self.config.ckpt is not None and self.completed_groups > 0:
+            self.save_checkpoint()
 
         # The periodic logger and the collector log to the W&B run, so they
         # must stop before finalize marks the run finished.
@@ -383,8 +410,9 @@ class Evals:
         for env_name in fired:
             self.eval_triggered_at[(env_name, step)] = now
         total_rollouts = sum(
-            self.eval_envs.get(env_name).config.group_size * len(self.eval_envs.get(env_name).examples)
-            for env_name in fired
+            self.eval_envs.get(request.env_name).config.group_size
+            for request in self.eval_source.queue
+            if request.step == step and request.env_name in fired
         )
 
         # The dispatcher only schedules eval in PREFER_EVAL, so nothing dispatches
@@ -428,15 +456,26 @@ class Evals:
 
             if isinstance(item, GroupCancellation):
                 eval_batch = self.eval_sink.cancel(item)
+                group_completed = False
             elif isinstance(item, DispatchFailure):
                 eval_batch = self.eval_sink.fail(item)
+                group_completed = not self.eval_sink.has_pending_group(item.group_id)
+                completed_task = (item.env_name, item.task_key, item.task_hash, item.step)
             else:
                 item_step = eval_work(item).step
                 await monitors.log([item], item_step, "eval", "all")
                 eval_batch = self.eval_sink.add(item)
+                group_id = episode_group_id(item)
+                group_completed = not self.eval_sink.has_pending_group(group_id)
+                completed_task = (episode_env_name(item), item.task.key, item.task.hash, item_step)
             if eval_batch is not None:
                 await self.finalize_eval_batch(eval_batch)
                 pending.discard(eval_batch.env_name)
+            if group_completed:
+                self.eval_source.mark_completed(*completed_task)
+                self.completed_groups += 1
+                if self.config.ckpt is not None and self.completed_groups % self.config.ckpt.interval == 0:
+                    self.save_checkpoint()
 
         if cancellation_task is not None:
             cancelled = await cancellation_task
@@ -444,6 +483,9 @@ class Evals:
                 f"Cancelled {cancelled} unfinished eval episodes for step {step}; "
                 f"advancing to checkpoint {superseding_step}"
             )
+
+    def save_checkpoint(self) -> None:
+        self.ckpt_manager.save(self.completed_groups, self.eval_source, self.eval_sink)
 
     async def finalize_eval_batch(self, batch: EvalBatch) -> None:
         """Persist + log one completed eval epoch through the monitors, mirroring the

--- a/src/prime_rl/evals/evals.py
+++ b/src/prime_rl/evals/evals.py
@@ -51,7 +51,6 @@ from prime_rl.orchestrator.patches import (
 from prime_rl.orchestrator.periodic_logger import PeriodicLogger
 from prime_rl.orchestrator.types import DispatchFailure, EvalBatch, GroupCancellation, Policy
 from prime_rl.orchestrator.utils import (
-    episode_env_name,
     episode_group_id,
     eval_work,
     intercept_vf_logging,
@@ -92,7 +91,7 @@ class Evals:
         self.last_step = (config.online.resume_step if config.online is not None else None) or 0
         self.eval_triggered_at: dict[tuple[str, int], float] = {}
         self.ckpt_manager = CheckpointManager(config.output_dir)
-        self.completed_groups = 0
+        self.last_saved_cursor = 0
         self.env_server_procs: list[Popen] = []
         self.dispatcher_task: asyncio.Task | None = None
 
@@ -166,11 +165,10 @@ class Evals:
             self.ckpt_manager.load(
                 resume_step,
                 self.eval_source,
-                self.eval_sink,
                 path=resume_path,
             )
-            self.completed_groups = resume_step
-            get_logger().info(f"Resuming evals after {self.completed_groups} completed task groups")
+            self.last_saved_cursor = self.eval_source.cursor
+            get_logger().info(f"Resuming evals from task cursor {self.eval_source.cursor}")
         self.policy = Policy(version=0, model_name=config.model)
 
         # Pessimistic per-episode token cost for the controller's starting cap,
@@ -277,8 +275,7 @@ class Evals:
         else:
             await self.watch()
 
-        if self.config.ckpt is not None and self.completed_groups > 0:
-            self.save_checkpoint()
+        self.maybe_save_checkpoint(force=True)
 
         # The periodic logger and the collector log to the W&B run, so they
         # must stop before finalize marks the run finished.
@@ -406,6 +403,10 @@ class Evals:
         if not fired:
             return
 
+        for env_name in fired:
+            task_count = self.eval_source.triggered_task_count(env_name, step)
+            self.eval_sink.set_batch_size(env_name, step, task_count * self.eval_sink.group_size_for(env_name))
+
         now = time.perf_counter()
         for env_name in fired:
             self.eval_triggered_at[(env_name, step)] = now
@@ -425,7 +426,7 @@ class Evals:
 
     async def consume_epoch(self, fired: list[str], step: int) -> None:
         """Consume one epoch, preempting it when a newer checkpoint is ready."""
-        pending = {env_name for env_name in fired if self.eval_sink.batch_size_for(env_name) > 0}
+        pending = {env_name for env_name in fired if self.eval_sink.batch_size_for(env_name, step) > 0}
         cancellation_task: asyncio.Task[int] | None = None
         superseding_step: int | None = None
         online = self.config.online
@@ -457,25 +458,28 @@ class Evals:
             if isinstance(item, GroupCancellation):
                 eval_batch = self.eval_sink.cancel(item)
                 group_completed = False
+                group_id = item.group_id
             elif isinstance(item, DispatchFailure):
                 eval_batch = self.eval_sink.fail(item)
                 group_completed = not self.eval_sink.has_pending_group(item.group_id)
-                completed_task = (item.env_name, item.task_key, item.task_hash, item.step)
+                group_id = item.group_id
             else:
                 item_step = eval_work(item).step
                 await monitors.log([item], item_step, "eval", "all")
                 eval_batch = self.eval_sink.add(item)
                 group_id = episode_group_id(item)
                 group_completed = not self.eval_sink.has_pending_group(group_id)
-                completed_task = (episode_env_name(item), item.task.key, item.task.hash, item_step)
             if eval_batch is not None:
                 await self.finalize_eval_batch(eval_batch)
                 pending.discard(eval_batch.env_name)
             if group_completed:
-                self.eval_source.mark_completed(*completed_task)
-                self.completed_groups += 1
-                if self.config.ckpt is not None and self.completed_groups % self.config.ckpt.interval == 0:
-                    self.save_checkpoint()
+                source_index = self.dispatcher.pop_source_index(group_id)
+                if self.config.online is not None:
+                    continue
+                if source_index is None:
+                    raise RuntimeError(f"Eval group {group_id} is missing its source cursor")
+                if self.eval_source.mark_completed(source_index):
+                    self.maybe_save_checkpoint()
 
         if cancellation_task is not None:
             cancelled = await cancellation_task
@@ -484,8 +488,16 @@ class Evals:
                 f"advancing to checkpoint {superseding_step}"
             )
 
-    def save_checkpoint(self) -> None:
-        self.ckpt_manager.save(self.completed_groups, self.eval_source, self.eval_sink)
+    def maybe_save_checkpoint(self, *, force: bool = False) -> None:
+        if self.config.ckpt is None:
+            return
+        cursor = self.eval_source.cursor
+        if cursor <= 0 or cursor == self.last_saved_cursor:
+            return
+        if not force and cursor - self.last_saved_cursor < self.config.ckpt.interval:
+            return
+        self.ckpt_manager.save(self.eval_source)
+        self.last_saved_cursor = cursor
 
     async def finalize_eval_batch(self, batch: EvalBatch) -> None:
         """Persist + log one completed eval epoch through the monitors, mirroring the

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -190,6 +190,7 @@ class Dispatcher:
 
         self.inflight: dict[asyncio.Task, InflightEpisode] = {}
         self.groups: dict[uuid.UUID, GroupState] = {}
+        self.source_indices_by_group: dict[str, int] = {}
 
         # Bounded so the dispatcher backpressures on a slow sink (unbounded
         # when no hard ceiling is configured — the dynamic cap still bounds
@@ -466,6 +467,8 @@ class Dispatcher:
             return False
         gid = uuid.uuid4()
         self.groups[gid] = fresh
+        if fresh.source_index is not None:
+            self.source_indices_by_group[str(gid)] = fresh.source_index
         return await self.schedule_group_episode(gid, fresh)
 
     def next_fresh_group(self, kind: WorkKind, envs) -> GroupState | None:
@@ -493,7 +496,11 @@ class Dispatcher:
             episodes_to_schedule=group_size,
             target_episodes=group_size,
             policy_version_at_start=self.policy.version,
+            source_index=request.source_index,
         )
+
+    def pop_source_index(self, group_id: str) -> int | None:
+        return self.source_indices_by_group.pop(group_id, None)
 
     async def schedule_group_episode(self, group_id: uuid.UUID, group: GroupState) -> bool:
         """Dispatch one ``run`` task for this group.
@@ -545,6 +552,7 @@ class Dispatcher:
             task=group.task,
             policy_version=group.policy_version_at_start,
             step=group.step,
+            source_index=group.source_index,
             client_config=client,
             started_at=time.monotonic(),
         )
@@ -710,6 +718,7 @@ class Dispatcher:
 
         if claimed:
             await safe_cancel_all([task for task, _ in claimed])
+        self.source_indices_by_group.pop(str(group_id), None)
         return cancelled
 
     async def cancel_inflight_episodes(self) -> None:
@@ -721,6 +730,7 @@ class Dispatcher:
         tasks = list(self.inflight.keys())
         self.inflight.clear()
         self.groups.clear()
+        self.source_indices_by_group.clear()
         if tasks:
             await safe_cancel_all(tasks)
 

--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from collections import defaultdict
-
-import verifiers.v1 as vf
+from typing import TYPE_CHECKING
 
 from prime_rl.orchestrator.envs import EvalEnvs
 from prime_rl.orchestrator.metrics import EvalEpisodes
 from prime_rl.orchestrator.types import DispatchFailure, EvalBatch, GroupCancellation
 from prime_rl.orchestrator.utils import episode_env_name, episode_group_id, eval_work
 from prime_rl.utils.logger import get_logger
+
+if TYPE_CHECKING:
+    import verifiers.v1 as vf
 
 
 class EvalSink:
@@ -24,6 +26,7 @@ class EvalSink:
         self.pending_batches: dict[tuple[str, int], list[vf.Episode]] = defaultdict(list)
         self.pending_batch_failures: dict[tuple[str, int], list[DispatchFailure]] = defaultdict(list)
         self.pending_batch_cancellations: dict[tuple[str, int], int] = defaultdict(int)
+        self.expected_batch_sizes: dict[tuple[str, int], int] = {}
 
     def add(self, episode: vf.Episode) -> EvalBatch | None:
         env_name = episode_env_name(episode)
@@ -34,7 +37,7 @@ class EvalSink:
         group.append(episode)
         if self._group_size(group_id) >= self.group_size_for(env_name):
             self.process_group(group_id)
-        if self._batch_size(bkey) >= self.batch_size_for(env_name):
+        if self._batch_size(bkey) >= self.batch_size_for(env_name, eval_step):
             return self.process_batch(bkey)
         return None
 
@@ -48,7 +51,7 @@ class EvalSink:
         self.pending_group_failures[group_id].append(failure)
         if self._group_size(group_id) >= self.group_size_for(failure.env_name):
             self.process_group(group_id)
-        if self._batch_size(bkey) >= self.batch_size_for(failure.env_name):
+        if self._batch_size(bkey) >= self.batch_size_for(failure.env_name, failure.step):
             return self.process_batch(bkey)
         return None
 
@@ -61,7 +64,7 @@ class EvalSink:
         self.pending_group_cancellations[group_id] = cancellation
         if self._group_size(group_id) >= self.group_size_for(cancellation.env_name):
             self.process_group(group_id)
-        if self._batch_size(bkey) >= self.batch_size_for(cancellation.env_name):
+        if self._batch_size(bkey) >= self.batch_size_for(cancellation.env_name, cancellation.step):
             return self.process_batch(bkey)
         return None
 
@@ -83,7 +86,14 @@ class EvalSink:
     def group_size_for(self, env_name: str) -> int:
         return self.eval_envs.get(env_name).config.group_size
 
-    def batch_size_for(self, env_name: str) -> int:
+    def set_batch_size(self, env_name: str, step: int, size: int) -> None:
+        self.expected_batch_sizes[(env_name, step)] = size
+
+    def batch_size_for(self, env_name: str, step: int | None = None) -> int:
+        if step is not None:
+            key = (env_name, step)
+            if key in self.expected_batch_sizes:
+                return self.expected_batch_sizes[key]
         env = self.eval_envs.get(env_name)
         return len(env.examples) * env.config.group_size
 
@@ -119,7 +129,7 @@ class EvalSink:
                 env_name,
                 eval_step,
                 batch_counts.get((env_name, eval_step), 0),
-                self.batch_size_for(env_name),
+                self.batch_size_for(env_name, eval_step),
                 buffered.get((env_name, eval_step), 0),
             )
             for env_name, eval_step in set(batch_counts) | set(buffered)
@@ -131,34 +141,6 @@ class EvalSink:
             or self.pending_group_failures.get(group_id)
             or self.pending_group_cancellations.get(group_id)
         )
-
-    def state_dict(self) -> dict:
-        """Return completed groups awaiting their epoch aggregate.
-
-        Partial groups are intentionally omitted: their requests are retried after
-        resume, keeping checkpoints independent of dispatcher and in-flight state.
-        """
-        return {
-            "pending_batches": {
-                key: [episode.to_record() for episode in episodes] for key, episodes in self.pending_batches.items()
-            },
-            "pending_batch_failures": dict(self.pending_batch_failures),
-            "pending_batch_cancellations": dict(self.pending_batch_cancellations),
-        }
-
-    def load_state_dict(self, state_dict: dict) -> None:
-        expected = {"pending_batches", "pending_batch_failures", "pending_batch_cancellations"}
-        if set(state_dict) != expected:
-            raise ValueError(f"Eval sink checkpoint fields must be {sorted(expected)}")
-        self.pending_batches = defaultdict(
-            list,
-            {
-                key: [vf.WireEpisode.model_validate(record) for record in records]
-                for key, records in state_dict["pending_batches"].items()
-            },
-        )
-        self.pending_batch_failures = defaultdict(list, state_dict["pending_batch_failures"])
-        self.pending_batch_cancellations = defaultdict(int, state_dict["pending_batch_cancellations"])
 
     def process_group(self, group_id: str) -> None:
         group = self.pending_groups.pop(group_id, [])
@@ -199,6 +181,7 @@ class EvalSink:
         episodes = self.pending_batches.pop(key, [])
         failures = self.pending_batch_failures.pop(key, [])
         cancelled = self.pending_batch_cancellations.pop(key, 0)
+        self.expected_batch_sizes.pop(key, None)
         return EvalBatch(
             env_name=env_name,
             step=step,

--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -125,6 +125,41 @@ class EvalSink:
             for env_name, eval_step in set(batch_counts) | set(buffered)
         ]
 
+    def has_pending_group(self, group_id: str) -> bool:
+        return bool(
+            self.pending_groups.get(group_id)
+            or self.pending_group_failures.get(group_id)
+            or self.pending_group_cancellations.get(group_id)
+        )
+
+    def state_dict(self) -> dict:
+        """Return completed groups awaiting their epoch aggregate.
+
+        Partial groups are intentionally omitted: their requests are retried after
+        resume, keeping checkpoints independent of dispatcher and in-flight state.
+        """
+        return {
+            "pending_batches": {
+                key: [episode.to_record() for episode in episodes] for key, episodes in self.pending_batches.items()
+            },
+            "pending_batch_failures": dict(self.pending_batch_failures),
+            "pending_batch_cancellations": dict(self.pending_batch_cancellations),
+        }
+
+    def load_state_dict(self, state_dict: dict) -> None:
+        expected = {"pending_batches", "pending_batch_failures", "pending_batch_cancellations"}
+        if set(state_dict) != expected:
+            raise ValueError(f"Eval sink checkpoint fields must be {sorted(expected)}")
+        self.pending_batches = defaultdict(
+            list,
+            {
+                key: [vf.WireEpisode.model_validate(record) for record in records]
+                for key, records in state_dict["pending_batches"].items()
+            },
+        )
+        self.pending_batch_failures = defaultdict(list, state_dict["pending_batch_failures"])
+        self.pending_batch_cancellations = defaultdict(int, state_dict["pending_batch_cancellations"])
+
     def process_group(self, group_id: str) -> None:
         group = self.pending_groups.pop(group_id, [])
         failures = self.pending_group_failures.pop(group_id, [])

--- a/src/prime_rl/orchestrator/eval_source.py
+++ b/src/prime_rl/orchestrator/eval_source.py
@@ -8,12 +8,15 @@ from __future__ import annotations
 
 from collections import Counter, deque
 from itertools import zip_longest
+from typing import TYPE_CHECKING
 
-import verifiers.v1 as vf
-
-from prime_rl.configs.orchestrator import EvalConfig
-from prime_rl.orchestrator.envs import EvalEnvs
 from prime_rl.orchestrator.types import TaskRequest
+
+if TYPE_CHECKING:
+    import verifiers.v1 as vf
+
+    from prime_rl.configs.orchestrator import EvalConfig
+    from prime_rl.orchestrator.envs import EvalEnvs
 
 
 class EvalSource:
@@ -36,7 +39,10 @@ class EvalSource:
             self.intervals[env.name] = env.config.interval
 
         self.queue: deque[TaskRequest] = deque()
-        self.completed: Counter[tuple[str, int, str, str]] = Counter()
+        self.cursor = 0
+        self._next_index = 0
+        self._completed: set[int] = set()
+        self._triggered_task_counts: dict[tuple[str, int], int] = {}
 
         # A fresh run evaluates the base policy. Resumed runs apply interval
         # rules to the loaded checkpoint and later policies.
@@ -54,6 +60,7 @@ class EvalSource:
         for name, interval in self.intervals.items():
             if (is_first or force or step % interval == 0) and self.tasks_by_env[name]:
                 fired.append(name)
+        queued_counts: Counter[str] = Counter()
         # Round-robin across fired envs (A₁, B₁, A₂, B₂, …) so the
         # dispatcher rotates at example granularity. ``try_schedule``'s
         # continue-group branch still keeps each example's group_size
@@ -63,37 +70,41 @@ class EvalSource:
             for env_name, task in zip(fired, round_tasks, strict=True):
                 if task is None:
                     continue
-                self.queue.append(TaskRequest(env_name=env_name, task=task, step=step))
-        return fired
+                source_index = self._next_index
+                self._next_index += 1
+                if source_index < self.cursor:
+                    continue
+                self.queue.append(TaskRequest(env_name=env_name, task=task, step=step, source_index=source_index))
+                queued_counts[env_name] += 1
+        for env_name, count in queued_counts.items():
+            self._triggered_task_counts[(env_name, step)] = count
+        return [name for name in fired if queued_counts[name]]
 
-    @staticmethod
-    def task_key(env_name: str, task: vf.Task, step: int) -> tuple[str, int, str, str]:
-        return env_name, step, task.key, task.hash
+    def triggered_task_count(self, env_name: str, step: int) -> int:
+        return self._triggered_task_counts.get((env_name, step), 0)
 
-    def mark_completed(self, env_name: str, task_key: str, task_hash: str, step: int) -> None:
-        self.completed[(env_name, step, task_key, task_hash)] += 1
+    def mark_completed(self, source_index: int) -> bool:
+        """Advance the durable cursor only across a fully completed prefix."""
+        if source_index < self.cursor:
+            return False
+        self._completed.add(source_index)
+        previous = self.cursor
+        while self.cursor in self._completed:
+            self._completed.remove(self.cursor)
+            self.cursor += 1
+        return self.cursor != previous
 
     def state_dict(self) -> dict:
-        return {"completed": dict(self.completed)}
+        return {"cursor": self.cursor}
 
     def load_state_dict(self, state_dict: dict) -> None:
-        if set(state_dict) != {"completed"}:
-            raise ValueError("Eval source checkpoint must contain only completed task groups")
-        self.completed = Counter(state_dict["completed"])
-        completed_steps = {key[1] for key, count in self.completed.items() if count}
-        if len(completed_steps) != 1:
-            raise ValueError("Eval source checkpoint must contain completed groups from exactly one eval step")
-        step = completed_steps.pop()
-        for env_name, tasks in self.tasks_by_env.items():
-            matched = Counter()
-            remaining = []
-            for task in tasks:
-                key = self.task_key(env_name, task, step)
-                if matched[key] < self.completed[key]:
-                    matched[key] += 1
-                else:
-                    remaining.append(task)
-            self.tasks_by_env[env_name] = remaining
+        if set(state_dict) != {"cursor"}:
+            raise ValueError("Eval source checkpoint must contain only a cursor")
+        cursor = state_dict["cursor"]
+        if type(cursor) is not int or cursor < 0:
+            raise ValueError(f"Eval source checkpoint cursor must be a non-negative integer, got {cursor!r}")
+        self.cursor = cursor
+        self._completed.clear()
 
     def next_task(self) -> TaskRequest | None:
         """Pop the next eval task, or ``None`` when the queue is empty."""

--- a/src/prime_rl/orchestrator/eval_source.py
+++ b/src/prime_rl/orchestrator/eval_source.py
@@ -6,7 +6,7 @@ including startup. The dispatcher pulls via ``next_task()`` until
 
 from __future__ import annotations
 
-from collections import deque
+from collections import Counter, deque
 from itertools import zip_longest
 
 import verifiers.v1 as vf
@@ -36,6 +36,7 @@ class EvalSource:
             self.intervals[env.name] = env.config.interval
 
         self.queue: deque[TaskRequest] = deque()
+        self.completed: Counter[tuple[str, int, str, str]] = Counter()
 
         # A fresh run evaluates the base policy. Resumed runs apply interval
         # rules to the loaded checkpoint and later policies.
@@ -51,7 +52,7 @@ class EvalSource:
             return []
         fired: list[str] = []
         for name, interval in self.intervals.items():
-            if is_first or force or step % interval == 0:
+            if (is_first or force or step % interval == 0) and self.tasks_by_env[name]:
                 fired.append(name)
         # Round-robin across fired envs (A₁, B₁, A₂, B₂, …) so the
         # dispatcher rotates at example granularity. ``try_schedule``'s
@@ -64,6 +65,35 @@ class EvalSource:
                     continue
                 self.queue.append(TaskRequest(env_name=env_name, task=task, step=step))
         return fired
+
+    @staticmethod
+    def task_key(env_name: str, task: vf.Task, step: int) -> tuple[str, int, str, str]:
+        return env_name, step, task.key, task.hash
+
+    def mark_completed(self, env_name: str, task_key: str, task_hash: str, step: int) -> None:
+        self.completed[(env_name, step, task_key, task_hash)] += 1
+
+    def state_dict(self) -> dict:
+        return {"completed": dict(self.completed)}
+
+    def load_state_dict(self, state_dict: dict) -> None:
+        if set(state_dict) != {"completed"}:
+            raise ValueError("Eval source checkpoint must contain only completed task groups")
+        self.completed = Counter(state_dict["completed"])
+        completed_steps = {key[1] for key, count in self.completed.items() if count}
+        if len(completed_steps) != 1:
+            raise ValueError("Eval source checkpoint must contain completed groups from exactly one eval step")
+        step = completed_steps.pop()
+        for env_name, tasks in self.tasks_by_env.items():
+            matched = Counter()
+            remaining = []
+            for task in tasks:
+                key = self.task_key(env_name, task, step)
+                if matched[key] < self.completed[key]:
+                    matched[key] += 1
+                else:
+                    remaining.append(task)
+            self.tasks_by_env[env_name] = remaining
 
     def next_task(self) -> TaskRequest | None:
         """Pop the next eval task, or ``None`` when the queue is empty."""

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias
-
-import verifiers.v1 as vf
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias
 
 from prime_rl.transports.batch import TrainingSample
 
 if TYPE_CHECKING:
+    import verifiers.v1 as vf
+
     from prime_rl.orchestrator.metrics import EvalEpisodes, TrainEpisodes
 
 
@@ -68,7 +68,10 @@ class DispatchFailure:
     error: vf.Error
 
 
-DispatchResult: TypeAlias = vf.WireEpisode | DispatchFailure | GroupCancellation
+if TYPE_CHECKING:
+    DispatchResult: TypeAlias = vf.WireEpisode | DispatchFailure | GroupCancellation
+else:
+    DispatchResult: TypeAlias = Any
 
 
 @dataclass(frozen=True)
@@ -78,6 +81,7 @@ class TaskRequest:
     env_name: str
     task: vf.Task
     step: int
+    source_index: int | None = None
 
 
 @dataclass
@@ -90,6 +94,7 @@ class InflightEpisode:
     task: vf.Task
     policy_version: int
     step: int
+    source_index: int | None = None
     client_config: vf.ClientConfig | None = None
     started_at: float = 0.0
     """``time.monotonic()`` at dispatch; feeds episode-duration estimates."""
@@ -108,6 +113,7 @@ class GroupState:
     target_episodes: int
     emitted: int = 0
     policy_version_at_start: int = 0
+    source_index: int | None = None
 
 
 @dataclass

--- a/tests/unit/evals/test_ckpt.py
+++ b/tests/unit/evals/test_ckpt.py
@@ -1,0 +1,93 @@
+import pickle
+from types import SimpleNamespace
+
+import pytest
+
+from prime_rl.evals.ckpt import CheckpointManager
+from prime_rl.orchestrator.eval_source import EvalSource
+
+
+def _task(key: str) -> SimpleNamespace:
+    return SimpleNamespace(key=key, hash=key)
+
+
+def _env(name: str, task_keys: list[str], *, interval: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        examples=[_task(key) for key in task_keys],
+        config=SimpleNamespace(interval=interval),
+    )
+
+
+def _eval_config() -> SimpleNamespace:
+    return SimpleNamespace(skip_first_step=False)
+
+
+def _queued_tasks(eval_source: EvalSource) -> list[tuple[str, str, int | None]]:
+    return [(request.env_name, request.task.key, request.source_index) for request in eval_source.queue]
+
+
+def test_eval_source_cursor_advances_only_over_completed_prefix() -> None:
+    eval_source = EvalSource(
+        [_env("math", ["m0", "m1"]), _env("code", ["c0", "c1"])],
+        _eval_config(),
+    )
+
+    assert eval_source.trigger(0) == ["math", "code"]
+    assert _queued_tasks(eval_source) == [
+        ("math", "m0", 0),
+        ("code", "c0", 1),
+        ("math", "m1", 2),
+        ("code", "c1", 3),
+    ]
+
+    assert eval_source.mark_completed(1) is False
+    assert eval_source.cursor == 0
+
+    assert eval_source.mark_completed(3) is False
+    assert eval_source.cursor == 0
+
+    assert eval_source.mark_completed(0) is True
+    assert eval_source.cursor == 2
+
+    assert eval_source.mark_completed(2) is True
+    assert eval_source.cursor == 4
+
+
+def test_eval_checkpoint_saves_only_cursor_and_resume_skips_completed_prefix(tmp_path) -> None:
+    eval_envs = [_env("math", ["m0", "m1"]), _env("code", ["c0", "c1"])]
+    eval_source = EvalSource(eval_envs, _eval_config())
+    eval_source.load_state_dict({"cursor": 2})
+
+    assert eval_source.trigger(0) == ["math", "code"]
+    assert _queued_tasks(eval_source) == [
+        ("math", "m1", 2),
+        ("code", "c1", 3),
+    ]
+    assert eval_source.triggered_task_count("math", 0) == 1
+    assert eval_source.triggered_task_count("code", 0) == 1
+
+    ckpt = CheckpointManager(tmp_path)
+    ckpt.save(eval_source)
+
+    with (ckpt.get_ckpt_path(2) / "progress.pt").open("rb") as f:
+        assert pickle.load(f) == {"cursor": 2}
+
+    assert ckpt.latest_step() == 2
+
+    restored_source = EvalSource(eval_envs, _eval_config())
+    ckpt.load(2, restored_source)
+
+    assert restored_source.state_dict() == {"cursor": 2}
+
+
+def test_eval_checkpoint_rejects_step_cursor_mismatch(tmp_path) -> None:
+    eval_source = EvalSource([_env("math", ["m0"])], _eval_config())
+    eval_source.load_state_dict({"cursor": 1})
+
+    ckpt = CheckpointManager(tmp_path)
+    ckpt.save(eval_source)
+
+    restored_source = EvalSource([_env("math", ["m0"])], _eval_config())
+    with pytest.raises(ValueError, match="contains cursor 1, expected step 2"):
+        ckpt.load(2, restored_source, path=ckpt.get_ckpt_path(1))


### PR DESCRIPTION
## Summary

- add top-level `[ckpt]` and `[resume]` support to standalone `uv run evals`
- write atomic cursor checkpoints at `<output_dir>/checkpoints/step_N/evals/progress.pt`, where N is the durable eval-source task cursor
- store only the cursor in eval progress checkpoints; generated episode records are not copied into checkpoint payloads
- resume with `--resume`, `--resume.step N`, or `--resume.dir path/to/checkpoints/step_N` by skipping the durable cursor prefix
- retry partial groups and out-of-order completions beyond the durable cursor
- size resumed eval batches to the remaining queued task suffix
- reject checkpointing in online mode, where progress is coupled to the trainer weight-broadcast lifecycle
- keep the training start-run skill current with the new workflow
- clarify that checkpoint writes use temp-file replacement so resume never observes a partial pickle

## Verification

- `uv run pytest tests/unit/evals/test_ckpt.py` — 3 passed
- focused `ruff check` — passed
- focused Python `ruff format --check` — passed
- `git diff --check` — passed

Local note: `uv run evals --help` is currently blocked before CLI loading by the locked `prime-sandboxes==0.2.39` / `connectrpc==0.11.1` import mismatch (`connectrpc.client` is missing).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared orchestrator types (`Dispatcher`, `EvalSource`, `EvalSink`) change, but checkpoint/resume logic is gated to standalone evals with config validation; unit tests cover cursor and I/O semantics.
> 
> **Overview**
> Standalone `uv run evals` can now be made **interruptible** via optional `[ckpt]` and `[resume]` on `EvalsConfig` (rejected when `[online]` is set).
> 
> Progress is a **task cursor** over round-robin eval tasks: `EvalSource` assigns `source_index`, advances the durable cursor only over a fully completed prefix (`mark_completed`), and on resume skips tasks below the loaded cursor. `CheckpointManager` writes only `{"cursor": N}` to `<output_dir>/checkpoints/step_N/evals/progress.pt` using atomic temp-file replace; saves run every `ckpt.interval` completed groups in standalone mode.
> 
> The evals loop loads resume state at setup, sizes epochs with `EvalSink.set_batch_size` from remaining queued tasks, and on each finished eval group calls `dispatcher.pop_source_index` to drive checkpointing. Online eval rollout totals use the triggered queue instead of full env example counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4dc69fac552a55cb6c7c412a0d4e1b194a39c03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->