### PR TITLE
bugfix: install prime-kernels extra in Docker build

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -96,7 +96,7 @@ ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 # mount here: .git would bust the cache every commit.
 COPY --from=manifests /manifests /app
 RUN --mount=type=cache,target=/usr/local/share/uv/cache \
-    uv sync --all-packages --extra gpu --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra disagg --extra gpt-oss --extra quack --group mamba-ssm --locked --no-dev \
+    uv sync --all-packages --extra gpu --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra disagg --extra gpt-oss --extra quack --extra kernels --group mamba-ssm --locked --no-dev \
         --no-install-workspace \
         --no-install-package prime-rl-configs \
         --no-install-package verifiers \
@@ -132,9 +132,9 @@ RUN --mount=type=cache,target=/usr/local/share/uv/cache \
     && \
     sed -i "s/fallback-version = \"0.0.0\"/fallback-version = \"${RENDERERS_PRETEND_VERSION}\"/" /app/deps/renderers/pyproject.toml \
     && \
-    uv sync --all-packages --extra gpu --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra disagg --extra gpt-oss --extra quack --group mamba-ssm --locked --no-dev \
+    uv sync --all-packages --extra gpu --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra disagg --extra gpt-oss --extra quack --extra kernels --group mamba-ssm --locked --no-dev \
     && \
-    /app/.venv/bin/python -c 'from importlib.metadata import version; [version(name) for name in ("deep-ep", "deep-gemm", "mamba-ssm", "nixl", "quack-kernels", "vllm", "vllm-router")]'
+    /app/.venv/bin/python -c 'from importlib.metadata import version; [version(name) for name in ("deep-ep", "deep-gemm", "mamba-ssm", "nixl", "prime-kernels", "quack-kernels", "vllm", "vllm-router")]'
 
 # Optional: build NIXL from source against the UCX 1.19 baked above. The PyPI
 # nixl wheel ships its own UCX which segfaults on prefill→decode KV transfer


### PR DESCRIPTION
## Why

Trainer crashes with `ModuleNotFoundError: No module named 'prime_kernels'` on startup. `collectives.py` imports it unconditionally at the top of the file.

## What

- `prime-kernels` is declared and pinned in `pyproject.toml`/`uv.lock` under its own `kernels` extra, but that extra was never passed to `uv sync` in `Dockerfile.cuda` — so it resolves but never actually installs.
- Add `--extra kernels` to both `uv sync` calls.
- Add `prime-kernels` to the post-sync version-check so a missing install fails the build loudly instead of shipping silently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docker build-only dependency wiring with no runtime logic changes; slightly larger images when the kernels extra is enabled.
> 
> **Overview**
> Fixes CUDA Docker images that could start the trainer without **`prime-kernels`**, causing **`ModuleNotFoundError: No module named 'prime_kernels'`** even though the package is pinned under the **`kernels`** optional extra.
> 
> Both **`uv sync`** stages in **`Dockerfile.cuda`** now pass **`--extra kernels`**, so the wheel is actually installed into the venv. The post-sync **`importlib.metadata`** smoke check also includes **`prime-kernels`**, so a missing install fails the image build instead of surfacing only at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180ec8e7944f5be98a55a24200959fff882b652d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->