### PR TITLE
bugfix: install EFA userspace stack in-place in the runtime stage

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -167,34 +167,6 @@ RUN find /usr/local/cuda-13.0/targets/*/lib \
            -o -name 'libnvjpeg*' -o -name 'libnvblas*' \) -delete \
     && find /usr/local/cuda-13.0 -name '*.a' ! -name 'libcudadevrt.a' ! -name 'libcudart_static.a' -delete
 
-# AWS EFA userspace stack: libfabric + the aws-ofi-nccl NCCL net plugin,
-# installed as one version-matched unit via AWS's official installer
-# rather than picking versions by hand. Do not substitute a host-mounted
-# copy of these libraries instead of building them in -- symbol-version
-# mismatches between a host's rdma-core and a container's can silently
-# break the NCCL plugin. --skip-kmod: containers share the host kernel and
-# must never build/load a kernel module themselves; the EFA driver is
-# expected to already be present on the host. --skip-limit-conf: ulimits
-# config doesn't apply inside a build. Same base OS as the runtime stage
-# below for glibc/rdma-core ABI compatibility.
-FROM nvidia/cuda:13.0.1-base-ubuntu24.04 AS efa-installer
-ENV DEBIAN_FRONTEND=noninteractive
-ARG EFA_INSTALLER_VERSION=1.47.0
-# One RUN: efa_installer.sh apt-get installs its own deps (pciutils,
-# libnl-3-200, tcl, ...) internally, so the package index has to survive
-# until after it runs. Purging /var/lib/apt/lists/* only at the very end
-# (not between the curl/tar deps and the installer invocation) keeps that
-# available.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl ca-certificates tar gzip \
-    && curl -fsSL "https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz" \
-        -o /tmp/aws-efa-installer.tar.gz \
-    && tar -xzf /tmp/aws-efa-installer.tar.gz -C /tmp \
-    && cd /tmp/aws-efa-installer \
-    && ./efa_installer.sh -y --skip-kmod --skip-limit-conf \
-    && cd / && rm -rf /tmp/aws-efa-installer.tar.gz /tmp/aws-efa-installer \
-    && apt-get clean autoclean && rm -rf /var/lib/apt/lists/*
-
 # Runtime image
 FROM nvidia/cuda:13.0.1-base-ubuntu24.04
 
@@ -230,6 +202,32 @@ RUN apt-get update && apt-get install -y \
     && ln -sf /usr/bin/python3.12 /usr/local/bin/python \
     && apt-get clean autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# AWS EFA userspace stack: libfabric + the aws-ofi-nccl NCCL net plugin,
+# installed as one version-matched unit via AWS's official installer rather
+# than picking versions by hand. Do not substitute a host-mounted copy of
+# these libraries instead of building them in -- symbol-version mismatches
+# between a host's rdma-core and a container's can silently break the NCCL
+# plugin. Run directly in this stage (not a separate one COPY'd in after):
+# the installer's own apt-get/dpkg step upgrades system rdma-core packages
+# (libibverbs, ibverbs-providers, librdmacm) in place to versions libfabric
+# actually links against -- copying only /opt/amazon out of an isolated
+# stage leaves that system-wide upgrade behind, so libfabric ends up paired
+# with whatever older rdma-core this image's own apt install pulled in and
+# fails to load (symbol version mismatch on libefa.so.1). --skip-kmod:
+# containers share the host kernel and must never build/load a kernel
+# module themselves; the EFA driver is expected to already be present on
+# the host. --skip-limit-conf: ulimits config doesn't apply inside a build.
+ARG EFA_INSTALLER_VERSION=1.47.0
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates tar gzip \
+    && curl -fsSL "https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz" \
+        -o /tmp/aws-efa-installer.tar.gz \
+    && tar -xzf /tmp/aws-efa-installer.tar.gz -C /tmp \
+    && cd /tmp/aws-efa-installer \
+    && ./efa_installer.sh -y --skip-kmod --skip-limit-conf \
+    && cd / && rm -rf /tmp/aws-efa-installer.tar.gz /tmp/aws-efa-installer \
+    && apt-get clean autoclean && rm -rf /var/lib/apt/lists/*
 
 # CUDA 13.0 toolkit (TileLang's runtime nvcc JIT)
 COPY --from=cuda-trim /usr/local/cuda-13.0 /usr/local/cuda-13.0
@@ -267,11 +265,6 @@ COPY --from=builder --chown=appuser:appuser /app/.venv/lib/python3.12/site-packa
 COPY --from=builder --chown=appuser:appuser /app/.venv/lib/python3.12/site-packages/flash_attn /app/.venv/lib/python3.12/site-packages/flash_attn
 COPY --from=builder --chown=appuser:appuser /app/.venv/lib/python3.12/site-packages/flash_attn_2_cuda*.so /app/.venv/lib/python3.12/site-packages/
 COPY --from=builder /opt/ucx /opt/ucx
-
-# EFA userspace stack from the dedicated stage above. Not added to
-# LD_LIBRARY_PATH here -- deployment configs opt into that only where
-# EFA is actually available, so this is inert everywhere else.
-COPY --from=efa-installer /opt/amazon /opt/amazon
 
 # Copy and set up entrypoint script
 COPY --chown=appuser:appuser scripts/docker-entrypoint.sh /app/docker-entrypoint.sh


### PR DESCRIPTION
## Why

`libfabric` needs a newer `libefa.so.1` (symbol version `EFA_1.4`) than this image's own apt-installed rdma-core provides, so NCCL fails to load the OFI plugin: `version 'EFA_1.4' not found`.

## What

- The AWS EFA installer upgrades rdma-core system-wide via its own apt/dpkg step, but running it in a separate build stage and copying out only `/opt/amazon` left that system-wide upgrade behind — libfabric ended up paired with the older, separately-apt-installed rdma-core.
- Run the installer directly in the runtime stage instead, so its rdma-core upgrade lands in place with no copy-forwarding gap.
- Verified locally: before the installer, stock rdma-core (50.0-2ubuntu0.2); after, upgraded to 61.0-1 system-wide, `libfabric.so.1` resolves `libefa.so.1` cleanly, and `libnccl-net-ofi.so` dlopens with zero missing dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CUDA image build and RDMA/EFA library versions used for multi-node NCCL; incorrect pairing could still break distributed training on EFA hosts, but the change targets a known symbol-version mismatch.
> 
> **Overview**
> Fixes NCCL OFI plugin load failures (`EFA_1.4` not found) by changing **how** the CUDA image gets the AWS EFA stack, not by adding new runtime behavior.
> 
> The dedicated `efa-installer` build stage and `COPY --from=efa-installer /opt/amazon` are removed. The same AWS `efa_installer.sh` run (still with `--skip-kmod` and `--skip-limit-conf`) now executes **in the final runtime image**, immediately after the base `apt` install of `libibverbs` / `librdmacm` and related packages. That way the installer’s system-wide rdma-core upgrades stay in the image libfabric actually runs in, instead of shipping only `/opt/amazon` from an isolated stage paired with older distro rdma-core.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f879a4bf88704c58b5719b1c8635258121ae2de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->