### PR TITLE
feat: carry SFT progress on samples and batches

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -240,6 +240,7 @@ Pulled from the console log and mirrored to W&B.
 - `val/loss`, `val/perplexity` — validation metrics when `[val]` is set, logged every `val.interval` steps.
 - `eval/{env}/...` — online eval metrics when `[eval]` is set, logged at each evaluated checkpoint step.
 - `progress/epoch`, `progress/num_samples`, `progress/num_tokens` — dataset progress.
+- `progress/ratio_padding_tokens` — fraction of the step's batch tokens that are padding (packing efficiency).
 - `progress/<subset>/ratio_{samples,tokens}` — when training on multiple HF subsets/splits, the realized mixing ratio.
 
 **Stability and optimization:**

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -1,7 +1,9 @@
 import json
 import uuid
 from collections import defaultdict
-from typing import Any, Literal, TypedDict, cast
+from dataclasses import dataclass, replace
+from functools import partial
+from typing import Any, Literal, cast
 
 import numpy as np
 import torch
@@ -20,24 +22,79 @@ from prime_rl.utils.chat_template import deserialize_tool_calls, normalize_messa
 from prime_rl.utils.logger import get_logger
 
 
-class Sample(TypedDict):
+@dataclass
+class Sample:
+    """One rendered training sample, carrying where in the dataset it came from."""
+
     input_ids: list[int]
     position_ids: list[int]
     loss_mask: list[bool]
     target_ids: list[int]
-    seq_lens: list[int]
-    mm_kwargs: dict[str, Tensor] | None
-    mm_token_type_ids: list[int] | None
+    mm_kwargs: dict[str, Tensor] | None = None
+    mm_token_type_ids: list[int] | None = None
+    source: str | None = None
+    step: int = 0
+    epoch: int = 0
+
+    @property
+    def num_tokens(self) -> int:
+        return len(self.input_ids)
 
 
-class Batch(TypedDict):
+@dataclass
+class Batch:
+    """One fixed-length row of packed samples, as CPU tensors ready for the forward pass."""
+
     input_ids: Int[Tensor, "batch seq"]
     position_ids: Int[Tensor, "batch seq"]
     target_ids: Int[Tensor, "batch seq"]
     loss_mask: Bool[Tensor, "batch seq"]
     seq_lens: Int[Tensor, "packed"]
+    samples: list[Sample]
     mm_kwargs: dict[str, Tensor] | None
     mm_token_type_ids: Int[Tensor, "batch seq"] | None
+
+    @property
+    def step(self) -> int:
+        """Furthest dataset position among the packed samples."""
+        return max(sample.step for sample in self.samples)
+
+    @property
+    def epoch(self) -> int:
+        return max(sample.epoch for sample in self.samples)
+
+    @property
+    def num_samples_by_source(self) -> dict[str | None, int]:
+        num_samples: dict[str | None, int] = defaultdict(int)
+        for sample in self.samples:
+            num_samples[sample.source] += 1
+        return dict(num_samples)
+
+    @property
+    def num_tokens_by_source(self) -> dict[str | None, int]:
+        num_tokens: dict[str | None, int] = defaultdict(int)
+        for sample in self.samples:
+            num_tokens[sample.source] += sample.num_tokens
+        return dict(num_tokens)
+
+    @property
+    def num_padding_tokens(self) -> int:
+        return max(0, self.input_ids.numel() - sum(sample.num_tokens for sample in self.samples))
+
+    def pin_memory(self) -> "Batch":
+        # The dataloader's pin-memory thread pins custom batch types through this method
+        return replace(
+            self,
+            input_ids=self.input_ids.pin_memory(),
+            position_ids=self.position_ids.pin_memory(),
+            target_ids=self.target_ids.pin_memory(),
+            loss_mask=self.loss_mask.pin_memory(),
+            seq_lens=self.seq_lens.pin_memory(),
+            mm_kwargs={key: value.pin_memory() for key, value in self.mm_kwargs.items()}
+            if self.mm_kwargs is not None
+            else None,
+            mm_token_type_ids=self.mm_token_type_ids.pin_memory() if self.mm_token_type_ids is not None else None,
+        )
 
 
 class StatefulIterableDataset(Stateful, IterableDataset):
@@ -45,8 +102,6 @@ class StatefulIterableDataset(Stateful, IterableDataset):
 
     def __init__(self, non_dp_size: int = 1):
         self.step, self.epoch = 0, 0
-        self.num_samples = defaultdict(int)
-        self.num_tokens = defaultdict(int)
         self.fast_forward = False
         self.non_dp_size = non_dp_size
         self._setup_world_info()
@@ -127,20 +182,14 @@ class FakeDataset(StatefulIterableDataset):
 
             seq_len, random_input_ids = self._draw_sample(generator)
             input_ids = [self.step - 1] * (seq_len + 1) if random_input_ids is None else random_input_ids
-            position_ids = list(range(seq_len))
-            loss_mask = [True] * seq_len
-            fake_sample = {
-                "input_ids": input_ids[:-1],
-                "target_ids": input_ids[1:],
-                "position_ids": position_ids,
-                "loss_mask": loss_mask,
-                "seq_lens": [seq_len],
-                "mm_kwargs": None,
-                "mm_token_type_ids": None,
-            }
-            self.num_samples["fake"] += 1
-            self.num_tokens["fake"] += len(input_ids)
-            yield fake_sample
+            yield Sample(
+                input_ids=input_ids[:-1],
+                target_ids=input_ids[1:],
+                position_ids=list(range(seq_len)),
+                loss_mask=[True] * seq_len,
+                source="fake",
+                step=self.step,
+            )
 
 
 def _flatten_mm_items(mm_items: dict[str, list[dict[str, Any]]]) -> dict[str, Tensor]:
@@ -238,7 +287,7 @@ class SFTDataset(StatefulIterableDataset):
             self.num_examples = min(self.num_examples, self.max_examples)
             self.dataset = self.dataset.take(self.max_examples)
 
-    def _process(self, example: dict) -> dict | None:
+    def _process(self, example: dict) -> Sample | None:
         def resolve_messages(example: dict) -> list[dict]:
             # `messages` takes precedence over explicit split fields and is interpreted
             # as a whole-chat training sample with an empty prompt. Null-check rather
@@ -377,15 +426,15 @@ class SFTDataset(StatefulIterableDataset):
         if mm_token_type_ids is not None:
             assert len(mm_token_type_ids) == len(input_ids)
 
