### PR TITLE
Add GLM-5.3 training and stack configs

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -187,7 +187,7 @@ For large MoE serving, splitting prefill and decode onto separate vLLM groups ca
 | Agentic (SWE, Lean) | 3:1 | Long growing contexts → prefill-heavy |
 | Non-agentic (math, chat) | 1:2 | Short prompts, long generations → decode-heavy |
 
-Example config: [`examples/advanced/glm-5.2/swe.toml`](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/examples/advanced/glm-5.2/swe.toml) — full RL run on `GLM-5` with P/D disaggregation behind a `vllm-router`, FP8 inference, and NCCL weight broadcast, paired with an inference config from [`examples/advanced/glm-5.2/infer/`](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples/advanced/glm-5.2/infer).
+Example config: [`examples/advanced/glm-5.2/swe.toml`](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/examples/advanced/glm-5.2/swe.toml) — full RL run on `GLM-5` with P/D disaggregation behind a `vllm-router`, FP8 inference, and NCCL weight broadcast, paired with an inference config from [`examples/advanced/glm-5.2/infer/`](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples/advanced/glm-5.2/infer). The GLM-5.3 llm-d stack lives under [`examples/advanced/glm-5.3/`](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples/advanced/glm-5.3).
 
 Monitor live queue depths to detect imbalance:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,7 +229,7 @@ The shipped end-to-end examples in [`examples/`](https://github.com/PrimeIntelle
 - [**Nemotron-3-Super**](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples/advanced/nemotron-3-super) — `Nemotron-3-Super-120B` hybrid-Mamba MoE on SWE at 131k context.
 - [**MiniMax-M2.5 SWE**](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples/advanced/minimax-m2.5) — `MiniMax-M2.5` on agentic SWE.
 - [**INTELLECT-3.1**](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples/advanced/intellect-3.1) — reproduces our INTELLECT-3.1 training run.
-- [**High-throughput GLM-5**](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples/advanced/glm-5.2) — large-scale `GLM-5`/`GLM-5.2` inference with P/D disaggregation and FP8.
+- [**High-throughput GLM-5**](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples/advanced/glm-5.2) — large-scale `GLM-5`/`GLM-5.2`/`GLM-5.3` inference with P/D disaggregation and FP8.
 
 ### Worked Example: Compose, Override, Dry-Run
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -233,7 +233,7 @@ gpus_per_node = 8
 Full multi-node configs ship under [`examples/advanced/`](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples/advanced):
 
 - [`nemotron-3-super/swe.toml`](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/examples/advanced/nemotron-3-super/swe.toml) — 4 trainer + 1 inference node RL on a 120B hybrid-Mamba MoE with NCCL weight broadcast.
-- [`glm-5.2/`](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples/advanced/glm-5.2) — large-scale and P/D-disaggregated inference across the GLM-5 family.
+- [`glm-5.2/`](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples/advanced/glm-5.2) and [`glm-5.3/`](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples/advanced/glm-5.3) — large-scale and P/D-disaggregated inference across the GLM-5 family.
 
 For inference-only multi-node, set `[deployment] type = "multi_node"` on an inference TOML — each node runs an independent vLLM replica (TP and DP must fit within one node), fronted by a single global router on node 0. Point clients at the router URL the launcher prints.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,8 +11,9 @@ End-to-end usage examples for prime-rl, referenced from the top-level [README](.
   - `hendrycks-sanity` — single-turn math, long-running
   - `dynamo` — five-step Qwen3 math training with external Dynamo inference and NCCL weight updates
 - **[`advanced/`](advanced)** — larger, mostly multi-node runs on frontier models, one folder
-  per model: `qwen3-30b-a3b` (math/swe/tool), `glm-4.5-air` (search/swe/terminal), `glm-5.2`
-  (large-scale + PD-disaggregated inference), `minimax-m2.5` (swe), `nemotron-3-super` (swe),
-  `intellect-3.1` (swe), `deepseek-v4-flash` (sft + a standalone vLLM serving pre-flight).
+  per model: `qwen3-30b-a3b` (math/swe/tool), `glm-4.5-air` (search/swe/terminal),
+  `glm-5.2` and `glm-5.3` (large-scale + PD-disaggregated inference), `minimax-m2.5` (swe),
+  `nemotron-3-super` (swe), `intellect-3.1` (swe), `deepseek-v4-flash` (sft + a standalone
+  vLLM serving pre-flight).
 
 Dev-sized (2-GPU) counterparts of `basic/` live in [`configs/basic/`](../configs/basic).

--- a/examples/advanced/glm-5.3/infer/pd-llmd.toml
+++ b/examples/advanced/glm-5.3/infer/pd-llmd.toml
@@ -1,0 +1,69 @@
+# GLM-5.3-Flash 16-node P/D stack: mooncake + llm-d router.
+#
+# Launch: uv run inference @ examples/advanced/glm-5.3/infer/pd-llmd.toml
+
+output_dir = "/shared/outputs/glm5.3-16node-llmd"
+
+use_deep_gemm = true
+enable_fp32_lm_head = true
+
+[kv_cache_offload]
+type = "mooncake"
+device_name = "mlx5_0,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_9,mlx5_10,mlx5_11"
+
+[kv_cache_offload.cpu]
+num_bytes = 1_000_000_000_000
+
+[deployment]
+type = "disaggregated"
+prefill_nodes_per_replica = 2
+num_prefill_replicas = 4
+decode_nodes_per_replica = 8
+num_decode_replicas = 1
+
+[deployment.prefill_env_vars]
+"VLLM_ENABLE_MOE_DP_CHUNK" = "0"
+"VLLM_DEEP_GEMM_WARMUP" = "skip"
+"UCX_RCACHE_MAX_UNRELEASED" = "1024"
+
+[deployment.decode_env_vars]
+"VLLM_DEEP_GEMM_WARMUP" = "skip"
+"UCX_RCACHE_MAX_UNRELEASED" = "1024"
+
+[deployment.prefill_vllm_overrides]
+"enable_dbo" = true
+
+[deployment.decode_vllm_overrides]
+"max_num_batched_tokens" = 96
+"max_num_seqs" = 96
+
+[router]
+type = "llm-d"
+non_cached_tokens = 128
+
+[router.scorers]
+"prefix-cache-scorer" = 3.0
+
+[router.prefill_scorer_overrides]
+"queue-scorer" = 4.0
+"active-request-scorer" = 5.0
+
+[router.decode_scorer_overrides]
+"active-request-scorer" = 5.0
+"kv-cache-utilization-scorer" = 4.0
+"queue-scorer" = 3.0
+
+[slurm]
+job_name = "glm5.3-16node-llmd"
+partition = "all"
+
+[vllm]
+model = "zai-org/GLM-5.3-Flash"
+max_model_len = 131072
+tool_call_parser = "glm47"
+reasoning_parser = "glm45"
+gpu_memory_utilization = 0.75
+enable_expert_parallel = true
+enable_eplb = false
+enable_ep_weight_filter = true
+safetensors_load_strategy = "prefetch"

--- a/examples/advanced/glm-5.3/swe-ablation.toml
+++ b/examples/advanced/glm-5.3/swe-ablation.toml
@@ -14,7 +14,7 @@ level = "debug"
 type = "nccl"
 port = 29502
 timeout = 12000
-quantize_in_weight_transfer = true
+quantize_in_weight_transfer = false
 
 [deployment]
 type = "multi_node"

--- a/examples/advanced/glm-5.3/swe-ablation.toml
+++ b/examples/advanced/glm-5.3/swe-ablation.toml
@@ -94,9 +94,9 @@ use_deep_gemm = true
 enable_fp32_lm_head = true
 
 [inference.env_vars]
-TRITON_CACHE_DIR = "/tmp/.triton-cache"
-VLLM_CACHE_ROOT = "/tmp/.vllm-cache"
-FLASHINFER_WORKSPACE_BASE = "/tmp/.flashinfer-cache"
+TRITON_CACHE_DIR = "/tmp/prime-rl-$USER/$SLURM_JOB_ID/triton"
+VLLM_CACHE_ROOT = "/tmp/prime-rl-$USER/$SLURM_JOB_ID/vllm"
+FLASHINFER_WORKSPACE_BASE = "/tmp/prime-rl-$USER/$SLURM_JOB_ID/flashinfer"
 
 [inference.vllm]
 model = "zai-org/GLM-5.3-Flash"

--- a/examples/advanced/glm-5.3/swe-ablation.toml
+++ b/examples/advanced/glm-5.3/swe-ablation.toml
@@ -1,0 +1,112 @@
+max_steps = 3
+seq_len = 131072
+clean = true
+
+[run]
+name = "glm53-flash-swe-b54"
+
+[log]
+level = "debug"
+
+[monitors.file]
+
+[weight_broadcast]
+type = "nccl"
+port = 29502
+timeout = 12000
+quantize_in_weight_transfer = true
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 2
+num_infer_nodes = 1
+num_infer_replicas = 2
+gpus_per_node = 8
+orchestrator_on_inference = true
+
+[slurm]
+job_name = "glm53-flash-swe-b54"
+partition = "all"
+
+[trainer]
+dist_timeout_seconds = 7200
+
+[trainer.model]
+name = "zai-org/GLM-5.3-Flash-BF16"
+impl = "custom"
+attn = "flash_attention_2"
+fused_lm_head_token_chunk_size = 1024
+cp = 8
+ep = 8
+optim_cpu_offload = false
+full_offload = true
+
+[trainer.model.quantization]
+type = "fp8"
+
+[trainer.model.moe.compute]
+type = "deepgemm_fp8"
+
+[trainer.model.ac]
+freq = 1
+
+[trainer.model.compile]
+
+[trainer.model.ac_offloading]
+max_inflight_activations = 1
+
+[trainer.optim]
+type = "sign_sgd"
+lr = 1e-6
+weight_decay = 0.0
+max_norm = "None"
+
+[orchestrator]
+batch_size = 54
+group_size = 6
+max_off_policy_steps = 1
+
+[orchestrator.concurrency]
+initial_inflight = 54
+max_inflight = 108
+
+[orchestrator.model]
+name = "zai-org/GLM-5.3-Flash"
+
+[orchestrator.renderer]
+name = "glm-5.1"
+clear_thinking = false
+
+[orchestrator.train.sampling]
+temperature = 1.0
+
+[orchestrator.train.sampling.extra_body.chat_template_kwargs]
+clear_thinking = false
+
+[[orchestrator.train.source]]
+name = "r2e"
+env.taskset.id = "r2e-gym"
+env.agent.harness.id = "rlm"
+env.agent.runtime.labels = ["glm53-flash-swe-b54"]
+
+[inference]
+use_deep_gemm = true
+enable_fp32_lm_head = true
+
+[inference.env_vars]
+TRITON_CACHE_DIR = "/tmp/.triton-cache"
+VLLM_CACHE_ROOT = "/tmp/.vllm-cache"
+FLASHINFER_WORKSPACE_BASE = "/tmp/.flashinfer-cache"
+
+[inference.vllm]
+model = "zai-org/GLM-5.3-Flash"
+max_model_len = 131072
+tool_call_parser = "glm47"
+reasoning_parser = "glm45"
+gpu_memory_utilization = 0.9
+data_parallel_size = 8
+data_parallel_size_local = 8
+enable_expert_parallel = true
+enable_eplb = false
+enable_ep_weight_filter = true
+safetensors_load_strategy = "prefetch"

--- a/examples/advanced/glm-5.3/swe-llmd.toml
+++ b/examples/advanced/glm-5.3/swe-llmd.toml
@@ -1,0 +1,150 @@
+max_steps = 10000000
+seq_len = 131072
+output_dir = "/shared/outputs" # FILL IN: point at your shared filesystem
+clean = true
+
+[run]
+name = "glm5.3-llmd"
+
+[log]
+level = "debug"
+
+[monitors.wandb]
+project = "glm5.3-llmd"
+name = "base"
+
+[weight_broadcast]
+type = "nccl"
+port = 29502
+timeout = 12000
+quantize_in_weight_transfer = true
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 16
+gpus_per_node = 8
+num_infer_replicas = 1
+
+[inference.deployment]
+type = "disaggregated"
+prefill_nodes_per_replica = 2
+num_prefill_replicas = 4
+decode_nodes_per_replica = 8
+num_decode_replicas = 1
+
+[inference.deployment.prefill_env_vars]
+"VLLM_ENABLE_MOE_DP_CHUNK" = "0"
+"VLLM_DEEP_GEMM_WARMUP" = "skip"
+"UCX_RCACHE_MAX_UNRELEASED" = "1024"
+
+[inference.deployment.decode_env_vars]
+"VLLM_DEEP_GEMM_WARMUP" = "skip"
+"UCX_RCACHE_MAX_UNRELEASED" = "1024"
+
+[inference.deployment.prefill_vllm_overrides]
+"enable_dbo" = true
+
+[inference.deployment.decode_vllm_overrides]
+"max_num_batched_tokens" = 96
+"max_num_seqs" = 96
+
+[inference.router]
+type = "llm-d"
+non_cached_tokens = 128
+
+[inference.router.scorers]
+"prefix-cache-scorer" = 3.0
+
+[inference.router.prefill_scorer_overrides]
+"queue-scorer" = 4.0
+"active-request-scorer" = 5.0
+
+[inference.router.decode_scorer_overrides]
+"active-request-scorer" = 5.0
+"kv-cache-utilization-scorer" = 4.0
+"queue-scorer" = 3.0
+
+[inference.vllm]
+model = "zai-org/GLM-5.3-Flash"
+max_model_len = 131072
+tool_call_parser = "glm47"
+reasoning_parser = "glm45"
+gpu_memory_utilization = 0.75
+enable_expert_parallel = true
+enable_eplb = false
+enable_ep_weight_filter = true
+safetensors_load_strategy = "prefetch"
+
+[slurm]
+job_name = "glm5.3-llmd"
+partition = "all" # FILL IN: set to your cluster's partition
+
+[trainer]
+dist_timeout_seconds = 1800
+enable_token_export = true
+
+[trainer.model]
+name = "zai-org/GLM-5.3-Flash-BF16"
+impl = "custom"
+attn = "flash_attention_2"
+fused_lm_head_token_chunk_size = 1024
+cp = 4
+ep = 8
+
+[trainer.model.quantization]
+type = "fp8"
+
+[trainer.model.moe.compute]
+type = "deepgemm_fp8"
+
+[trainer.model.ac]
+freq = 1
+
+[trainer.model.compile]
+
+[trainer.model.ac_offloading]
+max_inflight_activations = 1
+
+[trainer.optim]
+type = "adamw"
+lr = 1e-6
+weight_decay = 0.0
+
+[orchestrator]
+batch_size = 256
+group_size = 16
+max_off_policy_steps = 8
+
+[orchestrator.concurrency]
+initial_inflight = 256
+max_inflight = 512
+
+[orchestrator.model]
+name = "zai-org/GLM-5.3-Flash"
+
+[orchestrator.renderer]
+name = "glm-5.1"
+clear_thinking = false
+
+[orchestrator.train.sampling]
+temperature = 1.0
+
+[orchestrator.train.sampling.extra_body.chat_template_kwargs]
+clear_thinking = false
+
+[[orchestrator.train.source]]
+name = "r2e"
+env.taskset.id = "r2e-gym"
+env.agent.harness.id = "rlm"
+env.agent.runtime.labels = ["glm5.3-llmd"]
+
+[inference]
+use_deep_gemm = true
+enable_fp32_lm_head = true
+
+[inference.kv_cache_offload]
+type = "mooncake"
+device_name = "mlx5_0,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_9,mlx5_10,mlx5_11"
+
+[inference.kv_cache_offload.cpu]
+num_bytes = 1_000_000_000_000

--- a/examples/advanced/glm-5.3/swe-llmd.toml
+++ b/examples/advanced/glm-5.3/swe-llmd.toml
@@ -81,7 +81,6 @@ partition = "all" # FILL IN: set to your cluster's partition
 
 [trainer]
 dist_timeout_seconds = 1800
-enable_token_export = true
 
 [trainer.model]
 name = "zai-org/GLM-5.3-Flash-BF16"

--- a/examples/advanced/glm-5.3/swe-llmd.toml
+++ b/examples/advanced/glm-5.3/swe-llmd.toml
@@ -17,7 +17,7 @@ name = "base"
 type = "nccl"
 port = 29502
 timeout = 12000
-quantize_in_weight_transfer = true
+quantize_in_weight_transfer = false
 
 [deployment]
 type = "multi_node"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "loguru>=0.7.3",
     "pyarrow>=21.0.0",
     "numpy>=2.2.6",
-    "transformers==5.6.2",
+    "transformers==5.16.0",
     "wandb>=0.26.1",
     "wandb-workspaces>=0.4.3",
     "prime>=0.6.19",
@@ -148,7 +148,7 @@ override-dependencies = [
     # vLLM 0.28.0 requires quack-kernels 0.6.4. It requires this exact CUTLASS version.
     # Keep this pin aligned with quack-kernels and the flash-attn-4 revision below.
     "nvidia-cutlass-dsl==4.6.2",
-    "transformers==5.6.2",
+    "transformers==5.16.0",
     "torch>=2.13.0",
     "openenv-core",
 ]
@@ -272,8 +272,8 @@ vllm-router = [
     { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.2.0/vllm_router-0.2.0-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
 ]
 vllm = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_x86_64.whl", marker = "platform_machine == 'x86_64'" },
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
+    { url = "https://wheels.vllm.ai/98ed0856f31fa3aaf5e27464e2b4ef5a8ee6b2f5/vllm-0.28.1rc1.dev359%2Bg98ed0856f-cp38-abi3-manylinux_2_28_x86_64.whl", marker = "platform_machine == 'x86_64'" },
+    { url = "https://wheels.vllm.ai/98ed0856f31fa3aaf5e27464e2b4ef5a8ee6b2f5/vllm-0.28.1rc1.dev359%2Bg98ed0856f-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
 ]
 deep-ep = [
     { url = "https://github.com/PrimeIntellect-ai/prime-kernels/releases/download/v0.1.1/deep_ep-1.2.1+29d31c0-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" },

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -56,6 +56,19 @@ uv run rl @ examples/basic/reverse-text/rl.toml --dry-run                       
   --package prime-rl --package <env>` (one) — they're auto-discovered, no
   `pyproject.toml` edit needed. Keep `--all-extras` for training so a targeted
   package sync does not prune accelerator dependencies from the environment.
+- Node-local compiler and model cache roots must be unique per user and SLURM job.
+  Fixed paths under `/tmp` can be left owned by another container user and make
+  vLLM or FlashInfer fail at startup. Values in `inference.env_vars` are emitted
+  inside double-quoted shell exports, so paths such as
+  `/tmp/prime-rl-$USER/$SLURM_JOB_ID/flashinfer` expand on each allocated node. The
+  multi-node launcher appends a per-rank directory to `VLLM_CACHE_ROOT`,
+  `TRITON_CACHE_DIR`, and `FLASHINFER_WORKSPACE_BASE`; this also prevents concurrent
+  DeepGEMM JIT builds from racing in a shared `deep_gemm/tmp` directory. It marks the
+  environment as launcher-prepared so the inference entrypoint preserves those
+  per-rank overrides when it applies the resolved inference config.
+- Multi-node SLURM component commands use `uv run --no-sync`. Sync the environment
+  before submission; compute ranks must not contend on uv package-metadata locks
+  while starting concurrently from a shared cache.
 
 ## `sft` — SFT training
 

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -26,6 +26,7 @@ from prime_rl.utils.process import (
 
 INFERENCE_CONFIG = "inference.json"
 INFERENCE_SBATCH = "inference.sbatch"
+INFERENCE_ENV_PRESET = "PRIME_RL_INFERENCE_ENV_PRESET"
 
 
 def vllm_overrides_fragment(overrides: dict[str, Any]) -> str:
@@ -202,10 +203,12 @@ def inference_local(config: InferenceConfig):
     host = config.server.host or "0.0.0.0"
     port = config.server.port
 
-    # Apply the inference env (defaults + [inference.env_vars]) in-process so a standalone
-    # `uv run inference` gets the same environment the rl/SLURM launchers inject into the
-    # server subprocess. config.env_vars wins over the defaults; existing os.environ loses.
-    os.environ.update({**DEFAULT_COMMON_ENV_VARS, **DEFAULT_INFERENCE_ENV_VARS, **config.env_vars})
+    inference_env = {**DEFAULT_COMMON_ENV_VARS, **DEFAULT_INFERENCE_ENV_VARS, **config.env_vars}
+    if os.environ.pop(INFERENCE_ENV_PRESET, None) == "1":
+        for key, value in inference_env.items():
+            os.environ.setdefault(key, value)
+    else:
+        os.environ.update(inference_env)
 
     setup_vllm_env(config)
 

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -795,9 +795,9 @@ def monkey_patch_fp32_lm_head():
         if self._fp32_lm_head_enabled:
             logger.warning("fp32 lm_head ENABLED for this LogitsProcessor instance.")
 
-    def _patched_get_logits(self, hidden_states, lm_head, embedding_bias):
+    def _patched_get_logits(self, hidden_states, lm_head, embedding_bias, skip_gather=False):
         if not getattr(self, "_fp32_lm_head_enabled", False):
-            return _original_get_logits(self, hidden_states, lm_head, embedding_bias)
+            return _original_get_logits(self, hidden_states, lm_head, embedding_bias, skip_gather)
 
         # Native bf16xbf16 -> fp32 GEMM. torch.mm requires 2D inputs; vLLM v1's
         # generative path passes 2D [num_tokens, hidden_size] hidden_states, but
@@ -809,7 +809,11 @@ def monkey_patch_fp32_lm_head():
         if hidden_states.dim() > 2:
             logits = logits.reshape(*hidden_states.shape[:-1], -1)
 
-        logits = self._gather_logits(logits)
+        if skip_gather:
+            return logits
+
+        if lm_head.tp_size > 1:
+            logits = self._gather_logits(logits)
         if logits is not None:
             logits = logits[..., : self.org_vocab_size]
         return logits

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -6,10 +6,10 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from starlette.datastructures import State
 from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.launchers.cli_args import make_arg_parser, validate_parsed_serve_args
 from vllm.entrypoints.openai.api_server import init_app_state
-from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.serve.engine.protocol import ErrorResponse
 from vllm.entrypoints.serve.lora.protocol import LoadLoRAAdapterRequest
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -177,6 +177,7 @@ async def custom_init_app_state(
         state.serving_tokens = prime_serving
 
 
+import vllm.entrypoints.launchers.api_server.entry
 import vllm.entrypoints.openai.api_server
 import vllm.v1.utils
 from vllm.entrypoints.openai.api_server import build_app as _original_build_app
@@ -204,6 +205,11 @@ def custom_run_api_server_worker_proc(listen_address, sock, args, client_config=
 
 vllm.entrypoints.openai.api_server.init_app_state = custom_init_app_state
 vllm.entrypoints.openai.api_server.build_app = custom_build_app
+# vLLM 0.28 moved the active server implementation to launcher modules. The
+# deprecated OpenAI module re-exports these functions, but patching its names
+# alone does not change the references used by the launcher.
+vllm.entrypoints.launchers.api_server.entry.init_app_state = custom_init_app_state
+vllm.entrypoints.launchers.api_server.entry.build_app = custom_build_app
 vllm.v1.utils.run_api_server_worker_proc = custom_run_api_server_worker_proc
 
 

--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -28,16 +28,14 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from fastapi import Request
-from vllm.entrypoints.openai.engine.protocol import (
-    ErrorResponse,
-    RequestResponseMetadata,
-)
+from vllm.entrypoints.generate.base.protocol import RequestResponseMetadata
 from vllm.entrypoints.scale_out.token_in_token_out.protocol import (
     GenerateRequest,
     GenerateResponse,
     GenerateResponseChoice,
 )
 from vllm.entrypoints.scale_out.token_in_token_out.serving import ServingTokens
+from vllm.entrypoints.serve.engine.protocol import ErrorResponse
 from vllm.outputs import RequestOutput
 
 from prime_rl.inference.vllm.routed_experts import RoutedExpertsCapture

--- a/src/prime_rl/templates/_launch_rank.sh.j2
+++ b/src/prime_rl/templates/_launch_rank.sh.j2
@@ -21,7 +21,16 @@ launch_inference_rank() {
     # rank on the node. Node-local /tmp also avoids inheriting an absent submit-node TMPDIR.
     local rpcbase="/tmp/vllm-rpc-$USER-$SLURM_JOB_ID-$port"
     mkdir -p "$rpcbase"
-    local -a cmd=(uv run inference @ "$CONFIG_PATH"
+    local -a rank_env=(
+        "CUDA_VISIBLE_DEVICES=$gpus"
+        "VLLM_RPC_BASE_PATH=$rpcbase"
+        "PRIME_RL_INFERENCE_ENV_PRESET=1"
+    )
+    [ -n "${VLLM_CACHE_ROOT:-}" ] && rank_env+=("VLLM_CACHE_ROOT=$VLLM_CACHE_ROOT/rank-$port")
+    [ -n "${TRITON_CACHE_DIR:-}" ] && rank_env+=("TRITON_CACHE_DIR=$TRITON_CACHE_DIR/rank-$port")
+    [ -n "${FLASHINFER_WORKSPACE_BASE:-}" ] \
+        && rank_env+=("FLASHINFER_WORKSPACE_BASE=$FLASHINFER_WORKSPACE_BASE/rank-$port")
+    local -a cmd=(uv run --no-sync inference @ "$CONFIG_PATH"
         --server.host 0.0.0.0 --server.port "$port"
         --vllm.data-parallel-size "$dp" --vllm.data-parallel-size-local 1 --vllm.api-server-count 1)
     [ -n "$rpc" ] && cmd+=(--vllm.data-parallel-rpc-port "$rpc")
@@ -32,8 +41,7 @@ launch_inference_rank() {
         cmd+=(--vllm @ "$rpcbase/vllm-overrides.json")
     fi
     if [ -n "$nixl" ]; then
-        CUDA_VISIBLE_DEVICES="$gpus" VLLM_NIXL_SIDE_CHANNEL_PORT="$nixl" VLLM_RPC_BASE_PATH="$rpcbase" "${cmd[@]}" 2>&1 | tee -a "$log" &
-    else
-        CUDA_VISIBLE_DEVICES="$gpus" VLLM_RPC_BASE_PATH="$rpcbase" "${cmd[@]}" 2>&1 | tee -a "$log" &
+        rank_env+=("VLLM_NIXL_SIDE_CHANNEL_PORT=$nixl")
     fi
+    env "${rank_env[@]}" "${cmd[@]}" 2>&1 | tee -a "$log" &
 }

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -502,7 +502,7 @@ else
     echo $HOSTNAMES_STR | tee $LOG_DIR/trainer/node_${TRAIN_NODE_RANK}.log
 
     (
-        WANDB_SHARED_LABEL=trainer uv run torchrun \
+        WANDB_SHARED_LABEL=trainer uv run --no-sync torchrun \
             --role=trainer \
             --nnodes=$NUM_TRAIN_NODES \
             --nproc-per-node=$GPUS_PER_NODE \
@@ -549,12 +549,12 @@ if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
     # the script fails to parse.
 {%- for name in train_env_names %}
     mkdir -p $LOG_DIR/envs/train
-    uv run env-server @ $CONFIG_DIR/envs/train/{{ name }}.json \
+    uv run --no-sync env-server @ $CONFIG_DIR/envs/train/{{ name }}.json \
         > $LOG_DIR/envs/train/{{ name }}.log 2>&1 &
 {%- endfor %}
 {%- for name in eval_env_names %}
     mkdir -p $LOG_DIR/envs/eval
-    uv run env-server @ $CONFIG_DIR/envs/eval/{{ name }}.json \
+    uv run --no-sync env-server @ $CONFIG_DIR/envs/eval/{{ name }}.json \
         > $LOG_DIR/envs/eval/{{ name }}.log 2>&1 &
 {%- endfor %}
 {%- endif %}
@@ -563,7 +563,7 @@ if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
         {% if use_nccl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $MASTER_ADDR"
         {% elif use_nixl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $WEIGHT_BROADCAST_HOST"
         {% endif %}{% if use_zmq_transport %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --rollout_transport.host $ORCH_ADDR"
-        {% endif %}WANDB_SHARED_LABEL=orchestrator uv run orchestrator $ORCHESTRATOR_ARGS \
+        {% endif %}WANDB_SHARED_LABEL=orchestrator uv run --no-sync orchestrator $ORCHESTRATOR_ARGS \
             2>&1 | tee $LOG_DIR/orchestrator.log
         COMPONENT_CODE=$?
         if [ "$COMPONENT_CODE" -eq 0 ]; then

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1,6 +1,8 @@
 import logging
 import os
+import shutil
 import time
+import uuid
 from pathlib import Path
 from typing import cast
 
@@ -952,15 +954,22 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
                 "Found HF weight format in snapshot state dict and PrimeRL weight format in model state dict. Trying to auto-convert..."
             )
             snapshot_path = convert_dir / "prime"
-            if not snapshot_path.exists() and get_world().is_master:
-                logger.debug(
-                    f"Converting snapshot state dict to PrimeRL format and saving to {snapshot_path} on master rank. This is a one-time operation."
-                )
-                snapshot_state_dict = load_state_dict(source_path)
-                model.convert_to_prime(snapshot_state_dict)
-                save_state_dict(snapshot_state_dict, snapshot_path)
-                (snapshot_path / ".prime-v1").touch()
-                del snapshot_state_dict
+            if get_world().is_master:
+                marker_path = snapshot_path / ".prime-v1"
+                if snapshot_path.exists() and not marker_path.is_file():
+                    logger.warning(f"Removing incomplete PrimeRL conversion cache at {snapshot_path}")
+                    shutil.rmtree(snapshot_path)
+                if not snapshot_path.exists():
+                    staging_path = convert_dir / f".prime-{uuid.uuid4().hex}.tmp"
+                    logger.debug(
+                        f"Converting snapshot state dict to PrimeRL format and saving to {snapshot_path} on master rank. This is a one-time operation."
+                    )
+                    snapshot_state_dict = load_state_dict(source_path)
+                    model.convert_to_prime(snapshot_state_dict)
+                    save_state_dict(snapshot_state_dict, staging_path)
+                    (staging_path / ".prime-v1").touch()
+                    staging_path.rename(snapshot_path)
+                    del snapshot_state_dict
 
         elif snapshot_is_prime and not snapshot_is_hf and model.is_hf_state_dict(model_keys):
             logger.warning(

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -14,6 +14,7 @@ from prime_rl.trainer.models.afmoe import AfmoeConfig, AfmoeForCausalLM
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 from prime_rl.trainer.models.deepseek_v4 import DeepseekV4Config, DeepseekV4ForCausalLM
 from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig, Glm4MoeForCausalLM
+from prime_rl.trainer.models.glm5_next import Glm5NextConfig, Glm5NextForCausalLM, Glm5NextTextConfig
 from prime_rl.trainer.models.glm_moe_dsa import GlmMoeDsaConfig, GlmMoeDsaForCausalLM
 from prime_rl.trainer.models.gpt_oss import GptOssConfig, GptOssForCausalLM
 from prime_rl.trainer.models.laguna import LagunaConfig, LagunaForCausalLM
@@ -30,6 +31,8 @@ from prime_rl.trainer.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalL
 AutoConfig.register("afmoe", AfmoeConfig, exist_ok=True)
 AutoConfig.register("deepseek_v4", DeepseekV4Config, exist_ok=True)
 AutoConfig.register("glm4_moe", Glm4MoeConfig, exist_ok=True)
+AutoConfig.register("glm5_next", Glm5NextConfig, exist_ok=True)
+AutoConfig.register("glm5_next_text", Glm5NextTextConfig, exist_ok=True)
 AutoConfig.register("glm_moe_dsa", GlmMoeDsaConfig, exist_ok=True)
 AutoConfig.register("gpt_oss", GptOssConfig, exist_ok=True)
 AutoConfig.register("laguna", LagunaConfig, exist_ok=True)
@@ -49,6 +52,8 @@ _CUSTOM_CAUSAL_LM_MODELS: tuple[
     (AfmoeConfig, AfmoeForCausalLM),
     (DeepseekV4Config, DeepseekV4ForCausalLM),
     (Glm4MoeConfig, Glm4MoeForCausalLM),
+    (Glm5NextConfig, Glm5NextForCausalLM),
+    (Glm5NextTextConfig, Glm5NextForCausalLM),
     (GlmMoeDsaConfig, GlmMoeDsaForCausalLM),
     (LagunaConfig, LagunaForCausalLM),
     (MiniMaxM2Config, MiniMaxM2ForCausalLM),

--- a/src/prime_rl/trainer/models/glm5_next/__init__.py
+++ b/src/prime_rl/trainer/models/glm5_next/__init__.py
@@ -1,0 +1,10 @@
+from .configuration_glm5_next import Glm5NextConfig, Glm5NextTextConfig
+from .modeling_glm5_next import Glm5NextForCausalLM, Glm5NextModel, Glm5NextPreTrainedModel
+
+__all__ = [
+    "Glm5NextConfig",
+    "Glm5NextTextConfig",
+    "Glm5NextPreTrainedModel",
+    "Glm5NextModel",
+    "Glm5NextForCausalLM",
+]

--- a/src/prime_rl/trainer/models/glm5_next/configuration_glm5_next.py
+++ b/src/prime_rl/trainer/models/glm5_next/configuration_glm5_next.py
@@ -1,0 +1,283 @@
+from transformers.configuration_utils import PretrainedConfig
+
+
+def _default_layer_types(num_hidden_layers: int) -> list[str]:
+    return ["deepseek_sparse_attention"] * num_hidden_layers
+
+
+def _default_mlp_layer_types(num_hidden_layers: int, first_k_dense_replace: int) -> list[str]:
+    dense_layers = min(first_k_dense_replace, num_hidden_layers)
+    return ["dense"] * dense_layers + ["sparse"] * (num_hidden_layers - dense_layers)
+
+
+def _as_dict(config) -> dict:
+    if isinstance(config, PretrainedConfig):
+        return config.to_dict()
+    return dict(config)
+
+
+class Glm5NextTextConfig(PretrainedConfig):
+    model_type = "glm5_next_text"
+    base_config_key = "text_config"
+    keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {"num_local_experts": "n_routed_experts"}
+
+    base_model_tp_plan = {
+        "layers.*.self_attn.o_proj": "rowwise",
+        "layers.*.mlp.experts.gate_proj": "colwise",
+        "layers.*.mlp.experts.up_proj": "colwise",
+        "layers.*.mlp.experts.down_proj": "rowwise",
+        "layers.*.mlp.gate_proj": "colwise",
+        "layers.*.mlp.up_proj": "colwise",
+        "layers.*.mlp.down_proj": "rowwise",
+    }
+    base_model_pp_plan = {
+        "embed_tokens": (["input_ids"], ["inputs_embeds"]),
+        "layers": (["hidden_states"], ["hidden_states"]),
+        "norm": (["hidden_states"], ["hidden_states"]),
+    }
+
+    def __init__(self, **kwargs):
+        model_type = kwargs.pop("model_type", self.model_type)
+        vocab_size = kwargs.pop("vocab_size", 154880)
+        hidden_size = kwargs.pop("hidden_size", 4096)
+        head_dim = kwargs.pop("head_dim", None)
+        intermediate_size = kwargs.pop("intermediate_size", 12288)
+        num_hidden_layers = kwargs.pop("num_hidden_layers", 45)
+        num_attention_heads = kwargs.pop("num_attention_heads", 64)
+        num_key_value_heads = kwargs.pop("num_key_value_heads", None)
+        hidden_act = kwargs.pop("hidden_act", "silu")
+        rms_norm_eps = kwargs.pop("rms_norm_eps", 1e-5)
+        pad_token_id = kwargs.pop("pad_token_id", 154820)
+        bos_token_id = kwargs.pop("bos_token_id", None)
+        eos_token_id = kwargs.pop("eos_token_id", None)
+        rope_parameters = kwargs.pop("rope_parameters", None)
+        rope_theta = kwargs.pop("rope_theta", 10000.0)
+        max_position_embeddings = kwargs.pop("max_position_embeddings", 1048576)
+        tie_word_embeddings = kwargs.pop("tie_word_embeddings", False)
+
+        moe_intermediate_size = kwargs.pop("moe_intermediate_size", 2048)
+        moe_renormalize = kwargs.pop("moe_renormalize", True)
+        norm_topk_prob = kwargs.pop("norm_topk_prob", moe_renormalize)
+        scoring_func = kwargs.pop("scoring_func", "sigmoid")
+        n_routed_experts = kwargs.pop("n_routed_experts", 288)
+        num_experts_per_token = kwargs.pop("num_experts_per_token", 8)
+        num_experts_per_tok = kwargs.pop("num_experts_per_tok", num_experts_per_token)
+        n_shared_experts = kwargs.pop("n_shared_experts", 1)
+        routed_scaling_factor = kwargs.pop("routed_scaling_factor", 2.5)
+        topk_method = kwargs.pop("topk_method", "noaux_tc")
+        first_k_dense_replace = kwargs.pop("first_k_dense_replace", 3)
+        moe_layer_freq = kwargs.pop("moe_layer_freq", 1)
+        use_grouped_topk = kwargs.pop("use_grouped_topk", True)
+        n_group = kwargs.pop("n_group", 1)
+        topk_group = kwargs.pop("topk_group", 1)
+        router_aux_loss_coef = kwargs.pop("router_aux_loss_coef", 1e-3)
+        moe_router_dtype = kwargs.pop("moe_router_dtype", None)
+        output_router_logits = kwargs.pop("output_router_logits", False)
+
+        mla = kwargs.pop("mla", True)
+        q_lora_rank = kwargs.pop("q_lora_rank", 1536)
+        kv_lora_rank = kwargs.pop("kv_lora_rank", 512)
+        qk_nope_head_dim = kwargs.pop("qk_nope_head_dim", 256)
+        qk_rope_head_dim = kwargs.pop("qk_rope_head_dim", 0)
+        qk_head_dim = kwargs.pop("qk_head_dim", qk_nope_head_dim + qk_rope_head_dim)
+        v_head_dim = kwargs.pop("v_head_dim", 256)
+        mla_nope = kwargs.pop("mla_nope", kwargs.pop("mla_use_nope", True))
+        num_nextn_predict_layers = kwargs.pop("num_nextn_predict_layers", 1)
+
+        layer_types = kwargs.pop("layer_types", None)
+        mlp_layer_types = kwargs.pop("mlp_layer_types", None)
+        linear_cfg = kwargs.pop("linear_attn_config", {}) or {}
+        linear_head_dim = kwargs.pop("linear_head_dim", linear_cfg.get("head_dim", 128))
+        linear_num_heads = kwargs.pop("linear_num_heads", linear_cfg.get("num_heads", 64))
+        linear_conv_kernel_dim = kwargs.pop("linear_conv_kernel_dim", linear_cfg.get("short_conv_kernel_size", 4))
+        linear_lower_bound = kwargs.pop("linear_lower_bound", linear_cfg.get("gate_lower_bound", -5.0))
+
+        index_head_dim = kwargs.pop("index_head_dim", 128)
+        index_topk = kwargs.pop("index_topk", 2048)
+        index_n_heads = kwargs.pop("index_n_heads", 32)
+        index_dsa_use_layernorm = kwargs.pop("index_dsa_use_layernorm", True)
+        index_kpool_compress = kwargs.pop("index_kpool_compress", True)
+        index_kpool = kwargs.pop("index_kpool", 4)
+        index_kpool_always_select_tail = kwargs.pop("index_kpool_always_select_tail", True)
+        indexer_rope_interleave = kwargs.pop("indexer_rope_interleave", True)
+        indexer_types = kwargs.pop("indexer_types", None)
+        use_index_cache = kwargs.pop("use_index_cache", False)
+        index_topk_freq = kwargs.pop("index_topk_freq", 1)
+        index_topk_pattern = kwargs.pop("index_topk_pattern", None)
+
+        mhc = kwargs.pop("mhc", True)
+        mhc_num_residual_streams = kwargs.pop("mhc_num_residual_streams", kwargs.pop("hc_mult", 4))
+        hc_eps = kwargs.pop("hc_eps", 1e-6)
+        mhc_tau = kwargs.pop("mhc_tau", 0.05)
+        hres_vwnstyle = kwargs.pop("hres_vwnstyle", True)
+        mhc_no_norm_weight = kwargs.pop("mhc_no_norm_weight", False)
+        mhc_sinkhorn_iterations = kwargs.pop("mhc_sinkhorn_iterations", kwargs.pop("hc_sinkhorn_iters", 20))
+        mhc_post_mult_value = kwargs.pop("mhc_post_mult_value", 2.0)
+        swiglu_limit = kwargs.pop("swiglu_limit", None)
+        logit_scale = kwargs.pop("logit_scale", 1.0)
+        use_cache = kwargs.pop("use_cache", True)
+        attention_bias = kwargs.pop("attention_bias", False)
+        attention_dropout = kwargs.pop("attention_dropout", 0.0)
+        initializer_range = kwargs.pop("initializer_range", 0.02)
+
+        if num_key_value_heads is None:
+            num_key_value_heads = num_attention_heads
+        if layer_types is None:
+            layer_types = _default_layer_types(num_hidden_layers)
+        if mlp_layer_types is None:
+            mlp_layer_types = _default_mlp_layer_types(num_hidden_layers, first_k_dense_replace)
+        if len(layer_types) < num_hidden_layers:
+            raise ValueError(
+                f"GLM-5.3 layer_types has {len(layer_types)} entries for {num_hidden_layers} hidden layers"
+            )
+        if len(mlp_layer_types) < num_hidden_layers:
+            raise ValueError(
+                f"GLM-5.3 mlp_layer_types has {len(mlp_layer_types)} entries for {num_hidden_layers} hidden layers"
+            )
+        if hidden_act != "silu":
+            raise ValueError(f"GLM-5.3 only supports silu hidden_act, got {hidden_act!r}")
+        if scoring_func not in ("softmax", "sigmoid"):
+            raise ValueError(f"Unknown GLM-5.3 MoE scoring_func {scoring_func!r}")
+
+        self.model_type = model_type
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.head_dim = qk_rope_head_dim if head_dim in (None, 0) else head_dim
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_act = hidden_act
+        self.rms_norm_eps = rms_norm_eps
+        self.max_position_embeddings = max_position_embeddings
+        self.rope_parameters = rope_parameters
+        self.rope_theta = rope_theta
+
+        self.mla = mla
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_head_dim = qk_head_dim
+        self.v_head_dim = v_head_dim
+        self.mla_nope = mla_nope
+
+        self.n_routed_experts = n_routed_experts
+        self.num_experts_per_token = num_experts_per_tok
+        self.num_experts_per_tok = num_experts_per_tok
+        self.moe_renormalize = norm_topk_prob
+        self.norm_topk_prob = norm_topk_prob
+        self.n_shared_experts = n_shared_experts
+        self.routed_scaling_factor = routed_scaling_factor
+        self.topk_method = topk_method
+        self.scoring_func = scoring_func
+        self.moe_intermediate_size = moe_intermediate_size
+        self.first_k_dense_replace = first_k_dense_replace
+        self.moe_layer_freq = moe_layer_freq
+        self.use_grouped_topk = use_grouped_topk
+        self.n_group = n_group
+        self.topk_group = topk_group
+        self.router_aux_loss_coef = router_aux_loss_coef
+        self.load_balance_coeff = router_aux_loss_coef
+        self.moe_router_dtype = moe_router_dtype
+        self.output_router_logits = output_router_logits
+        self.num_nextn_predict_layers = num_nextn_predict_layers
+
+        self.glm5_layer_types = layer_types
+        self.layer_types = [
+            "linear_attention" if layer_type == "linear_attention" else "sparse" for layer_type in layer_types
+        ]
+        self.mlp_layer_types = mlp_layer_types
+        self.linear_head_dim = linear_head_dim
+        self.linear_num_heads = linear_num_heads
+        self.linear_conv_kernel_dim = linear_conv_kernel_dim
+        self.linear_lower_bound = linear_lower_bound
+
+        self.index_head_dim = index_head_dim
+        self.index_topk = index_topk
+        self.index_n_heads = index_n_heads
+        self.index_dsa_use_layernorm = index_dsa_use_layernorm
+        self.index_kpool_compress = index_kpool_compress
+        self.index_kpool = index_kpool
+        self.index_kpool_always_select_tail = index_kpool_always_select_tail
+        self.indexer_rope_interleave = indexer_rope_interleave
+        self.indexer_types = indexer_types
+        self.use_index_cache = use_index_cache
+        self.index_topk_freq = index_topk_freq
+        self.index_topk_pattern = index_topk_pattern
+
+        self.mhc = mhc
+        self.mhc_num_residual_streams = mhc_num_residual_streams
+        self.hc_mult = mhc_num_residual_streams
+        self.hc_eps = hc_eps
+        self.mhc_tau = mhc_tau
+        self.hres_vwnstyle = hres_vwnstyle
+        self.mhc_no_norm_weight = mhc_no_norm_weight
+        self.mhc_sinkhorn_iterations = mhc_sinkhorn_iterations
+        self.hc_sinkhorn_iters = mhc_sinkhorn_iterations
+        self.mhc_post_mult_value = mhc_post_mult_value
+        self.swiglu_limit = swiglu_limit
+        self.logit_scale = logit_scale
+        self.use_cache = use_cache
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        self.initializer_range = initializer_range
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+
+    @property
+    def is_mla(self):
+        return self.mla
+
+    @property
+    def is_moe(self):
+        return self.n_routed_experts is not None
+
+    @property
+    def is_linear_attn(self) -> bool:
+        return any(layer_type == "linear_attention" for layer_type in self.layer_types)
+
+    def is_kda_layer(self, layer_idx: int) -> bool:
+        return self.glm5_layer_types[layer_idx] == "linear_attention"
+
+    @property
+    def layers_block_type(self):
+        return [
+            "linear_attention" if layer_type == "linear_attention" else "attention"
+            for layer_type in self.glm5_layer_types
+        ]
+
+
+class Glm5NextConfig(Glm5NextTextConfig):
+    model_type = "glm5_next"
+    sub_configs = {"text_config": Glm5NextTextConfig}
+
+    def __init__(self, text_config=None, vision_config=None, **kwargs):
+        if text_config is not None:
+            text_kwargs = _as_dict(text_config)
+            for key in ("_attn_implementation", "attn_implementation"):
+                if key in kwargs:
+                    text_kwargs[key] = kwargs[key]
+            super().__init__(**text_kwargs)
+            self.text_config = Glm5NextTextConfig(**text_kwargs)
+        else:
+            super().__init__(**kwargs)
+            self.text_config = Glm5NextTextConfig(**self.to_dict())
+        self.model_type = Glm5NextConfig.model_type
+        self.vision_config = vision_config
+        self.image_token_id = kwargs.get("image_token_id")
+        self.video_token_id = kwargs.get("video_token_id")
+        self.image_start_token_id = kwargs.get("image_start_token_id")
+        self.image_end_token_id = kwargs.get("image_end_token_id")
+        self.video_start_token_id = kwargs.get("video_start_token_id")
+        self.video_end_token_id = kwargs.get("video_end_token_id")
+
+    def get_text_config(self, decoder: bool = False):
+        return getattr(self, "text_config", self)

--- a/src/prime_rl/trainer/models/glm5_next/configuration_glm5_next.py
+++ b/src/prime_rl/trainer/models/glm5_next/configuration_glm5_next.py
@@ -185,9 +185,7 @@ class Glm5NextTextConfig(PretrainedConfig):
         self.num_nextn_predict_layers = num_nextn_predict_layers
 
         self.glm5_layer_types = layer_types
-        self.layer_types = [
-            "linear_attention" if layer_type == "linear_attention" else "sparse" for layer_type in layer_types
-        ]
+        self.layer_types = layer_types
         self.mlp_layer_types = mlp_layer_types
         self.linear_head_dim = linear_head_dim
         self.linear_num_heads = linear_num_heads

--- a/src/prime_rl/trainer/models/glm5_next/converting_glm5_next.py
+++ b/src/prime_rl/trainer/models/glm5_next/converting_glm5_next.py
@@ -1,0 +1,25 @@
+"""HF<->PrimeRL weight conversion for text-only GLM-5.3."""
+
+from __future__ import annotations
+
+from prime_rl.trainer.models.conversion_ops import ConvOp, Drop, PrefixRename
+from prime_rl.trainer.models.glm4_moe.converting_glm4_moe import glm_moe_layer_ops
+
+
+def conversion_chain(config) -> list[ConvOp]:
+    ops: list[ConvOp] = [
+        PrefixRename("model.language_model.", "model."),
+        Drop("model.visual.", is_prefix=True),
+        Drop("visual.", is_prefix=True),
+    ]
+    for layer_idx in range(config.num_hidden_layers):
+        ops.extend(glm_moe_layer_ops(layer_idx))
+        p = f"model.layers.{layer_idx}.self_attn.indexer"
+        ops.append(Drop(f"{p}.index_kpool_compress_ape"))
+        ops.append(Drop(f"{p}.index_kpool_compress_gate"))
+
+    num_extra_layers = getattr(config, "num_nextn_predict_layers", 0) or 0
+    for layer_idx in range(config.num_hidden_layers, config.num_hidden_layers + num_extra_layers):
+        ops.append(Drop(f"model.layers.{layer_idx}.", is_prefix=True))
+
+    return ops

--- a/src/prime_rl/trainer/models/glm5_next/modeling_glm5_next.py
+++ b/src/prime_rl/trainer/models/glm5_next/modeling_glm5_next.py
@@ -1,0 +1,817 @@
+import warnings
+from typing import Optional, Union
+
+import torch
+import torch.distributed as dist
+from fla.modules import FusedRMSNormGated
+from fla.modules.conv import causal_conv1d as fla_causal_conv1d
+from fla.ops.cp import FLACPContext, build_cp_context
+from fla.ops.kda import chunk_kda
+from torch import Tensor, nn
+from transformers.cache_utils import Cache
+from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
+from transformers.modeling_outputs import BaseModelOutputWithPast
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs
+
+from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.glm_moe_dsa.configuration_glm_moe_dsa import _index_cache_skip_topk
+from prime_rl.trainer.models.glm_moe_dsa.sparse_mla_attention import GlmMoeDsaAttention, SparseMlaAttentionArgs
+from prime_rl.trainer.models.layers.activations import ActivationType
+from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
+from prime_rl.trainer.models.layers.mlp import FeedForward
+from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
+from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
+from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
+from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
+
+from .configuration_glm5_next import Glm5NextConfig, Glm5NextTextConfig
+from .converting_glm5_next import conversion_chain
+
+
+@torch.compiler.disable
+def _fla_causal_conv1d_cp(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    activation: str,
+    cp_context: FLACPContext,
+) -> torch.Tensor:
+    output, _ = fla_causal_conv1d(
+        x=x,
+        weight=weight,
+        bias=bias,
+        activation=activation,
+        cp_context=cp_context,
+    )
+    return output
+
+
+def _sparse_mla_attention_args(config: Glm5NextTextConfig, layer_idx: int) -> SparseMlaAttentionArgs:
+    if config.q_lora_rank is None:
+        raise ValueError("Sparse MLA attention requires q_lora_rank to be set")
+    return SparseMlaAttentionArgs(
+        hidden_size=config.hidden_size,
+        num_attention_heads=config.num_attention_heads,
+        kv_lora_rank=config.kv_lora_rank,
+        q_lora_rank=config.q_lora_rank,
+        qk_rope_head_dim=config.qk_rope_head_dim,
+        qk_nope_head_dim=config.qk_nope_head_dim,
+        qk_head_dim=config.qk_head_dim,
+        v_head_dim=config.v_head_dim,
+        attention_bias=config.attention_bias,
+        rms_norm_eps=config.rms_norm_eps,
+        index_n_heads=config.index_n_heads,
+        index_head_dim=config.index_head_dim,
+        index_topk=config.index_topk,
+        use_index_cache=getattr(config, "use_index_cache", False),
+        skip_topk=_index_cache_skip_topk(config, layer_idx),
+    )
+
+
+def _glm5_activation(config: Glm5NextTextConfig) -> ActivationType:
+    if config.swiglu_limit is None:
+        return config.hidden_act
+    if float(config.swiglu_limit) != 10.0:
+        raise NotImplementedError("GLM-5.3 SwiGLU clamping only supports swiglu_limit=10.0")
+    return "glm_clamped_swiglu"
+
+
+class Glm5NextLinearAttention(nn.Module):
+    def __init__(self, config: Glm5NextTextConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.head_dim = config.linear_head_dim
+        self.num_heads = config.linear_num_heads
+        self.projection_size = self.num_heads * self.head_dim
+        self.conv_kernel_size = config.linear_conv_kernel_dim
+        self.activation = config.hidden_act
+        self.lower_bound = config.linear_lower_bound
+
+        self.q_proj = nn.Linear(self.hidden_size, self.projection_size, bias=False)
+        self.k_proj = nn.Linear(self.hidden_size, self.projection_size, bias=False)
+        self.v_proj = nn.Linear(self.hidden_size, self.projection_size, bias=False)
+        self.b_proj = nn.Linear(self.hidden_size, self.num_heads, bias=False)
+        self.f_a_proj = nn.Linear(self.hidden_size, self.head_dim, bias=False)
+        self.f_b_proj = nn.Linear(self.head_dim, self.projection_size, bias=False)
+        self.g_a_proj = nn.Linear(self.hidden_size, self.head_dim, bias=False)
+        self.g_b_proj = nn.Linear(self.head_dim, self.projection_size, bias=False)
+
+        self.q_conv1d = nn.Conv1d(
+            self.projection_size,
+            self.projection_size,
+            bias=False,
+            kernel_size=self.conv_kernel_size,
+            groups=self.projection_size,
+            padding=self.conv_kernel_size - 1,
+        )
+        self.k_conv1d = nn.Conv1d(
+            self.projection_size,
+            self.projection_size,
+            bias=False,
+            kernel_size=self.conv_kernel_size,
+            groups=self.projection_size,
+            padding=self.conv_kernel_size - 1,
+        )
+        self.v_conv1d = nn.Conv1d(
+            self.projection_size,
+            self.projection_size,
+            bias=False,
+            kernel_size=self.conv_kernel_size,
+            groups=self.projection_size,
+            padding=self.conv_kernel_size - 1,
+        )
+
+        self.A_log = nn.Parameter(torch.empty(self.num_heads, dtype=torch.float32))
+        self.dt_bias = nn.Parameter(torch.empty(self.projection_size, dtype=torch.float32))
+        self.o_norm = FusedRMSNormGated(self.head_dim, eps=config.rms_norm_eps, activation="sigmoid")
+        self.o_proj = nn.Linear(self.projection_size, self.hidden_size, bias=False)
+
+        self.cp_group: dist.ProcessGroup | None = None
+        self.cp_rank: int = 0
+        self.cp_world_size: int = 1
+
+    def _build_cp_context(
+        self,
+        device: torch.device,
+        cu_seqlens: torch.LongTensor | None = None,
+        cu_seqlens_are_pre_shard: bool = False,
+    ) -> FLACPContext | None:
+        if self.cp_group is None:
+            return None
+        if cu_seqlens is None or not cu_seqlens_are_pre_shard:
+            raise ValueError("GLM-5.3 KDA context parallelism requires full pre-shard sequence boundaries")
+        return build_cp_context(
+            cu_seqlens=cu_seqlens.to(device=device, dtype=torch.int32),
+            group=self.cp_group,
+            conv1d_kernel_size=self.conv_kernel_size,
+        )
+
+    def _conv1d(
+        self,
+        x: torch.Tensor,
+        conv: nn.Conv1d,
+        cu_seqlens: torch.LongTensor | None,
+        cp_context: FLACPContext | None,
+    ) -> torch.Tensor:
+        weight = conv.weight.squeeze(1)
+        if cp_context is None:
+            out, _ = fla_causal_conv1d(
+                x=x,
+                weight=weight,
+                bias=conv.bias,
+                activation=self.activation,
+                cu_seqlens=cu_seqlens,
+            )
+            return out
+        return _fla_causal_conv1d_cp(
+            x=x,
+            weight=weight,
+            bias=conv.bias,
+            activation=self.activation,
+            cp_context=cp_context,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.LongTensor | None = None,
+        cu_seqlens_are_pre_shard: bool = False,
+    ) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+        cp_context = self._build_cp_context(hidden_states.device, cu_seqlens, cu_seqlens_are_pre_shard)
+
+        query = self._conv1d(self.q_proj(hidden_states), self.q_conv1d, cu_seqlens, cp_context)
+        key = self._conv1d(self.k_proj(hidden_states), self.k_conv1d, cu_seqlens, cp_context)
+        value = self._conv1d(self.v_proj(hidden_states), self.v_conv1d, cu_seqlens, cp_context)
+
+        query = query.reshape(batch_size, seq_len, self.num_heads, self.head_dim)
+        key = key.reshape(batch_size, seq_len, self.num_heads, self.head_dim)
+        value = value.reshape(batch_size, seq_len, self.num_heads, self.head_dim)
+
+        beta = self.b_proj(hidden_states)
+        gate_a = self.f_a_proj(hidden_states)
+        gate = self.f_b_proj(gate_a).reshape(batch_size, seq_len, self.num_heads, self.head_dim)
+
+        core_attn_out, _ = chunk_kda(
+            query,
+            key,
+            value,
+            g=gate,
+            beta=beta,
+            A_log=self.A_log,
+            dt_bias=self.dt_bias,
+            use_qk_l2norm_in_kernel=True,
+            use_gate_in_kernel=True,
+            use_beta_sigmoid_in_kernel=True,
+            safe_gate=True,
+            lower_bound=self.lower_bound,
+            cu_seqlens=cu_seqlens,
+            cp_context=cp_context,
+        )
+
+        output_gate = self.g_b_proj(self.g_a_proj(hidden_states)).reshape(
+            batch_size, seq_len, self.num_heads, self.head_dim
+        )
+        core_attn_out = self.o_norm(core_attn_out, output_gate)
+        core_attn_out = core_attn_out.reshape(batch_size, seq_len, self.projection_size)
+        return self.o_proj(core_attn_out)
+
+
+def _hc_expand(x: torch.Tensor, n: int) -> torch.Tensor:
+    return x.unsqueeze(-2).expand(*x.shape[:-1], n, x.shape[-1]).contiguous()
+
+
+def _hc_contract(x: torch.Tensor) -> torch.Tensor:
+    return x.mean(dim=-2)
+
+
+def _mhc_pre_torch(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+    residual_flat = residual.reshape(-1, hc_mult, hidden_size)
+    num_tokens = residual_flat.shape[0]
+
+    x = residual_flat.reshape(num_tokens, hc_mult * hidden_size).to(torch.float32)
+    fn = fn.to(torch.float32)
+    hc_scale = hc_scale.to(torch.float32)
+    hc_base = hc_base.to(torch.float32)
+    mixes = torch.matmul(x, fn.t())
+    sqrsum = x.square().sum(dim=-1, keepdim=True)
+    mixes = mixes * torch.rsqrt(sqrsum / (hc_mult * hidden_size) + rms_eps)
+
+    pre_logits = mixes[:, :hc_mult] * hc_scale[0] + hc_base[:hc_mult]
+    pre_mix = torch.sigmoid(pre_logits) + hc_pre_eps
+
+    post_logits = mixes[:, hc_mult : 2 * hc_mult] * hc_scale[1] + hc_base[hc_mult : 2 * hc_mult]
+    post_mix = torch.sigmoid(post_logits) * hc_post_mult_value
+
+    comb_logits = mixes[:, 2 * hc_mult :].reshape(num_tokens, hc_mult, hc_mult)
+    comb_logits = comb_logits * hc_scale[2] + hc_base[2 * hc_mult :].reshape(1, hc_mult, hc_mult)
+    comb_mix = torch.softmax(comb_logits, dim=-1) + hc_sinkhorn_eps
+    comb_mix = comb_mix / (comb_mix.sum(dim=-2, keepdim=True) + hc_sinkhorn_eps)
+    for _ in range(sinkhorn_repeat - 1):
+        comb_mix = comb_mix / (comb_mix.sum(dim=-1, keepdim=True) + hc_sinkhorn_eps)
+        comb_mix = comb_mix / (comb_mix.sum(dim=-2, keepdim=True) + hc_sinkhorn_eps)
+
+    layer_input = torch.sum(pre_mix.unsqueeze(-1) * residual_flat.to(torch.float32), dim=1).to(residual.dtype)
+    return (
+        post_mix.reshape(*outer_shape, hc_mult, 1),
+        comb_mix.reshape(*outer_shape, hc_mult, hc_mult),
+        layer_input.reshape(*outer_shape, hidden_size),
+    )
+
+
+def _mhc_post_torch(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    mixed_residual = torch.einsum("...ij,...ih->...jh", comb_res_mix.float(), residual.float())
+    post_term = post_layer_mix.float() * x.unsqueeze(-2).float()
+    return (mixed_residual + post_term).to(residual.dtype)
+
+
+class Glm5NextDecoderLayer(GradientCheckpointingLayer):
+    def __init__(self, config: Glm5NextTextConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.layer_idx = layer_idx
+        self.num_hidden_layers = config.num_hidden_layers
+        self.layer_type = config.glm5_layer_types[layer_idx]
+        self.mhc = bool(config.mhc)
+
+        if self.layer_type == "linear_attention":
+            self.self_attn = Glm5NextLinearAttention(config)
+        elif self.layer_type == "deepseek_sparse_attention":
+            self.self_attn = GlmMoeDsaAttention(_sparse_mla_attention_args(config, layer_idx))
+        else:
+            raise ValueError(f"Unsupported GLM-5.3 layer_type {self.layer_type!r}")
+
+        activation = _glm5_activation(config)
+        moe_args = MoEArgs(
+            num_experts=config.n_routed_experts,
+            expert_type="gated",
+            activation=activation,
+            score_func=config.scoring_func,
+            route_norm=config.norm_topk_prob,
+            route_scale=config.routed_scaling_factor,
+            score_before_experts=False,
+            top_k=config.num_experts_per_tok,
+            load_balance_coeff=config.load_balance_coeff,
+        )
+        self.mlp_type = config.mlp_layer_types[layer_idx]
+        if config.is_moe and self.mlp_type == "sparse":
+            shared_expert = None
+            if config.n_shared_experts > 0:
+                shared_expert = FeedForward(
+                    dim=config.hidden_size,
+                    hidden_dim=config.moe_intermediate_size * config.n_shared_experts,
+                    expert_type=moe_args.expert_type,
+                    activation=moe_args.activation,
+                )
+            self.mlp = MoE.from_args(
+                moe_args,
+                dim=config.hidden_size,
+                hidden_dim=config.moe_intermediate_size,
+                shared_expert=shared_expert,
+            )
+        else:
+            self.mlp = FeedForward(
+                dim=config.hidden_size,
+                hidden_dim=config.intermediate_size,
+                activation=activation,
+            )
+
+        self.input_layernorm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.rms_norm_eps))
+        self.post_attention_layernorm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.rms_norm_eps))
+
+        if self.mhc:
+            self.n = config.mhc_num_residual_streams
+            d_model = self.n * self.hidden_size
+            mix_hc = (2 + self.n) * self.n
+            self.hc_eps = config.hc_eps
+            self.rms_norm_eps = config.rms_norm_eps
+            self.mhc_sinkhorn_iterations = config.mhc_sinkhorn_iterations
+            self.mhc_post_mult_value = config.mhc_post_mult_value
+
+            self.hc_attn_fn = nn.Parameter(torch.empty(mix_hc, d_model, dtype=torch.float32))
+            self.hc_attn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
+            self.hc_attn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
+            self.hc_ffn_fn = nn.Parameter(torch.empty(mix_hc, d_model, dtype=torch.float32))
+            self.hc_ffn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
+            self.hc_ffn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
+
+    def set_context_parallel_attributes(self, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
+        self._cp_group = cp_group
+        self._cp_rank = cp_rank
+        self._cp_world_size = cp_world_size
+        if self.layer_type == "linear_attention":
+            self.self_attn.cp_group = cp_group
+            self.self_attn.cp_rank = cp_rank
+            self.self_attn.cp_world_size = cp_world_size
+        else:
+            self.self_attn.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
+
+    def _run_attention(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        ks: torch.Tensor | None,
+        ke: torch.Tensor | None,
+        cached_indices: torch.Tensor | None,
+        cu_seqlens: torch.LongTensor | None,
+        cu_seqlens_are_pre_shard: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if self.layer_type == "linear_attention":
+            return (
+                self.self_attn(
+                    hidden_states,
+                    cu_seqlens=cu_seqlens,
+                    cu_seqlens_are_pre_shard=cu_seqlens_are_pre_shard,
+                ),
+                cached_indices,
+            )
+        return self.self_attn(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            ks=ks,
+            ke=ke,
+            cached_indices=cached_indices,
+        )
+
+    def _hc_pre(
+        self,
+        x: torch.Tensor,
+        hc_fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return _mhc_pre_torch(
+            x,
+            hc_fn,
+            hc_scale,
+            hc_base,
+            rms_eps=self.rms_norm_eps,
+            hc_pre_eps=self.hc_eps,
+            hc_sinkhorn_eps=self.hc_eps,
+            hc_post_mult_value=self.mhc_post_mult_value,
+            sinkhorn_repeat=self.mhc_sinkhorn_iterations,
+        )
+
+    def _forward_without_mhc(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        ks: torch.Tensor | None,
+        ke: torch.Tensor | None,
+        cached_indices: torch.Tensor | None,
+        routed_experts: Optional[torch.LongTensor],
+        cu_seqlens: torch.LongTensor | None,
+        cu_seqlens_are_pre_shard: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, cached_indices = self._run_attention(
+            hidden_states,
+            position_embeddings,
+            ks,
+            ke,
+            cached_indices,
+            cu_seqlens,
+            cu_seqlens_are_pre_shard,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states, routed_experts=routed_experts)
+        hidden_states = residual + hidden_states
+        return hidden_states, cached_indices, None, None, None
+
+    def _forward_with_mhc(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        ks: torch.Tensor | None,
+        ke: torch.Tensor | None,
+        cached_indices: torch.Tensor | None,
+        routed_experts: Optional[torch.LongTensor],
+        cu_seqlens: torch.LongTensor | None,
+        cu_seqlens_are_pre_shard: bool,
+        hc_residual: torch.Tensor | None,
+        hc_post: torch.Tensor | None,
+        hc_comb: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+        x = hidden_states
+        if hc_post is None:
+            if hc_residual is None:
+                hc_residual = _hc_expand(x, self.n)
+            hc_post, hc_comb, x = self._hc_pre(hc_residual, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base)
+        else:
+            hc_residual = _mhc_post_torch(x, hc_residual, hc_post, hc_comb)
+            hc_post, hc_comb, x = self._hc_pre(hc_residual, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base)
+
+        x = self.input_layernorm(x)
+        x, cached_indices = self._run_attention(
+            x,
+            position_embeddings,
+            ks,
+            ke,
+            cached_indices,
+            cu_seqlens,
+            cu_seqlens_are_pre_shard,
+        )
+
+        hc_residual = _mhc_post_torch(x, hc_residual, hc_post, hc_comb)
+        hc_post, hc_comb, x = self._hc_pre(hc_residual, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base)
+        x = self.post_attention_layernorm(x)
+        x = self.mlp(x, routed_experts=routed_experts)
+
+        if self.layer_idx == self.num_hidden_layers - 1:
+            x = _mhc_post_torch(x, hc_residual, hc_post, hc_comb)
+            return _hc_contract(x), cached_indices, None, None, None
+        return x, cached_indices, hc_residual, hc_post, hc_comb
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        ks: torch.Tensor | None = None,
+        ke: torch.Tensor | None = None,
+        cached_indices: torch.Tensor | None = None,
+        routed_experts: Optional[torch.LongTensor] = None,
+        cu_seqlens: torch.LongTensor | None = None,
+        cu_seqlens_are_pre_shard: bool = False,
+        hc_residual: torch.Tensor | None = None,
+        hc_post: torch.Tensor | None = None,
+        hc_comb: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+        if not self.mhc:
+            return self._forward_without_mhc(
+                hidden_states,
+                position_embeddings,
+                ks,
+                ke,
+                cached_indices,
+                routed_experts,
+                cu_seqlens,
+                cu_seqlens_are_pre_shard,
+            )
+        return self._forward_with_mhc(
+            hidden_states,
+            position_embeddings,
+            ks,
+            ke,
+            cached_indices,
+            routed_experts,
+            cu_seqlens,
+            cu_seqlens_are_pre_shard,
+            hc_residual,
+            hc_post,
+            hc_comb,
+        )
+
+
+class Glm5NextPreTrainedModel(PreTrainedModelPrimeRL):
+    config_class = Glm5NextTextConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["Glm5NextDecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn = True
+    _supports_sdpa = False
+    _supports_flex_attn = False
+    _can_compile_fullgraph = False
+    _supports_attention_backend = True
+    _can_record_outputs = {
+        "hidden_states": Glm5NextDecoderLayer,
+    }
+
+    def _init_weights(self, module):
+        super()._init_weights(module)
+        text_config = self.config.get_text_config() if isinstance(self.config, Glm5NextConfig) else self.config
+        std = getattr(text_config, "initializer_range", 0.02)
+        if isinstance(module, MoE):
+            module.init_weights(std, buffer_device=module.tokens_per_expert.device)
+        elif isinstance(module, Glm5NextLinearAttention):
+            nn.init.zeros_(module.A_log)
+            nn.init.zeros_(module.dt_bias)
+        elif isinstance(module, Glm5NextDecoderLayer) and module.mhc:
+            for weight in (module.hc_attn_fn, module.hc_ffn_fn):
+                nn.init.trunc_normal_(weight, mean=0.0, std=std)
+            for bias in (module.hc_attn_base, module.hc_ffn_base):
+                nn.init.zeros_(bias)
+            for scale in (module.hc_attn_scale, module.hc_ffn_scale):
+                nn.init.ones_(scale)
+
+    @classmethod
+    def keep_in_fp32_for_weight_transfer(cls, name: str) -> bool:
+        return name.endswith(("mlp.router.selection_bias", "self_attn.A_log", "self_attn.dt_bias")) or ".hc_" in name
+
+    @classmethod
+    def is_hf_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return any(
+            "model.language_model.layers." in name
+            or "mlp.experts.1.up_proj" in name
+            or "mlp.experts.gate_up_proj" in name
+            or "self_attn.indexer.index_kpool_compress_" in name
+            for name in state_dict.keys()
+        )
+
+    @classmethod
+    def is_prime_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return any(name.startswith("model.") for name in state_dict.keys()) and not any(
+            name.startswith("model.language_model.") for name in state_dict.keys()
+        )
+
+    @classmethod
+    def conversion_chain(cls, config):
+        text_config = config.get_text_config() if isinstance(config, Glm5NextConfig) else config
+        return conversion_chain(text_config)
+
+
+class Glm5NextModel(Glm5NextPreTrainedModel):
+    def __init__(self, config: Glm5NextTextConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [Glm5NextDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.rms_norm_eps))
+        self.rotary_emb = self._create_rotary_emb(config)
+        self.gradient_checkpointing = False
+        self.post_init()
+
+    def _create_rotary_emb(self, config: Glm5NextTextConfig) -> RotaryEmbedding | None:
+        if config.qk_rope_head_dim == 0:
+            return None
+        rope_parameters = getattr(config, "rope_parameters", None) or {}
+        rope_type = rope_parameters.get("rope_type", "default") if isinstance(rope_parameters, dict) else "default"
+        rotary_config = RotaryEmbeddingConfig(
+            max_position_embeddings=config.max_position_embeddings,
+            rope_type=rope_type,
+            model_config=config,
+        )
+        return RotaryEmbedding(rotary_config)
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def set_context_parallel_attributes(self, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
+        self._cp_group = cp_group
+        self._cp_rank = cp_rank
+        self._cp_world_size = cp_world_size
+        for layer in self.layers:
+            layer.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
+
+    def _context_parallel_state(self) -> tuple[dist.ProcessGroup | None, int, int]:
+        if len(self.layers) == 0:
+            return None, 0, 1
+        layer = self.layers[0]
+        return getattr(layer, "_cp_group", None), getattr(layer, "_cp_rank", 0), getattr(layer, "_cp_world_size", 1)
+
+    def _gather_position_ids_for_cp(
+        self,
+        position_ids: torch.LongTensor,
+        cp_group: dist.ProcessGroup,
+        cp_world_size: int,
+    ) -> torch.LongTensor:
+        gathered_position_ids = [torch.empty_like(position_ids) for _ in range(cp_world_size)]
+        dist.all_gather(gathered_position_ids, position_ids.contiguous(), group=cp_group)
+        return torch.cat(gathered_position_ids, dim=1)
+
+    def _position_embeddings(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids_full: torch.LongTensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.rotary_emb is None:
+            shape = (*position_ids_full.shape, 0)
+            empty = hidden_states.new_empty(shape)
+            return empty, empty
+        return self.rotary_emb(hidden_states, position_ids_full)
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: Optional[torch.LongTensor] = None,
+        seq_lens_are_pre_shard: bool = False,
+    ) -> BaseModelOutputWithPast:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids is None:
+            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+        if seq_lens is None:
+            seq_lens = torch.tensor([inputs_embeds.shape[1]], dtype=torch.long, device=inputs_embeds.device)
+
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+            seq_lens.to(device=inputs_embeds.device),
+            total_tokens=None if seq_lens_are_pre_shard else inputs_embeds.shape[1],
+        )
+        del max_seqlen
+        torch._dynamo.mark_dynamic(cu_seqlens, 0)
+
+        cp_group, cp_rank, cp_world_size = self._context_parallel_state()
+        if cp_group is not None and cp_world_size > 1:
+            position_ids_full = self._gather_position_ids_for_cp(position_ids, cp_group, cp_world_size)
+        else:
+            position_ids_full = position_ids
+
+        flat_position_ids = position_ids_full.reshape(-1)
+        s_full = flat_position_ids.shape[0]
+        ks_full = torch.arange(s_full, dtype=torch.int32, device=flat_position_ids.device) - flat_position_ids.to(
+            torch.int32
+        )
+        ke_full = torch.arange(1, s_full + 1, dtype=torch.int32, device=flat_position_ids.device)
+
+        hidden_states = inputs_embeds
+        position_embeddings = self._position_embeddings(hidden_states, position_ids_full)
+
+        if cp_world_size > 1:
+            s_local = s_full // cp_world_size
+            ks = ks_full[cp_rank * s_local : (cp_rank + 1) * s_local].contiguous()
+            ke = ke_full[cp_rank * s_local : (cp_rank + 1) * s_local].contiguous()
+        else:
+            ks, ke = ks_full, ke_full
+
+        cached_indices = None
+        hc_residual = None
+        hc_post = None
+        hc_comb = None
+        use_index_cache = getattr(self.config, "use_index_cache", False)
+        for layer_idx, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
+            routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
+            hidden_states, next_cached_indices, hc_residual, hc_post, hc_comb = decoder_layer(
+                hidden_states,
+                position_embeddings=position_embeddings,
+                ks=ks,
+                ke=ke,
+                cached_indices=cached_indices,
+                routed_experts=routed_experts_layer,
+                cu_seqlens=cu_seqlens,
+                cu_seqlens_are_pre_shard=seq_lens_are_pre_shard,
+                hc_residual=hc_residual,
+                hc_post=hc_post,
+                hc_comb=hc_comb,
+            )
+            cached_indices = next_cached_indices if use_index_cache else None
+
+        hidden_states = self.norm(hidden_states)
+        return BaseModelOutputWithPast(last_hidden_state=hidden_states)
+
+
+class Glm5NextForCausalLM(Glm5NextPreTrainedModel, GenerationMixin):
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
+    _tp_plan = {"lm_head": "colwise_rep"}
+    _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+
+    def __init__(self, config, **kwargs):
+        text_config = config.get_text_config() if isinstance(config, Glm5NextConfig) else config
+        super().__init__(config, **kwargs)
+        self.model = Glm5NextModel(text_config)
+        self.vocab_size = text_config.vocab_size
+        self.lm_head = nn.Linear(text_config.hidden_size, text_config.vocab_size, bias=False)
+
+        warnings.warn(
+            "Glm5NextForCausalLM is experimental: KDA and mHC use correctness-first training paths, "
+            "and the sparse MLA indexer does not yet implement GLM-5.3 k-pool compression."
+        )
+        warnings.warn("`model.attn` is ignored, GLM-5.3 dispatches per-layer KDA/sparse MLA from layer_types.")
+
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.model.set_input_embeddings(value)
+
+    def set_context_parallel_attributes(self, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
+        self.model.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        temperature: Optional[torch.Tensor] = None,
+        routed_experts: Optional[torch.LongTensor] = None,
+        *,
+        seq_lens: torch.LongTensor,
+        seq_lens_are_pre_shard: bool = False,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> PrimeLmOutput:
+        del attention_mask, cache_position, kwargs
+        assert use_cache is None, "use_cache is not supported for custom glm5_next for now"
+        assert past_key_values is None, "past_key_values is not supported for custom glm5_next for now"
+
+        if position_ids is None:
+            if inputs_embeds is not None:
+                position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+            else:
+                position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).unsqueeze(0)
+
+        outputs: BaseModelOutputWithPast = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            routed_experts=routed_experts,
+            seq_lens=seq_lens,
+            seq_lens_are_pre_shard=seq_lens_are_pre_shard,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        return self.lm_head(
+            hidden_states[:, slice_indices, :],
+            labels[:, slice_indices] if labels is not None else None,
+            temperature=temperature,
+        )
+
+    def init_buffers_post_meta(self):
+        if self.model.rotary_emb is None:
+            return
+        rotary_emb = self.model.rotary_emb
+        inv_freq, rotary_emb.attention_scaling = rotary_emb.rope_init_fn(rotary_emb.config, rotary_emb.inv_freq.device)
+        rotary_emb.inv_freq.copy_(inv_freq)
+
+
+__all__ = [
+    "Glm5NextConfig",
+    "Glm5NextTextConfig",
+    "Glm5NextPreTrainedModel",
+    "Glm5NextModel",
+    "Glm5NextForCausalLM",
+]

--- a/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
@@ -37,6 +37,8 @@ class SparseMlaAttentionArgs:
 def apply_rope_interleave_single(
     t: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, unsqueeze_dim: int = 1
 ) -> torch.Tensor:
+    if t.shape[-1] == 0:
+        return t
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
     b, h, s, d = t.shape
@@ -240,7 +242,7 @@ class GlmMoeDsaAttention(nn.Module):
             position_embeddings_full=position_embeddings,
         )
 
-        out, _ = sparse_mla(sparse_q, sparse_kv, indices, self.scaling)
+        out, _ = sparse_mla(sparse_q, sparse_kv, indices, self.scaling, d_v=self.v_head_dim)
         out = torch.einsum("bshk,hdk->bshd", out, w_v)
         batch_size, total_tokens = out.shape[:2]
         out = out.reshape(batch_size, total_tokens, -1)

--- a/src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py
+++ b/src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py
@@ -115,6 +115,7 @@ def bwd(
     assert dtype == T.bfloat16
     assert accum_dtype == T.float32
     assert indices_dtype == T.int32
+    assert D_tail == 0 or D_tail % 4 == 0
 
     if sm_scale is None:
         sm_scale = (D + D_tail) ** (-0.5)
@@ -141,6 +142,7 @@ def bwd(
     NS = tilelang.cdiv(topk, block_size)
 
     split_store = 2
+    has_tail = D_tail > 0
 
     @T.prim_func
     def sparse_mla_bwd_kernel(
@@ -155,25 +157,27 @@ def bwd(
     ):
         with T.Kernel(S, B, kv_group * NH, threads=threads) as (s_i, by, bz):
             Q_shared = T.alloc_shared([block_H, D], dtype)
-            Q_tail_shared = T.alloc_shared([block_H, D_tail], dtype)
             KV_shared = T.alloc_shared([BS, D], dtype)
-            KV_tail_shared = T.alloc_shared([BS, D_tail], dtype)
             dO_shared = T.alloc_shared([block_H, D], dtype)
             mask = T.alloc_fragment([BS], "bool")
 
             P_shared_cast = T.alloc_shared([block_H, BS], dtype)
             dP_shared_cast = T.alloc_shared([block_H, BS], dtype)
             dQ_shared = T.alloc_shared([block_H, D], dtype)
-            dQ_tail_shared = T.alloc_shared([block_H, D_tail], dtype)
+            if has_tail:
+                Q_tail_shared = T.alloc_shared([block_H, D_tail], dtype)
+                KV_tail_shared = T.alloc_shared([BS, D_tail], dtype)
+                dQ_tail_shared = T.alloc_shared([block_H, D_tail], dtype)
 
             acc_p = T.alloc_fragment([block_H, BS], accum_dtype)
             acc_dp = T.alloc_fragment([block_H, BS], accum_dtype)
             acc_dq = T.alloc_fragment([block_H, D], accum_dtype)
-            acc_dq_tail = T.alloc_fragment([block_H, D_tail], accum_dtype)
             acc_dkv = T.alloc_fragment([BS, D], accum_dtype)
-            acc_dkv_tail = T.alloc_fragment([BS, D_tail], accum_dtype)
             acc_dkv_shared = T.alloc_shared([BS // split_store, D], accum_dtype)
-            acc_dkv_tail_shared = T.alloc_shared([BS // split_store, D_tail], accum_dtype)
+            if has_tail:
+                acc_dq_tail = T.alloc_fragment([block_H, D_tail], accum_dtype)
+                acc_dkv_tail = T.alloc_fragment([BS, D_tail], accum_dtype)
+                acc_dkv_tail_shared = T.alloc_shared([BS // split_store, D_tail], accum_dtype)
 
             # See sparse_mla_fwd: sentinel is at index S_kv - 1 (zero KV), valid indices
             # live in [0, S_kv - 1). Using this single bound makes the kernel work for
@@ -181,11 +185,13 @@ def bwd(
             max_kv_i = S_kv - 2
 
             T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, :D], Q_shared)
-            T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, D:], Q_tail_shared)
+            if has_tail:
+                T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, D:], Q_tail_shared)
             T.copy(dO[by, s_i, bz * block_H : (bz + 1) * block_H, :D], dO_shared)
 
             T.clear(acc_dq)
-            T.clear(acc_dq_tail)
+            if has_tail:
+                T.clear(acc_dq_tail)
 
             for i_i in T.Pipelined(NS, num_stages=num_stages):
                 for bi_i in T.Parallel(BS):
@@ -199,9 +205,12 @@ def bwd(
 
                 T.gemm(Q_shared, KV_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
 
-                for bi_i, d_i in T.Parallel(BS, D_tail):
-                    KV_tail_shared[bi_i, d_i] = KV[by, Indices[by, s_i, bz // NH, i_i * BS + bi_i], bz // NH, D + d_i]
-                T.gemm(Q_tail_shared, KV_tail_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
+                if has_tail:
+                    for bi_i, d_i in T.Parallel(BS, D_tail):
+                        KV_tail_shared[bi_i, d_i] = KV[
+                            by, Indices[by, s_i, bz // NH, i_i * BS + bi_i], bz // NH, D + d_i
+                        ]
+                    T.gemm(Q_tail_shared, KV_tail_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
 
                 for h_i, bi_i in T.Parallel(block_H, BS):
                     acc_p[h_i, bi_i] = T.exp2(
@@ -221,7 +230,8 @@ def bwd(
 
                 T.copy(acc_dp, dP_shared_cast)
                 T.gemm(dP_shared_cast, KV_shared, acc_dq, policy=T.GemmWarpPolicy.FullCol)
-                T.gemm(dP_shared_cast, KV_tail_shared, acc_dq_tail, policy=T.GemmWarpPolicy.FullCol)
+                if has_tail:
+                    T.gemm(dP_shared_cast, KV_tail_shared, acc_dq_tail, policy=T.GemmWarpPolicy.FullCol)
 
                 T.gemm(
                     dP_shared_cast,
@@ -233,17 +243,25 @@ def bwd(
                 )
                 T.gemm(P_shared_cast, dO_shared, acc_dkv, transpose_A=True, policy=T.GemmWarpPolicy.FullCol)
 
-                T.clear(acc_dkv_tail)
-                T.gemm(dP_shared_cast, Q_tail_shared, acc_dkv_tail, transpose_A=True, policy=T.GemmWarpPolicy.FullCol)
+                if has_tail:
+                    T.clear(acc_dkv_tail)
+                    T.gemm(
+                        dP_shared_cast,
+                        Q_tail_shared,
+                        acc_dkv_tail,
+                        transpose_A=True,
+                        policy=T.GemmWarpPolicy.FullCol,
+                    )
 
                 for s in range(split_store):
                     for bi_i, d_i in T.Parallel(BS, D):
                         if bi_i < BS // split_store:
                             acc_dkv_shared[bi_i, d_i] = acc_dkv[bi_i + s * (BS // split_store), d_i]
 
-                    for bi_i, d_i in T.Parallel(BS, D_tail):
-                        if bi_i < BS // split_store:
-                            acc_dkv_tail_shared[bi_i, d_i] = acc_dkv_tail[bi_i + s * (BS // split_store), d_i]
+                    if has_tail:
+                        for bi_i, d_i in T.Parallel(BS, D_tail):
+                            if bi_i < BS // split_store:
+                                acc_dkv_tail_shared[bi_i, d_i] = acc_dkv_tail[bi_i + s * (BS // split_store), d_i]
 
                     for bi_i, d_i in T.Parallel(BS // split_store, D // 4):
                         T.atomic_addx4(
@@ -256,22 +274,25 @@ def bwd(
                             acc_dkv_shared[bi_i, d_i * 4],
                         )
 
-                    for bi_i, d_i in T.Parallel(BS // split_store, D_tail // 4):
-                        T.atomic_addx4(
-                            dKV[
-                                by,
-                                Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
-                                bz // NH,
-                                D + d_i * 4,
-                            ],
-                            acc_dkv_tail_shared[bi_i, d_i * 4],
-                        )
+                    if has_tail:
+                        for bi_i, d_i in T.Parallel(BS // split_store, D_tail // 4):
+                            T.atomic_addx4(
+                                dKV[
+                                    by,
+                                    Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
+                                    bz // NH,
+                                    D + d_i * 4,
+                                ],
+                                acc_dkv_tail_shared[bi_i, d_i * 4],
+                            )
 
             T.copy(acc_dq, dQ_shared)
-            T.copy(acc_dq_tail, dQ_tail_shared)
+            if has_tail:
+                T.copy(acc_dq_tail, dQ_tail_shared)
 
             T.copy(dQ_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, :D])
-            T.copy(dQ_tail_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, D:])
+            if has_tail:
+                T.copy(dQ_tail_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, D:])
 
     return sparse_mla_bwd_kernel
 
@@ -295,7 +316,8 @@ def sparse_mla_backward(
     _, S_kv, kv_group, _ = kv.shape
     assert kv.shape[-1] == dim_plus_tail_dim
     assert kv.shape[0] == B
-    D = 512
+    D = out.shape[-1]
+    assert 0 < D <= dim_plus_tail_dim
     D_tail = dim_plus_tail_dim - D
     topk = indices.shape[-1]
     assert indices.shape == (B, S, kv_group, topk)

--- a/src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py
+++ b/src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py
@@ -41,7 +41,9 @@ def sparse_mla_fwd(
     threads=256,
 ):
     assert dim == tilelang.math.next_power_of_2(dim), f"haven't check padding correctness yet, dim={dim}"
-    assert tail_dim == tilelang.math.next_power_of_2(tail_dim), f"haven't check padding correctness yet, dim={tail_dim}"
+    assert tail_dim == 0 or tail_dim == tilelang.math.next_power_of_2(tail_dim), (
+        f"haven't check padding correctness yet, dim={tail_dim}"
+    )
     assert is_causal is True, "non-casual is not supported"
     assert topk % block_I == 0, "otherwise will load some index=0 thus causing wrong kv to be loaded"
     if sm_scale is None:
@@ -83,6 +85,7 @@ def sparse_mla_fwd(
         REPLICATE_H = 1
 
     H_per_block = padded_H if REPLICATE_H == 1 else 64
+    has_tail = tail_dim > 0
 
     @T.prim_func
     def main(
@@ -98,12 +101,13 @@ def sparse_mla_fwd(
             bz,
         ):
             Q_shared = T.alloc_shared([H_per_block, D], dtype)
-            Q_tail_shared = T.alloc_shared([H_per_block, D_tail], dtype)
             KV_shared = T.alloc_shared([BI, D], dtype)
-            K_tail_shared = T.alloc_shared([BI, D_tail], dtype)
             O_shared = T.alloc_shared([H_per_block, D], dtype)  # noqa: F841
             Lse_shared = T.alloc_shared([H_per_block], accum_dtype)  # noqa: F841
             mask = T.alloc_fragment([BI], "bool")
+            if has_tail:
+                Q_tail_shared = T.alloc_shared([H_per_block, D_tail], dtype)
+                K_tail_shared = T.alloc_shared([BI, D_tail], dtype)
 
             acc_o = T.alloc_fragment([H_per_block, D], accum_dtype)
             acc_s = T.alloc_fragment([H_per_block, BI], accum_dtype)
@@ -131,7 +135,8 @@ def sparse_mla_fwd(
             H1 = H0 + H_per_block
 
             T.copy(Q[b_i, s_i, H0:H1, :D], Q_shared)
-            T.copy(Q[b_i, s_i, H0:H1, D:], Q_tail_shared)
+            if has_tail:
+                T.copy(Q[b_i, s_i, H0:H1, D:], Q_tail_shared)
 
             for i_i in T.Pipelined(NI, num_stages=num_stages):
                 for bi_i in T.Parallel(BI):
@@ -139,8 +144,9 @@ def sparse_mla_fwd(
 
                 for bi_i, d_i in T.Parallel(BI, D):
                     KV_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, g_i, i_i * BI + bi_i], g_i, d_i]
-                for bi_i, d_i in T.Parallel(BI, D_tail):
-                    K_tail_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, g_i, i_i * BI + bi_i], g_i, D + d_i]
+                if has_tail:
+                    for bi_i, d_i in T.Parallel(BI, D_tail):
+                        K_tail_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, g_i, i_i * BI + bi_i], g_i, D + d_i]
 
                 for h_i, bi_i in T.Parallel(H_per_block, BI):
                     acc_s[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_s.dtype))
@@ -151,13 +157,14 @@ def sparse_mla_fwd(
                     transpose_B=True,
                     policy=T.GemmWarpPolicy.FullRow,
                 )
-                T.gemm(
-                    Q_tail_shared,
-                    K_tail_shared,
-                    acc_s,
-                    transpose_B=True,
-                    policy=T.GemmWarpPolicy.FullRow,
-                )
+                if has_tail:
+                    T.gemm(
+                        Q_tail_shared,
+                        K_tail_shared,
+                        acc_s,
+                        transpose_B=True,
+                        policy=T.GemmWarpPolicy.FullRow,
+                    )
                 T.copy(m_i, m_i_prev)
                 T.reduce_max(acc_s, m_i, dim=1, clear=False)
                 for h_i in T.Parallel(H_per_block):
@@ -201,8 +208,8 @@ def sparse_mla(
     batch, seq_len, heads, dim_plus_tail_dim = q.shape
     _, seq_len_kv, kv_group, _ = kv.shape
 
-    assert dim_plus_tail_dim == 576, "you should assign dim otherwise"
     dim = d_v
+    assert 0 < dim <= dim_plus_tail_dim
     assert kv.shape[-1] == dim_plus_tail_dim
     assert kv.shape[0] == batch
     tail_dim = dim_plus_tail_dim - dim

--- a/src/prime_rl/trainer/models/layers/activations.py
+++ b/src/prime_rl/trainer/models/layers/activations.py
@@ -18,6 +18,15 @@ class ClampedSwiglu(Activation):
         return (up + 1) * gate * torch.sigmoid(gate * 1.702)
 
 
+class GlmClampedSwiglu(Activation):
+    @staticmethod
+    def apply(gate: torch.Tensor | None, up: torch.Tensor) -> torch.Tensor:
+        assert gate is not None
+        gate = gate.clamp(max=10.0)
+        up = up.clamp(min=-10.0, max=10.0)
+        return gate * torch.sigmoid(gate) * up
+
+
 class Relu2(Activation):
     @staticmethod
     def apply(gate: torch.Tensor | None, up: torch.Tensor) -> torch.Tensor:
@@ -34,10 +43,11 @@ class Silu(Activation):
         return F.silu(gate) * up
 
 
-ActivationType = Literal["silu", "relu2", "clamped_swiglu"]
+ActivationType = Literal["silu", "relu2", "clamped_swiglu", "glm_clamped_swiglu"]
 
 ActivationDispatch: dict[ActivationType, type[Activation]] = {
     "clamped_swiglu": ClampedSwiglu,
+    "glm_clamped_swiglu": GlmClampedSwiglu,
     "silu": Silu,
     "relu2": Relu2,
 }

--- a/src/prime_rl/trainer/models/nemotron_h/configuration_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/configuration_nemotron_h.py
@@ -129,6 +129,13 @@ class NemotronHConfig(PretrainedConfig):
     def layer_types(self) -> list[str]:
         return self.layers_block_type
 
+    @layer_types.setter
+    def layer_types(self, value: list[str]) -> None:
+        # Transformers validates attention layer types after initialization, but
+        # this config uses the property for its broader Mamba/MoE block pattern.
+        if not hasattr(self, "layers_block_type"):
+            self.layers_block_type = value
+
     @property
     def num_hidden_layers(self) -> int:
         return len(self.layers_block_type)

--- a/tests/unit/inference/test_serving_tokens.py
+++ b/tests/unit/inference/test_serving_tokens.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 
 import numpy as np
 import pybase64
-from vllm.entrypoints.openai.engine.protocol import UsageInfo
 from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateResponse, GenerateResponseChoice
+from vllm.entrypoints.serve.engine.protocol import UsageInfo
 
 from prime_rl.inference.vllm.routed_experts import serialize_routed_experts
 from prime_rl.inference.vllm.serving_tokens import (

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -37,6 +37,12 @@ EXPECTED_PARSERS: list[tuple[str, str | None, str | None]] = [
     # GLM-5.1
     ("zai-org/GLM-5.1", "glm47", "glm45"),
     ("zai-org/GLM-5.1-FP8", "glm47", "glm45"),
+    # GLM-5.2
+    ("zai-org/GLM-5.2", "glm47", "glm45"),
+    ("zai-org/GLM-5.2-FP8", "glm47", "glm45"),
+    # GLM-5.3
+    ("zai-org/GLM-5.3-Flash", "glm47", "glm45"),
+    ("zai-org/GLM-5.3-Flash-BF16", "glm47", "glm45"),
     # MiniMax M2
     ("MiniMaxAI/MiniMax-M2", "minimax_m2", "minimax_m2_append_think"),
     ("MiniMaxAI/MiniMax-M2.1", "minimax_m2", "minimax_m2_append_think"),

--- a/tests/unit/train/models/test_glm5_next.py
+++ b/tests/unit/train/models/test_glm5_next.py
@@ -1,0 +1,98 @@
+import torch
+
+from prime_rl.trainer.models import get_custom_causal_lm_cls, supports_custom_impl
+from prime_rl.trainer.models.conversion_ops import apply_hf_to_prime
+from prime_rl.trainer.models.glm5_next import Glm5NextConfig, Glm5NextForCausalLM, Glm5NextTextConfig
+from prime_rl.trainer.models.glm5_next.converting_glm5_next import conversion_chain
+
+
+def _tiny_text_dict() -> dict:
+    return {
+        "vocab_size": 128,
+        "pad_token_id": 0,
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "moe_intermediate_size": 4,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 1,
+        "q_lora_rank": 4,
+        "kv_lora_rank": 4,
+        "qk_nope_head_dim": 4,
+        "qk_rope_head_dim": 0,
+        "v_head_dim": 4,
+        "layer_types": ["linear_attention", "linear_attention", "linear_attention", "deepseek_sparse_attention"],
+        "mlp_layer_types": ["dense", "dense", "dense", "sparse"],
+        "n_routed_experts": 2,
+        "num_experts_per_tok": 1,
+        "n_shared_experts": 1,
+        "num_nextn_predict_layers": 1,
+        "mhc": True,
+        "hc_mult": 4,
+        "hc_sinkhorn_iters": 20,
+        "linear_attn_config": {
+            "num_heads": 1,
+            "head_dim": 4,
+            "short_conv_kernel_size": 4,
+            "gate_lower_bound": -5.0,
+        },
+    }
+
+
+def test_glm5_next_config_folds_composite_text_config() -> None:
+    config = Glm5NextConfig(text_config=_tiny_text_dict(), vision_config={"model_type": "glm5_next_vision"})
+
+    assert config.model_type == "glm5_next"
+    assert config.get_text_config().model_type == "glm5_next_text"
+    assert config.hidden_size == 8
+    assert config.glm5_layer_types[-1] == "deepseek_sparse_attention"
+    assert config.layer_types[-1] == "sparse"
+    assert config.num_experts_per_tok == 1
+    assert config.mhc_num_residual_streams == 4
+    assert config.mhc_sinkhorn_iterations == 20
+    assert config.linear_head_dim == 4
+
+
+def test_glm5_next_custom_registry_supports_top_level_config() -> None:
+    config = Glm5NextConfig(text_config=_tiny_text_dict())
+
+    assert supports_custom_impl(config)
+    assert get_custom_causal_lm_cls(config) is Glm5NextForCausalLM
+
+
+def test_glm5_next_conversion_normalizes_composite_checkpoint_keys() -> None:
+    config = Glm5NextTextConfig(**_tiny_text_dict())
+    state_dict = {
+        "model.language_model.embed_tokens.weight": torch.zeros(128, 8),
+        "model.language_model.layers.3.mlp.experts.0.gate_proj.weight": torch.zeros(4, 8),
+        "model.language_model.layers.3.mlp.experts.0.down_proj.weight": torch.zeros(8, 4),
+        "model.language_model.layers.3.mlp.experts.0.up_proj.weight": torch.zeros(4, 8),
+        "model.language_model.layers.3.mlp.experts.1.gate_proj.weight": torch.ones(4, 8),
+        "model.language_model.layers.3.mlp.experts.1.down_proj.weight": torch.ones(8, 4),
+        "model.language_model.layers.3.mlp.experts.1.up_proj.weight": torch.ones(4, 8),
+        "model.language_model.layers.3.mlp.gate.weight": torch.zeros(2, 8),
+        "model.language_model.layers.3.mlp.gate.e_score_correction_bias": torch.zeros(2),
+        "model.language_model.layers.3.mlp.shared_experts.gate_proj.weight": torch.zeros(4, 8),
+        "model.language_model.layers.3.mlp.shared_experts.down_proj.weight": torch.zeros(8, 4),
+        "model.language_model.layers.3.mlp.shared_experts.up_proj.weight": torch.zeros(4, 8),
+        "model.language_model.layers.3.self_attn.indexer.index_kpool_compress_ape": torch.zeros(4, 8),
+        "model.language_model.layers.3.self_attn.indexer.index_kpool_compress_gate": torch.zeros(8, 8),
+        "model.language_model.layers.4.eh_proj.weight": torch.zeros(8, 8),
+        "model.visual.blocks.0.norm.weight": torch.zeros(8),
+        "lm_head.weight": torch.zeros(128, 8),
+    }
+
+    apply_hf_to_prime(state_dict, conversion_chain(config))
+
+    assert set(state_dict) == {
+        "lm_head.weight",
+        "model.embed_tokens.weight",
+        "model.layers.3.mlp.experts.down_proj",
+        "model.layers.3.mlp.experts.gate_proj",
+        "model.layers.3.mlp.experts.up_proj",
+        "model.layers.3.mlp.router.gate.weight",
+        "model.layers.3.mlp.router.selection_bias",
+        "model.layers.3.mlp.shared_expert.down_proj.weight",
+        "model.layers.3.mlp.shared_expert.gate_proj.weight",
+        "model.layers.3.mlp.shared_expert.up_proj.weight",
+    }
+    assert state_dict["model.layers.3.mlp.experts.gate_proj"].shape == (2, 4, 8)

--- a/tests/unit/train/models/test_glm5_next.py
+++ b/tests/unit/train/models/test_glm5_next.py
@@ -45,7 +45,7 @@ def test_glm5_next_config_folds_composite_text_config() -> None:
     assert config.get_text_config().model_type == "glm5_next_text"
     assert config.hidden_size == 8
     assert config.glm5_layer_types[-1] == "deepseek_sparse_attention"
-    assert config.layer_types[-1] == "sparse"
+    assert config.layer_types[-1] == "deepseek_sparse_attention"
     assert config.num_experts_per_tok == 1
     assert config.mhc_num_residual_streams == 4
     assert config.mhc_sinkhorn_iterations == 20

--- a/uv.lock
+++ b/uv.lock
@@ -145,7 +145,7 @@ overrides = [
     { name = "tilelang", specifier = "==0.1.12" },
     { name = "torch", marker = "sys_platform != 'linux'", specifier = ">=2.13.0" },
     { name = "torch", marker = "sys_platform == 'linux'", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cu130" },
-    { name = "transformers", specifier = "==5.6.2" },
+    { name = "transformers", specifier = "==5.16.0" },
 ]
 
 [[manifest.dependency-metadata]]
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "flashinfer-python"
-version = "0.6.16.post3"
+version = "0.6.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi" },
@@ -1920,9 +1920,9 @@ dependencies = [
     { name = "torch", version = "2.13.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/46/17045cb47b7b93fcb4e5303e398e6b129b86239930ac0875942a83d8b962/flashinfer_python-0.6.16.post3.tar.gz", hash = "sha256:9b146cfcc1454c80f3f99444db48013b3eadaeb32f2a399bd76c9471ecb72f04", size = 11076656, upload-time = "2026-08-08T01:14:16.408Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/72/12066c5f42a49e7eabe6ec445ac73c59785480bba1b763bd7e0a512f13c1/flashinfer_python-0.6.18.tar.gz", hash = "sha256:70a2074d78cb17ed39c98e5ed47f626c6e8bb29015cf028c49cbf8f2629405a1", size = 13286160, upload-time = "2026-08-29T02:09:18.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/dc/5367cb601fc9190cc75b4c141f5f7e9a224d1c26a1e983151823e02a25b3/flashinfer_python-0.6.16.post3-py3-none-any.whl", hash = "sha256:caf686b9b079abe1c9d65ab505698bd325e8072de40afd822f2c74f2ac3bc601", size = 15836034, upload-time = "2026-08-08T01:14:13.709Z" },
+    { url = "https://files.pythonhosted.org/packages/31/7d/3dae45fc293cd5f16cefe4dcf59683d964ca8faf2303ed7fff54f4bca490/flashinfer_python-0.6.18-py3-none-any.whl", hash = "sha256:d5d26edb48f8def0bf28b2c94415aef7f0754e2cd9e3cb3d6e7081262d068aad", size = 18347767, upload-time = "2026-08-29T02:09:15.868Z" },
 ]
 
 [[package]]
@@ -2726,6 +2726,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "instanttensor"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "torch", version = "2.13.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/69/a4dc4e0f0018a0e558b716e90bcb19cb6a8c7506f68e89a1493608cf5e62/instanttensor-0.1.9.tar.gz", hash = "sha256:d8692b97991c1a5fb2db7905b9a6ae90a7f967c7ddd853d35e41caa146750c02", size = 9618304, upload-time = "2026-05-27T21:33:46.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/01/667438b2c7b9caad3be48fe1363032574bb4a85d8d90b7a6e3ddf9979f53/instanttensor-0.1.9-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d957728161ec0d22a74bad3c0feb8fb9105736ab2585b48a0a0da8d330c6ff3", size = 5903991, upload-time = "2026-05-27T21:33:38.634Z" },
 ]
 
 [[package]]
@@ -5055,8 +5067,8 @@ all = [
     { name = "torchdata", marker = "sys_platform == 'linux'" },
     { name = "torchtitan", marker = "sys_platform == 'linux'" },
     { name = "torchvision", marker = "sys_platform == 'linux'" },
-    { name = "vllm", version = "0.28.0", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64' and sys_platform == 'linux'" },
-    { name = "vllm", version = "0.28.0", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.28.1rc1.dev359+g98ed0856f", source = { url = "https://wheels.vllm.ai/98ed0856f31fa3aaf5e27464e2b4ef5a8ee6b2f5/vllm-0.28.1rc1.dev359%2Bg98ed0856f-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.28.1rc1.dev359+g98ed0856f", source = { url = "https://wheels.vllm.ai/98ed0856f31fa3aaf5e27464e2b4ef5a8ee6b2f5/vllm-0.28.1rc1.dev359%2Bg98ed0856f-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "vllm-router", version = "0.2.0", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.2.0/vllm_router-0.2.0-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64' and sys_platform == 'linux'" },
     { name = "vllm-router", version = "0.2.0", source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.2.0/vllm_router-0.2.0-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
@@ -5105,8 +5117,8 @@ gpu = [
     { name = "torchdata", marker = "sys_platform == 'linux'" },
     { name = "torchtitan", marker = "sys_platform == 'linux'" },
     { name = "torchvision", marker = "sys_platform == 'linux'" },
-    { name = "vllm", version = "0.28.0", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64' and sys_platform == 'linux'" },
-    { name = "vllm", version = "0.28.0", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.28.1rc1.dev359+g98ed0856f", source = { url = "https://wheels.vllm.ai/98ed0856f31fa3aaf5e27464e2b4ef5a8ee6b2f5/vllm-0.28.1rc1.dev359%2Bg98ed0856f-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine != 'x86_64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.28.1rc1.dev359+g98ed0856f", source = { url = "https://wheels.vllm.ai/98ed0856f31fa3aaf5e27464e2b4ef5a8ee6b2f5/vllm-0.28.1rc1.dev359%2Bg98ed0856f-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 kernels = [
     { name = "prime-kernels", version = "0.1.0+cu130torch2.13.0", source = { url = "https://github.com/PrimeIntellect-ai/prime-kernels/releases/download/v0.1.1/prime_kernels-0.1.0+cu130torch2.13.0-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine != 'x86_64' and sys_platform == 'linux'" },
@@ -5197,13 +5209,13 @@ requires-dist = [
     { name = "torchdata", marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = ">=0.11.0" },
     { name = "torchtitan", marker = "sys_platform == 'linux' and extra == 'gpu'", git = "https://github.com/pytorch/torchtitan?rev=23e4dfc" },
     { name = "torchvision", marker = "sys_platform == 'linux' and extra == 'gpu'", index = "https://download.pytorch.org/whl/cu130" },
-    { name = "transformers", specifier = "==5.6.2" },
+    { name = "transformers", specifier = "==5.16.0" },
     { name = "uvicorn", marker = "extra == 'dashboard'", specifier = ">=0.30" },
     { name = "uvloop", specifier = ">=0.21.0" },
     { name = "verifiers", extras = ["harbor"], editable = "deps/verifiers" },
-    { name = "vllm", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_aarch64.whl" },
+    { name = "vllm", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://wheels.vllm.ai/98ed0856f31fa3aaf5e27464e2b4ef5a8ee6b2f5/vllm-0.28.1rc1.dev359%2Bg98ed0856f-cp38-abi3-manylinux_2_28_aarch64.whl" },
     { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", specifier = ">=0.28.0" },
-    { name = "vllm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_x86_64.whl" },
+    { name = "vllm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", url = "https://wheels.vllm.ai/98ed0856f31fa3aaf5e27464e2b4ef5a8ee6b2f5/vllm-0.28.1rc1.dev359%2Bg98ed0856f-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "vllm-router", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.2.0/vllm_router-0.2.0-cp38-abi3-manylinux_2_28_aarch64.whl" },
     { name = "vllm-router", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'disagg'" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.2.0/vllm_router-0.2.0-cp38-abi3-manylinux_2_28_x86_64.whl" },
@@ -6281,15 +6293,15 @@ wheels = [
 
 [[package]]
 name = "safetensors"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
-    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
 ]
 
 [[package]]
@@ -7175,19 +7187,19 @@ requires-dist = [{ name = "verifiers", extras = ["harbor"], specifier = ">=0.3.1
 
 [[package]]
 name = "tokenizers"
-version = "0.22.2"
+version = "0.23.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
     { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/1e/bc6587c5ab643b2e17776cace9070a2ae73549c86bffac9934a600bf3c31/tokenizers-0.23.2.tar.gz", hash = "sha256:7f0f085686b9de0d0079e6f874ae053600db64c5d13049e0bbc0119926d25aac", size = 385745, upload-time = "2026-09-03T08:55:42.89Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
-    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/67/49/22da045a91732384d3a3771816bf188dc5a1f702c32e635afa7c679c0bef/tokenizers-0.23.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:986670e43691469dcee610ea0f846f91a8f84e91fc6f7a48d4c064414c0ec2bf", size = 3101593, upload-time = "2026-09-03T08:55:28.587Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4d/8f569ed49372a3ed8e57099bd515055fd48d7c95912c4307cda6973c2168/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a37039b5dfc4af84eb3ef0a92f4307e28936c8f9adccba2629d36f652e9bf7a2", size = 3516830, upload-time = "2026-09-03T08:55:14.741Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ca/ca6b93c7820df123b2662a9469e8facc826ccc94e98fdd0d615f6431e73a/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41c2f84d172449b4dadb9cdc508e3e364076613c35b16e76ecfe47a60d1e3305", size = 3386843, upload-time = "2026-09-03T08:55:26.584Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/6a/1552b70fb0d9ab074fd3fc961435d01364e79c9058481822c3af6e8d402c/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:eb2f9c8a24da020ea8c11a01a19c1c2547912d92121ae4a01cfbca46125dee40", size = 9967367, upload-time = "2026-09-03T08:55:33.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d8/8e9e4e0b287a338d8f88976729628c9d22e8a54cfaf9777018a7f7cb58a0/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5c56bda1511921587789163e524d196ed8284174ac23abd7685d5ea8da6c4718", size = 10256304, upload-time = "2026-09-03T08:55:40.977Z" },
 ]
 
 [[package]]
@@ -7484,7 +7496,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.6.2"
+version = "5.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
@@ -7498,9 +7510,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/e9/c6c80a07690142a7d05444271f47b9f3c8aac7dea01d52e1137ee480ad78/transformers-5.6.2.tar.gz", hash = "sha256:e657134c3e5a6bc00a3c35f4e2674bb51adfcd89898495b788a18552bac2b91a", size = 8311867, upload-time = "2026-04-23T18:33:29.332Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/3b/51cf33e0c59f46d8e9cfdcee8fb6169a542728f822e0fa3c9f23967cb2ce/transformers-5.16.0.tar.gz", hash = "sha256:ef551c6d12e8c5c82b976720d8c1e6ed597fbed2c0f46c63be73a73ae80b9102", size = 9596373, upload-time = "2026-08-26T12:32:14.935Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/0b0218149b0d6f14df35f5b8f676fa83df4f19ed253c3cc447107ef86eca/transformers-5.6.2-py3-none-any.whl", hash = "sha256:f8d3a1bb96778fed9b8aabfd0dd6e19843e4b0f2bb6b59f32b8a92051b0f348f", size = 10364898, upload-time = "2026-04-23T18:33:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/b606c1a5d6a8aa6436bea8bfbbc0fce146859430db684debb5f740c216d3/transformers-5.16.0-py3-none-any.whl", hash = "sha256:2b4adda8d99bb4c1b208da5ed967e2625ad449087827a750cb3b23ce4000b139", size = 12014254, upload-time = "2026-08-26T12:32:10.987Z" },
 ]
 
 [[package]]
@@ -7914,8 +7926,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.28.0"
-source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_aarch64.whl" }
+version = "0.28.1rc1.dev359+g98ed0856f"
+source = { url = "https://wheels.vllm.ai/98ed0856f31fa3aaf5e27464e2b4ef5a8ee6b2f5/vllm-0.28.1rc1.dev359%2Bg98ed0856f-cp38-abi3-manylinux_2_28_aarch64.whl" }
 resolution-markers = [
     "platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
@@ -7937,6 +7949,7 @@ dependencies = [
     { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
     { name = "humming-kernels", extra = ["cu13"] },
     { name = "ijson" },
+    { name = "instanttensor" },
     { name = "jsonschema" },
     { name = "lark" },
     { name = "llguidance" },
@@ -7996,7 +8009,7 @@ dependencies = [
     { name = "xgrammar" },
 ]
 wheels = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:817b8181f7f61b4a62dc1d5d9ab39f2bfb60a6cb86c29879a78a147b85756787" },
+    { url = "https://wheels.vllm.ai/98ed0856f31fa3aaf5e27464e2b4ef5a8ee6b2f5/vllm-0.28.1rc1.dev359%2Bg98ed0856f-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a76bfbdbcc3cdb5e76078e8ca85b80a60e92314dababb807cdff5f0ae23c2a9" },
 ]
 
 [package.metadata]
@@ -8005,7 +8018,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.71.0" },
     { name = "apache-tvm-ffi", specifier = "==0.1.11" },
     { name = "av", marker = "extra == 'audio'" },
-    { name = "b12x", marker = "extra == 'b12x'", specifier = "==1.2.4" },
+    { name = "b12x", marker = "extra == 'b12x'", specifier = "==1.3.0" },
     { name = "blake3" },
     { name = "cachetools" },
     { name = "cbor2" },
@@ -8018,18 +8031,19 @@ requires-dist = [
     { name = "fastsafetensors", specifier = ">=0.3.3" },
     { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.3.3" },
     { name = "filelock", specifier = ">=3.16.1" },
-    { name = "flashinfer-python", specifier = "==0.6.16.post3" },
+    { name = "flashinfer-python", specifier = "==0.6.18" },
     { name = "helion", marker = "extra == 'helion'", specifier = "==1.4.0" },
-    { name = "huggingface-hub", specifier = ">=1.27.0" },
+    { name = "huggingface-hub", specifier = ">=1.28.0" },
     { name = "humming-kernels", extras = ["cu13"], specifier = "==0.1.12" },
     { name = "ijson" },
+    { name = "instanttensor", specifier = ">=0.1.9" },
     { name = "instanttensor", marker = "extra == 'instanttensor'", specifier = ">=0.1.9" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "lark", specifier = "==1.2.2" },
     { name = "llguidance", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'", specifier = ">=1.7.0,<1.8.0" },
     { name = "lm-format-enforcer", specifier = "==0.11.3" },
     { name = "matplotlib", marker = "extra == 'bench'" },
-    { name = "mcp" },
+    { name = "mcp", specifier = ">=2.0.0,<3.0.0" },
     { name = "mistral-common", extras = ["audio"], marker = "extra == 'audio'" },
     { name = "mistral-common", extras = ["image"], specifier = ">=1.11.6" },
     { name = "model-hosting-container-standards", specifier = ">=0.1.14,<1.0.0" },
@@ -8094,7 +8108,7 @@ requires-dist = [
     { name = "torchcodec", specifier = ">=0.14" },
     { name = "torchvision", specifier = "==0.28.0" },
     { name = "tqdm" },
-    { name = "transformers", specifier = ">=5.5.3" },
+    { name = "transformers", specifier = ">=5.10.4" },
     { name = "typing-extensions", specifier = ">=4.10" },
     { name = "vllm-gguf-plugin", marker = "extra == 'extra-quant'", specifier = ">=0.0.2" },
     { name = "watchfiles" },
@@ -8105,8 +8119,8 @@ provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttens
 
 [[package]]
 name = "vllm"
-version = "0.28.0"
-source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_x86_64.whl" }
+version = "0.28.1rc1.dev359+g98ed0856f"
+source = { url = "https://wheels.vllm.ai/98ed0856f31fa3aaf5e27464e2b4ef5a8ee6b2f5/vllm-0.28.1rc1.dev359%2Bg98ed0856f-cp38-abi3-manylinux_2_28_x86_64.whl" }
 resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
@@ -8128,6 +8142,7 @@ dependencies = [
     { name = "huggingface-hub", version = "1.28.0", source = { registry = "https://pypi.org/simple" } },
     { name = "humming-kernels", extra = ["cu13"] },
     { name = "ijson" },
+    { name = "instanttensor" },
     { name = "jsonschema" },
     { name = "lark" },
     { name = "llguidance" },
@@ -8187,7 +8202,7 @@ dependencies = [
     { name = "xgrammar" },
 ]
 wheels = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:addb0ffdaafd8155d75e9b3f5ddb3da28fdee9e8a7097ede91f7db2e9e1a3889" },
+    { url = "https://wheels.vllm.ai/98ed0856f31fa3aaf5e27464e2b4ef5a8ee6b2f5/vllm-0.28.1rc1.dev359%2Bg98ed0856f-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:e16f80f413f7932c349c6284bf418cdd0c6b3facd9c95b1b574f025735e66542" },
 ]
 
 [package.metadata]
@@ -8196,7 +8211,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.71.0" },
     { name = "apache-tvm-ffi", specifier = "==0.1.11" },
     { name = "av", marker = "extra == 'audio'" },
-    { name = "b12x", marker = "extra == 'b12x'", specifier = "==1.2.4" },
+    { name = "b12x", marker = "extra == 'b12x'", specifier = "==1.3.0" },
     { name = "blake3" },
     { name = "cachetools" },
     { name = "cbor2" },
@@ -8209,18 +8224,19 @@ requires-dist = [
     { name = "fastsafetensors", specifier = ">=0.3.3" },
     { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.3.3" },
     { name = "filelock", specifier = ">=3.16.1" },
-    { name = "flashinfer-python", specifier = "==0.6.16.post3" },
+    { name = "flashinfer-python", specifier = "==0.6.18" },
     { name = "helion", marker = "extra == 'helion'", specifier = "==1.4.0" },
-    { name = "huggingface-hub", specifier = ">=1.27.0" },
+    { name = "huggingface-hub", specifier = ">=1.28.0" },
     { name = "humming-kernels", extras = ["cu13"], specifier = "==0.1.12" },
     { name = "ijson" },
+    { name = "instanttensor", specifier = ">=0.1.9" },
     { name = "instanttensor", marker = "extra == 'instanttensor'", specifier = ">=0.1.9" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "lark", specifier = "==1.2.2" },
     { name = "llguidance", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'", specifier = ">=1.7.0,<1.8.0" },
     { name = "lm-format-enforcer", specifier = "==0.11.3" },
     { name = "matplotlib", marker = "extra == 'bench'" },
-    { name = "mcp" },
+    { name = "mcp", specifier = ">=2.0.0,<3.0.0" },
     { name = "mistral-common", extras = ["audio"], marker = "extra == 'audio'" },
     { name = "mistral-common", extras = ["image"], specifier = ">=1.11.6" },
     { name = "model-hosting-container-standards", specifier = ">=0.1.14,<1.0.0" },
@@ -8285,7 +8301,7 @@ requires-dist = [
     { name = "torchcodec", specifier = ">=0.14" },
     { name = "torchvision", specifier = "==0.28.0" },
     { name = "tqdm" },
-    { name = "transformers", specifier = ">=5.5.3" },
+    { name = "transformers", specifier = ">=5.10.4" },
     { name = "typing-extensions", specifier = ">=4.10" },
     { name = "vllm-gguf-plugin", marker = "extra == 'extra-quant'", specifier = ">=0.0.2" },
     { name = "watchfiles" },


### PR DESCRIPTION
## Summary

- add native GLM-5.3 Flash trainer support, including the `glm5_next` configuration, checkpoint conversion, model implementation, and focused model coverage
- add a four-node SWE ablation config for batch size 54 using 2 trainer nodes, 2 inference replicas, FP8/DeepGEMM, SignSGD, activation offload, and full trainer offload
- update the GLM-5.3 stack for Transformers 5.16 and the GLM-compatible vLLM development wheel
- make derived PrimeRL checkpoint conversion caches atomic and recover incomplete caches
- patch the active vLLM launcher API server so PrimeRL admin routes are installed with current vLLM
- use checkpoint-format weight transfer for GLM-5.3 until its quantized vLLM-kernel conversion is implemented
- isolate inference compiler caches by SLURM job and rank, preserve launcher-provided environment overrides, and use the pre-synced environment for multi-node subprocesses

## Configuration

- trainer: `zai-org/GLM-5.3-Flash-BF16`, CP8/EP8, FP8 dense weights, DeepGEMM FP8 MoE, activation checkpoint/offload, full CPU optimizer offload
- inference/orchestrator: `zai-org/GLM-5.3-Flash`, two 8-GPU inference replicas
- SWE ablation: batch size 54, group size 6, 131072-token context, three steps
- renderer: `glm-5.1` with `clear_thinking = false`

## Validation

- `uv run pytest -q tests/unit/inference tests/unit/train/models/test_glm5_next.py --disable-warnings` — 21 passed
- `uv run pytest -q tests/unit/transports/test_nccl_broadcast.py::test_batch_tensors_by_size tests/unit/inference --disable-warnings` — 19 passed during diagnosis; the temporary bounded-transfer change and its test were subsequently removed
- focused Ruff checks passed
- `uv run rl @ examples/advanced/glm-5.3/swe-ablation.toml --dry-run ...` passed
- `uv run rl @ examples/advanced/glm-5.3/swe-llmd.toml --dry-run ...` passed

## E2E status

An eight-node validation with 4 trainer nodes and 4 inference nodes reached healthy startup for all 32 inference workers, initialized all 32 trainer ranks with full CPU SignSGD offload, installed the PrimeRL admin endpoints, and formed the 33-rank NCCL broadcast group. Per-job/per-rank cache isolation eliminated concurrent DeepGEMM JIT collisions, and pre-synced subprocess launches eliminated shared uv metadata-lock timeouts.

It is **not yet rollout-complete**. With the original checkpoint broadcast protocol restored, startup broadcast requires a 13.81 GiB temporary inference CUDA allocation and OOMs. No rollout, forward/backward pass, optimizer step, or `mismatch_kl` metric was produced. The experimental bounded-transfer and per-layer reload-finalization changes were removed, as requested, and no validation job is active.
