### PR TITLE
chore: bump vllm to 0.28.0

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -462,7 +462,7 @@ class InferenceConfig(BaseConfig):
     """Run the lm_head projection in fp32 via a native bf16×bf16 → fp32 GEMM (``torch.mm`` with ``out_dtype=torch.float32``). Stabilizes logprob precision under FP8/bf16 inference, matching SGLang's ``--enable-fp32-lm-head``. Implemented as a monkey-patch over vLLM's LogitsProcessor, activated by setting ``additional_config["fp32_lm_head"] = True`` on the vLLM config."""
 
     enable_fp32_router_logits: bool = True
-    """Emit fp32 MoE router logits for DeepSeek-family models (incl. GLM-5.x) by setting ``out_dtype=float32`` on the gate: the bf16×bf16 gate GEMM writes its fp32 accumulator out unrounded instead of truncating logits to bf16 before expert scoring. Matches fp32-routed checkpoints (e.g. GLM-5.x, trained with Megatron ``--moe-router-dtype fp32``); pairs with ``trainer.model.moe_router_dtype = "float32"``. Implemented as a monkey-patch over vLLM's DeepseekV2MoE, activated by setting ``additional_config["fp32_router_logits"] = True`` on the vLLM config."""
+    """Emit fp32 MoE router logits: the bf16×bf16 gate GEMM writes its fp32 accumulator out unrounded instead of truncating logits to bf16 before expert scoring. Matches fp32-routed checkpoints (e.g. GLM-5.x, trained with Megatron ``--moe-router-dtype fp32``); pairs with ``trainer.model.moe_router_dtype = "float32"``. Implemented natively by vLLM, which reads ``moe_router_dtype`` off the HF config — this flag injects ``hf_overrides = {"moe_router_dtype": "float32"}`` (GLM-5.x gets fp32 routing regardless)."""
 
     # Launcher-only fields
 
@@ -607,6 +607,18 @@ class InferenceConfig(BaseConfig):
         if not hasattr(namespace, "logprobs_mode"):
             namespace.logprobs_mode = "processed_logprobs"
 
+        # Always surface cached prompt tokens in `usage` — the router's
+        # cache-discount billing counters parse them off /inference/v1/generate.
+        if "enable_prompt_tokens_details" not in extra_fields:
+            namespace.enable_prompt_tokens_details = True
+
+        # vLLM's DeepseekV2-family (and transformers-backend MoE) gates read
+        # `moe_router_dtype` off the HF config to pick the router logits dtype.
+        if self.enable_fp32_router_logits:
+            hf_overrides = getattr(namespace, "hf_overrides", None) or {}
+            hf_overrides.setdefault("moe_router_dtype", "float32")
+            namespace.hf_overrides = hf_overrides
+
         kv_transfer_config = self.build_kv_transfer_config()
         if kv_transfer_config is not None:
             namespace.kv_transfer_config = kv_transfer_config
@@ -616,8 +628,6 @@ class InferenceConfig(BaseConfig):
         additional_config = getattr(namespace, "additional_config", None) or {}
         if self.enable_fp32_lm_head:
             additional_config["fp32_lm_head"] = True
