### PR TITLE
feat: constant trainer batch size

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -413,7 +413,7 @@ demo_key = "demonstration"
 
 Scoring runs before curriculum admission, so a rollout that is later rejected still costs its reference compute.
 
-By default, zero-advantage RL tokens are removed before samples count toward the batch target. The orchestrator collects replacement samples, so rollout-based batches contain `orchestrator.batch_size` training traces. Samples that still carry CE or reference-KL components are retained, while pure zero-advantage RL samples are not shipped. Removing an RL token also removes its trainer/inference mismatch-KL contribution. Set `orchestrator.train.filter_zero_advantages = false` to retain them.
+By default, zero-advantage RL tokens are removed before samples count toward the batch target. The orchestrator collects replacement samples, so rollout-based batches contain `orchestrator.batch_size` training traces. Set `orchestrator.constant_trainer_batch_size = false` to filter after collection without replacement. This can improve orchestrator throughput, but it produces smaller trainer batches when samples have no signal. Samples that still carry CE or reference-KL components are retained, while pure zero-advantage RL samples are not shipped. Removing an RL token also removes its trainer/inference mismatch-KL contribution. Set `orchestrator.train.filter_zero_advantages = false` to retain them.
 
 ## Curricula
 

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -413,7 +413,9 @@ demo_key = "demonstration"
 
 Scoring runs before curriculum admission, so a rollout that is later rejected still costs its reference compute.
 
-By default, zero-advantage RL tokens are removed before samples count toward the batch target. The orchestrator collects replacement samples, so rollout-based batches contain `orchestrator.batch_size` training traces. Set `orchestrator.constant_trainer_batch_size = false` to filter after collection without replacement. This can improve orchestrator throughput, but it produces smaller trainer batches when samples have no signal. Samples that still carry CE or reference-KL components are retained, while pure zero-advantage RL samples are not shipped. Removing an RL token also removes its trainer/inference mismatch-KL contribution. Set `orchestrator.train.filter_zero_advantages = false` to retain them.
+The orchestrator filters samples with no training signal. This includes samples with zero advantage on all RL tokens. Samples that still carry CE or reference-KL components are retained. Filtering an RL token also removes its trainer/inference mismatch-KL contribution.
+
+`orchestrator.constant_trainer_batch_size` defaults to `true`. The orchestrator filters samples before they count toward the batch target. It collects replacements, so rollout-based batches contain `orchestrator.batch_size` training traces. Set the option to `false` to filter after collection without replacement. This setting can improve orchestrator throughput, but it produces smaller trainer batches.
 
 ## Curricula
 

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -413,7 +413,7 @@ demo_key = "demonstration"
 
 Scoring runs before curriculum admission, so a rollout that is later rejected still costs its reference compute.
 
-By default, zero-advantage RL tokens are removed after a complete batch cohort has been collected and before its payload is packed for the trainer. This does not backfill the batch. Samples that still carry CE or reference-KL components are retained, while pure zero-advantage RL samples are not shipped. Removing an RL token also removes its trainer/inference mismatch-KL contribution. Set `orchestrator.train.filter_zero_advantages = false` to retain them.
+By default, zero-advantage RL tokens are removed before samples count toward the batch target. The orchestrator collects replacement samples, so rollout-based batches contain `orchestrator.batch_size` training traces. Samples that still carry CE or reference-KL components are retained, while pure zero-advantage RL samples are not shipped. Removing an RL token also removes its trainer/inference mismatch-KL contribution. Set `orchestrator.train.filter_zero_advantages = false` to retain them.
 
 ## Curricula
 
@@ -425,7 +425,7 @@ Three small implementations are included:
 
 - `StandardSampler` is the default: it advances the task iterator and cycles finite tasksets in source order.
 - `DifficultyPoolSampler` samples finite tasksets with replacement and tracks each task's latest valid mean group reward. Each named pool has an inclusive reward threshold and a relative per-task sampling weight; weight `0` disables sampling from that pool. Unseen tasks use neutral weight `1.0`, so pool observations affect sampling immediately without waiting for a full taskset pass.
