### PR TITLE
fix(trainer): zero-index position_ids fallback in LM-head wrapper

### DIFF
--- a/src/prime_rl/trainer/models/layers/lm_head.py
+++ b/src/prime_rl/trainer/models/layers/lm_head.py
@@ -333,7 +333,7 @@ def _patch_model_forward(model: nn.Module) -> None:
         is_multimodal = kwargs.get("pixel_values") is not None
         if position_ids is None and not is_multimodal:
             reference_tensor = input_ids if input_ids is not None else inputs_embeds
-            position_ids = torch.arange(1, reference_tensor.shape[1] + 1, device=reference_tensor.device).unsqueeze(0)
+            position_ids = torch.arange(reference_tensor.shape[1], device=reference_tensor.device).unsqueeze(0)
         model_kwargs = {"input_ids": input_ids, "position_ids": position_ids, **kwargs}
         if inputs_embeds is not None:
             model_kwargs["inputs_embeds"] = inputs_embeds


### PR DESCRIPTION
Use the standard zero-indexing convention for `position_ids` in patched LM head forward,  (`_patch_model_forward`), rather than one-indexing. 

A uniform shift is mathematically invisible to RoPE, which sees only query-key angle differences, but it is wrong for attention that keys off absolute token indices (as is important for deepseek v4 where compression boundaries are tied to absolute positions).