### PR TITLE
Add GLM-5.3 text training model

### DIFF
--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -13,6 +13,7 @@ from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
 from prime_rl.trainer.models.afmoe import AfmoeConfig, AfmoeForCausalLM
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig, Glm4MoeForCausalLM
+from prime_rl.trainer.models.glm5_next import Glm5NextConfig, Glm5NextForCausalLM, Glm5NextTextConfig
 from prime_rl.trainer.models.glm_moe_dsa import GlmMoeDsaConfig, GlmMoeDsaForCausalLM
 from prime_rl.trainer.models.gpt_oss import GptOssConfig, GptOssForCausalLM
 from prime_rl.trainer.models.laguna import LagunaConfig, LagunaForCausalLM
@@ -28,6 +29,8 @@ from prime_rl.trainer.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalL
 # Make custom config discoverable by AutoConfig
 AutoConfig.register("afmoe", AfmoeConfig, exist_ok=True)
 AutoConfig.register("glm4_moe", Glm4MoeConfig, exist_ok=True)
+AutoConfig.register("glm5_next", Glm5NextConfig, exist_ok=True)
+AutoConfig.register("glm5_next_text", Glm5NextTextConfig, exist_ok=True)
 AutoConfig.register("glm_moe_dsa", GlmMoeDsaConfig, exist_ok=True)
 AutoConfig.register("laguna", LagunaConfig, exist_ok=True)
 AutoConfig.register("minimax_m2", MiniMaxM2Config, exist_ok=True)
