### PR TITLE
[DO NOT MERGE] fix: route muon-indivisible params to adamw (topology-dependent dion assert)

### DIFF
--- a/src/prime_rl/trainer/optim/__init__.py
+++ b/src/prime_rl/trainer/optim/__init__.py
@@ -122,12 +122,23 @@ def _create_muon_optimizer(
     parallel_dims: ParallelDims,
     lr: float | None = None,
 ) -> Optimizer:
+    if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
+        muon_mesh_size = parallel_dims.get_mesh("dp_shard_cp").size()
+    else:
+        muon_mesh_size = parallel_dims.world_mesh.size()
+
     def muon_enabled(n, p):
         if p.ndim < 2:
             return False
         if "lm_head" in n:
             return False
         if "embed_tokens" in n:
+            return False
+        # Muon distributes orthogonalization by sharding a parameter's leading dim
+        # across the mesh; dion asserts divisibility. Route indivisible params (e.g.
+        # small attention-gate projections) to adamw like the other muon-unsuitable
+        # params rather than crashing the step.
+        if p.shape[0] % muon_mesh_size != 0:
             return False
         return True
 


### PR DESCRIPTION
Fixes #3437: the first Muon step crashes training a large custom-impl MoE checkpoint on a 2-train-node topology:

```
dion/muon.py:457 muon_update_batch_async
AssertionError: Shard dimension 0 size 72 is not divisible by world size 16.
```

Root cause (**corrected** after review — this is *not* a #3411 regression, and nothing changed in how weights reach the optimizer): dion's distributed Muon shards each parameter's **leading dim across the mesh** and asserts divisibility. The checkpoint has heterogeneous attention gating — 12 full-attention layers with `g_proj (48, hidden)` and 36 sliding-attention layers with `g_proj (72, hidden)`. The muon mesh is `dp_shard_cp`: **72 divides a 1-node world (8) but not a 2-node world with cp=4 (16)** — so the same config steps fine on one topology and asserts on another. Dion pin and the muon param-grouping are unchanged for months; the failure is a divisibility accident of topology × checkpoint.

Fix: extend the `muon_enabled` predicate — parameters whose dim0 is not divisible by the muon mesh size go to the **existing adamw group**, exactly like the other muon-unsuitable parameters (1D, embeddings, `lm_head`). That makes routing topology-robust; for the affected model it's 36 small gate matrices (~8M params), negligible for optimization.

Notes:
- The check uses the mesh the default muon group is built on (`dp_shard_cp`, else world). The expert group's dedicated EP mesh can differ; fused expert dims divide cleanly in practice — a per-group check is the follow-up if that ever changes.
- Alternatives considered: padding/remainder handling inside dion (external package) — heavier, and arguably the better long-term home; this PR keeps prime-rl safe either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