-        if self.enable_fp32_router_logits:
-            additional_config["fp32_router_logits"] = True
         if additional_config:
             namespace.additional_config = additional_config
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ gpu = [
     "torchvision ; sys_platform == 'linux'",
     "torchaudio ; sys_platform == 'linux'",
     "torchdata>=0.11.0 ; sys_platform == 'linux'",
-    "vllm>=0.27.1 ; sys_platform == 'linux'",
+    "vllm>=0.28.0 ; sys_platform == 'linux'",
     "mooncake-transfer-engine>=0.3.10.post2 ; sys_platform == 'linux'",
     "ring-flash-attn>=0.1.8 ; sys_platform == 'linux'",
     "torchtitan ; sys_platform == 'linux'",
@@ -140,9 +140,9 @@ environments = [
 # See: https://github.com/pytorch/pytorch/issues/166122
 override-dependencies = [
     "nvidia-cudnn-cu13>=9.15 ; sys_platform == 'linux'",
-    # vLLM 0.27.1 requires quack-kernels 0.6.1. It requires this exact CUTLASS version.
+    # vLLM 0.28.0 requires quack-kernels 0.6.4. It requires this exact CUTLASS version.
     # Keep this pin aligned with quack-kernels and the flash-attn-4 revision below.
-    "nvidia-cutlass-dsl==4.6.0",
+    "nvidia-cutlass-dsl==4.6.2",
     "transformers==5.6.2",
     "torch>=2.13.0",
     "openenv-core",
@@ -199,10 +199,10 @@ requires-dist = ["nixl-cu13==0.10.1"]
 # so resolve that variant without installing both runtime packages.
 [[tool.uv.dependency-metadata]]
 name = "nvidia-cutlass-dsl"
-version = "4.6.0"
+version = "4.6.2"
 requires-dist = [
-    "nvidia-cutlass-dsl-libs-base==4.6.0",
-    "nvidia-cutlass-dsl-libs-cu13==4.6.0",
+    "nvidia-cutlass-dsl-libs-base==4.6.2",
+    "nvidia-cutlass-dsl-libs-cu13==4.6.2",
 ]
 
 [tool.uv.exclude-newer-package]
@@ -256,8 +256,8 @@ vllm-router = [
     { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.2.0/vllm_router-0.2.0-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
 ]
 vllm = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.27.1/vllm-0.27.1-cp38-abi3-manylinux_2_28_x86_64.whl", marker = "platform_machine == 'x86_64'" },
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.27.1/vllm-0.27.1-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
+    { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_x86_64.whl", marker = "platform_machine == 'x86_64'" },
+    { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
 ]
 deep-ep = [
     { url = "https://github.com/PrimeIntellect-ai/prime-kernels/releases/download/v0.1.1/deep_ep-1.2.1+29d31c0-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" },

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -207,7 +207,6 @@ def monkey_patch_minimax_m2_think_end_passthrough():
 
 
 def monkey_patch_return_routed_experts_with_nixl_connector():
-    from vllm import envs
     from vllm.config.vllm import VllmConfig
     from vllm.logger import init_logger
 
@@ -233,8 +232,11 @@ def monkey_patch_return_routed_experts_with_nixl_connector():
 
         if config.parallel_config.pipeline_parallel_size > 1:
             raise ValueError("--enable-return-routed-experts is incompatible with pipeline parallelism (PP > 1).")
-        if envs.VLLM_USE_V2_MODEL_RUNNER:
-            raise ValueError("VLLM_USE_V2_MODEL_RUNNER does not yet support: routed experts capture")
+        if config.use_v2_model_runner:
+            raise ValueError(
+                "The V2 model runner does not support routed experts capture - "
+                "set VLLM_USE_V2_MODEL_RUNNER=0 (the prime-rl launcher does this automatically)."
+            )
 
         # vLLM rejects every KV connector, but our P/D path uses NIXL and
         # stitches prefill/decode routed experts in the router. CPU KV offload
@@ -609,32 +611,6 @@ def monkey_patch_minimax_m2_for_lora():
     )
 
 
-def monkey_patch_harmony_stop_token_propagation():
-    """Fix: vLLM doesn't merge harmony stop tokens into per-request SamplingParams.
-
-    The harmony mode sets stop_token_ids (including <|call|> and <|return|>) in
-    default_sampling_params at server init, but ChatCompletionRequest.to_sampling_params()
-    ignores them, using only self.stop_token_ids (which defaults to []).
-
-    Upstream: https://github.com/vllm-project/vllm/issues/22519
-    """
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-
-    _original_to_sampling_params = ChatCompletionRequest.to_sampling_params
-
-    def _patched_to_sampling_params(self, max_tokens, default_sampling_params):
-        params = _original_to_sampling_params(self, max_tokens, default_sampling_params)
-        # Merge harmony stop tokens from default_sampling_params
-        default_stop_ids = default_sampling_params.get("stop_token_ids", [])
-        if default_stop_ids:
-            existing = set(params.stop_token_ids or [])
-            merged = list(existing | set(default_stop_ids))
-            params.stop_token_ids = merged
-        return params
-
-    ChatCompletionRequest.to_sampling_params = _patched_to_sampling_params
-
-
 def monkey_patch_no_moe_lora():
     """This disables LoRA for MoE layers and makes them pick better kernels.
 
@@ -715,45 +691,6 @@ def monkey_patch_fp32_lm_head():
     LogitsProcessor.__init__ = _patched_init
     LogitsProcessor._get_logits = _patched_get_logits
     logger.info("Installed fp32 lm_head patch (native out_dtype=fp32 mm).")
-
-
-def monkey_patch_fp32_router_logits():
-    """Emit fp32 MoE router logits for DeepSeek-family models (incl. GLM-5.x glm_moe_dsa).
-
-    vLLM's DeepseekV2MoE gate is a GateLinear with a bf16 weight and no out_dtype,
-    so router logits are rounded to bf16 before expert scoring. GLM-5.x was trained
-    with fp32 routing (Megatron ``--moe-router-dtype fp32``); upstream now runs its
-    gate fully in fp32 (vllm-project/vllm#47410, not in the pinned release).
-    Setting ``out_dtype=float32`` routes the gate through GateLinear's cuBLAS
-    bf16xbf16->fp32 tier: same GEMM, but the fp32 accumulator is written out
-    unrounded. Unlike the upstream PR, the gate weight stays bf16, so the LoRA
-    Triton kernel dtype assert and the bf16 weight-broadcast path are unaffected.
-
-    Activated by ``additional_config["fp32_router_logits"] = True``; the launcher
-    sets this when ``inference.enable_fp32_router_logits`` is set. The flag is read
-    at module construction, where vLLM guarantees a ``set_current_vllm_config()``
-    context. No-op if something else already set an out_dtype (e.g. the ROCm AITER
-    branch, whose kernel wants matching dtypes).
-    """
-    import torch
-    from vllm.config import get_current_vllm_config
-    from vllm.logger import init_logger
-    from vllm.model_executor.models.deepseek_v2 import DeepseekV2MoE
-
-    logger = init_logger(__name__)
-
-    _original_init = DeepseekV2MoE.__init__
-
-    def _patched_init(self, *args, **kwargs):
-        _original_init(self, *args, **kwargs)
-        additional_config = get_current_vllm_config().additional_config or {}
-        if not additional_config.get("fp32_router_logits", False):
-            return
-        if self.gate.out_dtype is None:
-            self.gate.set_out_dtype(torch.float32)
-
-    DeepseekV2MoE.__init__ = _patched_init
-    logger.info("Installed fp32 router logits patch (self-gates on additional_config['fp32_router_logits']).")
 
 
 def monkey_patch_dp_coordinator_startup_timeout():

--- a/src/prime_rl/inference/server.py
+++ b/src/prime_rl/inference/server.py
@@ -10,11 +10,11 @@ def setup_vllm_env(config: InferenceConfig):
     # spawn is more robust in vLLM nightlies and Qwen3-VL (fork can deadlock with multithreaded processes)
     os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
 
-    # Force the V1 GPU model runner. vLLM routes Llama/Mistral/Qwen3 plus MoE archs
-    # (DeepseekV2, Qwen2Moe, GraniteMoe) to the V2 runner by default, but V2 doesn't
-    # support routed-experts capture (the NIXL PD path rejects it). setdefault so it
-    # stays overridable.
-    os.environ.setdefault("VLLM_USE_V2_MODEL_RUNNER", "0")
+    # Router replay needs the V1 GPU model runner: V2 silently never captures
+    # routed experts. Everything else follows vLLM's own V1/V2 resolution.
+    # setdefault so it stays overridable.
+    if config.vllm.enable_return_routed_experts:
+        os.environ.setdefault("VLLM_USE_V2_MODEL_RUNNER", "0")
 
     # vLLM 0.24.0 flipped VLLM_ENFORCE_STRICT_TOOL_CALLING's default to True, which
     # grammar-constrains generation (xgrammar structural tags) for tool_choice

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -20,17 +20,13 @@ from prime_rl.utils.logger import get_logger
 logger = get_logger()
 from prime_rl.inference.patches import (
     monkey_patch_dp_coordinator_startup_timeout,
-    monkey_patch_harmony_stop_token_propagation,
     monkey_patch_nano_v3_reasoning_parser,
     monkey_patch_strip_routed_experts_from_chat,
     monkey_patch_tokenize_params_validation,
 )
 
-# NOTE: Fix harmony stop token propagation for GPT-OSS models
-# Upstream issue still open: https://github.com/vllm-project/vllm/issues/22519
-monkey_patch_harmony_stop_token_propagation()
 # NOTE: Monkeypatch TokenizeParams to fix overly conservative validation
-# Still needed in vLLM 0.20 — upstream rejects prompt_len > max_model_len - max_tokens
+# Still needed in vLLM 0.28 — upstream rejects prompt_len > max_model_len - max_tokens
 monkey_patch_tokenize_params_validation()
 # NOTE: Register Nano V3 reasoning parser so configs can use
 # `reasoning_parser = "nano_v3"` without a vLLM plugin file.

--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -3,22 +3,20 @@
 vLLM ships a generic tokens-in / tokens-out handler at
 ``vllm.entrypoints.scale_out.token_in_token_out.serving.ServingTokens`` that covers
 prefix-cache salting, lora dispatch, multimodal features, prompt logprobs,
-priority, ``data_parallel_rank`` header routing and server-side ``max_tokens``
-defaulting. We subclass it for the bits still missing from the upstream handler:
+priority, ``data_parallel_rank`` header routing, server-side ``max_tokens``
+defaulting and ``usage`` reporting. We subclass it for the bits still missing
+from the upstream handler:
 
-1. ``data_parallel_rank`` routing — read from the ``X-data-parallel-rank``
-   header and forwarded to ``engine_client.generate``. Upstream ``ServingTokens``
-   now does this too; we keep the equivalent path for the DP-replicated
-   inference servers prime-RL runs.
+1. Compact ``routed_experts`` export — when the engine emits routing
+   decisions, surface them as ``{data, shape, start, dtype}`` base64 raw-byte
+   objects (the form the PD router can merge and the renderers parse) instead
+   of upstream's single ``.npy`` base64 string.
 
-2. Compact ``routed_experts`` export — when the engine emits routing
-   decisions, surface them as base64 raw-byte payloads without requiring a vLLM
-   source fork.
-
-3. Server-side ``max_tokens`` defaulting — upstream ``ServingTokens`` now applies
-   this itself (via ``GenerateRequest.is_sampling_param_provided`` +
-   ``get_max_tokens``); we keep an equivalent guard so callers that omit
-   ``max_tokens`` don't truncate at vLLM's 16-token ``SamplingParams`` default.
+2. ``kv_transfer_params`` bridging — upstream ``ServingTokens.serve_tokens``
+   parses ``request.kv_transfer_params`` but never threads it into the engine,
+   so PD disagg never fires on ``/inference/v1/generate``. Fixed upstream by
+   https://github.com/vllm-project/vllm/pull/42644, which missed the 0.28.0
+   cut — drop the bridge once we pin a release that includes it.
 
 Everything else (request/response schema, sampling params, error handling)
 delegates to upstream so we track future vLLM changes for free.
@@ -26,16 +24,13 @@ delegates to upstream so we track future vLLM changes for free.
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, AsyncIterable
-from functools import cached_property
+from collections.abc import AsyncGenerator
 from typing import Any
 
 from fastapi import Request
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
-    PromptTokenUsageInfo,
     RequestResponseMetadata,
-    UsageInfo,
 )
 from vllm.entrypoints.scale_out.token_in_token_out.protocol import (
     GenerateRequest,
@@ -43,25 +38,20 @@ from vllm.entrypoints.scale_out.token_in_token_out.protocol import (
     GenerateResponseChoice,
 )
 from vllm.entrypoints.scale_out.token_in_token_out.serving import ServingTokens
-from vllm.entrypoints.serve.utils.api_utils import get_max_tokens
 from vllm.outputs import RequestOutput
-from vllm.sampling_params import RequestOutputKind, SamplingParams
 
 from prime_rl.inference.vllm.routed_experts import RoutedExpertsCapture
 
 
 class PrimeRlGenerateResponseChoice(GenerateResponseChoice):
-    routed_experts: dict[str, Any] | None = None
+    # Overrides upstream's base64 ``.npy`` string form with the compact
+    # ``{data, shape, start, dtype}`` object the PD router merges and the
+    # renderers parse.
+    routed_experts: dict[str, Any] | None = None  # type: ignore[assignment]
 
 
 class PrimeRlGenerateResponse(GenerateResponse):
     choices: list[PrimeRlGenerateResponseChoice]
-    # Upstream ``GenerateResponse`` doesn't declare a ``usage`` field, so the
-    # parent ``ServingTokens.serve_tokens_full_generator`` constructs it and
-    # Pydantic silently drops it on serialization. Declare it here so the
-    # router can extract per-run token counts (and cached-prefix tokens) for
-    # platform billing — see https://github.com/PrimeIntellect-ai/router/pull/43.
-    usage: UsageInfo | None = None
 
 
 class _GenerateRoutedExpertsCapture(RoutedExpertsCapture):
@@ -73,236 +63,29 @@ class _GenerateRoutedExpertsCapture(RoutedExpertsCapture):
             )
             for choice in response.choices
         ]
-        return PrimeRlGenerateResponse(
-            request_id=response.request_id,
-            choices=choices,
-            prompt_logprobs=response.prompt_logprobs,
-            kv_transfer_params=response.kv_transfer_params,
-        )
-
-
-class _FinalOutputCapture:
-    """Wraps a ``RequestOutput`` async generator to record the last yielded item.
-
-    Needed so the response builder can construct a ``usage`` block from
-    ``final_res.prompt_token_ids`` / ``output.token_ids`` / ``num_cached_tokens``
-    after delegating iteration to upstream.
-    """
-
-    def __init__(self, source: AsyncIterable[RequestOutput]) -> None:
-        # ``source`` may be any async-iterable — including
-        # ``_GenerateRoutedExpertsCapture``, which exposes the protocol via
-        # ``async def __aiter__`` (an async generator function) and has no
-        # ``__anext__`` method. Drive it through ``async for`` rather than
-        # poking ``__anext__`` directly so both shapes work.
-        self._source = source
-        self.final_res: RequestOutput | None = None
-
-    async def __aiter__(self) -> AsyncGenerator[RequestOutput, None]:
-        async for item in self._source:
-            self.final_res = item
-            yield item
-
-
-def _build_usage(final_res: RequestOutput) -> UsageInfo:
-    assert final_res.prompt_token_ids is not None
-    num_prompt_tokens = len(final_res.prompt_token_ids)
-    if final_res.encoder_prompt_token_ids is not None:
-        num_prompt_tokens += len(final_res.encoder_prompt_token_ids)
-    num_generated_tokens = sum(len(output.token_ids) for output in final_res.outputs)
-    usage = UsageInfo(
-        prompt_tokens=num_prompt_tokens,
-        completion_tokens=num_generated_tokens,
-        total_tokens=num_prompt_tokens + num_generated_tokens,
-    )
-    # Always emit cached tokens when vLLM reports any. Upstream gates this on
-    # ``enable_prompt_tokens_details`` (default False) for OpenAI-API compat,
-    # but ``/inference/v1/generate`` is prime-rl internal — the cache-discount
-    # billing pipeline always wants the cached subset surfaced.
-    if final_res.num_cached_tokens:
-        usage.prompt_tokens_details = PromptTokenUsageInfo(cached_tokens=final_res.num_cached_tokens)
-    return usage
-
-
-async def _client_set_max_tokens(raw_request: Request | None) -> bool:
-    """Whether the inbound JSON body carried ``sampling_params.max_tokens``.
-
-    ``GenerateRequest.sampling_params`` is parsed into a ``SamplingParams``
-    instance, which means an unset ``max_tokens`` is indistinguishable from
-    an explicit ``max_tokens=16`` once the request reaches the handler —
-    both surface as ``sampling_params.max_tokens == 16``. We re-read the
-    cached body to recover that distinction. When we can't (no raw_request,
-    non-JSON body, or read error), pessimistically assume the client did
-    set it so we never clobber an explicit value.
-    """
-    if raw_request is None:
-        return True
-    try:
-        body = await raw_request.json()
-    except Exception:
-        return True
-    if not isinstance(body, dict):
-        return True
-    sp = body.get("sampling_params")
-    return isinstance(sp, dict) and "max_tokens" in sp
+        return PrimeRlGenerateResponse(**{**dict(response), "choices": choices})
 
 
 class PrimeRlServingTokens(ServingTokens):
-    """ServingTokens + DP-rank routing + compact routed experts + max_tokens defaulting."""
-
-    @cached_property
-    def _max_tokens_defaults(self) -> tuple[dict, int | None]:
-        """Server-side ``max_tokens`` defaulting inputs, mirroring upstream ``ServingTokens``.
-
-        Computed lazily because ``custom_init_app_state`` swaps in this
-        subclass via ``object.__new__`` + ``__dict__.update`` (so our
-        ``__init__`` never runs).
-        """
-        diff = self.model_config.get_diff_sampling_param()
-        mc = self.model_config
-        override = (
-            diff.get("max_tokens")
-            if mc.generation_config not in ("auto", "vllm")
-            # Upstream uses ``getattr(..., {})`` directly. Defensive ``or {}``
-            # in case a downstream caller ever sets the attribute to ``None``
-            # (``getattr``'s default only fires when the attribute is missing,
-            # not when it exists with a ``None`` value).
-            else (getattr(mc, "override_generation_config", None) or {}).get("max_new_tokens")
-        )
-        return diff, override
+    """ServingTokens + compact routed experts + PD kv_transfer_params bridging."""
 
     async def serve_tokens(
         self,
         request: GenerateRequest,
         raw_request: Request | None = None,
-    ) -> PrimeRlGenerateResponse | ErrorResponse | AsyncGenerator[str, None]:
-        # Mirrors upstream ``ServingTokens.serve_tokens``. Diffs:
-        # (a) inject ``data_parallel_rank`` from the inbound header into
-        # ``engine_client.generate``; (b) default ``sampling_params.max_tokens``
-        # to ``max_model_len - prompt_len`` when the caller didn't set it; and
-        # (c) dispatch to our overridden response builder so ``routed_experts``
-        # makes it into the JSON.
-        error_check_ret = await self._check_model(request)
-        if error_check_ret is not None:
-            return error_check_ret
-
-        if self.engine_client.errored:
-            raise self.engine_client.dead_error
-
-        lora_request = self._maybe_get_adapters(request, supports_default_mm_loras=True)
-        model_name = self.models.model_name(lora_request)
-
-        request_id = f"generate-tokens-{self._base_request_id(raw_request, request.request_id)}"
-        request_metadata = RequestResponseMetadata(request_id=request_id)
-        if raw_request:
-            raw_request.state.request_metadata = request_metadata
-
-        # Build the engine input — features-aware (MM) or text-only fallback.
-        # Identical to upstream so we keep tracking it.
-        if features := request.features:
-            from vllm.entrypoints.scale_out.token_in_token_out.mm_serde import decode_mm_kwargs_item
-            from vllm.inputs import mm_input
-            from vllm.multimodal.inputs import (
-                MultiModalKwargsItem,
-                MultiModalKwargsItems,
-                PlaceholderRange,
-            )
-
-            mm_placeholders = {
-                modality: [PlaceholderRange(offset=p.offset, length=p.length) for p in ranges]
-                for modality, ranges in features.mm_placeholders.items()
-            }
-            mm_kwargs: dict[str, list[MultiModalKwargsItem | None]] = {}
-            if features.kwargs_data is not None:
-                for modality, items in features.kwargs_data.items():
-                    mm_kwargs[modality] = [decode_mm_kwargs_item(item) if item is not None else None for item in items]
-            else:
-                for modality, hashes in features.mm_hashes.items():
-                    mm_kwargs[modality] = [None] * len(hashes)
-            engine_input = mm_input(
-                prompt_token_ids=request.token_ids,
-                mm_kwargs=MultiModalKwargsItems(mm_kwargs),
-                mm_hashes=features.mm_hashes,
-                mm_placeholders=mm_placeholders,
-                cache_salt=request.cache_salt,
-            )
-        else:
-            (engine_input,) = await self.online_renderer.preprocess_completion(
-                request,
-                prompt_input=request.token_ids,
-                prompt_embeds=None,
-                skip_mm_cache=True,
-            )
-
-        sampling_params: SamplingParams = request.sampling_params
-
-        # Upstream ``ServingTokens.serve_tokens`` parses ``request.kv_transfer_params``
-        # but never threads it into the engine, so PD disagg never fires on
-        # ``/inference/v1/generate`` — decode receives an empty NIXL handshake
-        # and ends up re-prefilling the prompt locally (~100× slower under
-        # concurrency). Bridge it through ``sampling_params.extra_args`` so the
-        # engine's KV connector picks the params up.
-        #
-        # Upstream fix: https://github.com/vllm-project/vllm/pull/42644 — drop
-        # this block once we pin a vLLM version that includes it.
+    ) -> GenerateResponse | ErrorResponse | AsyncGenerator[str, None]:
+        # Upstream parses ``request.kv_transfer_params`` but never threads it
+        # into the engine, so decode receives an empty NIXL handshake and
+        # re-prefills the prompt locally (~100x slower under concurrency).
+        # Bridge it through ``sampling_params.extra_args`` so the engine's KV
+        # connector picks the params up. Fixed upstream by vllm#42644 (merged
+        # after 0.28.0) — drop once we pin a release that includes it.
         if request.kv_transfer_params is not None:
-            extra = sampling_params.extra_args or {}
+            extra = request.sampling_params.extra_args or {}
             extra["kv_transfer_params"] = request.kv_transfer_params
-            sampling_params.extra_args = extra
+            request.sampling_params.extra_args = extra
 
-        # Server-side ``max_tokens`` defaulting — see module docstring. Upstream
-        # ``ServingTokens`` now does this too; kept here so callers that omit
-        # ``max_tokens`` don't get capped at vLLM's 16-token ``SamplingParams``
-        # default.
-        if not await _client_set_max_tokens(raw_request):
-            diff_sp, override = self._max_tokens_defaults
-            sampling_params.max_tokens = get_max_tokens(
-                max_model_len=self.model_config.max_model_len,
-                max_tokens=None,
-                input_length=len(request.token_ids),
-                default_sampling_params=diff_sp,
-                override_max_tokens=override,
-            )
-
-        if self.force_no_detokenize:
-            sampling_params.detokenize = False
-        if request.stream:
-            sampling_params.output_kind = RequestOutputKind.DELTA
-
-        self._log_inputs(
-            request_id,
-            engine_input,
-            params=sampling_params,
-            lora_request=lora_request,
-        )
-
-        trace_headers = None if raw_request is None else await self._get_trace_headers(raw_request.headers)
-
-        result_generator = self.engine_client.generate(
-            engine_input,
-            sampling_params,
-            request_id,
-            lora_request=lora_request,
-            trace_headers=trace_headers,
-            priority=request.priority,
-            data_parallel_rank=self._get_data_parallel_rank(raw_request),
-        )
-
-        if request.stream:
-            # Streaming path: defer to upstream — prime-RL's renderer client
-            # only consumes the full response, so adding routed_experts to the
-            # streaming choice schema is unnecessary churn.
-            return self.serve_tokens_stream_generator(
-                request,
-                result_generator,
-                request_id,
-                model_name,
-                request_metadata,
-            )
-
-        return await self.serve_tokens_full_generator(
-            request, result_generator, request_id, model_name, request_metadata
-        )
+        return await super().serve_tokens(request, raw_request)
 
     async def serve_tokens_full_generator(  # type: ignore[override]
         self,
@@ -317,40 +100,17 @@ class PrimeRlServingTokens(ServingTokens):
         # experts surface in the JSON.
         capture: _GenerateRoutedExpertsCapture | None = None
         if self.model_config.enable_return_routed_experts:
-            start = request.sampling_params.routed_experts_prompt_start
             capture = _GenerateRoutedExpertsCapture(
                 result_generator,
-                start=start,
+                start=request.sampling_params.routed_experts_prompt_start,
             )
             result_generator = capture
-
-        # Always capture the final ``RequestOutput`` so we can attach a
-        # ``usage`` block to the response. The router parses ``usage`` for
-        # per-run billing metrics; without it the cache-discount counter
-        # (``vllm_router_run_cached_prompt_tokens_total``) stays at zero.
-        final_capture = _FinalOutputCapture(result_generator)
-        result_generator = final_capture
 
         response = await super().serve_tokens_full_generator(
             request, result_generator, request_id, model_name, request_metadata
         )
 
-        if not isinstance(response, GenerateResponse):
-            return response
-
-        if capture is not None:
+        if capture is not None and isinstance(response, GenerateResponse):
             response = capture.post_process(response)
-        elif not isinstance(response, PrimeRlGenerateResponse):
-            # Upgrade to the prime-rl subclass so the declared ``usage`` field
-            # actually surfaces in JSON (the parent class would drop it).
-            response = PrimeRlGenerateResponse(
-                request_id=response.request_id,
-                choices=[PrimeRlGenerateResponseChoice(**choice.model_dump()) for choice in response.choices],
-                prompt_logprobs=response.prompt_logprobs,
-                kv_transfer_params=response.kv_transfer_params,
-            )
-
-        if final_capture.final_res is not None:
-            response.usage = _build_usage(final_capture.final_res)
 
         return response

--- a/src/prime_rl/inference/vllm/worker/__init__.py
+++ b/src/prime_rl/inference/vllm/worker/__init__.py
@@ -3,7 +3,6 @@ import os
 
 from prime_rl.inference.patches import (
     monkey_patch_fp32_lm_head,
-    monkey_patch_fp32_router_logits,
     monkey_patch_minimax_m2_for_lora,
     monkey_patch_no_moe_lora,
 )
@@ -21,6 +20,3 @@ else:
 
 # Install fp32 lm_head patch; self-gates on additional_config["fp32_lm_head"] at call time
 monkey_patch_fp32_lm_head()
-
-# Install fp32 router logits patch; self-gates on additional_config["fp32_router_logits"]
-monkey_patch_fp32_router_logits()

--- a/tests/unit/inference/test_serving_tokens.py
+++ b/tests/unit/inference/test_serving_tokens.py
@@ -5,12 +5,11 @@ The full happy-path is owned upstream by vLLM's
 deltas here:
     * ``serialize_routed_experts`` round-trips a compact raw-byte payload.
     * The subclass attaches its overrides without monkey-patching the parent.
-    * ``_client_set_max_tokens`` distinguishes raw-body shapes correctly.
+    * ``post_process`` swaps in the compact routed_experts while preserving
+      the rest of the upstream response (``usage`` included).
 """
 
 from __future__ import annotations
-
-import asyncio
 
 import numpy as np
 import pybase64
@@ -19,12 +18,7 @@ from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateRespo
 
 from prime_rl.inference.vllm.routed_experts import serialize_routed_experts
 from prime_rl.inference.vllm.serving_tokens import (
-    PrimeRlGenerateResponse,
-    PrimeRlGenerateResponseChoice,
     PrimeRlServingTokens,
-    _build_usage,
-    _client_set_max_tokens,
-    _FinalOutputCapture,
     _GenerateRoutedExpertsCapture,
 )
 
@@ -34,17 +28,6 @@ def _decode_routed_experts(encoded: dict) -> np.ndarray:
         pybase64.b64decode_as_bytearray(encoded["data"]),
         dtype=np.uint8,
     ).reshape(encoded["shape"])
-
-
-class _FakeRawRequest:
-    def __init__(self, body):
-        self._body = body
-        self._raise = isinstance(body, Exception)
-
-    async def json(self):
-        if self._raise:
-            raise self._body
-        return self._body
 
 
 async def _empty_request_outputs():
@@ -81,8 +64,10 @@ def test_generate_response_post_process_replaces_upstream_routed_experts():
     compact_routed_experts = {"data": "AQID", "shape": [1, 1, 3], "start": 0}
     capture = _GenerateRoutedExpertsCapture(_empty_request_outputs())
     capture.routed_experts[0] = compact_routed_experts
+    usage = UsageInfo(prompt_tokens=4, completion_tokens=3, total_tokens=7)
     response = GenerateResponse(
         request_id="request-id",
+        model="test-model",
         choices=[
             GenerateResponseChoice(
                 index=0,
@@ -90,180 +75,16 @@ def test_generate_response_post_process_replaces_upstream_routed_experts():
                 routed_experts="upstream-npy-payload",
             )
         ],
+        usage=usage,
     )
 
     processed = capture.post_process(response)
 
     assert processed.choices[0].routed_experts == compact_routed_experts
-
-
-def test_client_set_max_tokens_recognizes_explicit_value():
-    body = {"token_ids": [1, 2, 3], "sampling_params": {"max_tokens": 256}}
-    assert asyncio.run(_client_set_max_tokens(_FakeRawRequest(body))) is True
-
-
-def test_client_set_max_tokens_detects_unset():
-    body = {"token_ids": [1, 2, 3], "sampling_params": {}}
-    assert asyncio.run(_client_set_max_tokens(_FakeRawRequest(body))) is False
-
-    body_without_sp = {"token_ids": [1, 2, 3]}
-    assert asyncio.run(_client_set_max_tokens(_FakeRawRequest(body_without_sp))) is False
-
-
-class _FakeOutput:
-    def __init__(self, token_ids):
-        self.token_ids = token_ids
-
-
-class _FakeRequestOutput:
-    """Minimal stand-in for ``vllm.outputs.RequestOutput``.
-
-    ``_build_usage`` only touches four attributes; constructing a real
-    ``RequestOutput`` would require a full ``CompletionOutput`` graph and
-    isn't worth it for a serialization-shape test.
-    """
-
-    def __init__(self, prompt_token_ids, output_token_ids_list, num_cached_tokens=0, encoder_prompt_token_ids=None):
-        self.prompt_token_ids = prompt_token_ids
-        self.encoder_prompt_token_ids = encoder_prompt_token_ids
-        self.outputs = [_FakeOutput(t) for t in output_token_ids_list]
-        self.num_cached_tokens = num_cached_tokens
-
-
-def test_prime_rl_generate_response_serializes_usage_block():
-    # Regression for prime-rl PR #2408: parent ``GenerateResponse`` doesn't
-    # declare ``usage``, so the field must be declared on the subclass for
-    # Pydantic to emit it in JSON. Without this the router can't extract
-    # per-run token / cache counts for billing.
-    response = PrimeRlGenerateResponse(
-        request_id="req-1",
-        choices=[PrimeRlGenerateResponseChoice(index=0, token_ids=[1, 2, 3])],
-        usage=UsageInfo(prompt_tokens=4, completion_tokens=3, total_tokens=7),
-    )
-    payload = response.model_dump(mode="json")
-    assert payload["usage"] == {
-        "prompt_tokens": 4,
-        "completion_tokens": 3,
-        "total_tokens": 7,
-        "prompt_tokens_details": None,
-    }
-
-
-def test_build_usage_sums_prompt_and_completion_tokens():
-    final_res = _FakeRequestOutput(
-        prompt_token_ids=[1, 2, 3, 4, 5],
-        output_token_ids_list=[[10, 11], [20, 21, 22]],
-    )
-    usage = _build_usage(final_res)
-    assert usage.prompt_tokens == 5
-    assert usage.completion_tokens == 5  # 2 + 3
-    assert usage.total_tokens == 10
-    assert usage.prompt_tokens_details is None
-
-
-def test_build_usage_includes_encoder_prompt_tokens():
-    final_res = _FakeRequestOutput(
-        prompt_token_ids=[1, 2, 3],
-        output_token_ids_list=[[10]],
-        encoder_prompt_token_ids=[100, 101],
-    )
-    usage = _build_usage(final_res)
-    assert usage.prompt_tokens == 5  # 3 + 2
-    assert usage.total_tokens == 6
-
-
-def test_build_usage_reports_cached_tokens_unconditionally():
-    # Unlike upstream's ``enable_prompt_tokens_details`` gate, prime-rl always
-    # surfaces cached tokens — the cache-discount billing pipeline needs them.
-    final_res = _FakeRequestOutput(
-        prompt_token_ids=[1, 2, 3, 4],
-        output_token_ids_list=[[10, 11]],
-        num_cached_tokens=3,
-    )
-    usage = _build_usage(final_res)
-    assert usage.prompt_tokens_details is not None
-    assert usage.prompt_tokens_details.cached_tokens == 3
-
-
-def test_build_usage_skips_cached_tokens_when_zero():
-    # Don't emit a details block with cached=0, which would be misleading
-    # to the router's billing extractor.
-    final_res = _FakeRequestOutput(
-        prompt_token_ids=[1, 2, 3, 4],
-        output_token_ids_list=[[10, 11]],
-        num_cached_tokens=0,
-    )
-    usage = _build_usage(final_res)
-    assert usage.prompt_tokens_details is None
-
-
-def test_final_output_capture_records_last_item():
-    async def _gen():
-        for r in [
-            _FakeRequestOutput(prompt_token_ids=[1], output_token_ids_list=[[1]]),
-            _FakeRequestOutput(prompt_token_ids=[1, 2], output_token_ids_list=[[1, 2]]),
-            _FakeRequestOutput(prompt_token_ids=[1, 2, 3], output_token_ids_list=[[1, 2, 3]]),
-        ]:
-            yield r
-
-    async def _drain(capture):
-        async for _ in capture:
-            pass
-
-    capture = _FinalOutputCapture(_gen())
-    asyncio.run(_drain(capture))
-    assert capture.final_res is not None
-    assert capture.final_res.prompt_token_ids == [1, 2, 3]
-
-
-def test_final_output_capture_works_over_async_def_aiter_source():
-    # ``_GenerateRoutedExpertsCapture`` exposes the async-iterator protocol
-    # via ``async def __aiter__`` (an async generator function) and has no
-    # ``__anext__``. The wrapper must drive it through ``async for`` rather
-    # than poking ``__anext__`` directly, or routed-experts runs raise
-    # AttributeError before the response is built.
-
-    class _AsyncGenAiterSource:
-        def __init__(self, items):
-            self._items = items
-
-        async def __aiter__(self):
-            for item in self._items:
-                yield item
-
-    items = [
-        _FakeRequestOutput(prompt_token_ids=[1], output_token_ids_list=[[1]]),
-        _FakeRequestOutput(prompt_token_ids=[1, 2], output_token_ids_list=[[1, 2]]),
-    ]
-    capture = _FinalOutputCapture(_AsyncGenAiterSource(items))
-
-    async def _drain():
-        async for _ in capture:
-            pass
-
-    asyncio.run(_drain())
-    assert capture.final_res is not None
-    assert capture.final_res.prompt_token_ids == [1, 2]
-
-
-def test_final_output_capture_handles_empty_stream():
-    capture = _FinalOutputCapture(_empty_request_outputs())
-
-    async def _drain():
-        async for _ in capture:
-            pass
-
-    asyncio.run(_drain())
-    assert capture.final_res is None
-
-
-def test_client_set_max_tokens_assumes_set_when_body_unreadable():
-    # No raw_request → can't tell, don't override.
-    assert asyncio.run(_client_set_max_tokens(None)) is True
-
-    # body read raises → can't tell, don't override.
-    err = ValueError("bad json")
-    assert asyncio.run(_client_set_max_tokens(_FakeRawRequest(err))) is True
-
-    # non-dict body → can't tell, don't override.
-    assert asyncio.run(_client_set_max_tokens(_FakeRawRequest([1, 2, 3]))) is True
+    assert processed.model == "test-model"
+    assert processed.usage == usage
+    # The compact object form must survive JSON serialization (the parent
+    # declares ``routed_experts`` as a base64 string).
+    payload = processed.model_dump(mode="json")
+    assert payload["choices"][0]["routed_experts"] == compact_routed_experts
+    assert payload["usage"]["total_tokens"] == 7

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ members = [
 ]
 overrides = [
     { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'", specifier = ">=9.15" },
-    { name = "nvidia-cutlass-dsl", specifier = "==4.6.0" },
+    { name = "nvidia-cutlass-dsl", specifier = "==4.6.2" },
     { name = "openenv-core" },
     { name = "torch", marker = "sys_platform != 'linux'", specifier = ">=2.13.0" },
     { name = "torch", marker = "sys_platform == 'linux'", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cu130" },
@@ -157,8 +157,8 @@ requires-dist = ["nixl-cu13==0.10.1"]
 
 [[manifest.dependency-metadata]]
 name = "nvidia-cutlass-dsl"
-version = "4.6.0"
-requires-dist = ["nvidia-cutlass-dsl-libs-base==4.6.0", "nvidia-cutlass-dsl-libs-cu13==4.6.0"]
+version = "4.6.2"
+requires-dist = ["nvidia-cutlass-dsl-libs-base==4.6.2", "nvidia-cutlass-dsl-libs-cu13==4.6.2"]
 
 [[package]]
 name = "absl-py"
@@ -578,7 +578,8 @@ dependencies = [
     { name = "google-genai" },
     { name = "google-search-results" },
     { name = "html2text" },
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "mistralai" },
     { name = "mpmath" },
     { name = "networkx" },
@@ -624,7 +625,8 @@ name = "black"
 version = "26.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
+    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "click", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "mypy-extensions" },
     { name = "packaging" },
     { name = "pathspec" },
@@ -949,9 +951,25 @@ requires-dist = [
 name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'arm64' and sys_platform == 'darwin'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -1287,7 +1305,8 @@ dependencies = [
     { name = "filelock" },
     { name = "fsspec", extra = ["http"] },
     { name = "httpx" },
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "multiprocess" },
     { name = "numpy" },
     { name = "packaging" },
@@ -1453,7 +1472,8 @@ name = "deshuffle-papers"
 version = "0.1.0"
 source = { editable = "deps/prime-envs/environments/reasoning/deshuffle_papers" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "verifiers" },
 ]
 
@@ -1568,7 +1588,8 @@ name = "drug-discovery-bench"
 version = "0.1.0"
 source = { editable = "deps/prime-envs/environments/science/drug_discovery_bench" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "verifiers", extra = ["harbor"] },
 ]
 
@@ -1790,15 +1811,15 @@ wheels = [
 
 [[package]]
 name = "fastsafetensors"
-version = "0.3.2"
+version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/33/c97b2bcbe06e0f011eedee0f41d4060f6344901a53c2703acc3dd7429713/fastsafetensors-0.3.2.tar.gz", hash = "sha256:9e358fce238684613a5c3ebb7800c52c5b3270c0bb5e4ed2191ee8f3d0431de1", size = 70409, upload-time = "2026-05-22T05:39:34.787Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/4c/f17bd54c933fd23648ce1e4272adf27d8d7e99b788c8859544bbd39f02e7/fastsafetensors-0.3.3.tar.gz", hash = "sha256:ba4fb59be8a6adbc91723848c3c6f57a9a9a5d2247d9768f84511380d01e554c", size = 77817, upload-time = "2026-07-07T07:21:47.121Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/bb/9f821eac9bddd41ea1c5cd9b6a597c002741f022ecf6f3ba5cfcc3e9c950/fastsafetensors-0.3.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69f4d8cbd3b542e5ddf7fee8136cf35e1524f9c30e118f64a0e846dab7e8de6b", size = 1877989, upload-time = "2026-06-04T09:02:56.11Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/68/a31c1661adf4d1b5ec29470ff991bde9094e4f347b0e6d1af8ba6b560d32/fastsafetensors-0.3.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6a932d7166c9e17e48aca3e5503d326bc6fc73fce6dc985ae6bd2ccc0f308b14", size = 1907188, upload-time = "2026-05-22T05:39:30.242Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/f95f7fc099ac1fc4c22aa46257d159eac88e29dd0765d21c4fc91caedb01/fastsafetensors-0.3.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c2f788a936ffd17938484360339645812e14cf1b2bdf4c18c035c713218e5a9", size = 1887326, upload-time = "2026-07-07T07:21:34.624Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8c/e3347b2a44a8ab9aced94fa450df4f309baa21f7f2981a8a7bd6a977f4d3/fastsafetensors-0.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3587bc66b8dec560ad903becf9540889013d4d47f0e10cf45f19bedc7b7bffa7", size = 1915478, upload-time = "2026-07-07T07:21:35.901Z" },
 ]
 
 [[package]]
@@ -1910,7 +1931,7 @@ version = "0.6.16.post3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi" },
-    { name = "click" },
+    { name = "click", version = "8.4.2", source = { registry = "https://pypi.org/simple" } },
     { name = "cuda-python" },
     { name = "cuda-tile" },
     { name = "einops" },
@@ -2345,13 +2366,28 @@ wheels = [
 name = "hf-xet"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'arm64' and sys_platform == 'darwin'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
-    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
-    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
 ]
 
 [[package]]
@@ -2451,10 +2487,13 @@ wheels = [
 name = "huggingface-hub"
 version = "1.16.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'arm64' and sys_platform == 'darwin'",
+]
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet" },
+    { name = "hf-xet", version = "1.5.0", source = { registry = "https://pypi.org/simple" } },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -2465,6 +2504,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
+dependencies = [
+    { name = "click", version = "8.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", version = "1.6.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ae/222a91937ebee7f62c0ca8f5ee0afd97577caf24c0abb927d1f5c7e9f6d2/huggingface_hub-1.28.0.tar.gz", hash = "sha256:46a2e950c09234de54093d587d1675382f0d08dbd600d9fb599b5932f5b2c6cb", size = 959609, upload-time = "2026-08-18T12:27:15.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/0e/eafef18f1a75e125e68395db21131db0cf868a128ecd2fce69b4df6c584b/huggingface_hub-1.28.0-py3-none-any.whl", hash = "sha256:58a8bacb03072edfc38067065e9dc24bbb34805410fcd36a1632de0b329660bb", size = 793202, upload-time = "2026-08-18T12:27:12.719Z" },
 ]
 
 [[package]]
@@ -2484,23 +2547,23 @@ requires-dist = [
 
 [[package]]
 name = "humming-kernels"
-version = "0.1.10"
+version = "0.1.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings" },
     { name = "jinja2" },
     { name = "numpy" },
     { name = "nvidia-ml-py" },
-    { name = "pyelftools" },
     { name = "safetensors" },
     { name = "tabulate" },
     { name = "torch", version = "2.13.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
     { name = "tqdm" },
     { name = "triton" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/4f/6977a31451c3f7aa1deaa76506d6cdeb74ef418ad8bcba2e98f7510b26ec/humming_kernels-0.1.10.tar.gz", hash = "sha256:da3e46fb9fc9eba2a9327c2e8135ead68e390c955acd7449f97ee7c71666c8b1", size = 220110, upload-time = "2026-07-02T10:22:57.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/b9/53797fff4b1b31b4567453a365646d724469b1bb0d76c07f8746617d0cb6/humming_kernels-0.1.12.tar.gz", hash = "sha256:c96c37c95f74379067d2d2d0c5154d12ee9a8cfa29a7c3370a7f3e34f207ca72", size = 259323, upload-time = "2026-07-31T14:28:23.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/ba/869bc24591d2b4fb0d8da821528072971052a934af077a11f77a0f2b3e79/humming_kernels-0.1.10-py3-none-any.whl", hash = "sha256:4ded0998ff085afeddde70baf93f97c2929969ec3d4a63a52cfec5072bc972b4", size = 184889, upload-time = "2026-07-02T10:22:56.031Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0f/01f871dc26f8d7e1683df9464890d48cfd5c4e46c4a264d7ee0868749197/humming_kernels-0.1.12-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:988e8b9da41e3679ae2816bdfb51acab53c05cc56254b5ca98e847f4efcf24fd", size = 318019, upload-time = "2026-07-31T14:28:19.925Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/a2/f96912ee7d68f56e61c15555657ffa057b8afbaa21241c63342b5969bb74/humming_kernels-0.1.12-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cd3ef712a93f3a9075ea99de2c72bcd3ec89dab3759b3a248d869f5507b60331", size = 322656, upload-time = "2026-07-31T14:28:21.511Z" },
 ]
 
 [package.optional-dependencies]
@@ -2992,7 +3055,7 @@ name = "kernels"
 version = "0.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
     { name = "kernels-data" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -3157,7 +3220,8 @@ version = "1.95.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
-    { name = "click" },
+    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "click", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "fastuuid" },
     { name = "httpx" },
     { name = "importlib-metadata" },
@@ -3181,7 +3245,8 @@ version = "0.1.0"
 source = { editable = "deps/prime-envs/environments/code/livecodebench" }
 dependencies = [
     { name = "datasets" },
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "verifiers" },
 ]
 
@@ -3688,7 +3753,8 @@ dependencies = [
     { name = "aiohttp" },
     { name = "cbor2" },
     { name = "certifi" },
-    { name = "click" },
+    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "click", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "grpclib" },
     { name = "protobuf" },
     { name = "rich" },
@@ -3728,7 +3794,7 @@ version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
     { name = "nixl" },
     { name = "numpy" },
     { name = "protobuf" },
@@ -4003,7 +4069,8 @@ name = "nltk"
 version = "3.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
+    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "click", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
@@ -4233,19 +4300,19 @@ wheels = [
 
 [[package]]
 name = "nvidia-cutlass-dsl"
-version = "4.6.0"
+version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nvidia-cutlass-dsl-libs-base" },
     { name = "nvidia-cutlass-dsl-libs-cu13" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/1c/fbddb760a0228df87a9e9d1e60b76ecbe6e18035f5853efe0b4563651b2b/nvidia_cutlass_dsl-4.6.0-py3-none-any.whl", hash = "sha256:e3e0e4d8df20d82c8401fa013f4d82021f41daa5fca3d24b55d4a677f2308ca8", size = 10459, upload-time = "2026-07-02T03:23:18.43Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ec/14e6ecbfed31ec35bbd1bb6965ae61f879370906a8f9c2e851e292704ba4/nvidia_cutlass_dsl-4.6.2-py3-none-any.whl", hash = "sha256:06ac62deb182a852dfb053032cf945bf02b9aa1bf502a18b129d280d7babb26c", size = 10460, upload-time = "2026-08-05T14:39:41.657Z" },
 ]
 
 [[package]]
 name = "nvidia-cutlass-dsl-libs-base"
-version = "4.6.0"
+version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-python" },
@@ -4256,13 +4323,13 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/f8/22653971fcab2a7ed581934f7a2708c9873fa6a8e8eb285422c8eed4ae01/nvidia_cutlass_dsl_libs_base-4.6.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6412572899b1c6d182e516b20f2b0a21874ec88d25234e6040fb2a4381de7a1a", size = 3321728, upload-time = "2026-07-02T03:25:28.888Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/38/e91f66739d2f8711d1a2457e68cd86d6fbae307ce66ce270a405d4dc6dc7/nvidia_cutlass_dsl_libs_base-4.6.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:e41cd5db4de4b535c30ae9ca4412b957800a62560019ae91fa51cf3ea89bf254", size = 2824817, upload-time = "2026-07-02T03:25:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/f3/4be98f2faa283471e355a42ecbc20956fb2c3b6dbc71861f483be277e99a/nvidia_cutlass_dsl_libs_base-4.6.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e129db7155d56ba4478be098c0f819e37690a6ce5d43a9a9a83bf1300d32c57f", size = 3321894, upload-time = "2026-08-05T14:12:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/54/1b/cf4a0837054bb4b9dc36cdd86f9d2e7fead3629e3373aaa7f7ec1e5e1542/nvidia_cutlass_dsl_libs_base-4.6.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:24dfaddad6077fd0de14eecaf66a72762f2f5f30ae1872231f5bf8b243ac2eac", size = 2824987, upload-time = "2026-08-05T14:12:49.618Z" },
 ]
 
 [[package]]
 name = "nvidia-cutlass-dsl-libs-core"
-version = "4.6.0"
+version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-python" },
@@ -4272,12 +4339,12 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/94/e4e2404ac06a477096ccf8127bf5d391510d36cafb4be86c8c15b4873b0d/nvidia_cutlass_dsl_libs_core-4.6.0-py3-none-any.whl", hash = "sha256:f9ea6d313a03cb11fa177da32e8747ad0cac51358850810f36aa6c4736192c27", size = 767713, upload-time = "2026-07-02T03:23:39.876Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/10c0089234a32f1379e1f213f28f8c7521a9ff0154e3acc58f613d5ef3be/nvidia_cutlass_dsl_libs_core-4.6.2-py3-none-any.whl", hash = "sha256:571d4b46fca1bfbb123d0dc348eaa7fd80af0014ddffc07b849e8195b2364333", size = 772393, upload-time = "2026-08-05T14:09:50.76Z" },
 ]
 
 [[package]]
 name = "nvidia-cutlass-dsl-libs-cu13"
-version = "4.6.0"
+version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-python" },
@@ -4288,8 +4355,8 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/bc/25d542974cc7d2594a22ce1df71c40f8900d44c10aef577cbf5ae7a37e5d/nvidia_cutlass_dsl_libs_cu13-4.6.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8c47899a5778dba4f30de76cce5e22bb5dc2a5bde4979ee1196ec9c6468e80e1", size = 86704408, upload-time = "2026-07-02T03:34:36.929Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/0f/bd8b25e6307764a7bfefa519241d6e417f3ba1c75ce548aa76b712a4fd15/nvidia_cutlass_dsl_libs_cu13-4.6.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4799fabc4bd1f7825ff00101ae0054c5cfb6769aefd6d9694f6da8c0f07e12c3", size = 88026053, upload-time = "2026-07-02T03:34:59.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/38/bbe5b8f1ef1a15e7bd1e2ea86686c38f15eeee0a4ba440a5d00d8222cb8e/nvidia_cutlass_dsl_libs_cu13-4.6.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b9543257622ce70d696c6a2bda7e9617ef5b1cc9f29bfe66f4b38d1d1e29a8cb", size = 86712108, upload-time = "2026-08-05T14:27:35.488Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/05/7874c37d50e112177a64a96dd6c7eaeacb1661ebb864e0fe5cfd9f706767/nvidia_cutlass_dsl_libs_cu13-4.6.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a299a623fad75eb752c1a4e447b924e9049ed396b037509c41a48da82d1f340a", size = 88036030, upload-time = "2026-08-05T14:27:58.991Z" },
 ]
 
 [[package]]
@@ -4387,7 +4454,8 @@ version = "0.1.0"
 source = { editable = "deps/prime-envs/environments/long_context/oolong_pairs" }
 dependencies = [
     { name = "datasets" },
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "verifiers" },
 ]
 
@@ -4523,7 +4591,8 @@ version = "0.1.3"
 source = { editable = "deps/prime-envs/environments/swe/openswe" }
 dependencies = [
     { name = "datasets" },
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "verifiers" },
 ]
 