-- `AdvRangeGate` rejects a group when every trainable-token advantage falls inside `reject_min` through `reject_max`. Unlike the built-in post-batch zero-advantage filtering, rejection requests replacement work. Groups without an advantage stream are admitted.
+- `AdvRangeGate` rejects a group when every trainable-token advantage falls inside `reject_min` through `reject_max`. Unlike the built-in token filter, it can reject a configurable advantage range. Groups without an advantage stream are admitted.
 
 ```toml
 [orchestrator.train.source.curriculum.sampler]

--- a/docs/training.md
+++ b/docs/training.md
@@ -133,7 +133,9 @@ Pulled from the console logs and mirrored to W&B.
 | Source | Metric | Reading |
 |---|---|---|
 | trainer | `time/wait_for_batch` | **high → orchestrator bottleneck** |
-| orchestrator | `time/wait_for_ckpt` | **high → trainer bottleneck** |
+| orchestrator | `time/wait_for_policy` | **high → trainer bottleneck** |
+
+The trainer warns when batch wait time exceeds active trainer time. Add inference nodes when this warning persists. The orchestrator warns when policy wait time exceeds active orchestrator time. Add trainer nodes when this warning persists. The orchestrator also warns when it discards more than half of an episode window. This warning reports stale, errored, and no-signal counts.
 
 ## SFT Trainer
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -58,7 +58,7 @@ A condensed view of the knobs you'll most often tune. For trainer-side paralleli
 | Knob | What it does |
 |---|---|
 | `orchestrator.batch_size` | Tasks per trainer step. |
-| `orchestrator.constant_trainer_batch_size` | Collect replacement samples after zero-advantage filtering. Enabled by default. Disable it for faster collection with variable trainer batch sizes. |
+| `orchestrator.constant_trainer_batch_size` | Keep trainer batches constant when samples have no training signal, such as zero advantage on all tokens. Enabled by default. Disable it for faster collection with variable trainer batch sizes. |
 | `orchestrator.group_size` | Rollouts generated per task. |
 | `orchestrator.max_off_policy_steps` | Maximum staleness of a trained rollout (default 8): the version a batch trains on minus the oldest version that generated the rollout, queue time included. Episodes past the bound are dropped; a group shares one dispatch version, so its episodes age out together. The main off-policy dial on long agentic rollouts — bump for throughput, lower for tighter on-policyness. Watch `off_policy/*` and `mismatch_kl/all/mean` when tuning. |
 | `[orchestrator.algo]` | Training algorithm — its `type` names it (`grpo` default, `max_rl`, `rae`, `hierarchical_grpo`, `opd`, `opsd`, `sft`, `echo`). See [Algorithms](#algorithms). |

--- a/docs/training.md
+++ b/docs/training.md
@@ -58,6 +58,7 @@ A condensed view of the knobs you'll most often tune. For trainer-side paralleli
 | Knob | What it does |
 |---|---|
 | `orchestrator.batch_size` | Tasks per trainer step. |
+| `orchestrator.constant_trainer_batch_size` | Collect replacement samples after zero-advantage filtering. Enabled by default. Disable it for faster collection with variable trainer batch sizes. |
 | `orchestrator.group_size` | Rollouts generated per task. |
 | `orchestrator.max_off_policy_steps` | Maximum staleness of a trained rollout (default 8): the version a batch trains on minus the oldest version that generated the rollout, queue time included. Episodes past the bound are dropped; a group shares one dispatch version, so its episodes age out together. The main off-policy dial on long agentic rollouts — bump for throughput, lower for tighter on-policyness. Watch `off_policy/*` and `mismatch_kl/all/mean` when tuning. |
 | `[orchestrator.algo]` | Training algorithm — its `type` names it (`grpo` default, `max_rl`, `rae`, `hierarchical_grpo`, `opd`, `opsd`, `sft`, `echo`). See [Algorithms](#algorithms). |

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -304,9 +304,6 @@ class TrainConfig(BaseConfig):
     sampling: TrainSamplingConfig = TrainSamplingConfig()
     """Shared training sampling configuration."""
 
-    filter_zero_advantages: bool = True
-    """Remove zero-advantage RL tokens from trainer payloads."""
-
     @model_validator(mode="after")
     def resolve_env_defaults(self):
         """Resolve per-env overrides: inherit group-level sampling (the worker ``pool``
@@ -555,7 +552,7 @@ class OrchestratorConfig(BaseConfig):
     """Samples to train on per step (rollout-based batching). Set this OR ``token_batch_size``."""
 
     constant_trainer_batch_size: bool = True
-    """Collect replacement samples when zero-advantage filtering shrinks a batch."""
+    """Require each batch to reach its effective sample target."""
 
     token_batch_size: int | None = Field(None, ge=1)
     """Tokens to train on per step (token-based batching). Set this OR ``batch_size``."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -305,7 +305,7 @@ class TrainConfig(BaseConfig):
     """Shared training sampling configuration."""
 
     filter_zero_advantages: bool = True
-    """Remove zero-advantage RL tokens before counting samples toward a batch."""
+    """Remove zero-advantage RL tokens from trainer payloads."""
 
     @model_validator(mode="after")
     def resolve_env_defaults(self):
@@ -553,6 +553,9 @@ class OrchestratorConfig(BaseConfig):
 
     batch_size: int | None = Field(None, ge=1)
     """Samples to train on per step (rollout-based batching). Set this OR ``token_batch_size``."""
+
+    constant_trainer_batch_size: bool = True
+    """Collect replacement samples when zero-advantage filtering shrinks a batch."""
 
     token_batch_size: int | None = Field(None, ge=1)
     """Tokens to train on per step (token-based batching). Set this OR ``batch_size``."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -305,7 +305,7 @@ class TrainConfig(BaseConfig):
     """Shared training sampling configuration."""
 
     filter_zero_advantages: bool = True
-    """Remove zero-advantage RL tokens after collecting a batch, before shipping it."""
+    """Remove zero-advantage RL tokens before counting samples toward a batch."""
 
     @model_validator(mode="after")
     def resolve_env_defaults(self):

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -154,7 +154,7 @@ All metrics print to the console log (and W&B when configured).
 
 The trainer warns when batch wait time exceeds active trainer time. Add inference nodes when this warning persists. The orchestrator warns when policy wait time exceeds active orchestrator time. Add trainer nodes when this warning persists. The orchestrator also warns when it discards more than half of an episode window and reports stale, errored, and no-signal counts.
 
-`orchestrator.constant_trainer_batch_size` defaults to `true`. It replaces samples removed by zero-advantage filtering. Set it to `false` for faster collection with variable trainer batch sizes.
+`orchestrator.constant_trainer_batch_size` defaults to `true`. It keeps each rollout batch at `orchestrator.batch_size` effective episodes. Set it to `false` for faster collection with variable trainer batch sizes.
 
 For live vLLM stats, query Prometheus directly:
 

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -152,6 +152,8 @@ All metrics print to the console log (and W&B when configured).
 | orchestrator | `off_policy/{mean,max}`, `off_policy/{in_flight,in_queue}/{mean,max}`, `off_policy/dropped` | per-step staleness of trained rollouts |
 | env server | event loop lag (min/mean/p90/p99/max), active task distribution | periodic |
 
+The trainer warns when batch wait time exceeds active trainer time. Add inference nodes when this warning persists. The orchestrator warns when policy wait time exceeds active orchestrator time. Add trainer nodes when this warning persists. The orchestrator also warns when it discards more than half of an episode window and reports stale, errored, and no-signal counts.
+
 For live vLLM stats, query Prometheus directly:
 
 ```bash

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -154,6 +154,8 @@ All metrics print to the console log (and W&B when configured).
 
 The trainer warns when batch wait time exceeds active trainer time. Add inference nodes when this warning persists. The orchestrator warns when policy wait time exceeds active orchestrator time. Add trainer nodes when this warning persists. The orchestrator also warns when it discards more than half of an episode window and reports stale, errored, and no-signal counts.
 
+`orchestrator.constant_trainer_batch_size` defaults to `true`. It replaces samples removed by zero-advantage filtering. Set it to `false` for faster collection with variable trainer batch sizes.
+
 For live vLLM stats, query Prometheus directly:
 
 ```bash

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -741,7 +741,11 @@ class Orchestrator:
             )
 
         shipped_episode_ids = {episode.id for episode in batch.cohort}
-        discarded_episodes = [episode for episode in batch.episodes if episode.id not in shipped_episode_ids]
+        discarded_episodes = [
+            episode
+            for episode in batch.episodes
+            if episode.id not in shipped_episode_ids and episode.id not in batch.buffered_episode_ids
+        ]
         stale_episodes = sum(episode.id in batch.episodes.cancelled for episode in discarded_episodes)
         errored_episodes = sum(
             episode.id not in batch.episodes.cancelled

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -731,6 +731,34 @@ class Orchestrator:
             metrics[f"batch/{env_name}"] = env_pool.num_traces / batch.episodes.num_traces
         metrics |= self.train_source.metrics()
         await monitors.log(metrics, step=step)
+
+        active_step_time = max(step_time - self.wait_for_policy_time, 0.0)
+        if step_time > 0 and self.wait_for_policy_time >= active_step_time:
+            get_logger().warning(
+                f"Orchestrator waited {format_time(self.wait_for_policy_time)} for policy updates, at least as long "
+                f"as its {format_time(active_step_time)} active step time. Train-inference compute is imbalanced; "
+                "add more trainer nodes."
+            )
+
+        shipped_episode_ids = {episode.id for episode in batch.cohort}
+        discarded_episodes = [episode for episode in batch.episodes if episode.id not in shipped_episode_ids]
+        stale_episodes = sum(episode.id in batch.episodes.cancelled for episode in discarded_episodes)
+        errored_episodes = sum(
+            episode.id not in batch.episodes.cancelled
+            and (not episode.ok or any(trace.has_error for trace in episode.traces))
+            for episode in discarded_episodes
+        )
+        num_attempts = len(batch.episodes) + len(batch.failures) + batch.cancelled_attempts
+        num_discarded = len(discarded_episodes) + len(batch.failures) + batch.cancelled_attempts
+        num_stale = stale_episodes + batch.stale_attempts
+        num_errored = errored_episodes + len(batch.failures)
+        num_no_signal = num_discarded - num_stale - num_errored
+        if num_attempts and num_discarded / num_attempts > 0.5:
+            get_logger().warning(
+                f"Discarded {num_discarded}/{num_attempts} episodes ({num_discarded / num_attempts:.1%}): "
+                f"stale={num_stale}, errored={num_errored}, no_signal={num_no_signal}. Review max_off_policy_steps, "
+                "episode errors, and reward signal."
+            )
         self.wait_for_policy_time = 0.0
 
         if self.heart is not None:

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -392,6 +392,7 @@ class TrainSink:
         samples = [sample for trace_samples in selected_by_trace.values() for sample in trace_samples]
 
         shipped_ids = set(selected_by_trace)
+        buffered_episode_ids = {self.episode_by_trace[trace_id].id for trace_id in self.pending_batch}
         traces_by_episode: dict[int, list[vf.Trace]] = defaultdict(list)
         selected_episodes: dict[int, vf.Episode] = {}
         for trace_id in selected_ids:
@@ -419,6 +420,7 @@ class TrainSink:
             cohort=cohort,
             samples=samples,
             failures=failures,
+            buffered_episode_ids=buffered_episode_ids,
             cancelled_attempts=cancelled_attempts,
             stale_attempts=stale_attempts,
         )

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -293,7 +293,7 @@ class TrainSink:
                         "it requires vLLM's native sampling-mask capture (>= 0.28)."
                     )
                 stamp_loss_routing(sample, env.algorithm.action_loss_type)
-            if self.config.train.filter_zero_advantages:
+            if self.config.train.filter_zero_advantages and self.config.constant_trainer_batch_size:
                 samples = [sample for sample in samples if _prune_zero_advantages(sample)]
             if samples:
                 samples_by_trace[trace.id] = samples
@@ -383,6 +383,12 @@ class TrainSink:
         for trace_id in selected_ids:
             del self.pending_batch[trace_id]
 
+        if self.config.train.filter_zero_advantages and not self.config.constant_trainer_batch_size:
+            selected_by_trace = {
+                trace_id: [sample for sample in samples if _prune_zero_advantages(sample)]
+                for trace_id, samples in selected
+            }
+            selected_by_trace = {trace_id: samples for trace_id, samples in selected_by_trace.items() if samples}
         samples = [sample for trace_samples in selected_by_trace.values() for sample in trace_samples]
 
         shipped_ids = set(selected_by_trace)

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -88,6 +88,8 @@ class TrainSink:
 
         self.pending_episodes = TrainEpisodes()
         self.pending_failures: list[DispatchFailure] = []
+        self.pending_cancelled_attempts = 0
+        self.pending_stale_attempts = 0
         self.pending_groups: dict[str, list[vf.Episode]] = defaultdict(list)
         self.pending_group_failures: dict[str, list[DispatchFailure]] = defaultdict(list)
         # A dropped group's terminal marker; its ``count`` fills in for the
@@ -243,6 +245,10 @@ class TrainSink:
         )
         n_owed = len(group) + len(failures) + (cancellation.count if cancellation is not None else 0)
         self.pending_failures.extend(failures)
+        if cancellation is not None:
+            self.pending_cancelled_attempts += cancellation.count
+            if cancellation.reason == "stale":
+                self.pending_stale_attempts += cancellation.count
 
         # A stale drop voids the whole group: every member shares the dispatch
         # version, so the arrived episodes are exactly as stale as the
@@ -287,6 +293,8 @@ class TrainSink:
                         "it requires vLLM's native sampling-mask capture (>= 0.28)."
                     )
                 stamp_loss_routing(sample, env.algorithm.action_loss_type)
+            if self.config.train.filter_zero_advantages:
+                samples = [sample for sample in samples if _prune_zero_advantages(sample)]
             if samples:
                 samples_by_trace[trace.id] = samples
 
@@ -375,12 +383,6 @@ class TrainSink:
         for trace_id in selected_ids:
             del self.pending_batch[trace_id]
 
-        if self.config.train.filter_zero_advantages:
-            selected_by_trace = {
-                trace_id: [sample for sample in samples if _prune_zero_advantages(sample)]
-                for trace_id, samples in selected
-            }
-            selected_by_trace = {trace_id: samples for trace_id, samples in selected_by_trace.items() if samples}
         samples = [sample for trace_samples in selected_by_trace.values() for sample in trace_samples]
 
         shipped_ids = set(selected_by_trace)
@@ -399,7 +401,18 @@ class TrainSink:
 
         episodes = self.pending_episodes
         failures = self.pending_failures
+        cancelled_attempts = self.pending_cancelled_attempts
+        stale_attempts = self.pending_stale_attempts
         if samples:
             self.pending_episodes = TrainEpisodes()
             self.pending_failures = []
-        return TrainBatch(episodes=episodes, cohort=cohort, samples=samples, failures=failures)
+            self.pending_cancelled_attempts = 0
+            self.pending_stale_attempts = 0
+        return TrainBatch(
+            episodes=episodes,
+            cohort=cohort,
+            samples=samples,
+            failures=failures,
+            cancelled_attempts=cancelled_attempts,
+            stale_attempts=stale_attempts,
+        )

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -293,7 +293,7 @@ class TrainSink:
                         "it requires vLLM's native sampling-mask capture (>= 0.28)."
                     )
                 stamp_loss_routing(sample, env.algorithm.action_loss_type)
-            if self.config.train.filter_zero_advantages and self.config.constant_trainer_batch_size:
+            if self.config.constant_trainer_batch_size:
                 samples = [sample for sample in samples if _prune_zero_advantages(sample)]
             if samples:
                 samples_by_trace[trace.id] = samples
@@ -383,7 +383,7 @@ class TrainSink:
         for trace_id in selected_ids:
             del self.pending_batch[trace_id]
 
-        if self.config.train.filter_zero_advantages and not self.config.constant_trainer_batch_size:
+        if not self.config.constant_trainer_batch_size:
             selected_by_trace = {
                 trace_id: [sample for sample in samples if _prune_zero_advantages(sample)]
                 for trace_id, samples in selected

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -124,6 +124,10 @@ class TrainBatch:
     cohort: TrainEpisodes
     samples: list[TrainingSample]
     failures: list[DispatchFailure]
+    # Group cancellations can account for attempts that returned no episode.
+    cancelled_attempts: int = 0
+    # Stale attempts are a subset of cancelled_attempts.
+    stale_attempts: int = 0
 
 
 @dataclass

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -124,6 +124,8 @@ class TrainBatch:
     cohort: TrainEpisodes
     samples: list[TrainingSample]
     failures: list[DispatchFailure]
+    # Episodes with traces retained for a later batch are not discarded.
+    buffered_episode_ids: set[str]
     # Group cancellations can account for attempts that returned no episode.
     cancelled_attempts: int = 0
     # Stale attempts are a subset of cancelled_attempts.

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -668,7 +668,7 @@ def train(config: TrainerConfig):
         # Log step metrics
         step_time = time.perf_counter() - step_start_time
         active_step_time = step_time - wait_for_batch_time
-        if wait_for_batch_time >= active_step_time:
+        if progress.step > start_step and wait_for_batch_time >= active_step_time:
             logger.warning(
                 f"Trainer waited {format_time(wait_for_batch_time)} for a batch, at least as long as its "
                 f"{format_time(active_step_time)} active step time. Train-inference compute is imbalanced; "

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -667,6 +667,13 @@ def train(config: TrainerConfig):
 
         # Log step metrics
         step_time = time.perf_counter() - step_start_time
+        active_step_time = step_time - wait_for_batch_time
+        if wait_for_batch_time >= active_step_time:
+            logger.warning(
+                f"Trainer waited {format_time(wait_for_batch_time)} for a batch, at least as long as its "
+                f"{format_time(active_step_time)} active step time. Train-inference compute is imbalanced; "
+                "add more inference nodes."
+            )
         step_message = f"Step {progress.step} | {format_time(step_time):>7} | Loss {tensor_stats['loss/mean']:.4f} | Entropy {tensor_stats['entropy/all/mean']:.4f}"
         if "mismatch_kl/all/mean" in tensor_stats:
             step_message += f" | Mismatch KL {tensor_stats['mismatch_kl/all/mean']:.4f}"


### PR DESCRIPTION
## Summary

- Add `orchestrator.constant_trainer_batch_size` with a default of `true`.
- Backfill filtered samples when constant batches are enabled.
- Keep faster, variable-size batches available when the option is disabled.
- Always filter samples with no training signal before trainer delivery.
- Warn about sustained trainer waits and orchestrator waits.
- Warn about high episode discard rates without counting buffered work.
- Report stale, errored, and no-signal discard counts.
- Update the training docs and run-monitoring skill.

## Breaking

- Remove `orchestrator.train.filter_zero_advantages`. Delete this field from existing configs. The orchestrator now always filters zero-advantage RL tokens.

## Verification

Before, zero-advantage filtering ran after batch selection. The orchestrator did not replace filtered samples. The trainer could receive fewer samples than `orchestrator.batch_size`.

Paired reverse-text runs used five steps, batch size 64, group size 4, sequence length 512, and 128 maximum completion tokens.

| `constant_trainer_batch_size` | Effective episodes by step | Mean orchestrator step | Total orchestrator time |
|---|---|---:|---:|
| `true` | 64, 64, 64, 64, 64 | 8.76s | 43.79s |
| `false` | 40, 40, 36, 44, 52 | 6.49s | 32.45s |

The default constant mode produced exactly 64 effective episodes on every step. It was 35% slower because it generated replacement episodes.

Additional five-step reverse-text runs exercised the warning paths:

- An 8-second local orchestrator delay triggered the trainer-wait warning.
- An 8-second local trainer delay triggered the orchestrator-wait warning.
- `max_off_policy_steps = 0` triggered discard warnings. One warning reported 48/56 discarded episodes: 40 stale, 0 errored, and 8 with no signal.

The local delays were temporary verification changes. They are not in this diff.

`uv run pytest tests/unit/test_configs.py tests/unit/orchestrator/test_batch.py tests/unit/orchestrator/test_metrics.py -q` passed with 172 tests.

`uv run pytest tests/unit/test_configs.py tests/unit/orchestrator/test_batch.py tests/unit/orchestrator/test_metrics.py tests/unit/orchestrator/test_advantage.py` passed with 182 tests.

`uv run ruff check` and `uv run ruff format --check` passed for all changed Python files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default batch assembly and removes a config knob, which can shift rollout compute vs trainer step size; behavior is documented but existing configs must drop `filter_zero_advantages`.
> 
> **Overview**
> Adds **`orchestrator.constant_trainer_batch_size`** (default **`true`**) so rollout batches still reach **`orchestrator.batch_size`** effective traces after dropping samples with no training signal (e.g. all-zero RL advantages). With constant mode, zero-advantage pruning happens **before** traces enter the pending batch so the sink keeps collecting replacements; with **`false`**, pruning runs at ship time for faster collection but **variable** trainer batch sizes.
> 
> **Breaking:** removes **`orchestrator.train.filter_zero_advantages`** — zero-advantage RL token filtering is always applied; only the timing/backfill behavior is controlled by the new flag.
> 
> **`TrainBatch`** now carries **`buffered_episode_ids`**, **`cancelled_attempts`**, and **`stale_attempts`** so the orchestrator can warn when more than half of a window’s attempts are discarded, split into **stale**, **errored**, and **no_signal**. The trainer and orchestrator also log imbalance warnings when **`time/wait_for_batch`** or **`time/wait_for_policy`** dominates active step time. Docs and the monitor-run skill document the knob and **`time/wait_for_policy`** (replacing **`time/wait_for_ckpt`** in guidance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2befb8878975ab6408793840cf8dd6e4ae9a0f1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->