### PR TITLE
bugfix: install libhwloc15 for aws-ofi-nccl in runtime image

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -226,6 +226,7 @@ RUN apt-get update && apt-get install -y \
     libibverbs1 \
     ibverbs-providers \
     librdmacm1 \
+    libhwloc15 \
     && ln -sf /usr/bin/python3.12 /usr/local/bin/python \
     && apt-get clean autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
## Why

NCCL now finds `libnccl-net-ofi.so` but fails to load it: `libhwloc.so.15: cannot open shared object file`, falling back to sockets.

## What

- Add `libhwloc15` to the runtime stage's apt install list.
- The EFA installer stage pulls in libhwloc as one of its own dependencies, but only `/opt/amazon` gets copied forward into the runtime stage — the shared lib itself never did.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-package addition to the Docker runtime image with no application code or auth/data-path changes.
> 
> **Overview**
> Fixes NCCL failing to load the AWS OFI network plugin (`libnccl-net-ofi.so`) because **`libhwloc.so.15`** was missing at runtime, which forced a fallback to sockets.
> 
> The CUDA **runtime** stage now **`apt install`s `libhwloc15`** alongside the other RDMA/EFA-related packages. The EFA installer stage already pulled in hwloc as a dependency, but only **`/opt/amazon`** is copied into the final image—not the distro **`libhwloc`** package—so the shared library never landed in the runtime filesystem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1d18804238afc171a4e8b856e86c24818d2b95d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->