@@ -5112,8 +5181,8 @@ all = [
     { name = "torchdata", marker = "sys_platform == 'linux'" },
     { name = "torchtitan", marker = "sys_platform == 'linux'" },
     { name = "torchvision", marker = "sys_platform == 'linux'" },
-    { name = "vllm", version = "0.27.1", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.27.1/vllm-0.27.1-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64' and sys_platform == 'linux'" },
-    { name = "vllm", version = "0.27.1", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.27.1/vllm-0.27.1-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.28.0", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.28.0", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "vllm-router", version = "0.2.0", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.2.0/vllm_router-0.2.0-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64' and sys_platform == 'linux'" },
     { name = "vllm-router", version = "0.2.0", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.2.0/vllm_router-0.2.0-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
@@ -5161,8 +5230,8 @@ gpu = [
     { name = "torchdata", marker = "sys_platform == 'linux'" },
     { name = "torchtitan", marker = "sys_platform == 'linux'" },
     { name = "torchvision", marker = "sys_platform == 'linux'" },
-    { name = "vllm", version = "0.27.1", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.27.1/vllm-0.27.1-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64' and sys_platform == 'linux'" },
-    { name = "vllm", version = "0.27.1", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.27.1/vllm-0.27.1-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.28.0", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.28.0", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 kernels = [
     { name = "prime-kernels", version = "0.1.0+cu130torch2.13.0", source = { url = "https://github.com/PrimeIntellect-ai/prime-kernels/releases/download/v0.1.1/prime_kernels-0.1.0+cu130torch2.13.0-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine != 'x86_64' and sys_platform == 'linux'" },
@@ -5254,9 +5323,9 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'dashboard'", specifier = ">=0.30" },
     { name = "uvloop", specifier = ">=0.21.0" },
     { name = "verifiers", extras = ["harbor"], editable = "deps/verifiers" },
-    { name = "vllm", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://github.com/vllm-project/vllm/releases/download/v0.27.1/vllm-0.27.1-cp38-abi3-manylinux_2_28_aarch64.whl" },
-    { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", specifier = ">=0.27.1" },
-    { name = "vllm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://github.com/vllm-project/vllm/releases/download/v0.27.1/vllm-0.27.1-cp38-abi3-manylinux_2_28_x86_64.whl" },
+    { name = "vllm", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_aarch64.whl" },
+    { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", specifier = ">=0.28.0" },
+    { name = "vllm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "vllm-router", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.2.0/vllm_router-0.2.0-cp38-abi3-manylinux_2_28_aarch64.whl" },
     { name = "vllm-router", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'disagg'" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.2.0/vllm_router-0.2.0-cp38-abi3-manylinux_2_28_x86_64.whl" },
@@ -5338,7 +5407,8 @@ name = "programbench"
 version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "jinja2" },
     { name = "junitparser" },
     { name = "pydantic" },
@@ -5358,7 +5428,8 @@ version = "0.2.0"
 source = { editable = "deps/prime-envs/environments/code/programbench_env" }
 dependencies = [
     { name = "datasets" },
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "prime-sandboxes" },
     { name = "programbench" },
     { name = "verifiers" },
@@ -5705,15 +5776,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyelftools"
-version = "0.32"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/ab/33968940b2deb3d92f5b146bc6d4009a5f95d1d06c148ea2f9ee965071af/pyelftools-0.32.tar.gz", hash = "sha256:6de90ee7b8263e740c8715a925382d4099b354f29ac48ea40d840cf7aa14ace5", size = 15047199, upload-time = "2025-02-19T14:20:05.549Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/43/700932c4f0638c3421177144a2e86448c0d75dbaee2c7936bda3f9fd0878/pyelftools-0.32-py3-none-any.whl", hash = "sha256:013df952a006db5e138b1edf6d8a68ecc50630adbd0d83a2d41e7f846163d738", size = 188525, upload-time = "2025-02-19T14:19:59.919Z" },
-]
-
-[[package]]
 name = "pygithub"
 version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5982,7 +6044,7 @@ wheels = [
 
 [[package]]
 name = "quack-kernels"
-version = "0.6.1"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi" },
@@ -5991,9 +6053,9 @@ dependencies = [
     { name = "torch", version = "2.13.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
     { name = "torch-c-dlpack-ext" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/17/890875f88f4d7da28faec9e6cf0a0cc565715b01474e50501fafc5bc71b4/quack_kernels-0.6.1.tar.gz", hash = "sha256:a694f89c91d137478de523c0227365a331ac9cb66790cfb08baa3dbfaafc71e7", size = 387353, upload-time = "2026-07-05T11:50:19.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/5c/67c4a0d54cbb8d4d05af73132d620d1900a193b33e0d5ea6a25829b941d2/quack_kernels-0.6.4.tar.gz", hash = "sha256:8bf08a0e1a85aecc892ce84f4b6ed7abb6a44ec7c68b83040abe174bc8c2b936", size = 845485, upload-time = "2026-08-07T23:25:31.94Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/65/a38a30a6ac96a757363a5be9d09cef799640bb143a64ba5a2f4d400d95d9/quack_kernels-0.6.1-py3-none-any.whl", hash = "sha256:266705ea82117e9b1c8a9e44d68a458519f2498d966c0efffd6812120c3995ad", size = 358439, upload-time = "2026-07-05T11:50:18.502Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f5/36ec7e075e90bd92bdf30fee0606f189348c2bbb0af6aebaf7382927c622/quack_kernels-0.6.4-py3-none-any.whl", hash = "sha256:e77c5d1f1299b0b38487fe8737df6c6975daa16bca7f7eb883bd1a74d09e7e78", size = 728458, upload-time = "2026-08-07T23:25:30.549Z" },
 ]
 
 [[package]]
@@ -6218,7 +6280,7 @@ name = "rich-toolkit"
 version = "0.19.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
+    { name = "click", version = "8.4.2", source = { registry = "https://pypi.org/simple" } },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
@@ -6279,7 +6341,8 @@ name = "s1-deepresearch"
 version = "0.1.0"
 source = { editable = "deps/prime-envs/environments/search/s1_deepresearch" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "verifiers" },
 ]
 
@@ -6422,7 +6485,8 @@ name = "sentence-transformers"
 version = "5.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "numpy" },
     { name = "scikit-learn" },
     { name = "scipy" },
@@ -7062,7 +7126,8 @@ name = "terminal-lego"
 version = "0.1.1"
 source = { editable = "deps/prime-envs/environments/terminal/terminal_lego" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "verifiers", extra = ["harbor"] },
 ]
 
@@ -7225,7 +7290,8 @@ name = "tokenizers"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
@@ -7540,7 +7606,8 @@ name = "transformers"
 version = "5.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -7634,7 +7701,8 @@ version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "click" },
+    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "click", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "rich" },
     { name = "shellingham" },
 ]
@@ -7779,7 +7847,8 @@ name = "uvicorn"
 version = "0.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
+    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "click", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
@@ -7950,7 +8019,8 @@ version = "0.1.0"
 source = { editable = "deps/prime-envs/environments/multimodal/virl39k" }
 dependencies = [
     { name = "datasets" },
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "math-verify" },
     { name = "verifiers" },
 ]
@@ -7980,8 +8050,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.27.1"
-source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.27.1/vllm-0.27.1-cp38-abi3-manylinux_2_28_aarch64.whl" }
+version = "0.28.0"
+source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_aarch64.whl" }
 resolution-markers = [
     "platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
@@ -8000,6 +8070,7 @@ dependencies = [
     { name = "fastsafetensors" },
     { name = "filelock" },
     { name = "flashinfer-python" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
     { name = "humming-kernels", extra = ["cu13"] },
     { name = "ijson" },
     { name = "jsonschema" },
@@ -8061,7 +8132,7 @@ dependencies = [
     { name = "xgrammar" },
 ]
 wheels = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.27.1/vllm-0.27.1-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:74c1a04548c9016ace8f6c03592edf62517152a0e833f46282556ffbe0796254" },
+    { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:817b8181f7f61b4a62dc1d5d9ab39f2bfb60a6cb86c29879a78a147b85756787" },
 ]
 
 [package.metadata]
@@ -8070,6 +8141,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.71.0" },
     { name = "apache-tvm-ffi", specifier = "==0.1.11" },
     { name = "av", marker = "extra == 'audio'" },
+    { name = "b12x", marker = "extra == 'b12x'", specifier = "==1.2.4" },
     { name = "blake3" },
     { name = "cachetools" },
     { name = "cbor2" },
@@ -8079,12 +8151,13 @@ requires-dist = [
     { name = "depyf", specifier = "==0.20.0" },
     { name = "einops" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.133.0,<0.137.0" },
-    { name = "fastsafetensors", specifier = ">=0.3.2" },
-    { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.3.2" },
+    { name = "fastsafetensors", specifier = ">=0.3.3" },
+    { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.3.3" },
     { name = "filelock", specifier = ">=3.16.1" },
     { name = "flashinfer-python", specifier = "==0.6.16.post3" },
     { name = "helion", marker = "extra == 'helion'", specifier = "==1.4.0" },
-    { name = "humming-kernels", extras = ["cu13"], specifier = "==0.1.10" },
+    { name = "huggingface-hub", specifier = ">=1.27.0" },
+    { name = "humming-kernels", extras = ["cu13"], specifier = "==0.1.12" },
     { name = "ijson" },
     { name = "instanttensor", marker = "extra == 'instanttensor'", specifier = ">=0.1.9" },
     { name = "jsonschema", specifier = ">=4.23.0" },
@@ -8101,7 +8174,7 @@ requires-dist = [
     { name = "numba", specifier = "==0.65.0" },
     { name = "numpy" },
     { name = "nvidia-cudnn-frontend", specifier = ">=1.19.1" },
-    { name = "nvidia-cutlass-dsl", extras = ["cu13"], specifier = "==4.6.0" },
+    { name = "nvidia-cutlass-dsl", extras = ["cu13"], specifier = "==4.6.2" },
     { name = "nvidia-deepstream-videodecode-cu13", marker = "extra == 'deepstream'", specifier = ">=9.0.2" },
     { name = "nvtx", specifier = "==0.2.15" },
     { name = "openai", specifier = ">=2.0.0" },
@@ -8131,7 +8204,7 @@ requires-dist = [
     { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "pyzmq", specifier = ">=25.0.0" },
-    { name = "quack-kernels", specifier = "==0.6.1" },
+    { name = "quack-kernels", specifier = "==0.6.4" },
     { name = "regex" },
     { name = "requests", specifier = ">=2.26.0" },
     { name = "runai-model-streamer", extras = ["azure", "gcs", "s3"], marker = "extra == 'runai'", specifier = ">=0.15.7" },
@@ -8162,14 +8235,14 @@ requires-dist = [
     { name = "vllm-gguf-plugin", marker = "extra == 'extra-quant'", specifier = ">=0.0.2" },
     { name = "watchfiles" },
     { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'", specifier = ">=0.2.1,<1.0.0" },
-    { name = "zentorch", marker = "extra == 'zen'", specifier = "==2.11.0.0" },
+    { name = "zentorch", marker = "extra == 'zen'", specifier = "==2.13.0.0" },
 ]
-provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttensor", "runai", "audio", "video", "deepstream", "flashinfer", "helion", "grpc", "otel", "extra-quant"]
+provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttensor", "runai", "audio", "video", "deepstream", "flashinfer", "b12x", "helion", "grpc", "otel", "extra-quant"]
 
 [[package]]
 name = "vllm"
-version = "0.27.1"
-source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.27.1/vllm-0.27.1-cp38-abi3-manylinux_2_28_x86_64.whl" }
+version = "0.28.0"
+source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_x86_64.whl" }
 resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
@@ -8188,6 +8261,7 @@ dependencies = [
     { name = "fastsafetensors" },
     { name = "filelock" },
     { name = "flashinfer-python" },
+    { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
     { name = "humming-kernels", extra = ["cu13"] },
     { name = "ijson" },
     { name = "jsonschema" },
@@ -8249,7 +8323,7 @@ dependencies = [
     { name = "xgrammar" },
 ]
 wheels = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.27.1/vllm-0.27.1-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:98e9fc2a1ed8549a733c9d1b242e2002b82367da9e29e37801761438cb3a2670" },
+    { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:addb0ffdaafd8155d75e9b3f5ddb3da28fdee9e8a7097ede91f7db2e9e1a3889" },
 ]
 
 [package.metadata]
@@ -8258,6 +8332,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.71.0" },
     { name = "apache-tvm-ffi", specifier = "==0.1.11" },
     { name = "av", marker = "extra == 'audio'" },
+    { name = "b12x", marker = "extra == 'b12x'", specifier = "==1.2.4" },
     { name = "blake3" },
     { name = "cachetools" },
     { name = "cbor2" },
@@ -8267,12 +8342,13 @@ requires-dist = [
     { name = "depyf", specifier = "==0.20.0" },
     { name = "einops" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.133.0,<0.137.0" },
-    { name = "fastsafetensors", specifier = ">=0.3.2" },
-    { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.3.2" },
+    { name = "fastsafetensors", specifier = ">=0.3.3" },
+    { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.3.3" },
     { name = "filelock", specifier = ">=3.16.1" },
     { name = "flashinfer-python", specifier = "==0.6.16.post3" },
     { name = "helion", marker = "extra == 'helion'", specifier = "==1.4.0" },
-    { name = "humming-kernels", extras = ["cu13"], specifier = "==0.1.10" },
+    { name = "huggingface-hub", specifier = ">=1.27.0" },
+    { name = "humming-kernels", extras = ["cu13"], specifier = "==0.1.12" },
     { name = "ijson" },
     { name = "instanttensor", marker = "extra == 'instanttensor'", specifier = ">=0.1.9" },
     { name = "jsonschema", specifier = ">=4.23.0" },
@@ -8289,7 +8365,7 @@ requires-dist = [
     { name = "numba", specifier = "==0.65.0" },
     { name = "numpy" },
     { name = "nvidia-cudnn-frontend", specifier = ">=1.19.1" },
-    { name = "nvidia-cutlass-dsl", extras = ["cu13"], specifier = "==4.6.0" },
+    { name = "nvidia-cutlass-dsl", extras = ["cu13"], specifier = "==4.6.2" },
     { name = "nvidia-deepstream-videodecode-cu13", marker = "extra == 'deepstream'", specifier = ">=9.0.2" },
     { name = "nvtx", specifier = "==0.2.15" },
     { name = "openai", specifier = ">=2.0.0" },
@@ -8319,7 +8395,7 @@ requires-dist = [
     { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "pyzmq", specifier = ">=25.0.0" },
-    { name = "quack-kernels", specifier = "==0.6.1" },
+    { name = "quack-kernels", specifier = "==0.6.4" },
     { name = "regex" },
     { name = "requests", specifier = ">=2.26.0" },
     { name = "runai-model-streamer", extras = ["azure", "gcs", "s3"], marker = "extra == 'runai'", specifier = ">=0.15.7" },
@@ -8350,9 +8426,9 @@ requires-dist = [
     { name = "vllm-gguf-plugin", marker = "extra == 'extra-quant'", specifier = ">=0.0.2" },
     { name = "watchfiles" },
     { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'", specifier = ">=0.2.1,<1.0.0" },
-    { name = "zentorch", marker = "extra == 'zen'", specifier = "==2.11.0.0" },
+    { name = "zentorch", marker = "extra == 'zen'", specifier = "==2.13.0.0" },
 ]
-provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttensor", "runai", "audio", "video", "deepstream", "flashinfer", "helion", "grpc", "otel", "extra-quant"]
+provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttensor", "runai", "audio", "video", "deepstream", "flashinfer", "b12x", "helion", "grpc", "otel", "extra-quant"]
 
 [[package]]
 name = "vllm-router"
@@ -8434,7 +8510,8 @@ name = "wandb"
 version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
+    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "click", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "gitpython" },
     { name = "packaging" },
     { name = "platformdirs" },


### PR DESCRIPTION
## Summary

Builds on the CUDA 13, Torch 2.13, and vLLM 0.27.1 stack from #3425.

- Bump vLLM to 0.28.0. Torch stays at 2.13.0+cu130; only the wheel pins move. vLLM 0.28 requires `nvidia-cutlass-dsl == 4.6.2` and `quack-kernels == 0.6.4`, so the override pin and its dependency metadata move with it.
- Drop patches obsoleted by the pinned release (reviewed the 0.27.0/0.27.1/0.28.0 release notes and diffed the patched vLLM sources between 0.27.1 and 0.28.0):
  - `monkey_patch_harmony_stop_token_propagation` — fixed upstream by vllm#35076 (in the release since 0.27.1).
  - `monkey_patch_fp32_router_logits` — vLLM reads `moe_router_dtype` off the HF config (vllm#47410) and forces fp32 routing for GLM-5.x. `inference.enable_fp32_router_logits` keeps its name and default but now injects `hf_overrides = {"moe_router_dtype": "float32"}` instead of patching `DeepseekV2MoE`.
  - `PrimeRlServingTokens` — upstream `serve_tokens` now handles DP-rank header routing, server-side `max_tokens` defaulting, and `usage` reporting (cached tokens surface via `--enable-prompt-tokens-details`, which the launcher now sets). The subclass shrinks to the compact `routed_experts` export and the `kv_transfer_params` engine bridge (vllm#42644 merged 6h after the 0.28.0 cut — drop at the next bump).
- Follow vLLM's own V1/V2 model runner resolution instead of pinning V1 globally. vLLM resolves non-MoE generate models (plus an arch allowlist) to the V2 runner. Only routed-experts capture still requires V1 (the V2 runner silently never captures routing decisions): the launcher pins `VLLM_USE_V2_MODEL_RUNNER=0` when `enable_return_routed_experts` is set, and the NIXL routed-experts patch rejects a V2 resolution explicitly.

Patches verified still needed on 0.28.0 (targets byte-identical or issue still open): kv-xfer freed-request assert (vllm#46240), qwen3_coder param newline trim, minimax-m2 think-end passthrough, TokenizeParams validation, DP coordinator startup timeout, LoRA expert-key acceptance (vllm#38522 closed unmerged), Qwen3.5-MoE 2D LoRA format, online-fp8 Parameter cast, nano_v3 reasoning parser, fp32 lm_head (kept over vLLM's `head_dtype=float32`, which upcasts the weight per forward instead of using an fp32-out GEMM), chat routed-experts strip.

Known 0.28 caveats:
- NIXL connector handshake version bumps 5 → 7: a 0.27 and a 0.28 engine refuse to transfer KV to each other, so rolling P/D upgrades need a full pool restart.
- vllm#50465 (batch-sharded sampling, merged after 0.28.0) silently drops sampling masks under TP; re-check vllm#53826 before the next bump.

Validated on GLM-4.5-Air SWE

<img width="882" height="241" alt="Screenshot 2026-08-28 at 9 08 56 PM" src="https://github.com/user-attachments/assets/d1af34c4-a80a-410b-bcdc-afdf0ffabd81" />

## Verification

- `uv lock --check`
- `uv run --frozen pytest -q tests/unit/test_configs.py tests/unit/inference` (137 passed)
- Ruff check and format checks for the changed Python files
- E2E reverse-text RL on this branch (Qwen3-0.6B-Reverse-Text-SFT, 20 steps, 1 trainer + 1 inference GPU, NCCL broadcast): reward 0.18 → 0.81, 0% rollout errors, 100% trainable, mismatch KL 0.003–0.005. The engine ran the V2 model runner (vLLM's default for this model) with the fp32 lm_head patch active. W&B: `reverse-text/reverse-text-vllm028-smoke`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> A broad inference dependency bump plus behavioral changes to MoE routing, model-runner selection, and P/D KV transfer bridging; misconfiguration could affect logprob fidelity, router replay, or disaggregated decode performance until upstream fixes land.
> 
> **Overview**
> Upgrades the GPU inference stack from **vLLM 0.27.1 to 0.28.0**, with matching lockfile and wheel pins (`nvidia-cutlass-dsl` 4.6.2, `quack-kernels` 0.6.4).
> 
> **Config / launcher:** `to_namespace()` now defaults **`enable_prompt_tokens_details`** so `/inference/v1/generate` `usage` includes cached prompt tokens for router billing. **`enable_fp32_router_logits`** no longer sets `additional_config`; it injects **`hf_overrides.moe_router_dtype = "float32"`** so vLLM’s native MoE routing path applies. **`VLLM_USE_V2_MODEL_RUNNER=0`** is set only when **`enable_return_routed_experts`** is on (V2 never captures routed experts); other models follow vLLM’s V1/V2 resolution.
> 
> **Removed patches** superseded by 0.28: harmony stop-token merge on chat completions, `DeepseekV2MoE` fp32 router monkey-patch, and most of the custom `ServingTokens` fork (DP routing, `max_tokens` defaulting, manual `usage` assembly). **`PrimeRlServingTokens`** now delegates to upstream `serve_tokens` except for **`kv_transfer_params` → `sampling_params.extra_args`** (PD disagg until vllm#42644 ships) and compact **`routed_experts`** post-processing.
> 
> **Other:** NIXL routed-experts guard uses **`config.use_v2_model_runner`** instead of the env flag. Unit tests for deleted helpers are trimmed; post-process test asserts `usage` is preserved from upstream responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c9264df8bb12af89eda7c238e2415e9a339857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->