-        return {
-            "input_ids": input_ids,
-            "target_ids": target_ids,
-            "loss_mask": loss_mask,
-            "position_ids": list(range(len(input_ids))),
-            "seq_lens": [len(input_ids)],
-            "mm_kwargs": mm_kwargs,
-            "mm_token_type_ids": mm_token_type_ids,
-        }
+        return Sample(
+            input_ids=input_ids,
+            target_ids=target_ids,
+            loss_mask=loss_mask,
+            position_ids=list(range(len(input_ids))),
+            mm_kwargs=mm_kwargs,
+            mm_token_type_ids=mm_token_type_ids,
+            source=example.get("__subset") or example.get("__split"),
+        )
 
     def __iter__(self):
         self._setup_world_info()
@@ -413,58 +462,44 @@ class SFTDataset(StatefulIterableDataset):
             example = dataset[(self.step - 1) % self.num_examples]
 
             # Process example
-            processed_example = self._process(cast(dict, example))
+            sample = self._process(cast(dict, example))
 
             # If processed example is None, skip it (e.g. if tokenized sample exceeds context window)
-            if processed_example is None:
+            if sample is None:
                 continue
 
             # Yield the example
+            sample.step, sample.epoch = self.step, self.epoch
             example = cast(dict, example)
-            subset_or_split = example.get("__subset") or example.get("__split")
             self.logger.debug(
                 f"Yield example {example.get('__index', '')}"
-                + (f" from {subset_or_split} " if subset_or_split else " ")
-                + f"with {len(processed_example.get('input_ids', []))} tokens ({sum(processed_example.get('loss_mask', []))} trainable tokens)"
+                + (f" from {sample.source} " if sample.source else " ")
+                + f"with {sample.num_tokens} tokens ({sum(sample.loss_mask)} trainable tokens)"
             )
-            self.num_samples[subset_or_split] += 1
-            self.num_tokens[subset_or_split] += len(processed_example.get("input_ids", []))
-            yield processed_example
+            yield sample
 
 
 class CatDataset(StatefulIterableDataset):
-    """Concatenate text and multimodal samples into one fixed-length row."""
+    """Group samples into packs that together fill one fixed-length row."""
 
     def __init__(self, dataset: StatefulIterableDataset, seq_len: int):
-        self.logger = get_logger()
         self.dataset = dataset
         self.seq_len = seq_len
         self.pending_sample: Sample | None = None
 
     def state_dict(self) -> dict:
-        state = {
-            "dataset": self.dataset.state_dict(),
-            "progress": {
-                "num_samples": dict(self.dataset.num_samples),
-                "num_tokens": dict(self.dataset.num_tokens),
-            },
-        }
+        state = {"dataset": self.dataset.state_dict()}
         if self.pending_sample is not None:
             state["pending_sample"] = self.pending_sample
         return state
 
     def load_state_dict(self, state_dict: dict):
         self.dataset.load_state_dict(state_dict["dataset"])
-        progress = state_dict.get("progress", {})
-        self.dataset.num_samples.update(progress.get("num_samples", {}))
-        self.dataset.num_tokens.update(progress.get("num_tokens", {}))
         self.pending_sample = state_dict.get("pending_sample")
 
     def __iter__(self):
-        packed_samples = defaultdict(list)
-        packed_samples["mm_kwargs"] = None
-        packed_samples["mm_token_type_ids"] = None
-        seq_len = 0
+        pack: list[Sample] = []
+        pack_len = 0
 
         pending_sample = self.pending_sample
         self.pending_sample = None
@@ -475,104 +510,102 @@ class CatDataset(StatefulIterableDataset):
             yield from self.dataset
 
         for sample in samples():
-            sample_len = len(sample["input_ids"])
-            would_overflow = seq_len + sample_len > self.seq_len
-            if seq_len > 0 and would_overflow:
+            if pack and pack_len + sample.num_tokens > self.seq_len:
+                # Stash the overflowing sample so a checkpoint taken now doesn't lose it
                 self.pending_sample = sample
-                yield self._finalize_pack(packed_samples, self.seq_len)
+                yield pack
                 self.pending_sample = None
-                packed_samples = defaultdict(list)
-                packed_samples["mm_kwargs"] = None
-                packed_samples["mm_token_type_ids"] = None
-                seq_len = 0
+                pack, pack_len = [], 0
 
-            existing_len = len(packed_samples["input_ids"])
-            for key in ("input_ids", "position_ids", "loss_mask", "target_ids"):
-                value = sample[key]
-                assert isinstance(value, list)
-                packed_samples[key].extend(value)
-            packed_samples["seq_lens"].append(sample_len)
+            pack.append(sample)
+            pack_len += sample.num_tokens
 
-            sample_mm_kwargs = sample.get("mm_kwargs")
-            sample_mm_type_ids = sample.get("mm_token_type_ids")
-            if sample_mm_kwargs is None:
-                if packed_samples["mm_token_type_ids"] is not None:
-                    packed_samples["mm_token_type_ids"].extend([0] * sample_len)
-            else:
-                if packed_samples["mm_kwargs"] is not None and (
-                    (packed_samples["mm_token_type_ids"] is None) != (sample_mm_type_ids is None)
-                ):
-                    raise ValueError("Cannot pack multimodal samples with mixed mm_token_type_ids")
+            if pack_len >= self.seq_len:
+                yield pack
+                pack, pack_len = [], 0
 
-                if packed_samples["mm_kwargs"] is None:
-                    packed_samples["mm_kwargs"] = dict(sample_mm_kwargs)
-                else:
-                    if packed_samples["mm_kwargs"].keys() != sample_mm_kwargs.keys():
-                        raise ValueError("Cannot pack multimodal samples with different mm_kwargs keys")
-                    for key, value in sample_mm_kwargs.items():
-                        packed_samples["mm_kwargs"][key] = torch.cat([packed_samples["mm_kwargs"][key], value], dim=0)
+        if pack:
+            yield pack
 
-                if packed_samples["mm_token_type_ids"] is None and sample_mm_type_ids is not None:
-                    packed_samples["mm_token_type_ids"] = [0] * existing_len
-                if packed_samples["mm_token_type_ids"] is not None:
-                    packed_samples["mm_token_type_ids"].extend(sample_mm_type_ids or [0] * sample_len)
 
