### PR TITLE
fix(evals): show resumed cursor progress

### DIFF
--- a/src/prime_rl/evals/evals.py
+++ b/src/prime_rl/evals/evals.py
@@ -551,10 +551,11 @@ class Evals:
         disp_drain = self.dispatcher.metrics.drained(train_envs=set(), eval_envs={env.name for env in self.eval_envs})
 
         parts = []
-        for env_name, step, arrived, expected, buffered in sorted(self.eval_sink.batch_progress()):
-            skipped = self.eval_source.skipped_task_count(env_name, step) * self.eval_sink.group_size_for(env_name)
-            shown_arrived = skipped + arrived
-            shown_expected = skipped + expected
+        for env_name, _step, arrived, expected, buffered in sorted(self.eval_sink.batch_progress()):
+            # ``expected`` is only the remaining suffix of a resumed epoch; add the
+            # cursor-skipped prefix back so progress shows against the full epoch.
+            total = self.eval_sink.batch_size_for(env_name)
+            shown_arrived, shown_expected = total - expected + arrived, total
             part = (
                 f"{env_name} {shown_arrived}/{shown_expected} ({shown_arrived / shown_expected:.1%})"
                 if shown_expected

--- a/src/prime_rl/evals/evals.py
+++ b/src/prime_rl/evals/evals.py
@@ -552,8 +552,6 @@ class Evals:
 
         parts = []
         for env_name, _step, arrived, expected, buffered in sorted(self.eval_sink.batch_progress()):
-            # ``expected`` is only the remaining suffix of a resumed epoch; add the
-            # cursor-skipped prefix back so progress shows against the full epoch.
             total = self.eval_sink.batch_size_for(env_name)
             shown_arrived, shown_expected = total - expected + arrived, total
             part = (

--- a/src/prime_rl/evals/evals.py
+++ b/src/prime_rl/evals/evals.py
@@ -551,8 +551,15 @@ class Evals:
         disp_drain = self.dispatcher.metrics.drained(train_envs=set(), eval_envs={env.name for env in self.eval_envs})
 
         parts = []
-        for env_name, _step, arrived, expected, buffered in sorted(self.eval_sink.batch_progress()):
-            part = f"{env_name} {arrived}/{expected} ({arrived / expected:.1%})" if expected else env_name
+        for env_name, step, arrived, expected, buffered in sorted(self.eval_sink.batch_progress()):
+            skipped = self.eval_source.skipped_task_count(env_name, step) * self.eval_sink.group_size_for(env_name)
+            shown_arrived = skipped + arrived
+            shown_expected = skipped + expected
+            part = (
+                f"{env_name} {shown_arrived}/{shown_expected} ({shown_arrived / shown_expected:.1%})"
+                if shown_expected
+                else env_name
+            )
             if buffered:
                 part += f" (+{buffered} buffered)"
             parts.append(part)

--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -98,7 +98,12 @@ class EvalSink:
         return len(env.examples) * env.config.group_size
 
     def batch_progress(self) -> list[tuple[str, int, int, int, int]]:
-        keys = set(self.pending_batches) | set(self.pending_batch_failures) | set(self.pending_batch_cancellations)
+        keys = (
+            set(self.pending_batches)
+            | set(self.pending_batch_failures)
+            | set(self.pending_batch_cancellations)
+            | set(self.expected_batch_sizes)
+        )
         batch_counts = {key: self._batch_size(key) for key in keys}
         buffered: dict[tuple[str, int], int] = {}
         group_ids = set(self.pending_groups) | set(self.pending_group_failures) | set(self.pending_group_cancellations)

--- a/src/prime_rl/orchestrator/eval_source.py
+++ b/src/prime_rl/orchestrator/eval_source.py
@@ -43,6 +43,7 @@ class EvalSource:
         self._next_index = 0
         self._completed: set[int] = set()
         self._triggered_task_counts: dict[tuple[str, int], int] = {}
+        self._skipped_task_counts: dict[tuple[str, int], int] = {}
 
         # A fresh run evaluates the base policy. Resumed runs apply interval
         # rules to the loaded checkpoint and later policies.
@@ -61,6 +62,7 @@ class EvalSource:
             if (is_first or force or step % interval == 0) and self.tasks_by_env[name]:
                 fired.append(name)
         queued_counts: Counter[str] = Counter()
+        skipped_counts: Counter[str] = Counter()
         # Round-robin across fired envs (A₁, B₁, A₂, B₂, …) so the
         # dispatcher rotates at example granularity. ``try_schedule``'s
         # continue-group branch still keeps each example's group_size
@@ -73,15 +75,20 @@ class EvalSource:
                 source_index = self._next_index
                 self._next_index += 1
                 if source_index < self.cursor:
+                    skipped_counts[env_name] += 1
                     continue
                 self.queue.append(TaskRequest(env_name=env_name, task=task, step=step, source_index=source_index))
                 queued_counts[env_name] += 1
-        for env_name, count in queued_counts.items():
-            self._triggered_task_counts[(env_name, step)] = count
+        for env_name in fired:
+            self._triggered_task_counts[(env_name, step)] = queued_counts[env_name]
+            self._skipped_task_counts[(env_name, step)] = skipped_counts[env_name]
         return [name for name in fired if queued_counts[name]]
 
     def triggered_task_count(self, env_name: str, step: int) -> int:
         return self._triggered_task_counts.get((env_name, step), 0)
+
+    def skipped_task_count(self, env_name: str, step: int) -> int:
+        return self._skipped_task_counts.get((env_name, step), 0)
 
     def mark_completed(self, source_index: int) -> bool:
         """Advance the durable cursor only across a fully completed prefix."""

--- a/src/prime_rl/orchestrator/eval_source.py
+++ b/src/prime_rl/orchestrator/eval_source.py
@@ -43,7 +43,6 @@ class EvalSource:
         self._next_index = 0
         self._completed: set[int] = set()
         self._triggered_task_counts: dict[tuple[str, int], int] = {}
-        self._skipped_task_counts: dict[tuple[str, int], int] = {}
 
         # A fresh run evaluates the base policy. Resumed runs apply interval
         # rules to the loaded checkpoint and later policies.
@@ -62,7 +61,6 @@ class EvalSource:
             if (is_first or force or step % interval == 0) and self.tasks_by_env[name]:
                 fired.append(name)
         queued_counts: Counter[str] = Counter()
-        skipped_counts: Counter[str] = Counter()
         # Round-robin across fired envs (A₁, B₁, A₂, B₂, …) so the
         # dispatcher rotates at example granularity. ``try_schedule``'s
         # continue-group branch still keeps each example's group_size
@@ -75,20 +73,15 @@ class EvalSource:
                 source_index = self._next_index
                 self._next_index += 1
                 if source_index < self.cursor:
-                    skipped_counts[env_name] += 1
                     continue
                 self.queue.append(TaskRequest(env_name=env_name, task=task, step=step, source_index=source_index))
                 queued_counts[env_name] += 1
-        for env_name in fired:
-            self._triggered_task_counts[(env_name, step)] = queued_counts[env_name]
-            self._skipped_task_counts[(env_name, step)] = skipped_counts[env_name]
+        for env_name, count in queued_counts.items():
+            self._triggered_task_counts[(env_name, step)] = count
         return [name for name in fired if queued_counts[name]]
 
     def triggered_task_count(self, env_name: str, step: int) -> int:
         return self._triggered_task_counts.get((env_name, step), 0)
-
-    def skipped_task_count(self, env_name: str, step: int) -> int:
-        return self._skipped_task_counts.get((env_name, step), 0)
 
     def mark_completed(self, source_index: int) -> bool:
         """Advance the durable cursor only across a fully completed prefix."""

--- a/tests/unit/evals/test_ckpt.py
+++ b/tests/unit/evals/test_ckpt.py
@@ -72,8 +72,6 @@ def test_eval_checkpoint_saves_only_cursor_and_resume_skips_completed_prefix(tmp
     ]
     assert eval_source.triggered_task_count("math", 0) == 1
     assert eval_source.triggered_task_count("code", 0) == 1
-    assert eval_source.skipped_task_count("math", 0) == 1
-    assert eval_source.skipped_task_count("code", 0) == 1
 
     ckpt = CheckpointManager(tmp_path)
     ckpt.save(eval_source)
@@ -99,29 +97,6 @@ def test_eval_checkpoint_rejects_step_cursor_mismatch(tmp_path) -> None:
     restored_source = EvalSource([_env("math", ["m0"])], _eval_config())
     with pytest.raises(ValueError, match="contains cursor 1, expected step 2"):
         ckpt.load(2, restored_source, path=ckpt.get_ckpt_path(1))
-
-
-def test_eval_source_counts_skipped_cursor_prefix_for_progress() -> None:
-    group_size = 4
-    eval_source = EvalSource(
-        [_env("math", ["m0", "m1", "m2"]), _env("code", ["c0", "c1"])],
-        _eval_config(),
-    )
-    eval_source.load_state_dict({"cursor": 3})
-
-    assert eval_source.trigger(0) == ["math", "code"]
-    assert _queued_tasks(eval_source) == [
-        ("code", "c1", 3),
-        ("math", "m2", 4),
-    ]
-    assert eval_source.skipped_task_count("math", 0) == 2
-    assert eval_source.skipped_task_count("code", 0) == 1
-    assert eval_source.triggered_task_count("math", 0) == 1
-    assert eval_source.triggered_task_count("code", 0) == 1
-
-    shown_arrived = eval_source.skipped_task_count("math", 0) * group_size
-    shown_expected = shown_arrived + eval_source.triggered_task_count("math", 0) * group_size
-    assert (shown_arrived, shown_expected) == (8, 12)
 
 
 def test_eval_sink_reports_expected_empty_batch_for_progress() -> None:

--- a/tests/unit/evals/test_ckpt.py
+++ b/tests/unit/evals/test_ckpt.py
@@ -66,6 +66,8 @@ def test_eval_checkpoint_saves_only_cursor_and_resume_skips_completed_prefix(tmp
     ]
     assert eval_source.triggered_task_count("math", 0) == 1
     assert eval_source.triggered_task_count("code", 0) == 1
+    assert eval_source.skipped_task_count("math", 0) == 1
+    assert eval_source.skipped_task_count("code", 0) == 1
 
     ckpt = CheckpointManager(tmp_path)
     ckpt.save(eval_source)
@@ -91,3 +93,26 @@ def test_eval_checkpoint_rejects_step_cursor_mismatch(tmp_path) -> None:
     restored_source = EvalSource([_env("math", ["m0"])], _eval_config())
     with pytest.raises(ValueError, match="contains cursor 1, expected step 2"):
         ckpt.load(2, restored_source, path=ckpt.get_ckpt_path(1))
+
+
+def test_eval_source_counts_skipped_cursor_prefix_for_progress() -> None:
+    group_size = 4
+    eval_source = EvalSource(
+        [_env("math", ["m0", "m1", "m2"]), _env("code", ["c0", "c1"])],
+        _eval_config(),
+    )
+    eval_source.load_state_dict({"cursor": 3})
+
+    assert eval_source.trigger(0) == ["math", "code"]
+    assert _queued_tasks(eval_source) == [
+        ("code", "c1", 3),
+        ("math", "m2", 4),
+    ]
+    assert eval_source.skipped_task_count("math", 0) == 2
+    assert eval_source.skipped_task_count("code", 0) == 1
+    assert eval_source.triggered_task_count("math", 0) == 1
+    assert eval_source.triggered_task_count("code", 0) == 1
+
+    shown_arrived = eval_source.skipped_task_count("math", 0) * group_size
+    shown_expected = shown_arrived + eval_source.triggered_task_count("math", 0) * group_size
+    assert (shown_arrived, shown_expected) == (8, 12)

--- a/tests/unit/evals/test_ckpt.py
+++ b/tests/unit/evals/test_ckpt.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import pytest
 
 from prime_rl.evals.ckpt import CheckpointManager
+from prime_rl.orchestrator.eval_sink import EvalSink
 from prime_rl.orchestrator.eval_source import EvalSource
 
 
@@ -11,12 +12,17 @@ def _task(key: str) -> SimpleNamespace:
     return SimpleNamespace(key=key, hash=key)
 
 
-def _env(name: str, task_keys: list[str], *, interval: int = 1) -> SimpleNamespace:
+def _env(name: str, task_keys: list[str], *, interval: int = 1, group_size: int = 1) -> SimpleNamespace:
     return SimpleNamespace(
         name=name,
         examples=[_task(key) for key in task_keys],
-        config=SimpleNamespace(interval=interval),
+        config=SimpleNamespace(interval=interval, group_size=group_size),
     )
+
+
+def _eval_envs(*envs: SimpleNamespace) -> SimpleNamespace:
+    by_name = {env.name: env for env in envs}
+    return SimpleNamespace(get=by_name.__getitem__)
 
 
 def _eval_config() -> SimpleNamespace:
@@ -116,3 +122,11 @@ def test_eval_source_counts_skipped_cursor_prefix_for_progress() -> None:
     shown_arrived = eval_source.skipped_task_count("math", 0) * group_size
     shown_expected = shown_arrived + eval_source.triggered_task_count("math", 0) * group_size
     assert (shown_arrived, shown_expected) == (8, 12)
+
+
+def test_eval_sink_reports_expected_empty_batch_for_progress() -> None:
+    eval_sink = EvalSink(eval_envs=_eval_envs(_env("math", ["m0"], group_size=4)))
+
+    eval_sink.set_batch_size("math", step=0, size=4)
+
+    assert eval_sink.batch_progress() == [("math", 0, 0, 4, 0)]


### PR DESCRIPTION
## Summary

- resumed standalone evals show progress against the full epoch instead of only the remaining suffix: the pipeline view derives shown totals from the full batch size (`EvalSink.batch_size_for`), so a run resumed at cursor 80/100 prints `80/100` instead of `0/20`; sink completion thresholds stay suffix-only so resumed epochs finish without re-waiting on skipped tasks
- `EvalSink.batch_progress` also reports expected-but-empty batches, so an env shows `0/N (0.0%)` immediately after its epoch fires, before any result arrives

Checkpoint format is unchanged — it still saves only the cursor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and progress-reporting only; eval batch completion thresholds and checkpoint format are unchanged.
> 
> **Overview**
> **Resumed standalone evals** now report epoch progress against the **full** batch size in the periodic pipeline view, not only the remaining suffix after a checkpoint cursor. `collect_pipeline_view` maps sink tuples (`arrived` / `expected` for the outstanding work) into `shown_arrived/shown_expected` using `EvalSink.batch_size_for`, so a resume at cursor 80/100 logs **80/100** instead of **0/20**. Completion logic in the sink is unchanged—it still waits only on the suffix.
> 
> **`EvalSink.batch_progress`** also unions in `expected_batch_sizes`, so an env appears as **0/N (0.0%)** as soon as its epoch is triggered, before any episodes land. A unit test covers that expected-but-empty batch case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4db44cc600b01df18a118da34e23a381f6829577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->