### PR TITLE
feat: chunk and seal trace streams

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/monitors.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/monitors.py
@@ -37,6 +37,11 @@ class FileMonitorConfig(BaseConfig):
     plain text). Sealed chunks use seekable frames: a reader still lands on one line,
     and ``zstd -dcf stream/* | jq`` reads a whole stream."""
 
+    float_decimals: int | None = 4
+    """Decimals kept for per-token float streams (logprobs, entropies, advantages) in
+    trace and annotation records; ``None`` keeps every digit. Training reads the wire,
+    not the records, so this only trades record size against overlay precision."""
+
 
 class PrimeMonitorConfig(BaseConfig):
     name: str | None = None

--- a/packages/prime-rl-configs/src/prime_rl/configs/monitors.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/monitors.py
@@ -28,6 +28,15 @@ class FileMonitorConfig(BaseConfig):
     """Path of the metrics JSONL file, relative to the file monitor's directory under the
     component's ``output_dir`` (``monitors/file/``; absolute paths win)."""
 
+    chunk_bytes: int = 5 * 1024**3
+    """Size at which a trace stream (the episodes, each producer's annotations) rolls to
+    a new numbered chunk file. A line never spans chunks."""
+
+    compress: bool = True
+    """Seal full chunks with zstd once the stream rolls past them (the live chunk stays
+    plain text). Sealed chunks use seekable frames: a reader still lands on one line,
+    and ``zstd -dcf stream/* | jq`` reads a whole stream."""
+
 
 class PrimeMonitorConfig(BaseConfig):
     name: str | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "openai>=1.106.1",
     "orjson>=3.11.0",
     "psutil>=7.0.0",
+    "pyzstd>=0.16.2",
     "rich>=14.0.0",
     "setproctitle>=1.3.0",
     "uvloop>=0.21.0",

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -182,7 +182,7 @@ cheap: a consumer browses them instead of the streams, and seeks by the chunk an
 offset they carry to read a single episode or its token streams. Both are derived, so
 deleting them only costs a reader the work of rebuilding what it needs. The stream
 holds native `vf.Episode` records (training tensors excluded; per-token floats rounded
-to 4 decimals), one line per episode in arrival order, whatever kind of work it did —
+to `monitors.file.float_decimals`, 4 by default), one line per episode in arrival order, whatever kind of work it did —
 including trace-less failures, curriculum-rejected work, and work that never enters a
 batch, so it is crash-durable. Each record carries its provenance: `env` (`id` plus the
 orchestrator's `name`), full `task`, `group` (`id`), and `run`.

--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -163,24 +163,29 @@ curl -s http://localhost:8100/metrics | grep -E "num_requests|gpu_cache_usage"  
 
 ```
 {run_dir}/monitors/file/metrics.jsonl                              # every metric row, tagged by producer
-{run_dir}/monitors/file/traces/stream.jsonl                        # every episode, appended as it arrives
-{run_dir}/monitors/file/traces/stream.index.jsonl                  # one compact row per episode, with its byte offset
-{run_dir}/monitors/file/traces/annotations/{producer}.jsonl        # trace updates: orch ship-time facts, trainer per-token streams
+{run_dir}/monitors/file/traces/stream/00000.jsonl.zst              # every episode, appended as it arrives: sealed chunks ...
+{run_dir}/monitors/file/traces/stream/00001.jsonl                  # ... and the live one, plain text
+{run_dir}/monitors/file/traces/stream.index.jsonl                  # one compact row per episode, with its chunk and byte offset
+{run_dir}/monitors/file/traces/annotations/{producer}/00000.jsonl  # trace updates: orch ship-time facts, trainer per-token streams
 {run_dir}/monitors/file/traces/annotations/{producer}.index.jsonl  # each update's scalars and where its record sits
 ```
 
 Everything the file monitor dumps lives under `monitors/file/`; nothing is written
 there when the monitor is off. The traces and everything written about them sit under
-`traces/`, and every index is named for the stream it indexes and sits beside it. Those
-indexes are what keep reading a run cheap: a consumer browses them instead of the
-streams, and seeks by the offsets they carry to read a single episode or its token
-streams. Both are derived, so deleting them only costs a reader the work of rebuilding
-what it needs. `stream.jsonl` is a stream of native `vf.Episode`
-records (training tensors excluded), one line per episode in arrival order, whatever
-kind of work it did — including trace-less failures, curriculum-rejected work, and
-work that never enters a batch, so it is crash-durable. Each record carries its
-provenance: `env` (`id` plus the orchestrator's `name`), full `task`, `group` (`id`),
-and `run`.
+`traces/`. Each stream is a directory of numbered chunks — the writer rolls to a new
+chunk at `monitors.file.chunk_bytes` (5 GiB) and, with `monitors.file.compress` (on),
+seals the full one with zstd in the background; a finished run seals its live chunk
+too. Sealed chunks use seekable frames, so a seek still costs one frame, and
+`zstd -dcf` streams them together with the plain live chunk. Every index is named for
+the stream it indexes and sits beside it. Those indexes are what keep reading a run
+cheap: a consumer browses them instead of the streams, and seeks by the chunk and
+offset they carry to read a single episode or its token streams. Both are derived, so
+deleting them only costs a reader the work of rebuilding what it needs. The stream
+holds native `vf.Episode` records (training tensors excluded; per-token floats rounded
+to 4 decimals), one line per episode in arrival order, whatever kind of work it did —
+including trace-less failures, curriculum-rejected work, and work that never enters a
+batch, so it is crash-durable. Each record carries its provenance: `env` (`id` plus the
+orchestrator's `name`), full `task`, `group` (`id`), and `run`.
 
 A trace has several steps, so each is stamped as its own event rather than implied by
 where the record sits. The file monitor stamps `info.kind` and `info.dispatch`/
@@ -196,10 +201,10 @@ its recomputed per-token logprobs and entropies. Readers fold the updates onto t
 stream records, newest winning.
 
 ```bash
-wc -l {run_dir}/monitors/file/traces/stream.jsonl
-jq '.traces[].rewards' {run_dir}/monitors/file/traces/stream.jsonl
-jq 'select(.ok | not) | {id, env: .env.id, errors}' {run_dir}/monitors/file/traces/stream.jsonl
-jq '{trace_id, info}' {run_dir}/monitors/file/traces/annotations/orch.jsonl
+wc -l {run_dir}/monitors/file/traces/stream.index.jsonl
+zstd -dcf {run_dir}/monitors/file/traces/stream/* | jq '.traces[].rewards'
+zstd -dcf {run_dir}/monitors/file/traces/stream/* | jq 'select(.ok | not) | {id, env: .env.id, errors}'
+jq '{trace_id, info}' {run_dir}/monitors/file/traces/annotations/orch.index.jsonl
 ```
 
 The batches consumed by the trainer are shipped over ZMQ by default, so nothing binary is written. With `rollout_transport.type = "filesystem"` they land at `{run_dir}/batches/step_{n}/rank_<rank>.bin` (one packed micro-batch file per trainer DP rank).

--- a/src/prime_rl/dashboard/server.py
+++ b/src/prime_rl/dashboard/server.py
@@ -19,12 +19,14 @@ import sys
 import threading
 import time
 from collections import OrderedDict
+from itertools import groupby
 from pathlib import Path
 
 import orjson
 
 from prime_rl.entrypoints.dashboard import DAEMON_FILE, DIRS_FILE, STATE_DIR, registry_lock
 from prime_rl.monitors.file.traces import get_annotations_dir, get_index_path, get_trace_stream
+from prime_rl.monitors.file.traces.chunks import open_chunk
 from prime_rl.monitors.file.traces.index import summarize_episode
 from prime_rl.monitors.file.traces.update import branch_node_paths, fold_trace_updates
 from prime_rl.utils.config import default_output_dir
@@ -518,13 +520,30 @@ def read_metrics(run: str, offset: int = 0) -> dict:
 # ------------------------------------------------------------------------ rollouts
 
 
+def _file_size(path: Path) -> int:
+    try:
+        return path.stat().st_size
+    except OSError:
+        return -1
+
+
 def traces_file(run_dir: Path) -> Path | None:
-    """The run's episode stream. prime-rl dumps it through the file monitor; a
-    verifiers ``uv run eval`` run writes its own at the run root."""
-    for path in (get_trace_stream(run_dir), run_dir / "traces.jsonl"):
-        if path.is_file() and path.stat().st_size > 0:
-            return path
+    """The run's episode stream: the chunk directory the file monitor writes, browsed
+    through its index, or the single ``traces.jsonl`` a verifiers ``uv run eval`` run
+    writes at the run root."""
+    stream = get_trace_stream(run_dir)
+    if _file_size(get_index_path(stream)) > 0:
+        return stream
+    bare = run_dir / "traces.jsonl"
+    if bare.is_file() and bare.stat().st_size > 0:
+        return bare
     return None
+
+
+def stream_version(path: Path) -> int:
+    """What a stream's readers key their caches on. Both shapes are append-only, so
+    a size is a version: the index for a chunked stream, the file itself for a bare one."""
+    return _file_size(get_index_path(path)) if path.is_dir() else _file_size(path)
 
 
 def require_stream(run_dir: Path) -> Path:
@@ -590,6 +609,11 @@ def line_offsets(path: Path) -> list[int]:
 
 
 def episode_summaries(path: Path) -> list[dict]:
+    """Every episode's full summary, nested reward/metric/timing maps included. Parsed
+    from the records themselves, resuming from the last one summarised, and persisted
+    so a revisit skips the parse."""
+    if path.is_dir():
+        return chunked_summaries(path)
     offsets = line_offsets(path)
     with _lock:
         cached_count, summaries = _lru_get(_summaries_cache, path) or (0, [])
@@ -616,6 +640,39 @@ def episode_summaries(path: Path) -> list[dict]:
     with _lock:
         _lru_put(_summaries_cache, path, (len(offsets), summaries))
     write_sidecar(path, summaries)
+    return summaries
+
+
+def chunked_summaries(stream: Path) -> list[dict]:
+    """The summaries of a chunked stream: its index says where each record sits, so the
+    walk opens each chunk once and seeks record to record."""
+    index = get_index_path(stream)
+    rows = index_rows(index) or []
+    with _lock:
+        cached_count, summaries = _lru_get(_summaries_cache, stream) or (0, [])
+        if cached_count > len(rows):
+            cached_count, summaries = 0, []
+    if cached_count == 0:
+        loaded = load_sidecar(index)
+        if loaded is not None:
+            summaries = loaded[: len(rows)]
+            cached_count = len(summaries)
+    if cached_count == len(rows):
+        with _lock:
+            _lru_put(_summaries_cache, stream, (cached_count, summaries))
+        return summaries
+    summaries = list(summaries[:cached_count])
+    for chunk, chunk_rows in groupby(rows[cached_count:], key=lambda row: row.get("chunk", 0)):
+        with open_chunk(stream, chunk) as f:
+            for row in chunk_rows:
+                f.seek(row.get("offset", 0))
+                try:
+                    summaries.append(summarize_episode(row["line"], orjson.loads(f.readline())))
+                except orjson.JSONDecodeError:
+                    summaries.append({"line": row["line"], "id": None, "error": "unparseable"})
+    with _lock:
+        _lru_put(_summaries_cache, stream, (len(rows), summaries))
+    write_sidecar(index, summaries)
     return summaries
 
 
@@ -717,54 +774,17 @@ def timeline_reward(trace: dict) -> float | None:
     )
 
 
-def _file_size(path: Path) -> int:
-    try:
-        return path.stat().st_size
-    except OSError:
-        return -1
-
-
-def annotations_files(run_dir: Path) -> list[Path]:
-    """The annotation records themselves, one file per producer — their indexes are
-    named for them, so a name that is already an index is one of those."""
+def annotation_streams(run_dir: Path) -> list[Path]:
+    """The annotation streams, one chunk directory per producer, each indexed beside it."""
     directory = get_annotations_dir(run_dir)
     if not directory.is_dir():
         return []
-    return sorted(path for path in directory.glob("*.jsonl") if not path.name.endswith(".index.jsonl"))
+    return sorted(path for path in directory.iterdir() if path.is_dir())
 
 
-def annotation_source(data: Path) -> Path:
-    """The file a producer's rows are read from: its index when it wrote one, else the
-    records themselves. Whatever depends on those rows versions itself by this file's
-    size - the record file can grow before its index row is flushed, and a version
-    taken from it would miss the index completing."""
-    index = get_index_path(data)
-    return index if index.is_file() else data
-
-
-def annotation_rows(data: Path) -> list[dict]:
-    """A producer's updates as index rows - ``{trace_id, info, offset}`` - read from its
-    index when it wrote one, and derived from the records themselves when it did not."""
-    rows = index_rows(get_index_path(data))
-    if rows is not None:
-        return rows
-    size = data.stat().st_size
-    with _lock:
-        cached = _lru_get(_index_cache, data)
-    if cached and cached[0] == size:
-        return cached[1]
-    rows, offset = [], 0
-    with data.open("rb") as f:
-        for raw in f:
-            try:
-                update = orjson.loads(raw)
-            except orjson.JSONDecodeError:
-                break
-            rows.append({"trace_id": update.get("trace_id"), "info": update.get("info"), "offset": offset})
-            offset += len(raw)
-    with _lock:
-        _lru_put(_index_cache, data, (size, rows))
-    return rows
+def annotation_rows(stream: Path) -> list[dict]:
+    """A producer's updates as its index rows - ``{trace_id, info, chunk, offset}``."""
+    return index_rows(get_index_path(stream)) or []
 
 
 def annotation_index(run_dir: Path) -> dict[str, dict]:
@@ -773,8 +793,8 @@ def annotation_index(run_dir: Path) -> dict[str, dict]:
     Reads the producers' indexes when they exist, so answering "which cohort, what
     credit" never touches the token streams — they can outweigh the traces themselves.
     A producer that wrote no index is read in full."""
-    files = annotations_files(run_dir)
-    key = tuple((data.name, _file_size(annotation_source(data))) for data in files)
+    files = annotation_streams(run_dir)
+    key = tuple((data.name, stream_version(data)) for data in files)
     cache_key = get_annotations_dir(run_dir)
     with _lock:
         cached = _lru_get(_annotations_cache, cache_key)
@@ -785,17 +805,17 @@ def annotation_index(run_dir: Path) -> dict[str, dict]:
     # the previous one must not see it change size under it.
     consumed, index = ({}, {}) if cached is None else (dict(cached[2]), dict(cached[1]))
 
-    def note(trace_id: str | None, info: dict, data: Path, offset: int) -> None:
+    def note(trace_id: str | None, info: dict, data: Path, chunk: int, offset: int) -> None:
         if not trace_id:
             return
         entry = index.setdefault(trace_id, {"info": {}, "at": []})
         entry["info"].update(info)
-        entry["at"].append((data, offset))
+        entry["at"].append((data, chunk, offset))
 
     for data in files:
         rows = annotation_rows(data)
         for row in rows[consumed.get(data, 0) :]:
-            note(row.get("trace_id"), row.get("info") or {}, data, row.get("offset", 0))
+            note(row.get("trace_id"), row.get("info") or {}, data, row.get("chunk", 0), row.get("offset", 0))
         consumed[data] = len(rows)
     with _lock:
         _lru_put(_annotations_cache, cache_key, (key, index, consumed))
@@ -806,9 +826,9 @@ def trace_updates(run_dir: Path, trace_id: str) -> list[dict]:
     """Every update recorded against one trace, read by seeking to each record."""
     entry = annotation_index(run_dir).get(trace_id)
     updates = []
-    for path, offset in (entry or {}).get("at", []):
+    for stream, chunk, offset in (entry or {}).get("at", []):
         try:
-            with path.open("rb") as f:
+            with open_chunk(stream, chunk) as f:
                 f.seek(offset)
                 updates.append(orjson.loads(f.readline()))
         except (OSError, orjson.JSONDecodeError):
@@ -1132,12 +1152,8 @@ def episode_rows(run_dir: Path) -> list[dict]:
     path = traces_file(run_dir)
     if path is None:
         return []
-    files = annotations_files(run_dir)
-    key = (
-        _file_size(stream_index_file(run_dir)),
-        path.stat().st_size,
-        *(_file_size(annotation_source(f)) for f in files),
-    )
+    files = annotation_streams(run_dir)
+    key = (stream_version(path), *(stream_version(f) for f in files))
     with _lock:
         cached = _lru_get(_rows_cache, run_dir)
     if cached and cached[0] == key:
@@ -1322,7 +1338,7 @@ def list_rollouts(run: str) -> dict:
 def stream_etag(run_dir: Path, path: Path) -> str:
     """What a listing depends on: the stream, and the annotations that give its rows
     their cohort and credit. Both are append-only, so their sizes are the version."""
-    return f"{path.stat().st_size}-{sum(_file_size(annotation_source(f)) for f in annotations_files(run_dir))}"
+    return f"{stream_version(path)}-{sum(stream_version(f) for f in annotation_streams(run_dir))}"
 
 
 def effective_steps(run_dir: Path) -> set[tuple[str, int]]:
@@ -1439,15 +1455,19 @@ def episode_series(run: str, kind: str | None = None, etag: str | None = None, a
     return {"etag": current_etag, "count": len(summaries), "after": max(0, after), "series": series}
 
 
-def read_episode_at(path: Path, line: int, offset: int | None = None) -> dict:
-    """One episode. A written index carries the byte offset, so reading it never
-    touches the rest of the stream."""
-    if offset is None:
+def read_episode_at(path: Path, line: int, at: tuple[int, int] | None = None) -> dict:
+    """One episode. A written index says which chunk and byte offset it sits at, so
+    reading it never touches the rest of the stream; a bare file is scanned for its
+    line offsets instead."""
+    if at is None:
         offsets = line_offsets(path)
         if not 1 <= line <= len(offsets):
             raise HTTPException(404, "episode line out of range")
-        offset = offsets[line - 1]
-    with path.open("rb") as f:
+        f, offset = path.open("rb"), offsets[line - 1]
+    else:
+        chunk, offset = at
+        f = open_chunk(path, chunk)
+    with f:
         f.seek(offset)
         try:
             return orjson.loads(f.readline())
@@ -1456,11 +1476,13 @@ def read_episode_at(path: Path, line: int, offset: int | None = None) -> dict:
             raise HTTPException(422, f"episode {line} is unparseable") from error
 
 
-def episode_offset(run_dir: Path, line: int) -> int | None:
+def episode_at(run_dir: Path, line: int) -> tuple[int, int] | None:
+    """Where the written index puts an episode: ``(chunk, offset)``, or None without one."""
     rows = written_index(run_dir)
     if rows is None or not 1 <= line <= len(rows):
         return None
-    return rows[line - 1].get("offset")
+    row = rows[line - 1]
+    return row.get("chunk", 0), row.get("offset", 0)
 
 
 @app.get("/api/runs/{run}/episodes/{line}")
@@ -1473,7 +1495,7 @@ def get_episode(
     """One episode, by its line in the stream, with every annotation folded on."""
     run_dir = get_run_dir(run)
     path = require_stream(run_dir)
-    rec = read_episode_at(path, line, episode_offset(run_dir, line))
+    rec = read_episode_at(path, line, episode_at(run_dir, line))
     # only the opened episode's streams are read, by seeking to each of its records
     for trace in rec.get("traces") or []:
         updates = trace_updates(run_dir, trace.get("id") or "")
@@ -1687,7 +1709,7 @@ async def view_events() -> "StreamingResponse":
 @app.get("/api/runs/{run}/episodes/{line}/timeline")
 def get_episode_timeline(run: str, line: int) -> dict:
     run_dir = get_run_dir(run)
-    return project_episode_timeline(read_episode_at(require_stream(run_dir), line, episode_offset(run_dir, line)))
+    return project_episode_timeline(read_episode_at(require_stream(run_dir), line, episode_at(run_dir, line)))
 
 
 # -------------------------------------------------------------------------- static

--- a/src/prime_rl/dashboard/server.py
+++ b/src/prime_rl/dashboard/server.py
@@ -1477,10 +1477,13 @@ def read_episode_at(path: Path, line: int, at: tuple[int, int] | None = None) ->
 
 
 def episode_at(run_dir: Path, line: int) -> tuple[int, int] | None:
-    """Where the written index puts an episode: ``(chunk, offset)``, or None without one."""
+    """Where the written index puts an episode: ``(chunk, offset)``. None only when the
+    stream has no index; an index that exists is authoritative for what lines there are."""
     rows = written_index(run_dir)
-    if rows is None or not 1 <= line <= len(rows):
+    if rows is None:
         return None
+    if not 1 <= line <= len(rows):
+        raise HTTPException(404, "episode line out of range")
     row = rows[line - 1]
     return row.get("chunk", 0), row.get("offset", 0)
 

--- a/src/prime_rl/monitors/file/monitor.py
+++ b/src/prime_rl/monitors/file/monitor.py
@@ -4,13 +4,14 @@ import asyncio
 import json
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TextIO
+from typing import TYPE_CHECKING, Any, BinaryIO, TextIO
 
 import orjson
 
 from prime_rl.configs.monitors import FileMonitorConfig
 from prime_rl.monitors.base import Kind, Monitor, Subset
 from prime_rl.monitors.file.traces import get_annotations_dir, get_index_path, get_trace_stream
+from prime_rl.monitors.file.traces.chunks import ChunkedJsonl
 from prime_rl.monitors.file.traces.index import index_row
 from prime_rl.monitors.file.traces.update import update_index_row
 from prime_rl.utils.pathing import get_file_monitor_dir
@@ -38,6 +39,7 @@ class FileMonitor(Monitor):
         self.path.parent.mkdir(parents=True, exist_ok=True)
         # Line-buffered append so a concurrently-running dashboard can tail the file.
         self.file = open(self.path, "a", buffering=1)  # noqa: SIM115
+        self._streams: dict[Path, tuple[ChunkedJsonl, BinaryIO]] = {}
         self.logger.info(f"Logging metrics and episodes to the local filesystem ({output_dir})")
 
     async def log_metrics(self, metrics: dict[str, Any], step: int | None) -> None:
@@ -54,6 +56,14 @@ class FileMonitor(Monitor):
             row["producer"] = self.producer
         self.file.write(json.dumps(row) + "\n")
 
+    def _stream(self, directory: Path) -> tuple[ChunkedJsonl, BinaryIO]:
+        """A stream and its index, opened on first use and kept open. Writers flush the
+        stream before the index: a row a reader sees points at a record it can read."""
+        if directory not in self._streams:
+            stream = ChunkedJsonl(directory, self.config.chunk_bytes, self.config.compress)
+            self._streams[directory] = (stream, open(get_index_path(directory), "ab"))
+        return self._streams[directory]
+
     async def log_episodes(self, episodes: list[vf.Episode], step: int, kind: Kind, subset: Subset) -> None:
         """Append each episode to the trace stream as it completes — every episode is
         serialized exactly once, in arrival order, whatever its kind, so an in-progress
@@ -64,45 +74,42 @@ class FileMonitor(Monitor):
             return
 
         def write() -> None:
-            path = get_trace_stream(self.output_dir)
-            path.parent.mkdir(parents=True, exist_ok=True)
+            stream, index = self._stream(get_trace_stream(self.output_dir))
             # An index row goes out with every episode: summarising the record here,
             # while it is already in hand, saves every reader from parsing a stream
             # that outgrows memory long before the run does.
-            with open(path, "ab") as f, open(get_index_path(path), "ab") as index:
-                offset = f.tell()
-                for episode in episodes:
-                    record = episode.to_record()
-                    line = orjson.dumps(record, default=str, option=OPTS)
-                    f.write(line)
-                    self._logged += 1
-                    index.write(orjson.dumps(index_row(self._logged, record, offset), default=str, option=OPTS))
-                    offset += len(line)
+            for episode in episodes:
+                record = episode.to_record()
+                chunk, offset = stream.append(orjson.dumps(record, default=str, option=OPTS))
+                self._logged += 1
+                index.write(orjson.dumps(index_row(self._logged, record, chunk, offset), default=str, option=OPTS))
+            stream.flush()
+            index.flush()
 
         # Record serialization is heavy pure-Python work; keep it off the event loop.
-        # Awaited (not fire-and-forget) so appends to one file never interleave.
+        # Awaited (not fire-and-forget) so appends to one stream never interleave.
         await asyncio.to_thread(write)
 
     async def log_annotations(self, updates: list[dict[str, Any]]) -> None:
-        """Append trace updates to this producer's annotation file — one writer per
-        file, so producers never interleave."""
+        """Append trace updates to this producer's annotation stream — one writer per
+        stream, so producers never interleave."""
         if not updates:
             return
 
         def write() -> None:
-            path = get_annotations_dir(self.output_dir) / f"{self.producer or 'unknown'}.jsonl"
-            path.parent.mkdir(parents=True, exist_ok=True)
+            stream, index = self._stream(get_annotations_dir(self.output_dir) / (self.producer or "unknown"))
             # the scalars go to a sibling index so a reader can answer "which cohort,
             # what credit" without touching the token streams
-            with open(path, "ab") as f, open(get_index_path(path), "ab") as index:
-                offset = f.tell()
-                for update in updates:
-                    line = orjson.dumps(update, option=OPTS)
-                    f.write(line)
-                    index.write(orjson.dumps(update_index_row(update, offset), option=OPTS))
-                    offset += len(line)
+            for update in updates:
+                chunk, offset = stream.append(orjson.dumps(update, option=OPTS))
+                index.write(orjson.dumps(update_index_row(update, chunk, offset), option=OPTS))
+            stream.flush()
+            index.flush()
 
         await asyncio.to_thread(write)
 
     async def finalize(self) -> None:
+        for stream, index in self._streams.values():
+            stream.close()
+            index.close()
         self.logger.info(f"Finalized metrics at {self.path}")

--- a/src/prime_rl/monitors/file/monitor.py
+++ b/src/prime_rl/monitors/file/monitor.py
@@ -79,7 +79,7 @@ class FileMonitor(Monitor):
             # while it is already in hand, saves every reader from parsing a stream
             # that outgrows memory long before the run does.
             for episode in episodes:
-                record = episode.to_record()
+                record = episode.to_record(float_decimals=self.config.float_decimals)
                 chunk, offset = stream.append(orjson.dumps(record, default=str, option=OPTS))
                 self._logged += 1
                 index.write(orjson.dumps(index_row(self._logged, record, chunk, offset), default=str, option=OPTS))

--- a/src/prime_rl/monitors/file/traces/__init__.py
+++ b/src/prime_rl/monitors/file/traces/__init__.py
@@ -1,8 +1,8 @@
 """Where the file monitor puts the traces, and everything written about them.
 
 The stream and its annotations live under one directory so nothing beside them has to
-be read as belonging to them, and every index is named for the stream it indexes and
-sits beside it.
+be read as belonging to them. Each stream is a directory of chunks (see ``chunks``),
+and every index is named for the stream it indexes and sits beside it.
 """
 
 from pathlib import Path
@@ -16,18 +16,18 @@ def get_trace_dir(output_dir: Path) -> Path:
 
 def get_trace_stream(output_dir: Path) -> Path:
     """Every episode, appended as it arrives."""
-    return get_trace_dir(output_dir) / "stream.jsonl"
+    return get_trace_dir(output_dir) / "stream"
 
 
 def get_annotations_dir(output_dir: Path) -> Path:
-    """One file per producer of trace updates: orch ship-time facts, trainer streams."""
+    """One stream per producer of trace updates: orch ship-time facts, trainer streams."""
     return get_trace_dir(output_dir) / "annotations"
 
 
-def get_index_path(path: Path) -> Path:
+def get_index_path(stream: Path) -> Path:
     """A stream's index, beside it, so a reader pairs the two without knowing who
     wrote them."""
-    return path.with_name(path.name.replace(".jsonl", ".index.jsonl"))
+    return stream.with_name(stream.name.removesuffix(".jsonl") + ".index.jsonl")
 
 
 __all__ = ["get_annotations_dir", "get_index_path", "get_trace_dir", "get_trace_stream"]

--- a/src/prime_rl/monitors/file/traces/chunks.py
+++ b/src/prime_rl/monitors/file/traces/chunks.py
@@ -1,0 +1,115 @@
+"""Chunked JSONL — an append-only stream split into numbered files, sealed as it grows.
+
+    stream/00000.jsonl.zst   sealed: zstd in seekable frames, so a reader still lands on one line
+    stream/00001.jsonl       live: plain text, so it can be tailed
+
+A line never spans chunks. Once a chunk reaches its size the writer moves on and seals it
+in the background: the compressed twin is written beside it and the plain file removed
+only once the twin is complete, so a reader that misses the plain file finds the sealed
+one. ``zstd -dcf stream/* | jq`` reads a whole stream, sealed and live alike.
+"""
+
+import shutil
+import threading
+from pathlib import Path
+from typing import BinaryIO
+
+import pyzstd
+
+LEVEL = 3
+"""zstd level: ~7x on episode records at hundreds of MB/s, so sealing keeps up with a run."""
+
+FRAME_BYTES = 4 << 20
+"""Independent frames in a sealed chunk: a seek decompresses one of these, not the chunk."""
+
+
+def chunk_path(directory: Path, number: int) -> Path:
+    return directory / f"{number:05d}.jsonl"
+
+
+def chunk_numbers(directory: Path) -> dict[int, bool]:
+    """Chunk number -> whether its plain file is present (a sealed chunk has none)."""
+    numbers: dict[int, bool] = {}
+    for path in directory.glob("*.jsonl*"):
+        number = int(path.name.split(".", 1)[0])
+        numbers[number] = numbers.get(number, False) or path.suffix == ".jsonl"
+    return numbers
+
+
+def open_chunk(directory: Path, number: int) -> BinaryIO:
+    """A chunk for seeking reads, whether still plain or already sealed."""
+    path = chunk_path(directory, number)
+    try:
+        return open(path, "rb")
+    except FileNotFoundError:
+        return pyzstd.SeekableZstdFile(path.with_name(path.name + ".zst"), "rb")
+
+
+def seal(path: Path) -> None:
+    """Compress a finished chunk beside itself, then drop the plain file."""
+    target = path.with_name(path.name + ".zst")
+    partial = target.with_name(target.name + ".tmp")
+    with (
+        open(path, "rb") as src,
+        pyzstd.SeekableZstdFile(partial, "wb", level_or_option=LEVEL, max_frame_content_size=FRAME_BYTES) as dst,
+    ):
+        shutil.copyfileobj(src, dst, 1 << 20)
+    partial.replace(target)
+    path.unlink()
+
+
+class ChunkedJsonl:
+    """Appends lines to the live chunk of a stream and reports where each one landed."""
+
+    def __init__(self, directory: Path, max_bytes: int, compress: bool) -> None:
+        directory.mkdir(parents=True, exist_ok=True)
+        self.directory = directory
+        self.max_bytes = max_bytes
+        self.compress = compress
+        self._sealing: list[threading.Thread] = []
+        numbers = chunk_numbers(directory)
+        last = max(numbers, default=-1)
+        # A relaunch appends to the live chunk it finds and starts a new one after a sealed
+        # last chunk; anything else still plain was left mid-seal by a crash.
+        self.number = last if numbers.get(last) else last + 1
+        for number, plain in numbers.items():
+            if plain and number != self.number and compress:
+                self._seal(number)
+        self.file = open(chunk_path(directory, self.number), "ab")
+        self.size = self.file.tell()
+
+    def append(self, line: bytes) -> tuple[int, int]:
+        """Write one line; returns ``(chunk, offset)``, the address a reader seeks to."""
+        if self.size and self.size + len(line) > self.max_bytes:
+            self._roll()
+        offset = self.size
+        self.file.write(line)
+        self.size += len(line)
+        return self.number, offset
+
+    def flush(self) -> None:
+        self.file.flush()
+
+    def close(self) -> None:
+        """Seal the live chunk too, so a finished run keeps nothing plain."""
+        self.file.close()
+        if not self.size:
+            chunk_path(self.directory, self.number).unlink()
+        elif self.compress:
+            self._seal(self.number)
+        for thread in self._sealing:
+            thread.join()
+
+    def _roll(self) -> None:
+        self.file.close()
+        if self.compress:
+            self._seal(self.number)
+        self.number += 1
+        self.file = open(chunk_path(self.directory, self.number), "ab")
+        self.size = 0
+
+    def _seal(self, number: int) -> None:
+        # not a daemon: a process that exits mid-seal waits for it rather than leaving a torn twin
+        thread = threading.Thread(target=seal, args=(chunk_path(self.directory, number),))
+        thread.start()
+        self._sealing.append(thread)

--- a/src/prime_rl/monitors/file/traces/index.py
+++ b/src/prime_rl/monitors/file/traces/index.py
@@ -2,9 +2,9 @@
 the stream to browse it.
 
 The file monitor writes a row as each episode lands, when the record is already in
-hand and summarising it is nearly free, and records the byte offset it wrote the
-episode at so a reader can seek straight to one. A stream another producer wrote has
-no index, so its reader derives the same rows itself.
+hand and summarising it is nearly free, and records the chunk and byte offset it wrote
+the episode at so a reader can seek straight to one. A stream another producer wrote
+has no index, so its reader derives the same rows itself.
 """
 
 
@@ -124,10 +124,11 @@ def _episode_duration(info: dict, timing: dict[str, float]) -> float | None:
     return sum(phases) if phases else None
 
 
-def index_row(line: int, rec: dict, offset: int) -> dict:
+def index_row(line: int, rec: dict, chunk: int, offset: int) -> dict:
     """The row the file monitor writes. The nested reward/metric/timing maps are left
     out: only the per-episode series view needs them, and they dominate the size."""
     row = summarize_episode(line, rec, offset)
+    row["chunk"] = chunk
     for key in ("rewards", "metrics", "timing"):
         row.pop(key, None)
     return row

--- a/src/prime_rl/monitors/file/traces/update.py
+++ b/src/prime_rl/monitors/file/traces/update.py
@@ -5,8 +5,8 @@ is an update naming the trace: an ``info`` dict merged into the trace's own, plu
 per-token streams over a branch, full-length across the branch's token prefix (nulls
 mark unknown positions, so a stream never depends on the producer's loss mask).
 
-Each producer appends its own file under the trace directory's ``annotations/``, so
-every file has exactly one writer. Readers fold the updates onto the arrival records
+Each producer appends its own stream under the trace directory's ``annotations/``, so
+every stream has exactly one writer. Readers fold the updates onto the arrival records
 in write order, newest wins.
 """
 
@@ -18,11 +18,11 @@ STREAM_FIELDS = ("advantages", "trainer_logprobs", "entropies")
 """Per-token streams an update may carry, compacted onto node fields of the same name."""
 
 
-def update_index_row(update: dict[str, Any], offset: int) -> dict[str, Any]:
+def update_index_row(update: dict[str, Any], chunk: int, offset: int) -> dict[str, Any]:
     """An update's scalars plus where its record sits. The per-token streams stay in
-    the annotation file: a reader browsing a run needs the scalars, and only the
+    the annotation stream: a reader browsing a run needs the scalars, and only the
     episode it opens needs the streams."""
-    return {"trace_id": update.get("trace_id"), "offset": offset, "info": update.get("info") or {}}
+    return {"trace_id": update.get("trace_id"), "chunk": chunk, "offset": offset, "info": update.get("info") or {}}
 
 
 def make_update(

--- a/src/prime_rl/trainer/rl/annotations.py
+++ b/src/prime_rl/trainer/rl/annotations.py
@@ -10,12 +10,18 @@ from torch import Tensor
 from prime_rl import monitors
 from prime_rl.monitors.file.traces.update import make_update
 
+RECORD_FLOAT_DECIMALS = 4
+"""The precision verifiers gives per-token floats in a record
+(``verifiers.v1.graph.RECORD_FLOAT_DECIMALS``); the trainer does not import verifiers."""
+
 
 class AnnotationWriter:
     """Collects the trainer's per-token streams (recomputed logprobs, entropies) during
     a step and logs them as trace updates — one record per trained sequence, keyed by
     ``(trace_id, branch_index)``. Streams are full-length over the sample's token prefix
-    so readers can fold them onto trace nodes without knowing the trainer's loss mask.
+    so readers can fold them onto trace nodes without knowing the trainer's loss mask;
+    positions outside that mask hold null, since a fold keeps sampled tokens only and a
+    run of nulls costs nothing once the stream is sealed.
 
     ``export`` accumulates locally per micro batch; ``flush`` gathers every rank's
     records to rank 0, the only rank running monitors. CP ranks past the first
@@ -50,8 +56,9 @@ class AnnotationWriter:
                 end -= 1
             if end <= span_start or not any(loss_mask[span_start:end]):
                 continue
-            logprob_span = trainer_logprobs[span_start:end]
-            entropy_span = entropies[span_start:end]
+            trained = loss_mask[span_start:end]
+            logprob_span = [v if m else None for v, m in zip(trainer_logprobs[span_start:end], trained)]
+            entropy_span = [v if m else None for v, m in zip(entropies[span_start:end], trained)]
             # After the right shift, a sample's first value crosses the packing boundary.
             logprob_span[0] = None
             entropy_span[0] = None
@@ -78,5 +85,7 @@ class AnnotationWriter:
 
 
 def _tensor_to_floats(tensor: Tensor) -> list[float | None]:
+    """Rounded like the record's own logprobs: the streams only ever colour an overlay,
+    and full-precision digits are the least compressible bytes a run writes."""
     values = tensor.detach().to(dtype=torch.float32, device="cpu").reshape(-1).tolist()
-    return [float(value) if math.isfinite(value) else None for value in values]
+    return [round(value, RECORD_FLOAT_DECIMALS) if math.isfinite(value) else None for value in values]

--- a/src/prime_rl/trainer/rl/annotations.py
+++ b/src/prime_rl/trainer/rl/annotations.py
@@ -10,10 +10,6 @@ from torch import Tensor
 from prime_rl import monitors
 from prime_rl.monitors.file.traces.update import make_update
 
-RECORD_FLOAT_DECIMALS = 4
-"""The precision verifiers gives per-token floats in a record
-(``verifiers.v1.graph.RECORD_FLOAT_DECIMALS``); the trainer does not import verifiers."""
-
 
 class AnnotationWriter:
     """Collects the trainer's per-token streams (recomputed logprobs, entropies) during
@@ -27,8 +23,9 @@ class AnnotationWriter:
     records to rank 0, the only rank running monitors. CP ranks past the first
     accumulate nothing since they share their micro batches."""
 
-    def __init__(self, parallel_dims: Any, world: Any) -> None:
+    def __init__(self, parallel_dims: Any, world: Any, float_decimals: int | None) -> None:
         self.world = world
+        self.float_decimals = float_decimals
         self.is_duplicate_rank = parallel_dims.cp_enabled and parallel_dims.world_mesh["cp"].get_local_rank() != 0
         self._pending: list[dict[str, Any]] = []
 
@@ -42,8 +39,8 @@ class AnnotationWriter:
         sequence_lengths = micro_batch["sequence_lengths"]
         loss_mask = [bool(v) for v in micro_batch["loss_mask"].detach().cpu().reshape(-1).tolist()]
         env_names = micro_batch["env_names"]
-        trainer_logprobs = _tensor_to_floats(model_output["logprobs"])
-        entropies = _tensor_to_floats(model_output["entropy"])
+        trainer_logprobs = _tensor_to_floats(model_output["logprobs"], self.float_decimals)
+        entropies = _tensor_to_floats(model_output["entropy"], self.float_decimals)
 
         start = 0
         for trace_id, branch_index, length in zip(trace_ids, branch_indices, sequence_lengths):
@@ -84,8 +81,10 @@ class AnnotationWriter:
         asyncio.run(monitors.log_annotations(records))
 
 
-def _tensor_to_floats(tensor: Tensor) -> list[float | None]:
+def _tensor_to_floats(tensor: Tensor, decimals: int | None) -> list[float | None]:
     """Rounded like the record's own logprobs: the streams only ever colour an overlay,
     and full-precision digits are the least compressible bytes a run writes."""
     values = tensor.detach().to(dtype=torch.float32, device="cpu").reshape(-1).tolist()
-    return [round(value, RECORD_FLOAT_DECIMALS) if math.isfinite(value) else None for value in values]
+    if decimals is None:
+        return [value if math.isfinite(value) else None for value in values]
+    return [round(value, decimals) if math.isfinite(value) else None for value in values]

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -258,7 +258,9 @@ def train(config: TrainerConfig):
         )
     logger.debug(f"Initialized data loader in {format_time(time.perf_counter() - t0)}")
 
-    annotation_writer = AnnotationWriter(parallel_dims, world)
+    annotation_writer = AnnotationWriter(
+        parallel_dims, world, config.monitors.file.float_decimals if config.monitors.file else None
+    )
 
     gc_handler = GarbageCollection(config.gc.interval) if config.gc else None
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -756,6 +756,7 @@ def train(config: TrainerConfig):
 
     logger.info(f"Peak memory: {max_peak_memory:.1f} GiB")
     logger.success("RL trainer finished")
+    asyncio.run(monitors.finalize())
 
     # Stop metrics/health server if configured
     if metrics_server is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -449,6 +449,19 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-zstd"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/f0/9ba1b05811aa5f5434f69768253129460a5744e1814f359efba39a01ce20/backports_zstd-1.7.0.tar.gz", hash = "sha256:1a967189c1822b6e85a2e550fdfc88a3272c17633ea0a4732dac5911a8034f2b", size = 1003722, upload-time = "2026-08-15T17:26:43.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/24/5556959c7d03bfee5ff14d7f07dd9bf8de737c69f81d823a32784ab39c34/backports_zstd-1.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bab192b934fdf5a03df4752556d9c8af2d058163fdfbafd4a253cdfe25449a6f", size = 367666, upload-time = "2026-08-15T17:25:39.233Z" },
+    { url = "https://files.pythonhosted.org/packages/40/4b/820acbc2c1d1d945aedca0c0d22546a948630ffb186df523098fbd669a95/backports_zstd-1.7.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c55e55e1e9dee312bc5e186386e6aa5207482a6d2242bd7c14709ded254f87f", size = 478240, upload-time = "2026-08-15T17:25:41.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/40/121917bd2671bc3f1507c25503c0554f0b52483edcca4e6210e6d22228df/backports_zstd-1.7.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:470895d0bcddc850766e593d1b26764fb138c2feed149f515a2627ef9587d54c", size = 496195, upload-time = "2026-08-15T17:25:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a4/372c3dd3017c3f93cda0acbc282f8073b70efdc1b56d1fdeebe023660725/backports_zstd-1.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:132ba81fad59d44958b7d10da31545e7128c469cfbc2e268d0eaab96daa64175", size = 484276, upload-time = "2026-08-15T17:25:48.129Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d0/e36c18c87a74421954502d123ff7027e0a63a7624dffa99ec0f7474deff9/backports_zstd-1.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:468b636ed365627b364c94be1c35a52858e13b5bc1fa3f068bbc71b1af65f3d7", size = 500735, upload-time = "2026-08-15T17:25:56.064Z" },
+]
+
+[[package]]
 name = "bashlex"
 version = "0.18"
 source = { registry = "https://pypi.org/simple" }
@@ -4954,6 +4967,7 @@ dependencies = [
     { name = "pyarrow" },
     { name = "pybase64" },
     { name = "pyzmq" },
+    { name = "pyzstd" },
     { name = "renderers", extra = ["multimodal"] },
     { name = "rich" },
     { name = "setproctitle" },
@@ -5116,6 +5130,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pybase64", specifier = ">=1.4.2" },
     { name = "pyzmq", specifier = ">=27.1.0" },
+    { name = "pyzstd", specifier = ">=0.16.2" },
     { name = "quack-kernels", marker = "sys_platform == 'linux' and extra == 'quack'", specifier = ">=0.4.1" },
     { name = "renderers", extras = ["multimodal"], editable = "deps/renderers" },
     { name = "rich", specifier = ">=14.0.0" },
@@ -5844,6 +5859,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ad9a73e3da1fab5b0e7e13402f0b2fb934ae1c876c51d0afff0e7c052eca31", size = 840995, upload-time = "2025-09-08T23:08:08.396Z" },
     { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
     { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
+]
+
+[[package]]
+name = "pyzstd"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-zstd" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/66/59fed71d0d2065e02974b40296f836a237c364c8bbe07295f2d0dc33c278/pyzstd-0.19.1.tar.gz", hash = "sha256:36723d3c915b3981de9198d0a2c82b2f5fe3eaa36e4d8d586937830a8afc7d72", size = 69531, upload-time = "2025-12-13T08:15:33.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/62/f55d1363512d1b1cc122af6ca5951008e42605b63675c7d6781affc7c475/pyzstd-0.19.1-py3-none-any.whl", hash = "sha256:267e2eb0de0291dfcb7ccfebc4ffe75b2f9d84e7007ac38844f6ccafc6dce081", size = 23779, upload-time = "2025-12-13T08:15:31.979Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Each trace stream (`traces/stream`, `traces/annotations/<producer>`) is now a directory of numbered chunks. `ChunkedJsonl` (`monitors/file/traces/chunks.py`) rolls at `monitors.file.chunk_bytes` (default 5 GiB; a line never spans chunks) and, with `monitors.file.compress` (default on), seals each full chunk with zstd in a background thread. The live chunk stays plain text; a finished run seals its live chunk too. A relaunch resumes the live chunk it finds and seals anything a crash left mid-seal.
- Sealed chunks use zstd's seekable format (`pyzstd`, 4 MiB frames), so a seek costs one frame, not the chunk. `zstd -dcf stream/* | jq` reads a whole stream, sealed and live alike.
- Index rows carry `chunk` beside `offset`; the dashboard resolves both through `open_chunk` (plain or sealed) for episodes and annotation records, keys its caches and etags on the index size, and parses chunked streams for the series view through the index, one chunk open at a time. Annotation readers rely on the producer's index (the file monitor always writes one).
- `monitors.file.float_decimals` (default 4, `None` for every digit) sets the precision of per-token float streams in both the episode records (`to_record(float_decimals=...)`) and the trainer's annotation streams. Trainer streams also hold `null` outside the loss mask - the fold keeps sampled tokens only, so nothing a reader sees changes, and runs of nulls seal to nothing. The trainer finalizes its monitors on exit so its live chunk seals.
- Submodule bump to verifiers main `cfc7c474` (PrimeIntellect-ai/verifiers#2495, merged): JSON records round per-token floats to `to_record(float_decimals=...)`, 4 by default. The msgpack wire keeps full precision, so the importance ratio is unaffected.

## Measurements

Replayed the 100-step, 33,342-episode scaleswe baseline (`ipo-baseline-rollouts-steps1-100`, 15.17 GB as one `stream.jsonl`) through the new writer with 5 GiB chunks:

| | raw | 4 dp | on disk (sealed) | total |
|---|---|---|---|---|
| 10 steps (5,696 episodes) | 1.06 GB | 0.89 GB | **0.10 GB** | 11.0x |
| 100 steps (33,342 episodes) | 15.17 GB | 12.66 GB | **1.38 GB** | 11.0x |
| 1000 steps (extrapolated from steps 11-100: 307 episodes, 157 MB raw per step) | 156 GB | 130 GB | **14.2 GB** | 11.0x |

Rounding contributes 1.20x on the plain bytes and lifts zstd from 6.9x to 9.2x, since mantissa digits were the incompressible part. Writing 33K episodes took 81.8 s with sealing vs 80.4 s plain: sealing runs beside the writer, not in front of it. The final 2.7 GB live chunk sealed in 4 s.

Dashboard against the sealed run (same box, 5 GiB chunks): open one episode 5.8 ms cold / 4.0 ms warm vs 3.9 / 3.4 ms plain; table page 17 ms cold (index only, unchanged); series view full parse of all 33K records 35.7 s sealed vs 39.7 s plain (orjson-bound, cached and persisted after the first pass). Browser check: traces table renders, episode viewer opens from a sealed chunk, no console errors. Unit suite: 571 passed.

## Breaking

- On-disk trace layout: `traces/stream.jsonl` → `traces/stream/<NNNNN>.jsonl[.zst]`, `traces/annotations/<producer>.jsonl` → `traces/annotations/<producer>/<NNNNN>.jsonl[.zst]`; index rows gain `chunk` and their `offset` is chunk-relative. Read a stream with `zstd -dcf <stream dir>/* | jq`. The dashboard reads only the new layout.
- Per-token floats in records (`logprobs`, `reference_logprobs`, `advantages`, trainer `trainer_logprobs`/`entropies`) are written with 4 decimals by default; set `monitors.file.float_decimals = None` (orchestrator and trainer) to keep full precision.
- New dependency `pyzstd`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking on-disk trace layout and default float precision affect observability and external readers; dashboard and monitor paths are heavily touched but training wire precision is unchanged per PR notes.
> 
> **Overview**
> **Trace on-disk layout is now chunked directories** instead of single `stream.jsonl` / `annotations/<producer>.jsonl` files. The file monitor writes through `ChunkedJsonl`: rolls at `monitors.file.chunk_bytes` (default 5 GiB), optionally seals full chunks with seekable zstd in background threads (`monitors.file.compress`, default on), and seals the live chunk on `finalize()` (trainer now calls `asyncio.run(monitors.finalize())` at shutdown). Index rows add **`chunk`** beside chunk-relative **`offset`**.
> 
> **`monitors.file.float_decimals`** (default 4) rounds per-token floats in episode `to_record(...)` and trainer annotation streams; trainer streams also emit **`null`** outside the loss mask for better compression without changing what readers fold onto traces.
> 
> The **dashboard** detects chunked streams via the index, reads episodes and annotations with `open_chunk` (plain or `.zst`), versions caches/etags on index size, and builds series summaries by walking the index one chunk at a time. **Breaking:** tools and scripts must use `zstd -dcf <stream-dir>/*` and per-producer chunk dirs under `annotations/`. New dependency **`pyzstd`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62a6893f75cbc770cbad06fd65d640aec13f058b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->