### PR TITLE
chore: bump verifiers 

### DIFF
--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -100,7 +100,7 @@ name = "openseeker"
 env.agent.harness.id = "rlm"
 env.agent.harness.skills = ["search"]
 env.agent.harness.forward_env = ["SERPER_API_KEY"]
-env.agent.harness.summarize_at_tokens = [65536, 131072]
+env.agent.harness.compaction.summarize_at_tokens = 98304
 env.agent.runtime.labels = ["glm45air-search"]
 env.taskset.id = "openseeker"
 
@@ -124,7 +124,7 @@ name = "redsearcher"
 env.agent.harness.id = "rlm"
 env.agent.harness.skills = ["search"]
 env.agent.harness.forward_env = ["SERPER_API_KEY"]
-env.agent.harness.summarize_at_tokens = [65536, 131072]
+env.agent.harness.compaction.summarize_at_tokens = 98304
 env.agent.runtime.labels = ["glm45air-search"]
 env.taskset.id = "redsearcher" # optional `difficulty` filter (easy/medium/hard)
 
@@ -154,7 +154,7 @@ num_examples = 500 # full set is 1266; cap eval at 500
 env.agent.harness.id = "rlm"
 env.agent.harness.skills = ["search"]
 env.agent.harness.forward_env = ["SERPER_API_KEY"]
-env.agent.harness.summarize_at_tokens = 98304
+env.agent.harness.compaction.summarize_at_tokens = 98304
 env.agent.runtime.labels = ["glm45air-search"]
 env.agent.timeout.rollout = 3600
 env.taskset.id = "browsecomp"

--- a/examples/advanced/glm-4.5-air/terminal.toml
+++ b/examples/advanced/glm-4.5-air/terminal.toml
@@ -96,7 +96,7 @@ num_turns_weight = 0.1
 [[orchestrator.train.source]]
 name = "tmax"
 env.agent.harness.id = "rlm"
-env.agent.harness.summarize_at_tokens = [65536, 131072]
+env.agent.harness.compaction.summarize_at_tokens = 98304
 env.agent.runtime.labels = ["glm45air-terminal"]
 env.taskset.id = "tmax"
 
@@ -123,7 +123,7 @@ interval = 20
 [[orchestrator.eval.source]]
 name = "swebench-verified"
 env.agent.harness.id = "rlm"
-env.agent.harness.summarize_at_tokens = 98304
+env.agent.harness.compaction.summarize_at_tokens = 98304
 env.agent.runtime.labels = ["glm45air-terminal"]
 env.agent.timeout.rollout = 3600
 env.taskset.id = "swebench-verified"
@@ -144,7 +144,7 @@ env.taskset.id = "swebench-verified"
 name = "terminal-bench-2"
 group_size = 4 # avg@4
 env.agent.harness.id = "rlm"
-env.agent.harness.summarize_at_tokens = 98304
+env.agent.harness.compaction.summarize_at_tokens = 98304
 env.agent.runtime.labels = ["glm45air-terminal"]
 env.agent.timeout.rollout = 3600
 env.taskset.id = "terminal-bench-2"

--- a/examples/advanced/nemotron-3-super/swe.toml
+++ b/examples/advanced/nemotron-3-super/swe.toml
@@ -89,7 +89,7 @@ truncate_history_thinking = false
 name = "scaleswe"
 env.taskset.id = "scaleswe"
 env.agent.harness.id = "rlm"
-env.agent.harness.summarize_at_tokens = [65536, 131072]
+env.agent.harness.compaction.summarize_at_tokens = 98304
 env.agent.runtime.labels = ["nemotron-3-super-swe"]
 
 [orchestrator.eval]
@@ -99,7 +99,7 @@ interval = 20
 name = "swebench-verified"
 env.taskset.id = "swebench-verified"
 env.agent.harness.id = "rlm"
-env.agent.harness.summarize_at_tokens = 98304
+env.agent.harness.compaction.summarize_at_tokens = 98304
 env.agent.runtime.labels = ["nemotron-3-super-swe"]
 env.agent.timeout.rollout = 3600
 

--- a/uv.lock
+++ b/uv.lock
@@ -7710,7 +7710,7 @@ ta = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.14.0" },
+    { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "anthropic", specifier = ">=0.78.0" },
     { name = "datasets", specifier = ">=3.3.0,<6.0.0" },
     { name = "gepa", specifier = ">=0.0.6" },


### PR DESCRIPTION
## Summary

- advance the `deps/verifiers` submodule from `e2103d6` to `d4a2177`
- include merged Bash and RLM context compaction from verifiers #2454 and #2459
- pick up nano-rlm compaction commit `4ef3438` through the default RLM harness pin
- refresh `uv.lock` for verifiers' `aiohttp>=3.14.1` requirement
- migrate three RLM examples to `compaction.summarize_at_tokens`; use the former range's `98_304` midpoint
- include the optional ACP semantic-edge and shared harness utility changes already on verifiers `main`

Companions: [verifiers #2454](https://github.com/PrimeIntellect-ai/verifiers/pull/2454), [verifiers #2459](https://github.com/PrimeIntellect-ai/verifiers/pull/2459), and [nano-rlm #147](https://github.com/PrimeIntellect-ai/nano-rlm/pull/147).

## Breaking

- RLM harness configs must move `summarize_at_tokens` to `compaction.summarize_at_tokens`.
- Leave `compaction` unset to disable proactive and reactive compaction.

## Verification

- `git diff --check`
- `uv lock`
- `uv lock --check`
- `uv run pytest -q tests/unit/test_configs.py` — 133 passed
- `git submodule status deps/verifiers` — `d4a217794fc0bfd70369a8230e56653c193da8ce`
- verified that `d4a2177` descends from the previous `e2103d6` pin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Submodule bump plus a breaking harness config shape affects all RLM runs still using the old `summarize_at_tokens` field; example migrations are mechanical but custom configs must be updated.
> 
> **Overview**
> Advances the **`deps/verifiers`** submodule to pick up merged Bash/RLM **context compaction** (and related harness defaults), with **`uv.lock`** refreshed so **`aiohttp`** meets the new **`>=3.14.1`** floor.
> 
> **Breaking for RLM harness TOML:** flat **`env.agent.harness.summarize_at_tokens`** is replaced by **`env.agent.harness.compaction.summarize_at_tokens`**. The three advanced examples (**`glm-4.5-air/search`**, **`glm-4.5-air/terminal`**, **`nemotron-3-super/swe`**) are updated accordingly—train sources that used a two-threshold list **`[65536, 131072]`** now use a single **`98304`** threshold; eval sources keep **`98304`** but under the nested **`compaction`** key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7429aba97da77a30db191432d5295827c64ae621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->