### PR TITLE
refactor(inference): use native vLLM weight reload and NCCL transfer

### DIFF
--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -76,6 +76,8 @@ uv run sft @ examples/basic/reverse-text/sft.toml --dry-run
 
 OpenAI-compatible API plus prime-rl custom endpoints (`/update_weights`, `/load_lora_adapter`, `/init_broadcaster`). Always use this entrypoint — never `vllm serve` directly. It starts a `vllm-router` on `server.port` (default 8000, the client-facing URL) fronting the engine on `backend_port` (default 8100); admin endpoints must target the engine port directly.
 
+Before debugging dependency import or version errors from a reused checkout, run `uv sync --all-extras --all-packages --locked`. Stale packages left in `.venv` can be imported even when they are absent from the lockfile; for example, a mismatched `flashinfer-cubin` can prevent vLLM from starting.
+
 ```bash
 uv run inference --vllm.model Qwen/Qwen3-0.6B
 uv run inference --vllm.model Qwen/Qwen3-0.6B --vllm.enforce-eager

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -5,6 +5,10 @@ import uvloop
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from starlette.datastructures import State
+from vllm.distributed.weight_transfer.base import (
+    WeightTransferInitRequest,
+    WeightTransferUpdateRequest,
+)
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.openai.api_server import init_app_state
 from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
@@ -79,7 +83,23 @@ async def resume(request: Request):
 @router.post("/update_weights")
 async def update_weights(request: Request):
     data = await request.json()
-    await engine_client(request).collective_rpc("update_weights_from_path", args=(data.get("weight_dir"),))
+    update_info = data.get("update_info")
+    if update_info is not None:
+        await engine_client(request).update_weights(WeightTransferUpdateRequest(update_info=update_info))
+    else:
+        await engine_client(request).collective_rpc("update_weights_from_path", args=(data.get("weight_dir"),))
+    return {"status": "ok"}
+
+
+@router.post("/start_weight_update")
+async def start_weight_update(request: Request):
+    await engine_client(request).start_weight_update()
+    return {"status": "ok"}
+
+
+@router.post("/finish_weight_update")
+async def finish_weight_update(request: Request):
+    await engine_client(request).finish_weight_update()
     return {"status": "ok"}
 
 
@@ -140,10 +160,22 @@ async def init_broadcaster(request: Request):
     inference_world_size = data.get("inference_world_size")
     quantize_in_weight_transfer = data.get("quantize_in_weight_transfer", False)
     session_id = data.get("session_id", "default")
-    await engine_client(request).collective_rpc(
-        "init_broadcaster",
-        args=(host, port, rank_offset, inference_world_size, timeout, quantize_in_weight_transfer, session_id),
-    )
+    if quantize_in_weight_transfer:
+        await engine_client(request).collective_rpc(
+            "init_broadcaster",
+            args=(host, port, rank_offset, inference_world_size, timeout, True, session_id),
+        )
+    else:
+        await engine_client(request).init_weight_transfer_engine(
+            WeightTransferInitRequest(
+                init_info={
+                    "master_address": host,
+                    "master_port": port,
+                    "rank_offset": rank_offset + 1,
+                    "world_size": inference_world_size + 1,
+                }
+            )
+        )
     return {"status": "ok"}
 
 
@@ -229,8 +261,11 @@ def server(config: InferenceConfig):
     assert args is not None
     validate_parsed_serve_args(args)
 
-    # Set the worker extension class based on the broadcast backend
+    # Default NCCL uses vLLM's native worker lifecycle; the extension remains
+    # available for liveness and the custom quantized transfer path.
     args.worker_extension_cls = WORKER_EXTENSION_CLS[config.weight_broadcast.type]
+    if config.weight_broadcast.type == "nccl":
+        args.weight_transfer_config = {"backend": "nccl"}
 
     if args.headless or args.api_server_count < 1:
         run_headless(args)

--- a/src/prime_rl/inference/vllm/worker/filesystem.py
+++ b/src/prime_rl/inference/vllm/worker/filesystem.py
@@ -1,10 +1,5 @@
 from typing import TYPE_CHECKING
 
-from torch.nn import Module
-from vllm.model_executor.model_loader import DefaultModelLoader, get_model_loader
-
-from prime_rl.inference.vllm.worker.weight_transfer import load_weights_checkpoint_layerwise
-
 # This is to get type hints for the Worker class but not actually extend it at runtime as this is required by vLLM worker extension
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
@@ -26,30 +21,5 @@ class FileSystemWeightUpdateWorker(Worker):
         return None
 
     def update_weights_from_path(self, weight_path: str) -> None:
-        """Update weights from a specified path in shared filesystem containing a HF-compatible checkpoint."""
-        # Get vLLM model runner and model
-        # When enforce_eager=True, model isn't wrapped by torch.compile so no .runnable attr
-        model_runner = self.model_runner
-        if hasattr(model_runner.model, "runnable"):
-            model = model_runner.model.runnable
-        else:
-            model = model_runner.model
-        assert isinstance(model, Module)
-
-        # Get vLLM model loader
-        model_loader = get_model_loader(self.load_config)
-        assert isinstance(model_loader, DefaultModelLoader)
-        local_source = DefaultModelLoader.Source(
-            weight_path,
-            revision=None,  # TODO: Check that this is correct or if we should use the default (model_config.revision)
-            prefix="",
-            fall_back_to_pt=getattr(model, "fall_back_to_pt_during_load", True),
-            allow_patterns_overrides=getattr(model, "allow_patterns_overrides", None),
-        )
-        weights_iterator = model_loader._get_weights_iterator(local_source)
-        load_weights_checkpoint_layerwise(
-            model,
-            weights_iterator,
-            self.model_runner.model_config,
-            self.vllm_config,
-        )
+        """Update weights from a specified path containing an HF-compatible checkpoint."""
+        self.reload_weights(weights_path=weight_path)

--- a/src/prime_rl/orchestrator/clients.py
+++ b/src/prime_rl/orchestrator/clients.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from collections.abc import Callable
 from pathlib import Path
@@ -15,6 +16,7 @@ from verifiers.v1.configs.client import EvalClientConfig, TrainClientConfig
 
 from prime_rl.configs.shared import ClientConfig
 from prime_rl.utils.logger import get_logger
+from prime_rl.utils.pathing import wait_for_path
 
 
 class PrefillScorer:
@@ -258,6 +260,12 @@ ADMIN_TIMEOUT_S = 300.0
 # can take longer than the other admin ops.
 UPDATE_WEIGHTS_TIMEOUT_S = 720.0
 
+NCCL_MANIFEST = "NCCL_MANIFEST.json"
+
+
+def get_nccl_chunk_manifest(weight_dir: Path, chunk_id: int) -> Path:
+    return weight_dir / f"NCCL_CHUNK_{chunk_id}.json"
+
 
 async def _admin_post(client: AsyncClient, path: str, *, timeout_s: float = ADMIN_TIMEOUT_S, **kwargs) -> None:
     """POST an admin op with a bounded per-attempt timeout, retrying transient errors.
@@ -277,6 +285,16 @@ async def _admin_post(client: AsyncClient, path: str, *, timeout_s: float = ADMI
                 **kwargs,
             )
             response.raise_for_status()
+
+
+async def _admin_post_once(client: AsyncClient, path: str, *, timeout_s: float = ADMIN_TIMEOUT_S, **kwargs) -> None:
+    """POST a non-idempotent admin operation exactly once."""
+    response = await client.post(
+        path,
+        timeout=httpx.Timeout(connect=10.0, read=timeout_s, write=60.0, pool=10.0),
+        **kwargs,
+    )
+    response.raise_for_status()
 
 
 async def _pause_engines(admin_clients: list[AsyncClient], *, step: int) -> None:
@@ -300,11 +318,40 @@ async def _resume_engines(admin_clients: list[AsyncClient]) -> None:
     logger.debug("All inference engines resumed")
 
 
+async def _receive_native_nccl_weights(admin_clients: list[AsyncClient], weight_dir: Path) -> None:
+    """Drive vLLM's native worker update lifecycle while the trainer sends chunks."""
+    manifest_path = weight_dir / NCCL_MANIFEST
+    manifest_path.unlink(missing_ok=True)
+    for chunk_manifest in weight_dir.glob("NCCL_CHUNK_*.json"):
+        chunk_manifest.unlink()
+
+    await asyncio.gather(*[_admin_post_once(client, "/start_weight_update") for client in admin_clients])
+    await wait_for_path(manifest_path, interval=0.1, log_interval=10)
+    num_chunks = int(json.loads(manifest_path.read_text())["num_chunks"])
+    for chunk_id in range(num_chunks):
+        chunk_path = get_nccl_chunk_manifest(weight_dir, chunk_id)
+        await wait_for_path(chunk_path, interval=0.1, log_interval=10)
+        update_info = json.loads(chunk_path.read_text())
+        await asyncio.gather(
+            *[
+                _admin_post_once(
+                    client,
+                    "/update_weights",
+                    json={"update_info": update_info},
+                    timeout_s=UPDATE_WEIGHTS_TIMEOUT_S,
+                )
+                for client in admin_clients
+            ]
+        )
+    await asyncio.gather(*[_admin_post_once(client, "/finish_weight_update") for client in admin_clients])
+
+
 async def update_weights(
     admin_clients: list[AsyncClient],
     weight_dir: Path | None,
     step: int = 0,
     on_paused: Callable[[], None] | None = None,
+    native_nccl: bool = False,
 ) -> None:
     """Update weights on static inference servers.
 
@@ -320,22 +367,30 @@ async def update_weights(
     weight_dir_posix = weight_dir.as_posix() if weight_dir is not None else None
 
     await _pause_engines(admin_clients, step=step)
+    update_succeeded = False
     try:
         if on_paused is not None:
             on_paused()
-        await asyncio.gather(
-            *[
-                _admin_post(
-                    admin_client,
-                    "/update_weights",
-                    json={"weight_dir": weight_dir_posix},
-                    timeout_s=UPDATE_WEIGHTS_TIMEOUT_S,
-                )
-                for admin_client in admin_clients
-            ]
-        )
+        if native_nccl:
+            if weight_dir is None:
+                raise ValueError("Native NCCL updates require a weight directory")
+            await _receive_native_nccl_weights(admin_clients, weight_dir)
+        else:
+            await asyncio.gather(
+                *[
+                    _admin_post(
+                        admin_client,
+                        "/update_weights",
+                        json={"weight_dir": weight_dir_posix},
+                        timeout_s=UPDATE_WEIGHTS_TIMEOUT_S,
+                    )
+                    for admin_client in admin_clients
+                ]
+            )
+        update_succeeded = True
     finally:
-        await _resume_engines(admin_clients)
+        if update_succeeded or not native_nccl:
+            await _resume_engines(admin_clients)
 
 
 def _is_retryable_lora_error(exception: BaseException) -> bool:

--- a/src/prime_rl/transports/weights/nccl.py
+++ b/src/prime_rl/transports/weights/nccl.py
@@ -1,3 +1,4 @@
+import json
 import pickle
 from pathlib import Path
 from typing import Callable, Generator, cast
@@ -9,9 +10,11 @@ from torch import Tensor
 from torch.distributed.tensor import DTensor
 from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
 from vllm.distributed.utils import StatelessProcessGroup
+from vllm.distributed.weight_transfer.nccl_common import trainer_init
+from vllm.distributed.weight_transfer.nccl_engine import NCCLTrainerInitInfo
 
 from prime_rl.configs.trainer import NCCLWeightBroadcastConfig
-from prime_rl.orchestrator.clients import init_nccl_broadcast, update_weights
+from prime_rl.orchestrator.clients import NCCL_MANIFEST, get_nccl_chunk_manifest, init_nccl_broadcast, update_weights
 from prime_rl.trainer.conversion_utils import get_max_layer_num
 from prime_rl.trainer.models import PreTrainedModelPrimeRL
 from prime_rl.trainer.utils import get_world
@@ -123,25 +126,38 @@ class NCCLBroadcaster:
 
         if self.world.is_master:
             disable_nccl_p2p_if_unavailable()
-            # Trainer is on rank 0 in process group with all inference GPUs
-            pg = StatelessProcessGroup.create(
-                host=host, port=port, rank=rank, world_size=world_size, store_timeout=timeout
-            )
-            self.communicator = PyNcclCommunicator(pg, device=device)
+            if quantize_in_weight_transfer:
+                pg = StatelessProcessGroup.create(
+                    host=host, port=port, rank=rank, world_size=world_size, store_timeout=timeout
+                )
+                self.communicator = PyNcclCommunicator(pg, device=device)
+            else:
+                self.communicator = trainer_init(
+                    NCCLTrainerInitInfo(
+                        master_address=host,
+                        master_port=port,
+                        world_size=world_size,
+                        packed=False,
+                        rank=rank,
+                    )
+                )
             self.logger.debug("Initialized NCCL broadcast on master rank")
         else:
             self.logger.debug("Initialized NCCL broadcast on non-master rank (no communicator)")
 
     @torch.no_grad()
-    def send(self, model: nn.Module) -> None:
+    def send(self, model: nn.Module, step_dir: Path) -> None:
         """Broadcast the state dict of a model into the inference pool using NCCL."""
         state_dict = model.state_dict()
         layer_prefix = get_layer_prefix(model.config)
         num_layers = get_max_layer_num(state_dict, layer_prefix)
         num_state_dict_to_send = num_layers + 1  # we send all layer plus the remaining weights
 
-        if self.world.is_master:
+        if self.world.is_master and self.quantize_in_weight_transfer:
             broadcast_integer(num_state_dict_to_send, self.communicator)
+
+        if self.world.is_master and not self.quantize_in_weight_transfer:
+            self._write_manifest(step_dir / NCCL_MANIFEST, {"num_chunks": num_state_dict_to_send})
 
         self.logger.debug(f"Broadcasting {num_state_dict_to_send} layer state dicts")
         preprocess_fn: Callable[[nn.Module, dict[str, Tensor], int], dict[str, Tensor]]
@@ -154,7 +170,29 @@ class NCCLBroadcaster:
             layer_state_dict = self._resolve_dtensors(layer_state_dict)
             layer_state_dict = preprocess_fn(model, layer_state_dict, layer_id)
             if self.world.is_master:
-                broadcast_state_dict(layer_state_dict, self.communicator)
+                if self.quantize_in_weight_transfer:
+                    broadcast_state_dict(layer_state_dict, self.communicator)
+                else:
+                    update_info = {
+                        "names": list(layer_state_dict),
+                        "dtype_names": [
+                            str(tensor.dtype).removeprefix("torch.") for tensor in layer_state_dict.values()
+                        ],
+                        "shapes": [list(tensor.shape) for tensor in layer_state_dict.values()],
+                    }
+                    self._write_manifest(
+                        get_nccl_chunk_manifest(step_dir, layer_id + 1),
+                        update_info,
+                    )
+                    for tensor in layer_state_dict.values():
+                        send = tensor if tensor.is_contiguous() else tensor.contiguous()
+                        self.communicator.broadcast(send, src=0)
+
+    @staticmethod
+    def _write_manifest(path: Path, payload: dict) -> None:
+        temporary_path = path.with_suffix(f"{path.suffix}.tmp")
+        temporary_path.write_text(json.dumps(payload))
+        temporary_path.replace(path)
 
     def _resolve_dtensors(self, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
         for key, value in list(state_dict.items()):
@@ -192,7 +230,7 @@ class NCCLWeightSender(WeightSender):
         # the collectives sit unmatched until NCCL's watchdog kills the process.
         if self.world.world_size > 1:
             dist.barrier()
-        self.nccl_broadcast_sender.send(model)
+        self.nccl_broadcast_sender.send(model, step_dir)
 
 
 class NCCLWeightReceiver(WeightReceiver):
@@ -217,4 +255,5 @@ class NCCLWeightReceiver(WeightReceiver):
             self.step_dir(step),
             step=step,
             on_paused=lambda: self._ack(step),
+            native_nccl=not self.config.quantize_in_weight_transfer,
         )

--- a/tests/unit/orchestrator/test_clients.py
+++ b/tests/unit/orchestrator/test_clients.py
@@ -6,7 +6,13 @@ import httpx
 from verifiers.v1.configs.client import EvalClientConfig
 
 from prime_rl.configs.shared import ClientConfig
-from prime_rl.orchestrator.clients import _is_retryable_lora_error, check_health, load_lora_adapter, setup_client
+from prime_rl.orchestrator.clients import (
+    _is_retryable_lora_error,
+    check_health,
+    load_lora_adapter,
+    setup_client,
+    update_weights,
+)
 
 
 def test_is_retryable_lora_error_returns_true_for_404():
@@ -117,3 +123,32 @@ def test_setup_client_preserves_chat_client_defaults():
         base_url="http://worker-a:8000/v1",
         headers={},
     )
+
+
+def test_update_weights_uses_native_nccl_lifecycle(tmp_path: Path):
+    client = AsyncMock()
+    on_paused = MagicMock()
+
+    with (
+        patch("prime_rl.orchestrator.clients._pause_engines", new=AsyncMock()) as pause,
+        patch("prime_rl.orchestrator.clients._resume_engines", new=AsyncMock()) as resume,
+        patch(
+            "prime_rl.orchestrator.clients._receive_native_nccl_weights",
+            new=AsyncMock(),
+            create=True,
+        ) as receive,
+    ):
+        asyncio.run(
+            update_weights(
+                [client],
+                tmp_path,
+                step=7,
+                on_paused=on_paused,
+                native_nccl=True,
+            )
+        )
+
+    pause.assert_awaited_once_with([client], step=7)
+    on_paused.assert_called_once_with()
+    receive.assert_awaited_once_with([client], tmp_path)
+    resume.assert_awaited_once_with([client])


### PR DESCRIPTION
## Summary

- rebase the native vLLM weight-transfer work from #3260 onto current Prime-RL main
- use vLLM `reload_weights` for filesystem checkpoint reloads
- use vLLM native NCCL initialization and start/update/finish lifecycle for unquantized transfers
- retain the existing custom path for quantized weight transfer
- publish per-chunk metadata atomically and avoid retrying non-idempotent lifecycle operations

This branch is based on Prime-RL main after the vLLM 0.28.0 upgrade in #3430. It is intended as the current-main replacement for #3260 and as the base for the rebased Dynamo integration work.

## Validation

- `uv run ruff check src/prime_rl/inference/vllm/server.py src/prime_rl/inference/vllm/worker/filesystem.py src/prime_rl/orchestrator/clients.py src/prime_rl/transports/weights/nccl.py tests/unit/orchestrator/test_clients.py`
- `uv run pytest tests/unit/orchestrator/test_clients.py -q` — 10 passed
- `git diff --check origin/main...HEAD`