### PR TITLE
fix(trainer): gate FP8 blockwise quantization on SM90/SM100

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -41,7 +41,7 @@ The custom path enables you to set EP, CP, selective activation checkpointing, l
 
 Set `[trainer.model.quantization]` to train dense linears and MoE expert GEMMs in low precision. Two backends are available via the `type` discriminator:
 
-- `type = "fp8"` — DeepGEMM FP8 blockwise (requires SM90+ / Hopper). Options: `enable_grouped_gemm` (FP8 MoE expert GEMM). Both default on.
+- `type = "fp8"` — DeepGEMM FP8 blockwise (requires SM90 (Hopper) or SM100 (Blackwell)). Options: `enable_grouped_gemm` (FP8 MoE expert GEMM). Both default on.
 - `type = "mxfp8"` — torchao MXFP8 microscaling (requires SM100+ / Blackwell). Options: `enable_grouped_gemm`, `enable_a2a` (MXFP8 expert-parallel all-to-all), and `recipe` (`mxfp8_rceil` default or `mxfp8_rceil_wgrad_with_hp`).
 
 ```toml

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1208,6 +1208,12 @@ def apply_quantization(model: nn.Module, config: ModelConfig) -> None:
         return
 
     if isinstance(quant, FP8Config):
+        capability = torch.cuda.get_device_capability()
+        if capability[0] not in (9, 10):
+            raise ValueError(
+                "FP8 blockwise quantization requires SM90 (Hopper) or SM100 (Blackwell), "
+                f"but device is SM{capability[0]}{capability[1]}."
+            )
         replace_linear_with_fp8_blockwise_linear(model, ignore_modules=quant.ignore_patterns)
     elif isinstance(quant, MXFP8Config):
         capability = torch.cuda.get_device_capability()


### PR DESCRIPTION
`apply_quantization` guards `MXFP8Config` on device capability but applies `FP8Config` unconditionally, even though `Float8BlockwiseLinear` documents an architecture requirement. Both branches were added together in #2910.

`model.py:1210` calls `replace_linear_with_fp8_blockwise_linear` with no check. Four lines below, `model.py:1213-1217` raises for MXFP8 when `capability < (10, 0)`. `fp8_linear.py:88-89` states the requirement the FP8 branch is missing: "Requires: SM90 (Hopper) or SM100 (Blackwell) GPU".

Without the guard the failure lands late and names neither FP8 nor the GPU. The layer swap logs success, then the first forward dies inside DeepGEMM:

```
INFO Replaced 1 linear layers with FP8 blockwise linear (skipped 0 by name, 0 by 128-divisibility)
RuntimeError: Assertion error (csrc/apis/../jit_kernels/impls/../heuristics/../../utils/layout.hpp:76): Unknown recipe
```

With it, the run stops at model construction, before FSDP and before the first step:

```
ValueError: FP8 blockwise quantization requires SM90 (Hopper) or SM100 (Blackwell), but device is SM120.
```

`apply_quantization` runs at construction, so this covers the FP8 grouped GEMM path too.

**Blast radius.** The check reads major version only, so nothing in the README support matrix or the MFU table changes: H100 and H200 are major 9, B200, GB200, B300 and GB300 are major 10. I verified this by patching `torch.cuda.get_device_capability`, and (9,0), (10,0) and (10,3) all still produce `Float8BlockwiseLinear` while (12,0), (12,1), (8,0) and (8,9) raise. The MXFP8 branch is unchanged. The only configurations affected are ones that already fail.

**Prior art.** #3077 and #3079 narrowed this same class of predicate in the attention path last month. From #3079: "resolve_auto_attn routed every GPU with major >= 9 that wasn't exactly SM100 to FA3, whose kernels are Hopper-only. Workstation Blackwell (RTX PRO 6000, SM120) then hit 'no kernel image is available for execution on the device' at runtime." Same shape, one file over.

`docs/advanced.md:44` says "requires SM90+ / Hopper", which reads as true on SM120 and disagrees with the class docstring, so it now matches. The MXFP8 line is untouched.

**Where this was observed.** An NVIDIA GB10 (SM121, aarch64) with `uv sync --all-extras --all-packages --locked`. That is one device and it is outside your tested list, so please treat it as a single data point. I have not reproduced this on an actual SM120 card such as an RTX 5090 or RTX PRO 6000; that case follows from the predicate and from the SM120 report in #3079 rather than from a measurement I made.

**Risk is low.** This adds a capability check to a path that already fails at runtime on unsupported architectures. No supported architecture changes behaviour, and no numerics, optimizer or parallelism code is touched. `ruff check` and `ruff format --check` pass on 0.15.14, and `pytest tests/unit -m "not gpu"` is 476 passed, 1 skipped.

Happy to switch this to a warning plus a BF16 fallback instead of a raise if you would rather not hard-fail. I went with the raise to match the MXFP8 branch directly above it.

Note in passing: `ue8m0_for_device` (`fp8_utils.py:22`) and the inline check at `fp8_grouped_gemm.py:36` are also `major >= 10`. With this gate they become unreachable on SM12x, so I left them alone.