-            seq_len += sample_len
+def cat_collate(packs: list[list[Sample]], seq_len: int) -> Batch:
+    """Concatenate one pack of samples into a fixed-length row, truncating and padding to ``seq_len``.
 
-            if seq_len >= self.seq_len:
-                yield self._finalize_pack(packed_samples, self.seq_len)
-                packed_samples = defaultdict(list)
-                packed_samples["mm_kwargs"] = None
-                packed_samples["mm_token_type_ids"] = None
-                seq_len = 0
+    CPU tensors only: this runs in dataloader workers then the trainer moves batches to the GPU
+    with async copies from pinned memory."""
+    (pack,) = packs
 
-        if seq_len > 0:
-            yield self._finalize_pack(packed_samples, self.seq_len)
+    input_ids: list[int] = []
+    position_ids: list[int] = []
+    loss_mask: list[bool] = []
+    target_ids: list[int] = []
+    mm_kwargs: dict[str, Tensor] | None = None
+    mm_token_type_ids: list[int] | None = None
 
-    def _finalize_pack(self, packed: dict[str, Any], seq_len: int) -> dict:
-        result: dict[str, Any] = {
-            k: packed[k][:seq_len] for k in ("input_ids", "position_ids", "loss_mask", "target_ids")
-        }
-        result["seq_lens"] = []
-        remaining = len(result["input_ids"])
-        for sample_len in packed["seq_lens"]:
-            if remaining <= 0:
-                break
-            kept = min(sample_len, remaining)
-            if kept > 0:
-                result["seq_lens"].append(kept)
-            remaining -= kept
-        pad_len = seq_len - len(result["input_ids"])
-        if pad_len > 0:
-            result["input_ids"].extend([0] * pad_len)
-            result["position_ids"].extend(range(pad_len))
-            result["loss_mask"].extend([False] * pad_len)
-            result["target_ids"].extend([0] * pad_len)
-            result["seq_lens"][-1] += pad_len
-        result["mm_kwargs"] = packed["mm_kwargs"]
-        if packed["mm_token_type_ids"] is not None:
-            result["mm_token_type_ids"] = packed["mm_token_type_ids"][:seq_len] + [0] * pad_len
+    for sample in pack:
+        existing_len = len(input_ids)
+        input_ids.extend(sample.input_ids)
+        position_ids.extend(sample.position_ids)
+        loss_mask.extend(sample.loss_mask)
+        target_ids.extend(sample.target_ids)
+
+        if sample.mm_kwargs is None:
+            if mm_token_type_ids is not None:
+                mm_token_type_ids.extend([0] * sample.num_tokens)
         else:
-            result["mm_token_type_ids"] = None
-        return result
+            if mm_kwargs is not None and ((mm_token_type_ids is None) != (sample.mm_token_type_ids is None)):
+                raise ValueError("Cannot pack multimodal samples with mixed mm_token_type_ids")
 
+            if mm_kwargs is None:
+                mm_kwargs = dict(sample.mm_kwargs)
+            else:
+                if mm_kwargs.keys() != sample.mm_kwargs.keys():
+                    raise ValueError("Cannot pack multimodal samples with different mm_kwargs keys")
+                for key, value in sample.mm_kwargs.items():
+                    mm_kwargs[key] = torch.cat([mm_kwargs[key], value], dim=0)
 
