### PR TITLE
Fix activation offload stream context under torch.compile

### DIFF
--- a/src/prime_rl/utils/act_offloading.py
+++ b/src/prime_rl/utils/act_offloading.py
@@ -150,8 +150,10 @@ class OffloadActivations(saved_tensors_hooks):
                     # Sync in, offload, and add an event to sync back later
                     self.s1.wait_stream(self.s0)
 
-                stream = self.s1 if self.use_streams else self.s0
-                with stream:
+                # Re-entering the current stream makes torch.compile treat it as an
+                # explicit user stream and can produce invalid Inductor code.
+                stream_context = self.s1 if self.use_streams else nullcontext()
+                with stream_context:
                     try:
                         cpu_tensor = torch.empty_like(activation, pin_memory=self.use_pin_memory, device="cpu")
                     except NotImplementedError as e:


### PR DESCRIPTION
## Summary

- avoid re-entering the current compute stream when asynchronous activation-offload streams are disabled
- preserve the existing explicit communication-stream context when streams are enabled

## Why

With Torch 2.13, entering the current stream explicitly inside the saved-tensor pack hook can make Inductor treat it as a user stream and emit invalid partition code that references an undefined stream variable. A `nullcontext()` keeps the copy on the already-current stream without exposing a redundant stream context to compilation.

## Validation

- `uv run --no-sync ruff check src/prime_rl/utils/act_offloading.py`
- `uv run --no-sync ruff format --check src/prime_rl/utils/act_offloading.py`
- exercised by the Qwen3.6-35B-A3B multimodal RL smoke through multiple optimizer steps with pinned activation offload enabled