### PR TITLE
improvement(docker): bundle AWS EFA libfabric + aws-ofi-nccl

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -167,6 +167,34 @@ RUN find /usr/local/cuda-13.0/targets/*/lib \
            -o -name 'libnvjpeg*' -o -name 'libnvblas*' \) -delete \
     && find /usr/local/cuda-13.0 -name '*.a' ! -name 'libcudadevrt.a' ! -name 'libcudart_static.a' -delete
 
+# AWS EFA userspace stack: libfabric + the aws-ofi-nccl NCCL net plugin,
+# installed as one version-matched unit via AWS's official installer
+# rather than picking versions by hand. Do not substitute a host-mounted
+# copy of these libraries instead of building them in -- symbol-version
+# mismatches between a host's rdma-core and a container's can silently
+# break the NCCL plugin. --skip-kmod: containers share the host kernel and
+# must never build/load a kernel module themselves; the EFA driver is
+# expected to already be present on the host. --skip-limit-conf: ulimits
+# config doesn't apply inside a build. Same base OS as the runtime stage
+# below for glibc/rdma-core ABI compatibility.
+FROM nvidia/cuda:13.0.1-base-ubuntu24.04 AS efa-installer
+ENV DEBIAN_FRONTEND=noninteractive
+ARG EFA_INSTALLER_VERSION=1.47.0
+# One RUN: efa_installer.sh apt-get installs its own deps (pciutils,
+# libnl-3-200, tcl, ...) internally, so the package index has to survive
+# until after it runs. Purging /var/lib/apt/lists/* only at the very end
+# (not between the curl/tar deps and the installer invocation) keeps that
+# available.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates tar gzip \
+    && curl -fsSL "https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz" \
+        -o /tmp/aws-efa-installer.tar.gz \
+    && tar -xzf /tmp/aws-efa-installer.tar.gz -C /tmp \
+    && cd /tmp/aws-efa-installer \
+    && ./efa_installer.sh -y --skip-kmod --skip-limit-conf \
+    && cd / && rm -rf /tmp/aws-efa-installer.tar.gz /tmp/aws-efa-installer \
+    && apt-get clean autoclean && rm -rf /var/lib/apt/lists/*
+
 # Runtime image
 FROM nvidia/cuda:13.0.1-base-ubuntu24.04
 
@@ -238,6 +266,11 @@ COPY --from=builder --chown=appuser:appuser /app/.venv/lib/python3.12/site-packa
 COPY --from=builder --chown=appuser:appuser /app/.venv/lib/python3.12/site-packages/flash_attn /app/.venv/lib/python3.12/site-packages/flash_attn
 COPY --from=builder --chown=appuser:appuser /app/.venv/lib/python3.12/site-packages/flash_attn_2_cuda*.so /app/.venv/lib/python3.12/site-packages/
 COPY --from=builder /opt/ucx /opt/ucx
+
+# EFA userspace stack from the dedicated stage above. Not added to
+# LD_LIBRARY_PATH here -- deployment configs opt into that only where
+# EFA is actually available, so this is inert everywhere else.
+COPY --from=efa-installer /opt/amazon /opt/amazon
 
 # Copy and set up entrypoint script
 COPY --chown=appuser:appuser scripts/docker-entrypoint.sh /app/docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- Bundles libfabric + the aws-ofi-nccl NCCL plugin into the image via AWS's official installer, so NCCL can find the OFI plugin at runtime instead of silently falling back to sockets
- Inert by default — only takes effect where a deployment's config points `LD_LIBRARY_PATH` at it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docker build-only change that adds optional EFA libraries without altering default runtime env or application code; main risk is larger images and relying on the pinned AWS installer URL/version.
> 
> **Overview**
> The CUDA runtime image now **ships the AWS EFA userspace stack** (libfabric and the **aws-ofi-nccl** NCCL plugin) so multi-node jobs on EFA-capable hosts can use NCCL’s OFI path instead of silently falling back to sockets.
> 
> A new **`efa-installer` build stage** on the same Ubuntu 24.04 base as runtime downloads AWS’s official installer (default **1.47.0**), runs it with **`--skip-kmod`** and **`--skip-limit-conf`**, and copies **`/opt/amazon`** into the final image. **`LD_LIBRARY_PATH` is unchanged** in the Dockerfile—deployments that have EFA on the host are expected to prepend those libraries when needed; elsewhere the bundle stays inert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 007d6d6b8af5e5f567fa94fce5e2b6f06e02d62a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->