-def cat_collate(samples: list[Sample]) -> Batch:
-    # CPU tensors only: this runs in dataloader workers then the trainer moves batches to the GPU with async copies from pinned memory
-    (sample,) = samples
-    mm_kwargs = sample.get("mm_kwargs")
-    mm_token_type_ids = sample.get("mm_token_type_ids")
-    return {
-        "input_ids": torch.tensor(sample["input_ids"], dtype=torch.long).unsqueeze(0),
-        "position_ids": torch.tensor(sample["position_ids"], dtype=torch.long).unsqueeze(0),
-        "loss_mask": torch.tensor(sample["loss_mask"], dtype=torch.bool).unsqueeze(0),
-        "target_ids": torch.tensor(sample["target_ids"], dtype=torch.long).unsqueeze(0),
-        "seq_lens": torch.tensor(sample["seq_lens"], dtype=torch.long),
-        "mm_kwargs": dict(mm_kwargs) if mm_kwargs is not None else None,
-        "mm_token_type_ids": (
+            if mm_token_type_ids is None and sample.mm_token_type_ids is not None:
+                mm_token_type_ids = [0] * existing_len
+            if mm_token_type_ids is not None:
+                mm_token_type_ids.extend(sample.mm_token_type_ids or [0] * sample.num_tokens)
+
+    input_ids = input_ids[:seq_len]
+    position_ids = position_ids[:seq_len]
+    loss_mask = loss_mask[:seq_len]
+    target_ids = target_ids[:seq_len]
+
+    seq_lens: list[int] = []
+    remaining = len(input_ids)
+    for sample in pack:
+        if remaining <= 0:
+            break
+        kept = min(sample.num_tokens, remaining)
+        if kept > 0:
+            seq_lens.append(kept)
+        remaining -= kept
+
+    pad_len = seq_len - len(input_ids)
+    if pad_len > 0:
+        input_ids.extend([0] * pad_len)
+        position_ids.extend(range(pad_len))
+        loss_mask.extend([False] * pad_len)
+        target_ids.extend([0] * pad_len)
+        seq_lens[-1] += pad_len
+    if mm_token_type_ids is not None:
+        mm_token_type_ids = mm_token_type_ids[:seq_len] + [0] * pad_len
+
+    return Batch(
+        input_ids=torch.tensor(input_ids, dtype=torch.long).unsqueeze(0),
+        position_ids=torch.tensor(position_ids, dtype=torch.long).unsqueeze(0),
+        loss_mask=torch.tensor(loss_mask, dtype=torch.bool).unsqueeze(0),
+        target_ids=torch.tensor(target_ids, dtype=torch.long).unsqueeze(0),
+        seq_lens=torch.tensor(seq_lens, dtype=torch.long),
+        samples=pack,
+        mm_kwargs=mm_kwargs,
+        mm_token_type_ids=(
             torch.tensor(mm_token_type_ids, dtype=torch.long).unsqueeze(0) if mm_token_type_ids is not None else None
         ),
-    }
+    )
 
 
 def setup_and_interleave_datasets(
@@ -683,44 +716,11 @@ def setup_dataset(
 
 
 def setup_dataloader(dataset: StatefulIterableDataset, config: DataConfig) -> StatefulDataLoader:
-    packing_dataset = CatDataset(dataset, config.seq_len * config.micro_batch_size)
+    seq_len = config.seq_len * config.micro_batch_size
     return StatefulDataLoader(
-        packing_dataset,
+        CatDataset(dataset, seq_len),
         batch_size=1,
-        collate_fn=cat_collate,
+        collate_fn=partial(cat_collate, seq_len=seq_len),
         num_workers=config.num_workers,
         pin_memory=True,
     )
-
-
-def get_dataset_state(dataloader: StatefulDataLoader) -> dict:
-    """Dataset position per worker for the startup log, parsed from ``StatefulDataLoader.state_dict()``.
-
-    The loader is the only source that is correct in every case: after a resume's
-    ``load_state_dict`` the restored position exists solely in the loader's stashed
-    state (it reaches the dataset copies inside workers when the iterator forks them;
-    the main-process dataset object stays at position zero). The keys are torchdata's
-    private worker-snapshot layout."""
-    snapshots = dataloader.state_dict()["_snapshot"]["_worker_snapshots"]
-    return {wid: snap["dataset_state"]["dataset"] for wid, snap in sorted(snapshots.items())}
-
-
-def get_dataset_progress(dataloader: StatefulDataLoader) -> dict:
-    """Dataset position and aggregate counters from dataloader workers."""
-    snapshot = dataloader.state_dict()["_snapshot"]
-    worker_snapshots = snapshot["_worker_snapshots"]
-    positions = [worker_snapshot["dataset_state"]["dataset"] for worker_snapshot in worker_snapshots.values()]
-    furthest = max(positions, key=lambda position: position["step"])
-    num_samples = defaultdict(int)
-    num_tokens = defaultdict(int)
-    for worker_snapshot in worker_snapshots.values():
-        progress = worker_snapshot["dataset_state"].get("progress", {})
-        for name, count in progress.get("num_samples", {}).items():
-            num_samples[name] += count
-        for name, count in progress.get("num_tokens", {}).items():
-            num_tokens[name] += count
-    return {
-        **furthest,
-        "num_samples": dict(num_samples),
-        "num_tokens": dict(num_tokens),
-    }

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -4,6 +4,7 @@ import math
 import time
 import asyncio
 from contextlib import nullcontext
+from dataclasses import dataclass, field
 from datetime import timedelta
 
 from renderers.base import create_renderer
@@ -41,8 +42,7 @@ from prime_rl.trainer.model import (
 from prime_rl.trainer.parallel_dims import get_parallel_dims, resolve_ep
 from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.sft.data import (
-    get_dataset_progress,
-    get_dataset_state,
+    Batch,
     load_sft_dataset,
     setup_dataloader,
     setup_dataset,
@@ -67,6 +67,13 @@ from prime_rl.utils.config import cli
 from prime_rl.utils.process import set_proc_title
 from prime_rl.utils.utils import clean_exit
 import torch.distributed as dist
+
+
+@dataclass
+class SFTProgress(Progress):
+    epoch: int = 0
+    samples_by_source: dict[str | None, int] = field(default_factory=dict)
+    tokens_by_source: dict[str | None, int] = field(default_factory=dict)
 
 
 @clean_exit
@@ -228,7 +235,7 @@ def train(config: SFTConfig):
         val_raw_dataset = load_sft_dataset(config.val.data)
 
     # Optionally, resume training from a checkpoint
-    progress = Progress()
+    progress = SFTProgress()
 
     if checkpoint_step is not None:
         resume_dir = config.resume.dir if config.resume else None
@@ -250,7 +257,7 @@ def train(config: SFTConfig):
             scheduler = setup_scheduler(optimizer, config.scheduler, scheduler_steps, config.optim.lr)
         logger.info(
             f"Resuming from step {checkpoint_step} (total_tokens={progress.total_tokens}, "
-            f"total_samples={progress.total_samples}, dataset_state={get_dataset_state(dataloader)})"
+            f"total_samples={progress.total_samples}, epoch={progress.epoch})"
         )
     else:
         logger.info("Starting from scratch")
@@ -267,17 +274,17 @@ def train(config: SFTConfig):
     dp_cp_group = parallel_dims.get_mesh("dp_cp").get_group()
     cp_size = parallel_dims.cp
 
-    def compute_loss(micro_batch: dict) -> tuple[torch.Tensor, torch.Tensor]:
+    def compute_loss(micro_batch: Batch) -> tuple[torch.Tensor, torch.Tensor]:
         """Forward pass returning (loss_sum, token_count) over unmasked tokens."""
-        input_ids = micro_batch["input_ids"].to("cuda", non_blocking=True)
-        position_ids = micro_batch["position_ids"].to("cuda", non_blocking=True)
-        target_ids = micro_batch["target_ids"].to("cuda", non_blocking=True)
-        loss_mask = micro_batch["loss_mask"].to("cuda", non_blocking=True)
-        seq_lens = micro_batch["seq_lens"].to("cuda", non_blocking=True)
-        mm_kwargs = micro_batch.get("mm_kwargs")
+        input_ids = micro_batch.input_ids.to("cuda", non_blocking=True)
+        position_ids = micro_batch.position_ids.to("cuda", non_blocking=True)
+        target_ids = micro_batch.target_ids.to("cuda", non_blocking=True)
+        loss_mask = micro_batch.loss_mask.to("cuda", non_blocking=True)
+        seq_lens = micro_batch.seq_lens.to("cuda", non_blocking=True)
+        mm_kwargs = micro_batch.mm_kwargs
         if mm_kwargs is not None:
             mm_kwargs = {key: value.to("cuda", non_blocking=True) for key, value in mm_kwargs.items()}
-        mm_type_ids = micro_batch.get("mm_token_type_ids")
+        mm_type_ids = micro_batch.mm_token_type_ids
         if mm_type_ids is not None:
             mm_type_ids = mm_type_ids.to("cuda", non_blocking=True)
 
@@ -476,7 +483,7 @@ def train(config: SFTConfig):
             step_local_token_count = torch.tensor(0, dtype=torch.int64, device="cuda")
         else:
             micro_batches = [next(dataiter) for _ in range(grad_accum_steps)]
-            local_token_count = sum(int(micro_batch["loss_mask"].sum()) for micro_batch in micro_batches)
+            local_token_count = sum(int(micro_batch.loss_mask.sum()) for micro_batch in micro_batches)
             global_step_token_count = torch.tensor(local_token_count, dtype=torch.int64, device="cuda")
             dist.all_reduce(global_step_token_count, op=dist.ReduceOp.SUM, group=dp_cp_group)
             global_token_count_val = global_step_token_count.item() // cp_size
@@ -491,10 +498,21 @@ def train(config: SFTConfig):
                 overlap_optimizer=not run_validation_this_step,
             )
 
+        step_padding_tokens = 0
+        step_batch_tokens = 0
         for micro_step, micro_batch in enumerate(micro_batches):
+            progress.total_samples = max(progress.total_samples, micro_batch.step)
+            progress.epoch = max(progress.epoch, micro_batch.epoch)
+            for source, num_samples in micro_batch.num_samples_by_source.items():
+                progress.samples_by_source[source] = progress.samples_by_source.get(source, 0) + num_samples
+            for source, num_tokens in micro_batch.num_tokens_by_source.items():
+                progress.tokens_by_source[source] = progress.tokens_by_source.get(source, 0) + num_tokens
+            step_padding_tokens += micro_batch.num_padding_tokens
+            step_batch_tokens += micro_batch.input_ids.numel()
+
             if config.log.log_data:
                 print_sample(
-                    micro_batch["input_ids"].flatten().tolist(), micro_batch["loss_mask"].flatten().tolist(), tokenizer
+                    micro_batch.input_ids.flatten().tolist(), micro_batch.loss_mask.flatten().tolist(), tokenizer
                 )
 
             with maybe_record_function("forward"):
@@ -596,8 +614,6 @@ def train(config: SFTConfig):
         num_local_tokens = config.data.seq_len * (config.data.batch_size // dp_size)
         num_tokens = dp_size * num_local_tokens
         progress.total_tokens += num_tokens
-        dataset_progress = get_dataset_progress(dataloader)
-        progress.total_samples = dataset_progress["step"]
         perf_counter = get_perf_counter(model, config.data.seq_len)
         perf_counter.count_tokens(num_tokens)
         throughput = perf_counter.get_tokens_per_second() or 0
@@ -619,26 +635,25 @@ def train(config: SFTConfig):
         logger.success(step_message)
 
         # Log progress metrics
-        samples_by_source = dataset_progress["num_samples"]
-        tokens_by_source = dataset_progress["num_tokens"]
-        total_samples = sum(samples_by_source.values())
-        total_tokens = sum(tokens_by_source.values())
+        total_samples = sum(progress.samples_by_source.values())
+        total_tokens = sum(progress.tokens_by_source.values())
         progress_metrics = {
-            "progress/epoch": dataset_progress["epoch"],
+            "progress/epoch": progress.epoch,
             "progress/num_samples": progress.total_samples,
             "progress/num_tokens": progress.total_tokens,
+            "progress/ratio_padding_tokens": step_padding_tokens / step_batch_tokens,
             "step": progress.step,
         }
         # At least two subsets/splits
-        if len(samples_by_source) > 1:
+        if len(progress.samples_by_source) > 1:
             progress_metrics.update(
                 **{
                     f"progress/{subset_or_split}/ratio_samples": num_samples / total_samples
-                    for subset_or_split, num_samples in samples_by_source.items()
+                    for subset_or_split, num_samples in progress.samples_by_source.items()
                 },
                 **{
                     f"progress/{subset_or_split}/ratio_tokens": num_tokens / total_tokens
-                    for subset_or_split, num_tokens in tokens_by_source.items()
+                    for subset_or_split, num_tokens in progress.tokens_by_source.items()
                 },
             )
         asyncio.run(monitors.log(progress_metrics, step=progress.step))

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -1,12 +1,13 @@
 import gc
 import os
+from collections import defaultdict
 
 import pytest
 import torch
 from datasets import Dataset
 
 from prime_rl.configs.sft import FakeDataConfig, SFTDataConfig
-from prime_rl.trainer.sft.data import FakeDataset, SFTDataset, get_dataset_progress, get_dataset_state, setup_dataloader
+from prime_rl.trainer.sft.data import FakeDataset, SFTDataset, setup_dataloader
 from prime_rl.trainer.world import reset_world
 
 
@@ -28,23 +29,12 @@ def test_fake_dataset_single_rank_state():
     _, dataloader = setup_fake_dataloader(config)
     dataiter = iter(dataloader)
 
-    # Initial state
-    assert get_dataset_state(dataloader) == {"worker_0": {"step": 0, "epoch": 0}}
-
     # Iterate over samples
-    micro_batch = next(dataiter)
-    print(micro_batch)
-    assert micro_batch["input_ids"].unique().item() == 0
-    assert get_dataset_state(dataloader) == {"worker_0": {"step": 1, "epoch": 0}}
-    micro_batch = next(dataiter)
-    assert micro_batch["input_ids"].unique().item() == 1
-    assert get_dataset_state(dataloader) == {"worker_0": {"step": 2, "epoch": 0}}
-    micro_batch = next(dataiter)
-    assert micro_batch["input_ids"].unique().item() == 2
-    assert get_dataset_state(dataloader) == {"worker_0": {"step": 3, "epoch": 0}}
-    micro_batch = next(dataiter)
-    assert micro_batch["input_ids"].unique().item() == 3
-    assert get_dataset_state(dataloader) == {"worker_0": {"step": 4, "epoch": 0}}
+    for step in range(4):
+        micro_batch = next(dataiter)
+        assert micro_batch.input_ids.unique().item() == step
+        assert micro_batch.step == step + 1
+        assert micro_batch.epoch == 0
 
 
 @pytest.mark.parametrize("rank", [0, 1], ids=["rank0", "rank1"])
@@ -62,16 +52,13 @@ def test_fake_dataset_multi_rank_state(rank: int, non_dp_size: int):
     _, dataloader = setup_fake_dataloader(config, non_dp_size)
     dataiter = iter(dataloader)
 
-    # Initial state
-    assert get_dataset_state(dataloader) == {"worker_0": {"step": 0, "epoch": 0}}
-
     data_rank = rank // non_dp_size
     data_world_size = 2 // non_dp_size
     for index in range(6):
         expected_sample = index * data_world_size + data_rank
         micro_batch = next(dataiter)
-        assert micro_batch["input_ids"].unique().item() == expected_sample
-        assert get_dataset_state(dataloader) == {"worker_0": {"step": expected_sample + 1, "epoch": 0}}
+        assert micro_batch.input_ids.unique().item() == expected_sample
+        assert micro_batch.step == expected_sample + 1
 
 
 def test_fake_dataset_single_rank_resume():
@@ -82,9 +69,9 @@ def test_fake_dataset_single_rank_resume():
     # First 2 samples
     for step in range(2):
         micro_batch = next(dataiter)
-        assert micro_batch["input_ids"].shape == (1, 128)
-        assert micro_batch["input_ids"].unique().item() == step
-        assert get_dataset_state(dataloader) == {"worker_0": {"step": step + 1, "epoch": 0}}
+        assert micro_batch.input_ids.shape == (1, 128)
+        assert micro_batch.input_ids.unique().item() == step
+        assert micro_batch.step == step + 1
 
     # Reload dataloader
     state_dict = dataloader.state_dict()
@@ -95,9 +82,9 @@ def test_fake_dataset_single_rank_resume():
     # Second two samples
     for step in range(2, 4):
         micro_batch = next(dataiter)
-        assert micro_batch["input_ids"].shape == (1, 128)
-        assert micro_batch["input_ids"].unique().item() == step
-        assert get_dataset_state(dataloader) == {"worker_0": {"step": step + 1, "epoch": 0}}
+        assert micro_batch.input_ids.shape == (1, 128)
+        assert micro_batch.input_ids.unique().item() == step
+        assert micro_batch.step == step + 1
 
 
 def test_fake_dataset_single_rank_state_with_packing():
@@ -108,16 +95,11 @@ def test_fake_dataset_single_rank_state_with_packing():
     step = 0
     for _ in range(8):
         micro_batch = next(dataiter)
-        num_packed_examples = len(micro_batch["input_ids"][micro_batch["loss_mask"]].unique())
-        step += num_packed_examples
-        assert micro_batch["input_ids"].shape == (1, 128)
-        assert micro_batch["seq_lens"].sum() == micro_batch["input_ids"].shape[1]
-        worker_state = dataloader.state_dict()["_snapshot"]["_worker_snapshots"]["worker_0"]["dataset_state"]
-        pending_sample = worker_state.get("pending_sample")
-        expected_dataset_step = step + (pending_sample is not None)
-        assert get_dataset_state(dataloader) == {"worker_0": {"step": expected_dataset_step, "epoch": 0}}
-        if pending_sample is not None:
-            assert pending_sample["input_ids"][0] == step
+        step += len(micro_batch.samples)
+        assert micro_batch.input_ids.shape == (1, 128)
+        assert micro_batch.seq_lens.sum() == micro_batch.input_ids.shape[1]
+        assert micro_batch.step == step
+        assert micro_batch.num_padding_tokens == (~micro_batch.loss_mask).sum().item()
 
     state_dict = dataloader.state_dict()
     rng_state = torch.random.get_rng_state()
@@ -130,7 +112,7 @@ def test_fake_dataset_single_rank_state_with_packing():
     resumed_batch = next(resumed_dataiter)
 
     for key in ("input_ids", "position_ids", "target_ids", "loss_mask", "seq_lens"):
-        torch.testing.assert_close(resumed_batch[key], expected_batch[key])
+        torch.testing.assert_close(getattr(resumed_batch, key), getattr(expected_batch, key))
 
 
 @pytest.mark.parametrize("num_workers", [1, 2])
@@ -191,25 +173,30 @@ def test_dataloader_shards_across_ranks_and_workers(
         dataloader = setup_epoch_dataloader()
         dataiter = iter(dataloader)
         epochs = set()
+        num_samples_by_source = defaultdict(int)
+        num_tokens_by_source = defaultdict(int)
 
-        def next_sample(dataiter, dataloader, index: int) -> int:
+        def next_sample(dataiter, index: int) -> int:
             micro_batch = next(dataiter)
             # After the causal shift, the first target is DummyRenderer's first character, offset by its two special tokens.
-            sample = micro_batch["target_ids"][0, 0].item() - ord("0") - 2
+            sample = micro_batch.target_ids[0, 0].item() - ord("0") - 2
             worker_id = index % num_workers
             worker_round = index // num_workers
             data_rank = rank // non_dp_size
             position = worker_round * data_world_size * num_workers + data_rank * num_workers + worker_id
-            progress = get_dataset_progress(dataloader)
+            for source, num_samples in micro_batch.num_samples_by_source.items():
+                num_samples_by_source[source] += num_samples
+            for source, num_tokens in micro_batch.num_tokens_by_source.items():
+                num_tokens_by_source[source] += num_tokens
             assert sample == position % num_examples
-            assert progress["step"] == position + 1
-            assert progress["epoch"] == position // num_examples
-            assert progress["num_samples"] == {"fake": index + 1}
-            assert progress["num_tokens"] == {"fake": (index + 1) * config.seq_len}
-            epochs.add(progress["epoch"])
+            assert micro_batch.step == position + 1
+            assert micro_batch.epoch == position // num_examples
+            assert dict(num_samples_by_source) == {"fake": index + 1}
+            assert dict(num_tokens_by_source) == {"fake": (index + 1) * config.seq_len}
+            epochs.add(micro_batch.epoch)
             return sample
 
-        samples = [next_sample(dataiter, dataloader, index) for index in range(samples_before_resume)]
+        samples = [next_sample(dataiter, index) for index in range(samples_before_resume)]
 
         state_dict = dataloader.state_dict()
         del dataiter, dataloader
@@ -218,9 +205,7 @@ def test_dataloader_shards_across_ranks_and_workers(
         dataloader = setup_epoch_dataloader()
         dataloader.load_state_dict(state_dict)
         dataiter = iter(dataloader)
-        samples.extend(
-            next_sample(dataiter, dataloader, index) for index in range(samples_before_resume, samples_per_rank)
-        )
+        samples.extend(next_sample(dataiter, index) for index in range(samples_before_resume, samples_per_rank))
 
         samples_by_rank.append(samples)
         assert epochs == {0, 1}
@@ -236,7 +221,7 @@ def test_dataloader_shards_across_ranks_and_workers(
     assert sorted(sample for samples in unique_samples for sample in samples) == expected
 
 
-def test_dataloader_progress_is_monotonic_with_uneven_workers():
+def test_batch_metadata_with_uneven_workers():
     config = FakeDataConfig(
         batch_size=1,
         micro_batch_size=1,
@@ -248,11 +233,13 @@ def test_dataloader_progress_is_monotonic_with_uneven_workers():
     _, dataloader = setup_fake_dataloader(config)
     dataiter = iter(dataloader)
 
-    positions = []
+    seen_steps = []
     for _ in range(12):
-        next(dataiter)
-        positions.append(get_dataset_progress(dataloader)["step"])
+        micro_batch = next(dataiter)
+        assert micro_batch.num_samples_by_source == {"fake": len(micro_batch.samples)}
+        assert micro_batch.num_padding_tokens == (~micro_batch.loss_mask).sum().item()
+        seen_steps.extend(sample.step for sample in micro_batch.samples)
 
     del dataiter, dataloader
     gc.collect()
-    assert positions == sorted(positions)
+    assert len(seen_steps) == len(set(seen_steps))

--- a/tests/unit/train/sft/test_fake_dataset.py
+++ b/tests/unit/train/sft/test_fake_dataset.py
@@ -43,10 +43,10 @@ def test_fake_dataset_random_resume(length: str, data_world_size: int):
             next(dataiter)
 
         state_dict = dataset.state_dict()
-        expected = [next(dataiter)["input_ids"] for _ in range(2)]
+        expected = [next(dataiter).input_ids for _ in range(2)]
 
         resumed = make(data_rank)
         resumed.load_state_dict(state_dict)
         resumed_dataiter = iter(resumed)
-        assert [next(resumed_dataiter)["input_ids"] for _ in range(2)] == expected
+        assert [next(resumed_dataiter).input_ids for _ in range(2)] == expected
         assert resumed.state_dict() == dataset.state_dict()

--- a/tests/unit/train/sft/test_sft_dataset.py
+++ b/tests/unit/train/sft/test_sft_dataset.py
@@ -8,7 +8,7 @@ from renderers.base import MultiModalData, PlaceholderRange, RenderedTrainingSam
 from transformers import AutoTokenizer
 
 import prime_rl.trainer.sft.data as sft_data
-from prime_rl.trainer.sft.data import CatDataset, SFTDataset, _drop_null_fields
+from prime_rl.trainer.sft.data import CatDataset, Sample, SFTDataset, _drop_null_fields, cat_collate
 from prime_rl.trainer.utils import print_sample
 
 _BOS_TOKEN_ID = 0
@@ -74,7 +74,7 @@ def test_sft_first_exhausted(build_dummy_dataset, dummy_renderer, max_epochs: in
     num_samples = 0
     sampling_order = []
     for x in dataset:
-        sampling_order.append(x["target_ids"][:-1])
+        sampling_order.append(x.target_ids[:-1])
         num_samples += 1
     assert num_samples == max_epochs * min([len(d) for d in ds]) * len(ds)
     assert sampling_order == [_sample_token_ids("a0"), _sample_token_ids("b0")] * max_epochs
@@ -90,7 +90,7 @@ def test_sft_all_exhausted(build_dummy_dataset, dummy_renderer, max_epochs: int)
     num_samples = 0
     sampling_order = []
     for x in dataset:
-        sampling_order.append(x["target_ids"][:-1])
+        sampling_order.append(x.target_ids[:-1])
         num_samples += 1
     assert num_samples == max_epochs * max([len(d) for d in ds]) * len(ds)
     print(sampling_order)
@@ -124,7 +124,7 @@ def test_sft_all_exhausted_with_probs(build_dummy_dataset, dummy_renderer, probs
     num_samples = 0
     sampling_freq = []
     for x in dataset:
-        sampling_freq.append(x["target_ids"][0])
+        sampling_freq.append(x.target_ids[0])
         num_samples += 1
     sampling_freq = Counter(sampling_freq)
     ratio_a = sampling_freq[ord("a") + 2] / num_samples
@@ -149,13 +149,13 @@ def test_sft_dataset_state(build_dummy_dataset, dummy_renderer):
     # Epoch 1
     for i in range(4):
         sample = next(dataiter)
-        assert sample["target_ids"][:-1] == _sample_token_ids(str(i))
+        assert sample.target_ids[:-1] == _sample_token_ids(str(i))
         assert dataset.state_dict() == {"epoch": 0, "step": i + 1}
 
     # Epoch 2
     for i in range(4):
         sample = next(dataiter)
-        assert sample["target_ids"][:-1] == _sample_token_ids(str(i))
+        assert sample.target_ids[:-1] == _sample_token_ids(str(i))
         assert dataset.state_dict() == {"epoch": 1, "step": 4 + i + 1}
 
     with pytest.raises(StopIteration):
@@ -178,7 +178,7 @@ def test_sft_dataset_state_resume(build_dummy_dataset, dummy_renderer):
     # Epoch 1
     for i in range(4):
         sample = next(dataiter)
-        assert sample["target_ids"][:-1] == _sample_token_ids(str(i))
+        assert sample.target_ids[:-1] == _sample_token_ids(str(i))
         assert dataset.state_dict() == {"epoch": 0, "step": i + 1}
 
     # Resuming from checkpoint cross epoch
@@ -196,7 +196,7 @@ def test_sft_dataset_state_resume(build_dummy_dataset, dummy_renderer):
     # Epoch 2.1
     for i in range(2):
         sample = next(dataiter)
-        assert sample["target_ids"][:-1] == _sample_token_ids(str(i))
+        assert sample.target_ids[:-1] == _sample_token_ids(str(i))
         assert dataset.state_dict() == {"epoch": 1, "step": 4 + i + 1}
 
     # Resuming from checkpoint mid epoch
@@ -214,7 +214,7 @@ def test_sft_dataset_state_resume(build_dummy_dataset, dummy_renderer):
     # Epoch 2.2
     for i in range(2, 4):
         sample = next(dataiter)
-        assert sample["target_ids"][:-1] == _sample_token_ids(str(i))
+        assert sample.target_ids[:-1] == _sample_token_ids(str(i))
         assert dataset.state_dict() == {"epoch": 1, "step": 4 + i + 1}
 
     with pytest.raises(StopIteration):
@@ -237,7 +237,7 @@ def test_multiturn_loss_mask():
     tokenizer = AutoTokenizer.from_pretrained("PrimeIntellect/Qwen3-0.6B")  # Properly handles multi-turn think
     dataset = SFTDataset(dataset, create_renderer(tokenizer), max_examples=1)
     sample = next(iter(dataset))
-    print_sample(sample["input_ids"], sample["loss_mask"], tokenizer)
+    print_sample(sample.input_ids, sample.loss_mask, tokenizer)
 
 
 def test_multiturn_loss_mask_with_tools():
@@ -300,7 +300,7 @@ def test_multiturn_loss_mask_with_tools():
     tokenizer = AutoTokenizer.from_pretrained("PrimeIntellect/Qwen3-0.6B")  # Properly handles multi-turn think
     dataset = SFTDataset(dataset, create_renderer(tokenizer), max_examples=1)
     sample = next(iter(dataset))
-    print_sample(sample["input_ids"], sample["loss_mask"], tokenizer)
+    print_sample(sample.input_ids, sample.loss_mask, tokenizer)
 
 
 def test_messages_rows_are_equivalent_to_empty_prompt_completion():
@@ -409,16 +409,15 @@ def _sft_sample(
     *,
     mm_kwargs: dict[str, torch.Tensor] | None = None,
     mm_token_type_ids: list[int] | None = None,
-) -> dict:
-    return {
-        "input_ids": input_ids,
-        "position_ids": list(range(len(input_ids))),
-        "loss_mask": [True] * len(input_ids),
-        "target_ids": [x + 1 for x in input_ids],
-        "seq_lens": [len(input_ids)],
-        "mm_kwargs": mm_kwargs,
-        "mm_token_type_ids": mm_token_type_ids,
-    }
+) -> Sample:
+    return Sample(
+        input_ids=input_ids,
+        position_ids=list(range(len(input_ids))),
+        loss_mask=[True] * len(input_ids),
+        target_ids=[x + 1 for x in input_ids],
+        mm_kwargs=mm_kwargs,
+        mm_token_type_ids=mm_token_type_ids,
+    )
 
 
 def test_cat_dataset_packs_multimodal_samples():
@@ -444,13 +443,14 @@ def test_cat_dataset_packs_multimodal_samples():
         seq_len=5,
     )
 
-    packed = next(iter(dataset))
+    packed = cat_collate([next(iter(dataset))], seq_len=5)
 
-    assert packed["input_ids"] == [1, 2, 3, 4, 5]
-    assert packed["seq_lens"] == [2, 3]
-    assert packed["mm_token_type_ids"] == [0, 1, 0, 1, 1]
-    assert packed["mm_kwargs"]["pixel_values"].shape == (5, 3)
-    assert packed["mm_kwargs"]["image_grid_thw"].tolist() == [[1, 1, 2], [1, 1, 3]]
+    assert packed.input_ids.tolist() == [[1, 2, 3, 4, 5]]
+    assert packed.seq_lens.tolist() == [2, 3]
+    assert packed.mm_token_type_ids.tolist() == [[0, 1, 0, 1, 1]]
+    assert packed.mm_kwargs["pixel_values"].shape == (5, 3)
+    assert packed.mm_kwargs["image_grid_thw"].tolist() == [[1, 1, 2], [1, 1, 3]]
+    assert packed.num_padding_tokens == 0
 
 
 def test_cat_dataset_packs_text_and_multimodal_samples_together():
@@ -472,16 +472,18 @@ def test_cat_dataset_packs_text_and_multimodal_samples_together():
     )
 
     dataiter = iter(dataset)
-    packed = next(dataiter)
-    text_pack = next(dataiter)
+    packed = cat_collate([next(dataiter)], seq_len=5)
+    text_pack = cat_collate([next(dataiter)], seq_len=5)
 
-    assert packed["input_ids"] == [1, 2, 3, 4, 0]
-    assert packed["loss_mask"] == [True, True, True, True, False]
-    assert packed["seq_lens"] == [1, 2, 2]
-    assert packed["mm_kwargs"] is not None
-    assert packed["mm_token_type_ids"] == [0, 0, 1, 0, 0]
-    assert text_pack["input_ids"] == [5, 6, 0, 0, 0]
-    assert text_pack["loss_mask"] == [True, True, False, False, False]
-    assert text_pack["seq_lens"] == [5]
-    assert text_pack["mm_kwargs"] is None
-    assert text_pack["mm_token_type_ids"] is None
+    assert packed.input_ids.tolist() == [[1, 2, 3, 4, 0]]
+    assert packed.loss_mask.tolist() == [[True, True, True, True, False]]
+    assert packed.seq_lens.tolist() == [1, 2, 2]
+    assert packed.mm_kwargs is not None
+    assert packed.mm_token_type_ids.tolist() == [[0, 0, 1, 0, 0]]
+    assert packed.num_padding_tokens == 1
+    assert text_pack.input_ids.tolist() == [[5, 6, 0, 0, 0]]
+    assert text_pack.loss_mask.tolist() == [[True, True, False, False, False]]
+    assert text_pack.seq_lens.tolist() == [5]
+    assert text_pack.mm_kwargs is None
+    assert text_pack.mm_token_type_ids is None
+    assert text_pack.num_padding_tokens == 3


### PR DESCRIPTION
## Summary

- `Sample` is now a dataclass that carries its own metadata: `source` (the subset/split it came from), `step` (the dataset position when it was emitted), and `epoch`.
- `Batch` is a dataclass that keeps the list of `samples` it packs. Progress is exposed as computed properties over those samples: `step`, `epoch`, `num_samples_by_source`, `num_tokens_by_source`, and `num_padding_tokens`.
- `CatDataset` only groups samples into packs and checkpoints the pending sample. `cat_collate` concatenates, truncates, pads, and tensorizes a pack into a `Batch` (with a `pin_memory` method, since torch pins custom batch types through it).
- The trainer accumulates progress from the batches it consumes into `SFTProgress` (epoch and per-source counters on top of `Progress`), which is checkpointed with the app state. `get_dataset_progress` and `get_dataset_state`, which parsed torchdata's private `_snapshot._worker_snapshots` layout, are removed.
- New `progress/ratio_padding_tokens` metric: the padded fraction of each step's batch tokens.

Semantics note: `progress/num_samples` and `progress/epoch` now reflect samples the trainer consumed, not the furthest worker cursor, so they no longer include worker prefetch.

## Breaking

- SFT trainer checkpoints written before this PR fail to resume with `Missing key in checkpoint state_dict: app.progress.epoch` (the checkpointed progress gained fields). Resume such runs with `ckpt.skip_progress = true`, or restart.
- The SFT dataloader checkpoint no longer stores per-source counters, and stores the pending sample as a `Sample` instead of a dict. A pre-PR dataloader checkpoint that held a pending sample cannot restore it.

## Verification

- `uv run pytest tests/unit/train/sft/ -q` passed with 47 tests.
- A 2-worker `StatefulDataLoader` smoke on this box confirmed batch tensors are pinned through `Batch.pin_memory` and metadata properties are populated.
- The old-checkpoint resume failure mode was reproduced with a standalone DCP save/load round trip.
