### PR TITLE
fix: keep bounded sampling masks sparse

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -17,6 +17,77 @@ def apply_shared_vllm_patches():
     monkey_patch_return_routed_experts_with_nixl_connector()
     monkey_patch_kv_xfer_finished_tolerate_freed()
     monkey_patch_online_fp8_parameter_cast()
+    monkey_patch_bounded_sampling_mask()
+
+
+def monkey_patch_bounded_sampling_mask():
+    """Keep bounded sampling masks sparse across the device-to-host copy."""
+    from contextvars import ContextVar
+    from typing import NamedTuple
+
+    import numpy as np
+    from vllm.v1.outputs import SamplingMaskLists
+    from vllm.v1.worker.gpu.sample.output import SamplingMaskTensors
+    from vllm.v1.worker.gpu.sample.sampler import Sampler
+
+    original_call = Sampler.__call__
+    original_from_logits = SamplingMaskTensors.from_logits
+    if getattr(original_call, "_prime_rl_uses_sparse_sampling_masks", False):
+        return
+
+    max_sparse_width = 512
+    use_sparse: ContextVar[bool] = ContextVar("use_sparse_sampling_mask", default=False)
+
+    class SparseSamplingMaskTensors(NamedTuple):
+        token_ids: torch.Tensor
+        counts: torch.Tensor
+
+        def to_cpu_nonblocking(self):
+            if self.token_ids.device.type == "cpu":
+                return self
+            return SparseSamplingMaskTensors(
+                self.token_ids.to("cpu", non_blocking=True),
+                self.counts.to("cpu", non_blocking=True),
+            )
+
+        def tolists(self, num_sampled_tokens: np.ndarray) -> SamplingMaskLists:
+            sampled_rows = np.flatnonzero(num_sampled_tokens)
+            counts = self.counts.numpy()[sampled_rows]
+            offsets = np.empty(len(counts) + 1, dtype=np.int64)
+            offsets[0] = 0
+            np.cumsum(counts, dtype=np.int64, out=offsets[1:])
+            token_ids = self.token_ids.numpy()[sampled_rows]
+            token_ids = token_ids[token_ids >= 0]
+            return SamplingMaskLists(
+                token_ids=token_ids,
+                offsets=offsets,
+                cu_num_generated_tokens=np.cumsum(np.concatenate(([0], num_sampled_tokens))).tolist(),
+            )
+
+    def _call(self, logits, input_batch):
+        top_k = self.sampling_states.top_k.np[input_batch.idx_mapping_np]
+        token = use_sparse.set(self.return_sampling_mask and int(top_k.max()) <= max_sparse_width)
+        try:
+            return original_call(self, logits, input_batch)
+        finally:
+            use_sparse.reset(token)
+
+    def _from_logits(cls, logits, num_sampled_tokens):
+        if not use_sparse.get():
+            return original_from_logits(logits, num_sampled_tokens)
+
+        width = min(max_sparse_width + 1, logits.shape[1])
+        values, token_ids = logits.topk(width, dim=-1)
+        finite = torch.isfinite(values)
+        overflow = finite[:, -1:] if width > max_sparse_width else torch.zeros_like(finite[:, :1])
+        keep = finite & ~overflow & (num_sampled_tokens[:, None] > 0)
+        token_ids = token_ids.to(torch.int32).masked_fill_(~keep, -1)
+        counts = keep.sum(dim=-1, dtype=torch.int32)
+        return SparseSamplingMaskTensors(token_ids, counts)
+
+    _call._prime_rl_uses_sparse_sampling_masks = True
+    Sampler.__call__ = _call
+    SamplingMaskTensors.from_logits = classmethod(_from_logits)
 
 
 def monkey_patch_online_fp8_parameter_cast():


### PR DESCRIPTION
## Summary

- keep sampling masks with at most 512 IDs sparse during device-to-host transfer
- preserve vLLM's scheduler and response formats
- fall back to vLLM's full-vocabulary bitset for wider masks
- restore the bounded sampling-mask optimization from #3235 on current `main`

## Verification

- `uv run --no-sync pytest -q tests/unit/inference` (3 passed)
- `uv run --no-sync ruff check src/prime_rl/inference/patches.py`
- `uv run --no-sync ruff format --check src/prime_rl/inference/patches.py`

The paired live-training benchmark ran 10 steps per revision with the same
Qwen3-0.6B model, Reverse Text environment, V2 runner, sampling replay
(`top_p = 0.95`, bounded to `top_k = 512`), nodes, and warm caches. `main` ran
first and this PR ran immediately afterward. Request- and token-normalized
metrics account for the different trajectories sampled during live training.

| Metric | `main` | This PR | Change |
| --- | ---: | ---: | ---: |
| Complete 10-step orchestrator loop | 58.3 s | 52.9 s | -9.3% |
| Mean vLLM request inference time | 890 ms | 354 ms | -60.2% / 2.51x faster |
| vLLM decode time per generated token | 9.72 ms | 3.95 ms | -59.4% / 2.46x faster |
| Mean agent model-call time, steps 2-10 | 837 ms | 391 ms | -53.2% / 2.14x faster |

- [`main` W&B run](https://wandb.ai/primeintellect/sampling-replay-perf/runs/6807a113b43946acbb858311fef4fe62)
- [PR W&B run](https://wandb.ai/primeintellect/sampling-replay-perf/runs/3e6e39b768064bd1a900e45ec3c25ea2)

A targeted batch-384 sampling-mask benchmark reduced device-to-host data from
6.94 MiB to 0.75 MiB and CPU mask materialization from 211 ms to 1.20 ms. This
isolates the regression to vLLM's dense vocabulary-width bitset conversion;
the HTTP payload, router, environment server, and trainer are downstream of
that work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Monkey-patches core vLLM v1 sampler/mask conversion on every worker; incorrect sparse logic could break sampling replay or mask payloads, though behavior is gated to bounded top-k and falls back to upstream.
> 
> **Overview**
> **Restores a sparse path for vLLM sampling masks** when `return_sampling_mask` is on and effective `top_k` is at most 512, avoiding the dense full-vocabulary bitset that regressed device-to-host transfer and CPU materialization.
> 
> A new `monkey_patch_bounded_sampling_mask()` is wired into `apply_shared_vllm_patches()`. It wraps `Sampler.__call__` (via a `ContextVar`) and replaces `SamplingMaskTensors.from_logits` to build `SparseSamplingMaskTensors` from a bounded `topk` over logits, with `to_cpu_nonblocking` / `tolists` still emitting vLLM’s `SamplingMaskLists` so scheduler and response formats stay unchanged. Wider masks or disabled sparse mode **fall back** to stock vLLM behavior; the patch is idempotent via `_prime_rl_uses_sparse_sampling_masks`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae64d7f04d9d152e6fe9e4245d69288cefe1095a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->