### PR TITLE
chore: defer ring-flash-attn imports to the ring-CP path

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -69,7 +69,6 @@ from prime_rl import monitors
 from prime_rl.utils.config import cli
 from prime_rl.utils.process import set_proc_title
 from prime_rl.utils.utils import clean_exit, resolve_latest_ckpt_step
-from ring_flash_attn import substitute_hf_flash_attn
 
 
 @clean_exit
@@ -195,6 +194,10 @@ def train(config: TrainerConfig):
         cp_group = parallel_dims.world_mesh["cp"].get_group()
         cp_rank = parallel_dims.world_mesh["cp"].get_local_rank()
         if config.model.cp_style == "ring":
+            # Delayed import: ring_flash_attn imports flash_attn at module scope, which
+            # only the ring path needs.
+            from ring_flash_attn import substitute_hf_flash_attn
+
             substitute_hf_flash_attn(cp_group, heads_k_stride=1)
             substitute_ring_attn(cp_group, heads_k_stride=1, attn_impl=config.model.attn)
         else:

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -7,7 +7,6 @@ from contextlib import nullcontext
 from datetime import timedelta
 
 from renderers.base import create_renderer
-from ring_flash_attn import substitute_hf_flash_attn
 from torch.nn import CrossEntropyLoss
 
 # Import environment before any other imports
@@ -132,6 +131,10 @@ def train(config: SFTConfig):
         cp_group = parallel_dims.world_mesh["cp"].get_group()
         cp_rank = parallel_dims.world_mesh["cp"].get_local_rank()
         if config.model.cp_style == "ring":
+            # Delayed import: ring_flash_attn imports flash_attn at module scope, which
+            # only the ring path needs.
+            from ring_flash_attn import substitute_hf_flash_attn
+
             substitute_hf_flash_attn(cp_group, heads_k_stride=1)
             substitute_ring_attn(cp_group, heads_k_stride=1, attn_impl=config.model.attn)
         else:

--- a/src/prime_rl/utils/cp.py
+++ b/src/prime_rl/utils/cp.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-# ruff: noqa: I001 — `prime_rl._compat` must run before `ring_flash_attn` imports below.
+# ruff: noqa: I001 — `prime_rl._compat` must run before the deferred `ring_flash_attn` import.
 import prime_rl._compat  # noqa: F401
 
 from typing import TYPE_CHECKING
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from ring_flash_attn import update_ring_flash_attn_params
 
 from prime_rl.trainer.distributed.collectives import all_gather
 from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
@@ -162,6 +161,10 @@ def setup_cp_attention_params(
     )
 
     if cp_style == "ring":
+        # Delayed import: ring_flash_attn imports flash_attn at module scope, which only
+        # the ring path needs.
+        from ring_flash_attn import update_ring_flash_attn_params
+
         update_ring_flash_attn_params(cu_seqlens, cp_group)
     elif cp_style == "ulysses":
         # Delayed import: ulysses_attn lives under trainer.models, which imports


### PR DESCRIPTION
## Change

`ring_flash_attn` imports `flash_attn` at module scope, so importing the trainer requires a
flash-attn build even for runs that never touch ring attention: no-CP runs (`cp=1`, the
default) and `cp_style="ulysses"` runs.

Move the three module-scope `ring_flash_attn` imports into the `cp_style == "ring"` branches
that use them:

- `src/prime_rl/utils/cp.py` — `update_ring_flash_attn_params`, used once in `setup_cp_attention_params`
- `src/prime_rl/trainer/rl/train.py`, `src/prime_rl/trainer/sft/train.py` — `substitute_hf_flash_attn`, called only
  under `cp_style == "ring"`

This matches what the surrounding code already does. `flash_attn` itself is guarded by
`try/except ImportError` in `src/prime_rl/trainer/models/layers/attn.py`, `substitute_ring_attn` already imports
`src/prime_rl/trainer/models/layers/ring_attn.py` lazily, the ulysses branch of `setup_cp_attention_params` already
defers its own import, and `src/prime_rl/entrypoints/trainer.py` documents deferring heavy ML imports
(`ring_flash_attn` among them) as the intent. The ring path was the one place that still
imported eagerly.

Note this is about the ring path, not the attention backend: `substitute_ring_attn` imports
`ring_flash_attn` for every `attn_impl` (sdpa falls back to `llama3_flash_attn_varlen_func`), so
`cp_style="ring"` still needs flash-attn regardless of `attn`.

No behavior change: the same imports happen, just on first use of the ring path instead of at
module import. `prime_rl._compat` stays at module scope in `src/prime_rl/utils/cp.py` — it patches
transformers for both `ring_flash_attn` and the mamba hub-kernels shim, and it must still run
before the deferred import.

## Verification

Ran `src/prime_rl/utils/cp.py` before and after, on three machines with neither `flash-attn` nor
`ring-flash-attn` installed (torch 2.13.0+cu130 on an L40S and a B200, torch 2.13.0+xpu on an
Intel Arc Pro B60). Identical results on all three:

```
before: IMPORT FAILED: ModuleNotFoundError: No module named 'ring_flash_attn'
after:  IMPORT OK, leaked flash-attn modules: none
        ring path raises at call time as expected: No module named 'ring_flash_attn'
```

The third line is the point: the import moved rather than disappeared, so a ring-CP run still
gets a clear error if flash-attn is missing.

Also walked the module-scope import graph from `trainer.rl.train`, `trainer.sft.train` and
`trainer.models` — 125 first-party modules — for imports that run at import time and are not
inside a `try/except ImportError`:

| | eager flash-attn imports at module scope |
| --- | --- |
| before | `utils/cp.py:12`, `trainer/rl/train.py:71`, `trainer/sft/train.py:10` |
| after | none |

The three guarded `flash_attn` imports in `src/prime_rl/trainer/models/layers/attn.py` are
untouched by this PR; they already degrade to `None` when flash-attn is absent.