@@ -46,6 +49,8 @@ _CUSTOM_CAUSAL_LM_MODELS: tuple[
     (Qwen3Config, Qwen3ForCausalLM),
     (AfmoeConfig, AfmoeForCausalLM),
     (Glm4MoeConfig, Glm4MoeForCausalLM),
+    (Glm5NextConfig, Glm5NextForCausalLM),
+    (Glm5NextTextConfig, Glm5NextForCausalLM),
     (GlmMoeDsaConfig, GlmMoeDsaForCausalLM),
     (LagunaConfig, LagunaForCausalLM),
     (MiniMaxM2Config, MiniMaxM2ForCausalLM),

--- a/src/prime_rl/trainer/models/glm5_next/__init__.py
+++ b/src/prime_rl/trainer/models/glm5_next/__init__.py
@@ -1,0 +1,10 @@
+from .configuration_glm5_next import Glm5NextConfig, Glm5NextTextConfig
+from .modeling_glm5_next import Glm5NextForCausalLM, Glm5NextModel, Glm5NextPreTrainedModel
+
+__all__ = [
+    "Glm5NextConfig",
+    "Glm5NextTextConfig",
+    "Glm5NextPreTrainedModel",
+    "Glm5NextModel",
+    "Glm5NextForCausalLM",
+]

--- a/src/prime_rl/trainer/models/glm5_next/configuration_glm5_next.py
+++ b/src/prime_rl/trainer/models/glm5_next/configuration_glm5_next.py
@@ -1,0 +1,283 @@
+from transformers.configuration_utils import PretrainedConfig
+
+
+def _default_layer_types(num_hidden_layers: int) -> list[str]:
+    return ["deepseek_sparse_attention"] * num_hidden_layers
+
+
+def _default_mlp_layer_types(num_hidden_layers: int, first_k_dense_replace: int) -> list[str]:
+    dense_layers = min(first_k_dense_replace, num_hidden_layers)
+    return ["dense"] * dense_layers + ["sparse"] * (num_hidden_layers - dense_layers)
+
+
+def _as_dict(config) -> dict:
+    if isinstance(config, PretrainedConfig):
+        return config.to_dict()
+    return dict(config)
+
+
+class Glm5NextTextConfig(PretrainedConfig):
+    model_type = "glm5_next_text"
+    base_config_key = "text_config"
+    keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {"num_local_experts": "n_routed_experts"}
+
+    base_model_tp_plan = {
+        "layers.*.self_attn.o_proj": "rowwise",
+        "layers.*.mlp.experts.gate_proj": "colwise",
+        "layers.*.mlp.experts.up_proj": "colwise",
+        "layers.*.mlp.experts.down_proj": "rowwise",
+        "layers.*.mlp.gate_proj": "colwise",
+        "layers.*.mlp.up_proj": "colwise",
+        "layers.*.mlp.down_proj": "rowwise",
+    }
+    base_model_pp_plan = {
+        "embed_tokens": (["input_ids"], ["inputs_embeds"]),
+        "layers": (["hidden_states"], ["hidden_states"]),
+        "norm": (["hidden_states"], ["hidden_states"]),
+    }
+
+    def __init__(self, **kwargs):
+        model_type = kwargs.pop("model_type", self.model_type)
+        vocab_size = kwargs.pop("vocab_size", 154880)
+        hidden_size = kwargs.pop("hidden_size", 4096)
+        head_dim = kwargs.pop("head_dim", None)
+        intermediate_size = kwargs.pop("intermediate_size", 12288)
+        num_hidden_layers = kwargs.pop("num_hidden_layers", 45)
+        num_attention_heads = kwargs.pop("num_attention_heads", 64)
+        num_key_value_heads = kwargs.pop("num_key_value_heads", None)
+        hidden_act = kwargs.pop("hidden_act", "silu")
+        rms_norm_eps = kwargs.pop("rms_norm_eps", 1e-5)
+        pad_token_id = kwargs.pop("pad_token_id", 154820)
+        bos_token_id = kwargs.pop("bos_token_id", None)
+        eos_token_id = kwargs.pop("eos_token_id", None)
+        rope_parameters = kwargs.pop("rope_parameters", None)
+        rope_theta = kwargs.pop("rope_theta", 10000.0)
+        max_position_embeddings = kwargs.pop("max_position_embeddings", 1048576)
+        tie_word_embeddings = kwargs.pop("tie_word_embeddings", False)
+
+        moe_intermediate_size = kwargs.pop("moe_intermediate_size", 2048)
+        moe_renormalize = kwargs.pop("moe_renormalize", True)
+        norm_topk_prob = kwargs.pop("norm_topk_prob", moe_renormalize)
+        scoring_func = kwargs.pop("scoring_func", "sigmoid")
+        n_routed_experts = kwargs.pop("n_routed_experts", 288)
+        num_experts_per_token = kwargs.pop("num_experts_per_token", 8)
+        num_experts_per_tok = kwargs.pop("num_experts_per_tok", num_experts_per_token)
+        n_shared_experts = kwargs.pop("n_shared_experts", 1)
+        routed_scaling_factor = kwargs.pop("routed_scaling_factor", 2.5)
+        topk_method = kwargs.pop("topk_method", "noaux_tc")
+        first_k_dense_replace = kwargs.pop("first_k_dense_replace", 3)
+        moe_layer_freq = kwargs.pop("moe_layer_freq", 1)
+        use_grouped_topk = kwargs.pop("use_grouped_topk", True)
+        n_group = kwargs.pop("n_group", 1)
+        topk_group = kwargs.pop("topk_group", 1)
+        router_aux_loss_coef = kwargs.pop("router_aux_loss_coef", 1e-3)
+        moe_router_dtype = kwargs.pop("moe_router_dtype", None)
+        output_router_logits = kwargs.pop("output_router_logits", False)
+
+        mla = kwargs.pop("mla", True)
+        q_lora_rank = kwargs.pop("q_lora_rank", 1536)
+        kv_lora_rank = kwargs.pop("kv_lora_rank", 512)
+        qk_nope_head_dim = kwargs.pop("qk_nope_head_dim", 256)
+        qk_rope_head_dim = kwargs.pop("qk_rope_head_dim", 0)
+        qk_head_dim = kwargs.pop("qk_head_dim", qk_nope_head_dim + qk_rope_head_dim)
+        v_head_dim = kwargs.pop("v_head_dim", 256)
+        mla_nope = kwargs.pop("mla_nope", kwargs.pop("mla_use_nope", True))
+        num_nextn_predict_layers = kwargs.pop("num_nextn_predict_layers", 1)
+
+        layer_types = kwargs.pop("layer_types", None)
+        mlp_layer_types = kwargs.pop("mlp_layer_types", None)
+        linear_cfg = kwargs.pop("linear_attn_config", {}) or {}
+        linear_head_dim = kwargs.pop("linear_head_dim", linear_cfg.get("head_dim", 128))
+        linear_num_heads = kwargs.pop("linear_num_heads", linear_cfg.get("num_heads", 64))
+        linear_conv_kernel_dim = kwargs.pop("linear_conv_kernel_dim", linear_cfg.get("short_conv_kernel_size", 4))
+        linear_lower_bound = kwargs.pop("linear_lower_bound", linear_cfg.get("gate_lower_bound", -5.0))
+
+        index_head_dim = kwargs.pop("index_head_dim", 128)
+        index_topk = kwargs.pop("index_topk", 2048)
+        index_n_heads = kwargs.pop("index_n_heads", 32)
+        index_dsa_use_layernorm = kwargs.pop("index_dsa_use_layernorm", True)
+        index_kpool_compress = kwargs.pop("index_kpool_compress", True)
+        index_kpool = kwargs.pop("index_kpool", 4)
+        index_kpool_always_select_tail = kwargs.pop("index_kpool_always_select_tail", True)
+        indexer_rope_interleave = kwargs.pop("indexer_rope_interleave", True)
+        indexer_types = kwargs.pop("indexer_types", None)
+        use_index_cache = kwargs.pop("use_index_cache", False)
+        index_topk_freq = kwargs.pop("index_topk_freq", 1)
+        index_topk_pattern = kwargs.pop("index_topk_pattern", None)
+
+        mhc = kwargs.pop("mhc", True)
+        mhc_num_residual_streams = kwargs.pop("mhc_num_residual_streams", kwargs.pop("hc_mult", 4))
+        hc_eps = kwargs.pop("hc_eps", 1e-6)
+        mhc_tau = kwargs.pop("mhc_tau", 0.05)
+        hres_vwnstyle = kwargs.pop("hres_vwnstyle", True)
+        mhc_no_norm_weight = kwargs.pop("mhc_no_norm_weight", False)
+        mhc_sinkhorn_iterations = kwargs.pop("mhc_sinkhorn_iterations", kwargs.pop("hc_sinkhorn_iters", 20))
+        mhc_post_mult_value = kwargs.pop("mhc_post_mult_value", 2.0)
+        swiglu_limit = kwargs.pop("swiglu_limit", None)
+        logit_scale = kwargs.pop("logit_scale", 1.0)
+        use_cache = kwargs.pop("use_cache", True)
+        attention_bias = kwargs.pop("attention_bias", False)
+        attention_dropout = kwargs.pop("attention_dropout", 0.0)
+        initializer_range = kwargs.pop("initializer_range", 0.02)
+
+        if num_key_value_heads is None:
+            num_key_value_heads = num_attention_heads
+        if layer_types is None:
+            layer_types = _default_layer_types(num_hidden_layers)
+        if mlp_layer_types is None:
+            mlp_layer_types = _default_mlp_layer_types(num_hidden_layers, first_k_dense_replace)
+        if len(layer_types) < num_hidden_layers:
+            raise ValueError(
+                f"GLM-5.3 layer_types has {len(layer_types)} entries for {num_hidden_layers} hidden layers"
+            )
+        if len(mlp_layer_types) < num_hidden_layers:
+            raise ValueError(
+                f"GLM-5.3 mlp_layer_types has {len(mlp_layer_types)} entries for {num_hidden_layers} hidden layers"
+            )
+        if hidden_act != "silu":
+            raise ValueError(f"GLM-5.3 only supports silu hidden_act, got {hidden_act!r}")
+        if scoring_func not in ("softmax", "sigmoid"):
+            raise ValueError(f"Unknown GLM-5.3 MoE scoring_func {scoring_func!r}")
+
+        self.model_type = model_type
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.head_dim = qk_rope_head_dim if head_dim in (None, 0) else head_dim
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_act = hidden_act
+        self.rms_norm_eps = rms_norm_eps
+        self.max_position_embeddings = max_position_embeddings
+        self.rope_parameters = rope_parameters
+        self.rope_theta = rope_theta
+
+        self.mla = mla
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_head_dim = qk_head_dim
+        self.v_head_dim = v_head_dim
+        self.mla_nope = mla_nope
+
+        self.n_routed_experts = n_routed_experts
+        self.num_experts_per_token = num_experts_per_tok
+        self.num_experts_per_tok = num_experts_per_tok
+        self.moe_renormalize = norm_topk_prob
+        self.norm_topk_prob = norm_topk_prob
+        self.n_shared_experts = n_shared_experts
+        self.routed_scaling_factor = routed_scaling_factor
+        self.topk_method = topk_method
+        self.scoring_func = scoring_func
+        self.moe_intermediate_size = moe_intermediate_size
+        self.first_k_dense_replace = first_k_dense_replace
+        self.moe_layer_freq = moe_layer_freq
+        self.use_grouped_topk = use_grouped_topk
+        self.n_group = n_group
+        self.topk_group = topk_group
+        self.router_aux_loss_coef = router_aux_loss_coef
+        self.load_balance_coeff = router_aux_loss_coef
+        self.moe_router_dtype = moe_router_dtype
+        self.output_router_logits = output_router_logits
+        self.num_nextn_predict_layers = num_nextn_predict_layers
+
+        self.glm5_layer_types = layer_types
+        self.layer_types = [
+            "linear_attention" if layer_type == "linear_attention" else "sparse" for layer_type in layer_types
+        ]
+        self.mlp_layer_types = mlp_layer_types
+        self.linear_head_dim = linear_head_dim
+        self.linear_num_heads = linear_num_heads
+        self.linear_conv_kernel_dim = linear_conv_kernel_dim
+        self.linear_lower_bound = linear_lower_bound
+
+        self.index_head_dim = index_head_dim
+        self.index_topk = index_topk
+        self.index_n_heads = index_n_heads
+        self.index_dsa_use_layernorm = index_dsa_use_layernorm
+        self.index_kpool_compress = index_kpool_compress
+        self.index_kpool = index_kpool
+        self.index_kpool_always_select_tail = index_kpool_always_select_tail
+        self.indexer_rope_interleave = indexer_rope_interleave
+        self.indexer_types = indexer_types
+        self.use_index_cache = use_index_cache
+        self.index_topk_freq = index_topk_freq
+        self.index_topk_pattern = index_topk_pattern
+
+        self.mhc = mhc
+        self.mhc_num_residual_streams = mhc_num_residual_streams
+        self.hc_mult = mhc_num_residual_streams
+        self.hc_eps = hc_eps
+        self.mhc_tau = mhc_tau
+        self.hres_vwnstyle = hres_vwnstyle
+        self.mhc_no_norm_weight = mhc_no_norm_weight
+        self.mhc_sinkhorn_iterations = mhc_sinkhorn_iterations
+        self.hc_sinkhorn_iters = mhc_sinkhorn_iterations
+        self.mhc_post_mult_value = mhc_post_mult_value
+        self.swiglu_limit = swiglu_limit
+        self.logit_scale = logit_scale
+        self.use_cache = use_cache
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        self.initializer_range = initializer_range
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+
+    @property
+    def is_mla(self):
+        return self.mla
+
+    @property
+    def is_moe(self):
+        return self.n_routed_experts is not None
+
+    @property
+    def is_linear_attn(self) -> bool:
+        return any(layer_type == "linear_attention" for layer_type in self.layer_types)
+
+    def is_kda_layer(self, layer_idx: int) -> bool:
+        return self.glm5_layer_types[layer_idx] == "linear_attention"
+
+    @property
+    def layers_block_type(self):
+        return [
+            "linear_attention" if layer_type == "linear_attention" else "attention"
+            for layer_type in self.glm5_layer_types
+        ]
+
+
+class Glm5NextConfig(Glm5NextTextConfig):
+    model_type = "glm5_next"
+    sub_configs = {"text_config": Glm5NextTextConfig}
+
+    def __init__(self, text_config=None, vision_config=None, **kwargs):
+        if text_config is not None:
+            text_kwargs = _as_dict(text_config)
+            for key in ("_attn_implementation", "attn_implementation"):
+                if key in kwargs:
+                    text_kwargs[key] = kwargs[key]
+            super().__init__(**text_kwargs)
+            self.text_config = Glm5NextTextConfig(**text_kwargs)
+        else:
+            super().__init__(**kwargs)
+            self.text_config = Glm5NextTextConfig(**self.to_dict())
+        self.model_type = Glm5NextConfig.model_type
+        self.vision_config = vision_config
+        self.image_token_id = kwargs.get("image_token_id")
+        self.video_token_id = kwargs.get("video_token_id")
+        self.image_start_token_id = kwargs.get("image_start_token_id")
+        self.image_end_token_id = kwargs.get("image_end_token_id")
+        self.video_start_token_id = kwargs.get("video_start_token_id")
+        self.video_end_token_id = kwargs.get("video_end_token_id")
+
+    def get_text_config(self, decoder: bool = False):
+        return getattr(self, "text_config", self)

--- a/src/prime_rl/trainer/models/glm5_next/converting_glm5_next.py
+++ b/src/prime_rl/trainer/models/glm5_next/converting_glm5_next.py
@@ -1,0 +1,25 @@
+"""HF<->PrimeRL weight conversion for text-only GLM-5.3."""
+
+from __future__ import annotations
+
+from prime_rl.trainer.models.conversion_ops import ConvOp, Drop, PrefixRename
+from prime_rl.trainer.models.glm4_moe.converting_glm4_moe import glm_moe_layer_ops
+
+
+def conversion_chain(config) -> list[ConvOp]:
+    ops: list[ConvOp] = [
+        PrefixRename("model.language_model.", "model."),
+        Drop("model.visual.", is_prefix=True),
+        Drop("visual.", is_prefix=True),
+    ]
+    for layer_idx in range(config.num_hidden_layers):
+        ops.extend(glm_moe_layer_ops(layer_idx))
+        p = f"model.layers.{layer_idx}.self_attn.indexer"
+        ops.append(Drop(f"{p}.index_kpool_compress_ape"))
+        ops.append(Drop(f"{p}.index_kpool_compress_gate"))
+
+    num_extra_layers = getattr(config, "num_nextn_predict_layers", 0) or 0
+    for layer_idx in range(config.num_hidden_layers, config.num_hidden_layers + num_extra_layers):
+        ops.append(Drop(f"model.layers.{layer_idx}.", is_prefix=True))
+
+    return ops

--- a/src/prime_rl/trainer/models/glm5_next/modeling_glm5_next.py
+++ b/src/prime_rl/trainer/models/glm5_next/modeling_glm5_next.py
@@ -1,0 +1,817 @@
+import warnings
+from typing import Optional, Union
+
+import torch
+import torch.distributed as dist
+from fla.modules import FusedRMSNormGated
+from fla.modules.conv import causal_conv1d as fla_causal_conv1d
+from fla.ops.cp import FLACPContext, build_cp_context
+from fla.ops.kda import chunk_kda
+from torch import Tensor, nn
+from transformers.cache_utils import Cache
+from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
+from transformers.modeling_outputs import BaseModelOutputWithPast
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs
+
+from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.glm_moe_dsa.configuration_glm_moe_dsa import _index_cache_skip_topk
+from prime_rl.trainer.models.glm_moe_dsa.sparse_mla_attention import GlmMoeDsaAttention, SparseMlaAttentionArgs
+from prime_rl.trainer.models.layers.activations import ActivationType
+from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
+from prime_rl.trainer.models.layers.mlp import FeedForward
+from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
+from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
+from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
+
+from .configuration_glm5_next import Glm5NextConfig, Glm5NextTextConfig
+from .converting_glm5_next import conversion_chain
+
+
+@torch.compiler.disable
+def _fla_causal_conv1d_cp(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    activation: str,
+    cp_context: FLACPContext,
+) -> torch.Tensor:
+    output, _ = fla_causal_conv1d(
+        x=x,
+        weight=weight,
+        bias=bias,
+        activation=activation,
+        cp_context=cp_context,
+    )
+    return output
+
+
+def _sparse_mla_attention_args(config: Glm5NextTextConfig, layer_idx: int) -> SparseMlaAttentionArgs:
+    if config.q_lora_rank is None:
+        raise ValueError("Sparse MLA attention requires q_lora_rank to be set")
+    return SparseMlaAttentionArgs(
+        hidden_size=config.hidden_size,
+        num_attention_heads=config.num_attention_heads,
+        kv_lora_rank=config.kv_lora_rank,
+        q_lora_rank=config.q_lora_rank,
+        qk_rope_head_dim=config.qk_rope_head_dim,
+        qk_nope_head_dim=config.qk_nope_head_dim,
+        qk_head_dim=config.qk_head_dim,
+        v_head_dim=config.v_head_dim,
+        attention_bias=config.attention_bias,
+        rms_norm_eps=config.rms_norm_eps,
+        index_n_heads=config.index_n_heads,
+        index_head_dim=config.index_head_dim,
+        index_topk=config.index_topk,
+        use_index_cache=getattr(config, "use_index_cache", False),
+        skip_topk=_index_cache_skip_topk(config, layer_idx),
+    )
+
+
+def _glm5_activation(config: Glm5NextTextConfig) -> ActivationType:
+    if config.swiglu_limit is None:
+        return config.hidden_act
+    if float(config.swiglu_limit) != 10.0:
+        raise NotImplementedError("GLM-5.3 SwiGLU clamping only supports swiglu_limit=10.0")
+    return "glm_clamped_swiglu"
+
+
+class Glm5NextLinearAttention(nn.Module):
+    def __init__(self, config: Glm5NextTextConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.head_dim = config.linear_head_dim
+        self.num_heads = config.linear_num_heads
+        self.projection_size = self.num_heads * self.head_dim
+        self.conv_kernel_size = config.linear_conv_kernel_dim
+        self.activation = config.hidden_act
+        self.lower_bound = config.linear_lower_bound
+
+        self.q_proj = nn.Linear(self.hidden_size, self.projection_size, bias=False)
+        self.k_proj = nn.Linear(self.hidden_size, self.projection_size, bias=False)
+        self.v_proj = nn.Linear(self.hidden_size, self.projection_size, bias=False)
+        self.b_proj = nn.Linear(self.hidden_size, self.num_heads, bias=False)
+        self.f_a_proj = nn.Linear(self.hidden_size, self.head_dim, bias=False)
+        self.f_b_proj = nn.Linear(self.head_dim, self.projection_size, bias=False)
+        self.g_a_proj = nn.Linear(self.hidden_size, self.head_dim, bias=False)
+        self.g_b_proj = nn.Linear(self.head_dim, self.projection_size, bias=False)
+
+        self.q_conv1d = nn.Conv1d(
+            self.projection_size,
+            self.projection_size,
+            bias=False,
+            kernel_size=self.conv_kernel_size,
+            groups=self.projection_size,
+            padding=self.conv_kernel_size - 1,
+        )
+        self.k_conv1d = nn.Conv1d(
+            self.projection_size,
+            self.projection_size,
+            bias=False,
+            kernel_size=self.conv_kernel_size,
+            groups=self.projection_size,
+            padding=self.conv_kernel_size - 1,
+        )
+        self.v_conv1d = nn.Conv1d(
+            self.projection_size,
+            self.projection_size,
+            bias=False,
+            kernel_size=self.conv_kernel_size,
+            groups=self.projection_size,
+            padding=self.conv_kernel_size - 1,
+        )
+
+        self.A_log = nn.Parameter(torch.empty(self.num_heads, dtype=torch.float32))
+        self.dt_bias = nn.Parameter(torch.empty(self.projection_size, dtype=torch.float32))
+        self.o_norm = FusedRMSNormGated(self.head_dim, eps=config.rms_norm_eps, activation="sigmoid")
+        self.o_proj = nn.Linear(self.projection_size, self.hidden_size, bias=False)
+
+        self.cp_group: dist.ProcessGroup | None = None
+        self.cp_rank: int = 0
+        self.cp_world_size: int = 1
+
+    def _build_cp_context(
+        self,
+        device: torch.device,
+        cu_seqlens: torch.LongTensor | None = None,
+        cu_seqlens_are_pre_shard: bool = False,
+    ) -> FLACPContext | None:
+        if self.cp_group is None:
+            return None
+        if cu_seqlens is None or not cu_seqlens_are_pre_shard:
+            raise ValueError("GLM-5.3 KDA context parallelism requires full pre-shard sequence boundaries")
+        return build_cp_context(
+            cu_seqlens=cu_seqlens.to(device=device, dtype=torch.int32),
+            group=self.cp_group,
+            conv1d_kernel_size=self.conv_kernel_size,
+        )
+
+    def _conv1d(
+        self,
+        x: torch.Tensor,
+        conv: nn.Conv1d,
+        cu_seqlens: torch.LongTensor | None,
+        cp_context: FLACPContext | None,
+    ) -> torch.Tensor:
+        weight = conv.weight.squeeze(1)
+        if cp_context is None:
+            out, _ = fla_causal_conv1d(
+                x=x,
+                weight=weight,
+                bias=conv.bias,
+                activation=self.activation,
+                cu_seqlens=cu_seqlens,
+            )
+            return out
+        return _fla_causal_conv1d_cp(
+            x=x,
+            weight=weight,
+            bias=conv.bias,
+            activation=self.activation,
+            cp_context=cp_context,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.LongTensor | None = None,
+        cu_seqlens_are_pre_shard: bool = False,
+    ) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+        cp_context = self._build_cp_context(hidden_states.device, cu_seqlens, cu_seqlens_are_pre_shard)
+
+        query = self._conv1d(self.q_proj(hidden_states), self.q_conv1d, cu_seqlens, cp_context)
+        key = self._conv1d(self.k_proj(hidden_states), self.k_conv1d, cu_seqlens, cp_context)
+        value = self._conv1d(self.v_proj(hidden_states), self.v_conv1d, cu_seqlens, cp_context)
+
+        query = query.reshape(batch_size, seq_len, self.num_heads, self.head_dim)
+        key = key.reshape(batch_size, seq_len, self.num_heads, self.head_dim)
+        value = value.reshape(batch_size, seq_len, self.num_heads, self.head_dim)
+
+        beta = self.b_proj(hidden_states)
+        gate_a = self.f_a_proj(hidden_states)
+        gate = self.f_b_proj(gate_a).reshape(batch_size, seq_len, self.num_heads, self.head_dim)
+
+        core_attn_out, _ = chunk_kda(
+            query,
+            key,
+            value,
+            g=gate,
+            beta=beta,
+            A_log=self.A_log,
+            dt_bias=self.dt_bias,
+            use_qk_l2norm_in_kernel=True,
+            use_gate_in_kernel=True,
+            use_beta_sigmoid_in_kernel=True,
+            safe_gate=True,
+            lower_bound=self.lower_bound,
+            cu_seqlens=cu_seqlens,
+            cp_context=cp_context,
+        )
+
+        output_gate = self.g_b_proj(self.g_a_proj(hidden_states)).reshape(
+            batch_size, seq_len, self.num_heads, self.head_dim
+        )
+        core_attn_out = self.o_norm(core_attn_out, output_gate)
+        core_attn_out = core_attn_out.reshape(batch_size, seq_len, self.projection_size)
+        return self.o_proj(core_attn_out)
+
+
+def _hc_expand(x: torch.Tensor, n: int) -> torch.Tensor:
+    return x.unsqueeze(-2).expand(*x.shape[:-1], n, x.shape[-1]).contiguous()
+
+
+def _hc_contract(x: torch.Tensor) -> torch.Tensor:
+    return x.mean(dim=-2)
+
+
+def _mhc_pre_torch(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+    residual_flat = residual.reshape(-1, hc_mult, hidden_size)
+    num_tokens = residual_flat.shape[0]
+
+    x = residual_flat.reshape(num_tokens, hc_mult * hidden_size).to(torch.float32)
+    fn = fn.to(torch.float32)
+    hc_scale = hc_scale.to(torch.float32)
+    hc_base = hc_base.to(torch.float32)
+    mixes = torch.matmul(x, fn.t())
+    sqrsum = x.square().sum(dim=-1, keepdim=True)
+    mixes = mixes * torch.rsqrt(sqrsum / (hc_mult * hidden_size) + rms_eps)
+
+    pre_logits = mixes[:, :hc_mult] * hc_scale[0] + hc_base[:hc_mult]
+    pre_mix = torch.sigmoid(pre_logits) + hc_pre_eps
+
+    post_logits = mixes[:, hc_mult : 2 * hc_mult] * hc_scale[1] + hc_base[hc_mult : 2 * hc_mult]
+    post_mix = torch.sigmoid(post_logits) * hc_post_mult_value
+
+    comb_logits = mixes[:, 2 * hc_mult :].reshape(num_tokens, hc_mult, hc_mult)
+    comb_logits = comb_logits * hc_scale[2] + hc_base[2 * hc_mult :].reshape(1, hc_mult, hc_mult)
+    comb_mix = torch.softmax(comb_logits, dim=-1) + hc_sinkhorn_eps
+    comb_mix = comb_mix / (comb_mix.sum(dim=-2, keepdim=True) + hc_sinkhorn_eps)
+    for _ in range(sinkhorn_repeat - 1):
+        comb_mix = comb_mix / (comb_mix.sum(dim=-1, keepdim=True) + hc_sinkhorn_eps)
+        comb_mix = comb_mix / (comb_mix.sum(dim=-2, keepdim=True) + hc_sinkhorn_eps)
+
+    layer_input = torch.sum(pre_mix.unsqueeze(-1) * residual_flat.to(torch.float32), dim=1).to(residual.dtype)
+    return (
+        post_mix.reshape(*outer_shape, hc_mult, 1),
+        comb_mix.reshape(*outer_shape, hc_mult, hc_mult),
+        layer_input.reshape(*outer_shape, hidden_size),
+    )
+
+
+def _mhc_post_torch(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    mixed_residual = torch.einsum("...ij,...ih->...jh", comb_res_mix.float(), residual.float())
+    post_term = post_layer_mix.float() * x.unsqueeze(-2).float()
+    return (mixed_residual + post_term).to(residual.dtype)
+
+
+class Glm5NextDecoderLayer(GradientCheckpointingLayer):
+    def __init__(self, config: Glm5NextTextConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.layer_idx = layer_idx
+        self.num_hidden_layers = config.num_hidden_layers
+        self.layer_type = config.glm5_layer_types[layer_idx]
+        self.mhc = bool(config.mhc)
+
+        if self.layer_type == "linear_attention":
+            self.self_attn = Glm5NextLinearAttention(config)
+        elif self.layer_type == "deepseek_sparse_attention":
+            self.self_attn = GlmMoeDsaAttention(_sparse_mla_attention_args(config, layer_idx))
+        else:
+            raise ValueError(f"Unsupported GLM-5.3 layer_type {self.layer_type!r}")
+
+        activation = _glm5_activation(config)
+        moe_args = MoEArgs(
+            num_experts=config.n_routed_experts,
+            expert_type="gated",
+            activation=activation,
+            score_func=config.scoring_func,
+            route_norm=config.norm_topk_prob,
+            route_scale=config.routed_scaling_factor,
+            score_before_experts=False,
+            top_k=config.num_experts_per_tok,
+            load_balance_coeff=config.load_balance_coeff,
+        )
+        self.mlp_type = config.mlp_layer_types[layer_idx]
+        if config.is_moe and self.mlp_type == "sparse":
+            shared_expert = None
+            if config.n_shared_experts > 0:
+                shared_expert = FeedForward(
+                    dim=config.hidden_size,
+                    hidden_dim=config.moe_intermediate_size * config.n_shared_experts,
+                    expert_type=moe_args.expert_type,
+                    activation=moe_args.activation,
+                )
+            self.mlp = MoE.from_args(
+                moe_args,
+                dim=config.hidden_size,
+                hidden_dim=config.moe_intermediate_size,
+                shared_expert=shared_expert,
+            )
+        else:
+            self.mlp = FeedForward(
+                dim=config.hidden_size,
+                hidden_dim=config.intermediate_size,
+                activation=activation,
+            )
+
+        self.input_layernorm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.rms_norm_eps))
+        self.post_attention_layernorm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.rms_norm_eps))
+
+        if self.mhc:
+            self.n = config.mhc_num_residual_streams
+            d_model = self.n * self.hidden_size
+            mix_hc = (2 + self.n) * self.n
+            self.hc_eps = config.hc_eps
+            self.rms_norm_eps = config.rms_norm_eps
+            self.mhc_sinkhorn_iterations = config.mhc_sinkhorn_iterations
+            self.mhc_post_mult_value = config.mhc_post_mult_value
+
+            self.hc_attn_fn = nn.Parameter(torch.empty(mix_hc, d_model, dtype=torch.float32))
+            self.hc_attn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
+            self.hc_attn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
+            self.hc_ffn_fn = nn.Parameter(torch.empty(mix_hc, d_model, dtype=torch.float32))
+            self.hc_ffn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
+            self.hc_ffn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
+
+    def set_context_parallel_attributes(self, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
+        self._cp_group = cp_group
+        self._cp_rank = cp_rank
+        self._cp_world_size = cp_world_size
+        if self.layer_type == "linear_attention":
+            self.self_attn.cp_group = cp_group
+            self.self_attn.cp_rank = cp_rank
+            self.self_attn.cp_world_size = cp_world_size
+        else:
+            self.self_attn.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
+
+    def _run_attention(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        ks: torch.Tensor | None,
+        ke: torch.Tensor | None,
+        cached_indices: torch.Tensor | None,
+        cu_seqlens: torch.LongTensor | None,
+        cu_seqlens_are_pre_shard: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if self.layer_type == "linear_attention":
+            return (
+                self.self_attn(
+                    hidden_states,
+                    cu_seqlens=cu_seqlens,
+                    cu_seqlens_are_pre_shard=cu_seqlens_are_pre_shard,
+                ),
+                cached_indices,
+            )
+        return self.self_attn(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            ks=ks,
+            ke=ke,
+            cached_indices=cached_indices,
+        )
+
+    def _hc_pre(
+        self,
+        x: torch.Tensor,
+        hc_fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return _mhc_pre_torch(
+            x,
+            hc_fn,
+            hc_scale,
+            hc_base,
+            rms_eps=self.rms_norm_eps,
+            hc_pre_eps=self.hc_eps,
+            hc_sinkhorn_eps=self.hc_eps,
+            hc_post_mult_value=self.mhc_post_mult_value,
+            sinkhorn_repeat=self.mhc_sinkhorn_iterations,
+        )
+
+    def _forward_without_mhc(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        ks: torch.Tensor | None,
+        ke: torch.Tensor | None,
+        cached_indices: torch.Tensor | None,
+        routed_experts: Optional[torch.LongTensor],
+        cu_seqlens: torch.LongTensor | None,
+        cu_seqlens_are_pre_shard: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, cached_indices = self._run_attention(
+            hidden_states,
+            position_embeddings,
+            ks,
+            ke,
+            cached_indices,
+            cu_seqlens,
+            cu_seqlens_are_pre_shard,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states, routed_experts=routed_experts)
+        hidden_states = residual + hidden_states
+        return hidden_states, cached_indices, None, None, None
+
+    def _forward_with_mhc(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        ks: torch.Tensor | None,
+        ke: torch.Tensor | None,
+        cached_indices: torch.Tensor | None,
+        routed_experts: Optional[torch.LongTensor],
+        cu_seqlens: torch.LongTensor | None,
+        cu_seqlens_are_pre_shard: bool,
+        hc_residual: torch.Tensor | None,
+        hc_post: torch.Tensor | None,
+        hc_comb: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+        x = hidden_states
+        if hc_post is None:
+            if hc_residual is None:
+                hc_residual = _hc_expand(x, self.n)
+            hc_post, hc_comb, x = self._hc_pre(hc_residual, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base)
+        else:
+            hc_residual = _mhc_post_torch(x, hc_residual, hc_post, hc_comb)
+            hc_post, hc_comb, x = self._hc_pre(hc_residual, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base)
+
+        x = self.input_layernorm(x)
+        x, cached_indices = self._run_attention(
+            x,
+            position_embeddings,
+            ks,
+            ke,
+            cached_indices,
+            cu_seqlens,
+            cu_seqlens_are_pre_shard,
+        )
+
+        hc_residual = _mhc_post_torch(x, hc_residual, hc_post, hc_comb)
+        hc_post, hc_comb, x = self._hc_pre(hc_residual, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base)
+        x = self.post_attention_layernorm(x)
+        x = self.mlp(x, routed_experts=routed_experts)
+
+        if self.layer_idx == self.num_hidden_layers - 1:
+            x = _mhc_post_torch(x, hc_residual, hc_post, hc_comb)
+            return _hc_contract(x), cached_indices, None, None, None
+        return x, cached_indices, hc_residual, hc_post, hc_comb
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        ks: torch.Tensor | None = None,
+        ke: torch.Tensor | None = None,
+        cached_indices: torch.Tensor | None = None,
+        routed_experts: Optional[torch.LongTensor] = None,
+        cu_seqlens: torch.LongTensor | None = None,
+        cu_seqlens_are_pre_shard: bool = False,
+        hc_residual: torch.Tensor | None = None,
+        hc_post: torch.Tensor | None = None,
+        hc_comb: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+        if not self.mhc:
+            return self._forward_without_mhc(
+                hidden_states,
+                position_embeddings,
+                ks,
+                ke,
+                cached_indices,
+                routed_experts,
+                cu_seqlens,
+                cu_seqlens_are_pre_shard,
+            )
+        return self._forward_with_mhc(
+            hidden_states,
+            position_embeddings,
+            ks,
+            ke,
+            cached_indices,
+            routed_experts,
+            cu_seqlens,
+            cu_seqlens_are_pre_shard,
+            hc_residual,
+            hc_post,
+            hc_comb,
+        )
+
+
+class Glm5NextPreTrainedModel(PreTrainedModelPrimeRL):
+    config_class = Glm5NextTextConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["Glm5NextDecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn = True
+    _supports_sdpa = False
+    _supports_flex_attn = False
+    _can_compile_fullgraph = False
+    _supports_attention_backend = True
+    _can_record_outputs = {
+        "hidden_states": Glm5NextDecoderLayer,
+    }
+
+    def _init_weights(self, module):
+        super()._init_weights(module)
+        text_config = self.config.get_text_config() if isinstance(self.config, Glm5NextConfig) else self.config
+        std = getattr(text_config, "initializer_range", 0.02)
+        if isinstance(module, MoE):
+            module.init_weights(std, buffer_device=module.tokens_per_expert.device)
+        elif isinstance(module, Glm5NextLinearAttention):
+            nn.init.zeros_(module.A_log)
+            nn.init.zeros_(module.dt_bias)
+        elif isinstance(module, Glm5NextDecoderLayer) and module.mhc:
+            for weight in (module.hc_attn_fn, module.hc_ffn_fn):
+                nn.init.trunc_normal_(weight, mean=0.0, std=std)
+            for bias in (module.hc_attn_base, module.hc_ffn_base):
+                nn.init.zeros_(bias)
+            for scale in (module.hc_attn_scale, module.hc_ffn_scale):
+                nn.init.ones_(scale)
+
+    @classmethod
+    def keep_in_fp32_for_weight_transfer(cls, name: str) -> bool:
+        return name.endswith(("mlp.router.selection_bias", "self_attn.A_log", "self_attn.dt_bias")) or ".hc_" in name
+
+    @classmethod
+    def is_hf_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return any(
+            "model.language_model.layers." in name
+            or "mlp.experts.1.up_proj" in name
+            or "mlp.experts.gate_up_proj" in name
+            or "self_attn.indexer.index_kpool_compress_" in name
+            for name in state_dict.keys()
+        )
+
+    @classmethod
+    def is_prime_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return any(name.startswith("model.") for name in state_dict.keys()) and not any(
+            name.startswith("model.language_model.") for name in state_dict.keys()
+        )
+
+    @classmethod
+    def conversion_chain(cls, config):
+        text_config = config.get_text_config() if isinstance(config, Glm5NextConfig) else config
+        return conversion_chain(text_config)
+
+
+class Glm5NextModel(Glm5NextPreTrainedModel):
+    def __init__(self, config: Glm5NextTextConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [Glm5NextDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.rms_norm_eps))
+        self.rotary_emb = self._create_rotary_emb(config)
+        self.gradient_checkpointing = False
+        self.post_init()
+
+    def _create_rotary_emb(self, config: Glm5NextTextConfig) -> RotaryEmbedding | None:
+        if config.qk_rope_head_dim == 0:
+            return None
+        rope_parameters = getattr(config, "rope_parameters", None) or {}
+        rope_type = rope_parameters.get("rope_type", "default") if isinstance(rope_parameters, dict) else "default"
+        rotary_config = RotaryEmbeddingConfig(
+            max_position_embeddings=config.max_position_embeddings,
+            rope_type=rope_type,
+            model_config=config,
+        )
+        return RotaryEmbedding(rotary_config)
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def set_context_parallel_attributes(self, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
+        self._cp_group = cp_group
+        self._cp_rank = cp_rank
+        self._cp_world_size = cp_world_size
+        for layer in self.layers:
+            layer.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
+
+    def _context_parallel_state(self) -> tuple[dist.ProcessGroup | None, int, int]:
+        if len(self.layers) == 0:
+            return None, 0, 1
+        layer = self.layers[0]
+        return getattr(layer, "_cp_group", None), getattr(layer, "_cp_rank", 0), getattr(layer, "_cp_world_size", 1)
+
+    def _gather_position_ids_for_cp(
+        self,
+        position_ids: torch.LongTensor,
+        cp_group: dist.ProcessGroup,
+        cp_world_size: int,
+    ) -> torch.LongTensor:
+        gathered_position_ids = [torch.empty_like(position_ids) for _ in range(cp_world_size)]
+        dist.all_gather(gathered_position_ids, position_ids.contiguous(), group=cp_group)
+        return torch.cat(gathered_position_ids, dim=1)
+
+    def _position_embeddings(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids_full: torch.LongTensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.rotary_emb is None:
+            shape = (*position_ids_full.shape, 0)
+            empty = hidden_states.new_empty(shape)
+            return empty, empty
+        return self.rotary_emb(hidden_states, position_ids_full)
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: Optional[torch.LongTensor] = None,
+        seq_lens_are_pre_shard: bool = False,
+    ) -> BaseModelOutputWithPast:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids is None:
+            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+        if seq_lens is None:
+            seq_lens = torch.tensor([inputs_embeds.shape[1]], dtype=torch.long, device=inputs_embeds.device)
+
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device),
+            total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+        )
+        del max_seqlen
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+
+        cp_group, cp_rank, cp_world_size = self._context_parallel_state()
+        if cp_group is not None and cp_world_size > 1:
+            position_ids_full = self._gather_position_ids_for_cp(position_ids, cp_group, cp_world_size)
+        else:
+            position_ids_full = position_ids
+
+        flat_position_ids = position_ids_full.reshape(-1)
+        s_full = flat_position_ids.shape[0]
+        ks_full = torch.arange(s_full, dtype=torch.int32, device=flat_position_ids.device) - flat_position_ids.to(
+            torch.int32
+        )
+        ke_full = torch.arange(1, s_full + 1, dtype=torch.int32, device=flat_position_ids.device)
+
+        hidden_states = inputs_embeds
+        position_embeddings = self._position_embeddings(hidden_states, position_ids_full)
+
+        if cp_world_size > 1:
+            s_local = s_full // cp_world_size
+            ks = ks_full[cp_rank * s_local : (cp_rank + 1) * s_local].contiguous()
+            ke = ke_full[cp_rank * s_local : (cp_rank + 1) * s_local].contiguous()
+        else:
+            ks, ke = ks_full, ke_full
+
+        cached_indices = None
+        hc_residual = None
+        hc_post = None
+        hc_comb = None
+        use_index_cache = getattr(self.config, "use_index_cache", False)
+        for layer_idx, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
+            routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
+            hidden_states, next_cached_indices, hc_residual, hc_post, hc_comb = decoder_layer(
+                hidden_states,
+                position_embeddings=position_embeddings,
+                ks=ks,
+                ke=ke,
+                cached_indices=cached_indices,
+                routed_experts=routed_experts_layer,
+                cu_seqlens=cu_seqlens,
+                cu_seqlens_are_pre_shard=seq_lens_are_pre_shard,
+                hc_residual=hc_residual,
+                hc_post=hc_post,
+                hc_comb=hc_comb,
+            )
+            cached_indices = next_cached_indices if use_index_cache else None
+
+        hidden_states = self.norm(hidden_states)
+        return BaseModelOutputWithPast(last_hidden_state=hidden_states)
+
+
+class Glm5NextForCausalLM(Glm5NextPreTrainedModel, GenerationMixin):
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
+    _tp_plan = {"lm_head": "colwise_rep"}
+    _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+
+    def __init__(self, config, **kwargs):
+        text_config = config.get_text_config() if isinstance(config, Glm5NextConfig) else config
+        super().__init__(config, **kwargs)
+        self.model = Glm5NextModel(text_config)
+        self.vocab_size = text_config.vocab_size
+        self.lm_head = nn.Linear(text_config.hidden_size, text_config.vocab_size, bias=False)
+
+        warnings.warn(
+            "Glm5NextForCausalLM is experimental: KDA and mHC use correctness-first training paths, "
+            "and the sparse MLA indexer does not yet implement GLM-5.3 k-pool compression."
+        )
+        warnings.warn("`model.attn` is ignored, GLM-5.3 dispatches per-layer KDA/sparse MLA from layer_types.")
+
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.model.set_input_embeddings(value)
+
+    def set_context_parallel_attributes(self, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
+        self.model.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        temperature: Optional[torch.Tensor] = None,
+        routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
+        seq_lens_are_pre_shard: bool = False,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> PrimeLmOutput:
+        del attention_mask, cache_position, kwargs
+        assert use_cache is None, "use_cache is not supported for custom glm5_next for now"
+        assert past_key_values is None, "past_key_values is not supported for custom glm5_next for now"
+
+        if position_ids is None:
+            if inputs_embeds is not None:
+                position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+            else:
+                position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).unsqueeze(0)
+
+        outputs: BaseModelOutputWithPast = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            routed_experts=routed_experts,
+            seq_lens=seq_lens,
+            seq_lens_are_pre_shard=seq_lens_are_pre_shard,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        return self.lm_head(
+            hidden_states[:, slice_indices, :],
+            labels[:, slice_indices] if labels is not None else None,
+            temperature=temperature,
+        )
+
+    def init_buffers_post_meta(self):
+        if self.model.rotary_emb is None:
+            return
+        rotary_emb = self.model.rotary_emb
+        inv_freq, rotary_emb.attention_scaling = rotary_emb.rope_init_fn(rotary_emb.config, rotary_emb.inv_freq.device)
+        rotary_emb.inv_freq.copy_(inv_freq)
+
+
+__all__ = [
+    "Glm5NextConfig",
+    "Glm5NextTextConfig",
+    "Glm5NextPreTrainedModel",
+    "Glm5NextModel",
+    "Glm5NextForCausalLM",
+]

--- a/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
@@ -40,22 +40,25 @@ class _SparseMLA(torch.autograd.Function):
     """Autograd wrapper for tilelang sparse MLA forward/backward kernels."""
 
     @staticmethod
-    def forward(ctx, q, kv, indices, sm_scale):
-        out, lse = sparse_mla_fwd_interface(q, kv, indices, sm_scale=sm_scale)
+    def forward(ctx, q, kv, indices, sm_scale, d_v):
+        out, lse = sparse_mla_fwd_interface(q, kv, indices, sm_scale=sm_scale, d_v=d_v)
         ctx.save_for_backward(q, kv, out, indices, lse)
         ctx.sm_scale = sm_scale
+        ctx.d_v = d_v
         return out
 
     @staticmethod
     def backward(ctx, do):
         q, kv, out, indices, lse = ctx.saved_tensors
-        dq, dkv = sparse_mla_bwd(q, kv, out, do.contiguous(), indices, lse, sm_scale=ctx.sm_scale)
-        return dq, dkv, None, None
+        dq, dkv = sparse_mla_bwd(q, kv, out, do.contiguous(), indices, lse, sm_scale=ctx.sm_scale, d_v=ctx.d_v)
+        return dq, dkv, None, None, None
 
 
 def apply_rope_interleave_single(
     t: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, unsqueeze_dim: int = 1
 ) -> torch.Tensor:
+    if t.shape[-1] == 0:
+        return t
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
     b, h, s, d = t.shape
@@ -268,6 +271,6 @@ class GlmMoeDsaAttention(nn.Module):
             position_embeddings_full=position_embeddings,
         )
 
-        out = _SparseMLA.apply(sparse_q, sparse_kv, indices, self.scaling)
+        out = _SparseMLA.apply(sparse_q, sparse_kv, indices, self.scaling, self.v_head_dim)
         cached_indices = indices if self.use_index_cache else None
         return self.output_proj(out, w_v), cached_indices

--- a/src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py
+++ b/src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py
@@ -115,6 +115,7 @@ def bwd(
     assert dtype == T.bfloat16
     assert accum_dtype == T.float32
     assert indices_dtype == T.int32
+    assert D_tail == 0 or D_tail % 4 == 0
 
     if sm_scale is None:
         sm_scale = (D + D_tail) ** (-0.5)
@@ -141,6 +142,7 @@ def bwd(
     NS = tilelang.cdiv(topk, block_size)
 
     split_store = 2
+    has_tail = D_tail > 0
 
     @T.prim_func
     def sparse_mla_bwd_kernel(
@@ -155,25 +157,27 @@ def bwd(
     ):
         with T.Kernel(S, B, kv_group * NH, threads=threads) as (s_i, by, bz):
             Q_shared = T.alloc_shared([block_H, D], dtype)
-            Q_tail_shared = T.alloc_shared([block_H, D_tail], dtype)
             KV_shared = T.alloc_shared([BS, D], dtype)
-            KV_tail_shared = T.alloc_shared([BS, D_tail], dtype)
             dO_shared = T.alloc_shared([block_H, D], dtype)
             mask = T.alloc_fragment([BS], "bool")
 
             P_shared_cast = T.alloc_shared([block_H, BS], dtype)
             dP_shared_cast = T.alloc_shared([block_H, BS], dtype)
             dQ_shared = T.alloc_shared([block_H, D], dtype)
-            dQ_tail_shared = T.alloc_shared([block_H, D_tail], dtype)
+            if has_tail:
+                Q_tail_shared = T.alloc_shared([block_H, D_tail], dtype)
+                KV_tail_shared = T.alloc_shared([BS, D_tail], dtype)
+                dQ_tail_shared = T.alloc_shared([block_H, D_tail], dtype)
 
             acc_p = T.alloc_fragment([block_H, BS], accum_dtype)
             acc_dp = T.alloc_fragment([block_H, BS], accum_dtype)
             acc_dq = T.alloc_fragment([block_H, D], accum_dtype)
-            acc_dq_tail = T.alloc_fragment([block_H, D_tail], accum_dtype)
             acc_dkv = T.alloc_fragment([BS, D], accum_dtype)
-            acc_dkv_tail = T.alloc_fragment([BS, D_tail], accum_dtype)
             acc_dkv_shared = T.alloc_shared([BS // split_store, D], accum_dtype)
-            acc_dkv_tail_shared = T.alloc_shared([BS // split_store, D_tail], accum_dtype)
+            if has_tail:
+                acc_dq_tail = T.alloc_fragment([block_H, D_tail], accum_dtype)
+                acc_dkv_tail = T.alloc_fragment([BS, D_tail], accum_dtype)
+                acc_dkv_tail_shared = T.alloc_shared([BS // split_store, D_tail], accum_dtype)
 
             # See sparse_mla_fwd: sentinel is at index S_kv - 1 (zero KV), valid indices
             # live in [0, S_kv - 1). Using this single bound makes the kernel work for
@@ -181,11 +185,13 @@ def bwd(
             max_kv_i = S_kv - 2
 
             T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, :D], Q_shared)
-            T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, D:], Q_tail_shared)
+            if has_tail:
+                T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, D:], Q_tail_shared)
             T.copy(dO[by, s_i, bz * block_H : (bz + 1) * block_H, :D], dO_shared)
 
             T.clear(acc_dq)
-            T.clear(acc_dq_tail)
+            if has_tail:
+                T.clear(acc_dq_tail)
 
             for i_i in T.Pipelined(NS, num_stages=num_stages):
                 for bi_i in T.Parallel(BS):
@@ -199,9 +205,12 @@ def bwd(
 
                 T.gemm(Q_shared, KV_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
 
-                for bi_i, d_i in T.Parallel(BS, D_tail):
-                    KV_tail_shared[bi_i, d_i] = KV[by, Indices[by, s_i, bz // NH, i_i * BS + bi_i], bz // NH, D + d_i]
-                T.gemm(Q_tail_shared, KV_tail_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
+                if has_tail:
+                    for bi_i, d_i in T.Parallel(BS, D_tail):
+                        KV_tail_shared[bi_i, d_i] = KV[
+                            by, Indices[by, s_i, bz // NH, i_i * BS + bi_i], bz // NH, D + d_i
+                        ]
+                    T.gemm(Q_tail_shared, KV_tail_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
 
                 for h_i, bi_i in T.Parallel(block_H, BS):
                     acc_p[h_i, bi_i] = T.exp2(
@@ -221,7 +230,8 @@ def bwd(
 
                 T.copy(acc_dp, dP_shared_cast)
                 T.gemm(dP_shared_cast, KV_shared, acc_dq, policy=T.GemmWarpPolicy.FullCol)
-                T.gemm(dP_shared_cast, KV_tail_shared, acc_dq_tail, policy=T.GemmWarpPolicy.FullCol)
+                if has_tail:
+                    T.gemm(dP_shared_cast, KV_tail_shared, acc_dq_tail, policy=T.GemmWarpPolicy.FullCol)
 
                 T.gemm(
                     dP_shared_cast,
@@ -233,17 +243,25 @@ def bwd(
                 )
                 T.gemm(P_shared_cast, dO_shared, acc_dkv, transpose_A=True, policy=T.GemmWarpPolicy.FullCol)
 
-                T.clear(acc_dkv_tail)
-                T.gemm(dP_shared_cast, Q_tail_shared, acc_dkv_tail, transpose_A=True, policy=T.GemmWarpPolicy.FullCol)
+                if has_tail:
+                    T.clear(acc_dkv_tail)
+                    T.gemm(
+                        dP_shared_cast,
+                        Q_tail_shared,
+                        acc_dkv_tail,
+                        transpose_A=True,
+                        policy=T.GemmWarpPolicy.FullCol,
+                    )
 
                 for s in range(split_store):
                     for bi_i, d_i in T.Parallel(BS, D):
                         if bi_i < BS // split_store:
                             acc_dkv_shared[bi_i, d_i] = acc_dkv[bi_i + s * (BS // split_store), d_i]
 
-                    for bi_i, d_i in T.Parallel(BS, D_tail):
-                        if bi_i < BS // split_store:
-                            acc_dkv_tail_shared[bi_i, d_i] = acc_dkv_tail[bi_i + s * (BS // split_store), d_i]
+                    if has_tail:
+                        for bi_i, d_i in T.Parallel(BS, D_tail):
+                            if bi_i < BS // split_store:
+                                acc_dkv_tail_shared[bi_i, d_i] = acc_dkv_tail[bi_i + s * (BS // split_store), d_i]
 
                     for bi_i, d_i in T.Parallel(BS // split_store, D // 4):
                         T.atomic_addx4(
@@ -256,27 +274,30 @@ def bwd(
                             acc_dkv_shared[bi_i, d_i * 4],
                         )
 
-                    for bi_i, d_i in T.Parallel(BS // split_store, D_tail // 4):
-                        T.atomic_addx4(
-                            dKV[
-                                by,
-                                Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
-                                bz // NH,
-                                D + d_i * 4,
-                            ],
-                            acc_dkv_tail_shared[bi_i, d_i * 4],
-                        )
+                    if has_tail:
+                        for bi_i, d_i in T.Parallel(BS // split_store, D_tail // 4):
+                            T.atomic_addx4(
+                                dKV[
+                                    by,
+                                    Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
+                                    bz // NH,
+                                    D + d_i * 4,
+                                ],
+                                acc_dkv_tail_shared[bi_i, d_i * 4],
+                            )
 
             T.copy(acc_dq, dQ_shared)
-            T.copy(acc_dq_tail, dQ_tail_shared)
+            if has_tail:
+                T.copy(acc_dq_tail, dQ_tail_shared)
 
             T.copy(dQ_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, :D])
-            T.copy(dQ_tail_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, D:])
+            if has_tail:
+                T.copy(dQ_tail_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, D:])
 
     return sparse_mla_bwd_kernel
 
 
-def sparse_mla_bwd(q, kv, o, do, indices, lse, sm_scale=None):
+def sparse_mla_bwd(q, kv, o, do, indices, lse, sm_scale=None, d_v=None):
     assert q.is_contiguous()
     assert kv.is_contiguous()
     assert indices.is_contiguous()
@@ -285,7 +306,9 @@ def sparse_mla_bwd(q, kv, o, do, indices, lse, sm_scale=None):
     _, S_kv, kv_group, _ = kv.shape
     assert kv.shape[-1] == dim_plus_tail_dim
     assert kv.shape[0] == B
-    D = 512
+    D = o.shape[-1] if d_v is None else d_v
+    assert D == o.shape[-1]
+    assert 0 < D <= dim_plus_tail_dim
     D_tail = dim_plus_tail_dim - D
     topk = indices.shape[-1]
     assert indices.shape == (B, S, kv_group, topk)

--- a/src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py
+++ b/src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py
@@ -38,7 +38,9 @@ def sparse_mla_fwd(
     threads=256,
 ):
     assert dim == tilelang.math.next_power_of_2(dim), f"haven't check padding correctness yet, dim={dim}"
-    assert tail_dim == tilelang.math.next_power_of_2(tail_dim), f"haven't check padding correctness yet, dim={tail_dim}"
+    assert tail_dim == 0 or tail_dim == tilelang.math.next_power_of_2(tail_dim), (
+        f"haven't check padding correctness yet, dim={tail_dim}"
+    )
     assert is_causal is True, "non-casual is not supported"
     assert topk % block_I == 0, "otherwise will load some index=0 thus causing wrong kv to be loaded"
     if sm_scale is None:
@@ -80,6 +82,7 @@ def sparse_mla_fwd(
         REPLICATE_H = 1
 
     H_per_block = padded_H if REPLICATE_H == 1 else 64
+    has_tail = tail_dim > 0
 
     @T.prim_func
     def main(
@@ -95,12 +98,13 @@ def sparse_mla_fwd(
             bz,
         ):
             Q_shared = T.alloc_shared([H_per_block, D], dtype)
-            Q_tail_shared = T.alloc_shared([H_per_block, D_tail], dtype)
             KV_shared = T.alloc_shared([BI, D], dtype)
-            K_tail_shared = T.alloc_shared([BI, D_tail], dtype)
             O_shared = T.alloc_shared([H_per_block, D], dtype)  # noqa: F841
             Lse_shared = T.alloc_shared([H_per_block], accum_dtype)  # noqa: F841
             mask = T.alloc_fragment([BI], "bool")
+            if has_tail:
+                Q_tail_shared = T.alloc_shared([H_per_block, D_tail], dtype)
+                K_tail_shared = T.alloc_shared([BI, D_tail], dtype)
 
             acc_o = T.alloc_fragment([H_per_block, D], accum_dtype)
             acc_s = T.alloc_fragment([H_per_block, BI], accum_dtype)
@@ -128,7 +132,8 @@ def sparse_mla_fwd(
             H1 = H0 + H_per_block
 
             T.copy(Q[b_i, s_i, H0:H1, :D], Q_shared)
-            T.copy(Q[b_i, s_i, H0:H1, D:], Q_tail_shared)
+            if has_tail:
+                T.copy(Q[b_i, s_i, H0:H1, D:], Q_tail_shared)
 
             for i_i in T.Pipelined(NI, num_stages=num_stages):
                 for bi_i in T.Parallel(BI):
@@ -136,8 +141,9 @@ def sparse_mla_fwd(
 
                 for bi_i, d_i in T.Parallel(BI, D):
                     KV_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, g_i, i_i * BI + bi_i], g_i, d_i]
-                for bi_i, d_i in T.Parallel(BI, D_tail):
-                    K_tail_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, g_i, i_i * BI + bi_i], g_i, D + d_i]
+                if has_tail:
+                    for bi_i, d_i in T.Parallel(BI, D_tail):
+                        K_tail_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, g_i, i_i * BI + bi_i], g_i, D + d_i]
 
                 for h_i, bi_i in T.Parallel(H_per_block, BI):
                     acc_s[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_s.dtype))
@@ -148,13 +154,14 @@ def sparse_mla_fwd(
                     transpose_B=True,
                     policy=T.GemmWarpPolicy.FullRow,
                 )
-                T.gemm(
-                    Q_tail_shared,
-                    K_tail_shared,
-                    acc_s,
-                    transpose_B=True,
-                    policy=T.GemmWarpPolicy.FullRow,
-                )
+                if has_tail:
+                    T.gemm(
+                        Q_tail_shared,
+                        K_tail_shared,
+                        acc_s,
+                        transpose_B=True,
+                        policy=T.GemmWarpPolicy.FullRow,
+                    )
                 T.copy(m_i, m_i_prev)
                 T.reduce_max(acc_s, m_i, dim=1, clear=False)
                 for h_i in T.Parallel(H_per_block):
@@ -188,8 +195,8 @@ def sparse_mla_fwd_interface(q, kv, indices, sm_scale=None, d_v=512, block_I=64,
     batch, seq_len, heads, dim_plus_tail_dim = q.shape
     _, seq_len_kv, kv_group, _ = kv.shape
 
-    assert dim_plus_tail_dim == 576, "you should assign dim otherwise"
     dim = d_v
+    assert 0 < dim <= dim_plus_tail_dim
     assert kv.shape[-1] == dim_plus_tail_dim
     assert kv.shape[0] == batch
     tail_dim = dim_plus_tail_dim - dim

--- a/src/prime_rl/trainer/models/layers/activations.py
+++ b/src/prime_rl/trainer/models/layers/activations.py
@@ -18,6 +18,15 @@ class ClampedSwiglu(Activation):
         return (up + 1) * gate * torch.sigmoid(gate * 1.702)
 
 
+class GlmClampedSwiglu(Activation):
+    @staticmethod
+    def apply(gate: torch.Tensor | None, up: torch.Tensor) -> torch.Tensor:
+        assert gate is not None
+        gate = gate.clamp(max=10.0)
+        up = up.clamp(min=-10.0, max=10.0)
+        return gate * torch.sigmoid(gate) * up
+
+
 class Relu2(Activation):
     @staticmethod
     def apply(gate: torch.Tensor | None, up: torch.Tensor) -> torch.Tensor:
@@ -34,10 +43,11 @@ class Silu(Activation):
         return F.silu(gate) * up
 
 
-ActivationType = Literal["silu", "relu2", "clamped_swiglu"]
+ActivationType = Literal["silu", "relu2", "clamped_swiglu", "glm_clamped_swiglu"]
 
 ActivationDispatch: dict[ActivationType, type[Activation]] = {
     "clamped_swiglu": ClampedSwiglu,
+    "glm_clamped_swiglu": GlmClampedSwiglu,
     "silu": Silu,
     "relu2": Relu2,
 }

--- a/tests/unit/train/models/test_glm5_next.py
+++ b/tests/unit/train/models/test_glm5_next.py
@@ -1,0 +1,98 @@
+import torch
+
+from prime_rl.trainer.models import get_custom_causal_lm_cls, supports_custom_impl
+from prime_rl.trainer.models.conversion_ops import apply_hf_to_prime
+from prime_rl.trainer.models.glm5_next import Glm5NextConfig, Glm5NextForCausalLM, Glm5NextTextConfig
+from prime_rl.trainer.models.glm5_next.converting_glm5_next import conversion_chain
+
+
+def _tiny_text_dict() -> dict:
+    return {
+        "vocab_size": 128,
+        "pad_token_id": 0,
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "moe_intermediate_size": 4,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 1,
+        "q_lora_rank": 4,
+        "kv_lora_rank": 4,
+        "qk_nope_head_dim": 4,
+        "qk_rope_head_dim": 0,
+        "v_head_dim": 4,
+        "layer_types": ["linear_attention", "linear_attention", "linear_attention", "deepseek_sparse_attention"],
+        "mlp_layer_types": ["dense", "dense", "dense", "sparse"],
+        "n_routed_experts": 2,
+        "num_experts_per_tok": 1,
+        "n_shared_experts": 1,
+        "num_nextn_predict_layers": 1,
+        "mhc": True,
+        "hc_mult": 4,
+        "hc_sinkhorn_iters": 20,
+        "linear_attn_config": {
+            "num_heads": 1,
+            "head_dim": 4,
+            "short_conv_kernel_size": 4,
+            "gate_lower_bound": -5.0,
+        },
+    }
+
+
+def test_glm5_next_config_folds_composite_text_config() -> None:
+    config = Glm5NextConfig(text_config=_tiny_text_dict(), vision_config={"model_type": "glm5_next_vision"})
+
+    assert config.model_type == "glm5_next"
+    assert config.get_text_config().model_type == "glm5_next_text"
+    assert config.hidden_size == 8
+    assert config.glm5_layer_types[-1] == "deepseek_sparse_attention"
+    assert config.layer_types[-1] == "sparse"
+    assert config.num_experts_per_tok == 1
+    assert config.mhc_num_residual_streams == 4
+    assert config.mhc_sinkhorn_iterations == 20
+    assert config.linear_head_dim == 4
+
+
+def test_glm5_next_custom_registry_supports_top_level_config() -> None:
+    config = Glm5NextConfig(text_config=_tiny_text_dict())
+
+    assert supports_custom_impl(config)
+    assert get_custom_causal_lm_cls(config) is Glm5NextForCausalLM
+
+
+def test_glm5_next_conversion_normalizes_composite_checkpoint_keys() -> None:
+    config = Glm5NextTextConfig(**_tiny_text_dict())
+    state_dict = {
+        "model.language_model.embed_tokens.weight": torch.zeros(128, 8),
+        "model.language_model.layers.3.mlp.experts.0.gate_proj.weight": torch.zeros(4, 8),
+        "model.language_model.layers.3.mlp.experts.0.down_proj.weight": torch.zeros(8, 4),
+        "model.language_model.layers.3.mlp.experts.0.up_proj.weight": torch.zeros(4, 8),
+        "model.language_model.layers.3.mlp.experts.1.gate_proj.weight": torch.ones(4, 8),
+        "model.language_model.layers.3.mlp.experts.1.down_proj.weight": torch.ones(8, 4),
+        "model.language_model.layers.3.mlp.experts.1.up_proj.weight": torch.ones(4, 8),
+        "model.language_model.layers.3.mlp.gate.weight": torch.zeros(2, 8),
+        "model.language_model.layers.3.mlp.gate.e_score_correction_bias": torch.zeros(2),
+        "model.language_model.layers.3.mlp.shared_experts.gate_proj.weight": torch.zeros(4, 8),
+        "model.language_model.layers.3.mlp.shared_experts.down_proj.weight": torch.zeros(8, 4),
+        "model.language_model.layers.3.mlp.shared_experts.up_proj.weight": torch.zeros(4, 8),
+        "model.language_model.layers.3.self_attn.indexer.index_kpool_compress_ape": torch.zeros(4, 8),
+        "model.language_model.layers.3.self_attn.indexer.index_kpool_compress_gate": torch.zeros(8, 8),
+        "model.language_model.layers.4.eh_proj.weight": torch.zeros(8, 8),
+        "model.visual.blocks.0.norm.weight": torch.zeros(8),
+        "lm_head.weight": torch.zeros(128, 8),
+    }
+
+    apply_hf_to_prime(state_dict, conversion_chain(config))
+
+    assert set(state_dict) == {
+        "lm_head.weight",
+        "model.embed_tokens.weight",
+        "model.layers.3.mlp.experts.down_proj",
+        "model.layers.3.mlp.experts.gate_proj",
+        "model.layers.3.mlp.experts.up_proj",
+        "model.layers.3.mlp.router.gate.weight",
+        "model.layers.3.mlp.router.selection_bias",
+        "model.layers.3.mlp.shared_expert.down_proj.weight",
+        "model.layers.3.mlp.shared_expert.gate_proj.weight",
+        "model.layers.3.mlp.shared_expert.up_proj.weight",
+    }
+    assert state_dict["model.layers.3.mlp.experts.gate_proj"].shape == (2, 4, 8)


### PR DESCRIPTION
## Summary
- rebase on latest `origin/main` after the MoE/token-dispatcher refactor
- add text-only GLM-5.3 / `glm5_next` config, model, registry, and HF checkpoint conversion
- implement KDA linear-attention layers, mHC residual routing, and GLM per-layer KDA/sparse MLA dispatch
- add GLM's `swiglu_limit=10.0` behavior as a refactor-compatible `glm_clamped_swiglu` activation instead of carrying the old MoE expert wrappers forward
- relax sparse MLA kernels for GLM-5.3 value/rope dimensions; drop multimodal, MTP, and sparse-indexer k-pool-compression checkpoint weights for this first training path

## Verification
```bash
uv run ruff check src/prime_rl/trainer/models/__init__.py src/prime_rl/trainer/models/layers/activations.py src/prime_rl/trainer/models/glm5_next src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py tests/unit/train/models/test_glm5_next.py
```

```bash
uv run python -m py_compile src/prime_rl/trainer/models/__init__.py src/prime_rl/trainer/models/layers/activations.py src/prime_rl/trainer/models/glm5_next/*.py src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py tests/unit/train/models/test_glm5_next.py
```

```bash
uv run pytest tests/unit/train/models/test_glm5_next.py tests/unit/train/models/test_moe.py tests/unit/train/models/test_moe_conversions.py
```

- CUDA smoke: refactored `MoE.from_args` sparse path with `glm_clamped_swiglu`
- CUDA smoke: tiny GLM-5.3 KDA + mHC forward with injected PrimeRL LM head
- meta smoke: full public BF16 GLM-5.3 config constructs all 45 text layers
- config smoke: `AutoConfig.from_pretrained("zai-org/GLM-5.3-Flash-BF16")` resolves to PrimeRL `Glm5NextForCausalLM`

## Caveats
- full KDA backward was not verified locally because FLA selected TileLang and this host lacks `/usr/local/cuda/bin/nvcc`
- sparse MLA runtime was not verified locally because the existing sparse-indexer fp8 Triton path rejects RTX 3090 fp8 dtype support
- sparse-indexer k-pool compression is not implemented yet; those HF tensors are dropped during conversion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new training model plus changes to shared sparse-MLA kernels and MoE paths; several features are explicitly incomplete or correctness-first with limited local verification.
> 
> **Overview**
> Adds **text-only GLM-5.3** (`glm5_next` / `glm5_next_text`) to PrimeRL: config, causal LM implementation, `AutoConfig` + custom causal-LM registry, and HF→Prime conversion that strips vision, MTP extra layers, and unimplemented indexer k-pool compression weights.
> 
> The new stack mixes **KDA linear-attention** layers (FLA `chunk_kda`), **sparse MLA** via reused `GlmMoeDsaAttention`, **mHC** multi-stream residuals, and dense vs MoE MLPs per `layer_types` / `mlp_layer_types`. Shared **MoE** gains optional **SwiGLU clamping** (`swiglu_limit`, GLM limit 10.0 on grouped-mm paths). **Sparse MLA TileLang kernels** now take configurable value dim `d_v`, skip the Q/K tail when `D_tail == 0`, and RoPE interleave no-ops on zero-width rope dims—needed for GLM-5.3’s nope-only MLA setup.
> 
> `Glm5NextForCausalLM` is marked **experimental** (no KV cache, fused MoE + FP8 incompatible with clamping, k-pool compression not modeled). Unit tests cover composite config folding, registry dispatch, and conversion key normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79f1219c85aa0a79cace06246cbde2defc57c989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->