### PR TITLE
chore(nixl): use device-agnostic torch calls in weight transfer

### DIFF
--- a/src/prime_rl/inference/vllm/worker/nixl.py
+++ b/src/prime_rl/inference/vllm/worker/nixl.py
@@ -482,7 +482,7 @@ class NIXLWeightUpdateWorker(Worker):
         started = time.perf_counter()
         self.apply_transfer_plan(plan)
         update_mla_absorbed_weights(self.raw_model)
-        torch.cuda.synchronize(self.device)
+        torch.accelerator.synchronize(self.device)
         logger.info(
             "Applied NIXL policy update on rank %d in %.2fs",
             self.model_express.rank,
@@ -527,7 +527,7 @@ class NIXLWeightUpdateWorker(Worker):
             return transfer_group
 
         def prefetch_group(group_index: int) -> WeightTransferGroup:
-            torch.cuda.set_device(self.device)
+            torch.accelerator.set_device_index(self.device)
             return pull_group(group_index)
 
         def replay_group(transfer_group: WeightTransferGroup) -> None:
@@ -568,12 +568,12 @@ class NIXLWeightUpdateWorker(Worker):
                 for group_index in range(len(plan.groups)):
                     transfer_group = pull.result() if pull is not None else pull_group(group_index)
 
-                    torch.cuda.synchronize(self.device)
+                    torch.accelerator.synchronize(self.device)
                     if executor is not None and group_index + 1 < len(plan.groups):
                         pull = executor.submit(prefetch_group, group_index + 1)
 
                     replay_group(transfer_group)
-                    torch.cuda.synchronize(self.device)
+                    torch.accelerator.synchronize(self.device)
             finally:
                 cancelled.set()
                 if executor is not None:

--- a/src/prime_rl/transports/weights/nixl/nixl.py
+++ b/src/prime_rl/transports/weights/nixl/nixl.py
@@ -80,7 +80,7 @@ class NIXLWeightSender(WeightSender):
         self.config = config
         self.parallel_dims = parallel_dims
         if self.is_serving_rank:
-            set_ucx_env_defaults(torch.cuda.current_device())
+            set_ucx_env_defaults(torch.accelerator.current_device_index())
             self.nixl_agent = NixlAgent(make_agent_name("trainer", self.world.rank))
         self.initialized = False
         self.transfer_group_names: list[str] = []
@@ -264,7 +264,7 @@ class NIXLWeightSender(WeightSender):
                 TrainerAgent(
                     name=self.nixl_agent.name,
                     metadata=self.nixl_agent.get_metadata(),
-                    device_id=torch.cuda.current_device(),
+                    device_id=torch.accelerator.current_device_index(),
                 )
             ],
             staging_buffer_count=self.staging_buffer_count,
@@ -422,7 +422,7 @@ class NIXLWeightSender(WeightSender):
             if self.is_serving_rank:
                 for shard in self.staged_shards_by_group.get(group, ()):
                     shard.copy_to_staging()
-                torch.cuda.synchronize()
+                torch.accelerator.synchronize()
                 notification = group_notification(group, self.group_generations[group])
                 for peer in self.inference_peers:
                     self.nixl_agent.send_notification(peer, notification)


### PR DESCRIPTION
## Change

Replace the hardcoded `torch.cuda` calls in the NIXL weight-transfer path with their
`torch.accelerator` equivalents, the API this repo already uses in
`src/prime_rl/utils/act_offloading.py`:

| before | after |
| --- | --- |
| `torch.cuda.synchronize(device)` | `torch.accelerator.synchronize(device)` |
| `torch.cuda.set_device(device)` | `torch.accelerator.set_device_index(device)` |
| `torch.cuda.current_device()` | `torch.accelerator.current_device_index()` |

Seven call sites across the vLLM update worker and the trainer-side sender. On a CUDA
accelerator each pair is the same underlying call, so this is a no-op: no new
abstraction, no config, no dispatch on device type.

`torch.accelerator.current_device_index()` requires torch >= 2.7; the project pins
torch >= 2.13.

## Verification

On an L40S/B200 (torch 2.13.0+cu130), `torch.accelerator.current_device_index()` returns the
same index as `torch.cuda.current_device()`, and both `synchronize(device)` and
`set_device_index(device)` accept the worker's `torch.device` and succeed.
