### PR TITLE
fix(evals): show error rate on partially evaluated epochs

### DIFF
--- a/src/prime_rl/evals/evals.py
+++ b/src/prime_rl/evals/evals.py
@@ -537,6 +537,7 @@ class Evals:
             get_logger().warning(
                 f"Partially evaluated {batch.env_name} (Step {batch.step}) | "
                 f"{format_time(elapsed):>7} | Reward {eff.reward.mean():.4f} | "
+                f"Error {full.has_error.mean():.1%} | "
                 f"Completed {len(episodes)}/{total_attempts} | Cancelled {batch.cancelled}/{total_attempts}"
             )
             return


### PR DESCRIPTION
## Summary

- the partially-evaluated (cancelled-epoch) warning line in the `uv run evals` entrypoint log now shows the `Error` rate next to `Reward` — previously it reported reward with no signal of how many completed episodes errored

```
Partially evaluated swebench-pro (Step 240) |  1m 32s | Reward 0.4167 | Error 5.0% | Completed 92/100 | Cancelled 8/100
```

The completed-epoch success line already shows `Error` and is unchanged:

```
Evaluated swebench-pro (Step 240) |  1m 32s | Reward 0.4167 | Turns 3.2 | Branches 1.0 | Error 5.0% | Truncation 2.0%
```

## Verification

- `uv run ruff check src/prime_rl/evals/evals.py` — passed
- `uv run ruff format --check src/prime_rl/evals/evals.py` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change in eval finalization; no behavior, scheduling, or metric emission changes.
> 
> **Overview**
> When an eval epoch is **cancelled** (e.g. superseded by a newer checkpoint), the warning log line now includes the **Error** rate from completed episodes, using the same `full.has_error` formatting as the full **Evaluated** success line.
> 
> Previously that partial-eval message only showed reward and completion/cancel counts, so operators could not see how many finished rollouts failed without digging into metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010a7eceb61c71fa105ffadf7b4dc4e6708fc188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->