### PR TITLE
feat(dashboard): surface task and judge evidence

### DIFF
--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -2226,6 +2226,7 @@ let currentEpisode = null;
 let currentLine = null;
 let currentTraceIdx = 0;
 let currentBranchIdx = 0;
+let currentEvidenceView = null;
 let episodeOpenVersion = 0;
 let episodeEnrichmentVersion = 0;
 let currentTimeline = null;
@@ -2410,6 +2411,7 @@ async function openEpisode(line, target = {}) {
   currentEpisode = episode;
   currentTraceIdx = target.trace ?? 0;
   currentBranchIdx = target.branch ?? 0;
+  currentEvidenceView = target.evidence ?? null;
   if (traceView === "timeline") await ensureTimeline();
   renderEpisode();
   await ensureTokens();
@@ -2736,6 +2738,88 @@ function toolDefinitionsHtml(trace) {
   );
 }
 
+const TASK_SCAFFOLD_FIELDS = new Set([
+  "idx", "name", "description", "prompt", "system_prompt", "image", "workdir",
+  "network_allow", "network_block", "artifacts", "timeout", "resources",
+]);
+const TASK_EVIDENCE_FIELD_ORDER = new Map([["question", 0], ["answer", 1]]);
+
+function evidenceText(value) {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value, null, 2);
+}
+
+function taskEvidenceHtml(trace) {
+  const data = trace.task?.data;
+  if (!data || typeof data !== "object") return "";
+  const fields = Object.entries(data)
+    .filter(([key, value]) => !TASK_SCAFFOLD_FIELDS.has(key) && value != null)
+    .sort(
+      ([a], [b]) =>
+        (TASK_EVIDENCE_FIELD_ORDER.get(a) ?? 2) - (TASK_EVIDENCE_FIELD_ORDER.get(b) ?? 2)
+    );
+  if (!fields.length) return "";
+  const previewKeys = fields.map(([key]) => key).join(" · ");
+  const body = fields
+    .map(
+      ([key, value]) =>
+        `<section class="evidence-field"><header><span>${esc(key)}</span>` +
+        `<button class="icon-btn" data-copy-task="${esc(key)}" title="copy ${esc(key)}">${COPY_SVG}</button></header>` +
+        `<pre>${esc(evidenceText(value))}</pre></section>`
+    )
+    .join("");
+  return (
+    `<details class="task-evidence standalone" open><summary><span class="context-label">Task data</span>` +
+    `<span class="entry-preview">${esc(previewKeys)}</span><span class="entry-chev">›</span></summary>` +
+    `<div class="evidence-fields">${body}</div></details>`
+  );
+}
+
+function judgeEvidenceHtml(trace) {
+  const records = Array.isArray(trace.info?.judge_calls) ? trace.info.judge_calls : [];
+  if (!records.length) return "";
+  const calls = records
+    .map((record, index) => {
+      const request = record.request;
+      const response = record.response;
+      const messages = request.messages;
+      const responseText = messageText(response.message);
+      const { input, cached, output } = normalizedCallUsage(response.usage);
+      const chips = [];
+      if (request.model) chips.push(request.model);
+      if (input != null) chips.push(`${fmtCompact(input)} in`);
+      if (cached != null) chips.push(`${fmtCompact(cached)} cache`);
+      if (output != null) chips.push(`${fmtCompact(output)} out`);
+      const prompt = messages
+        .map(
+          (message, messageIndex) =>
+            `<section class="judge-message"><header><span>${String(messageIndex + 1).padStart(2, "0")}</span>` +
+            `<strong>${esc(message.role || "message")}</strong></header>` +
+            `<div>${esc(messageText(message))}</div></section>`
+        )
+        .join("");
+      const parsed = response.parsed == null
+        ? ""
+        : `<section class="judge-result parsed"><header>Parsed verdict</header><pre>${esc(evidenceText(response.parsed))}</pre></section>`;
+      return (
+        `<details class="entry judge-entry" open><summary><span class="entry-num">J${String(index + 1).padStart(2, "0")}</span>` +
+        `<span class="entry-role">${esc(record.name)}</span>` +
+        `<span class="entry-preview">${preview(responseText, 180)}</span>` +
+        chips.map((chip) => `<span class="chip">${esc(chip)}</span>`).join("") +
+        `<button class="icon-btn" data-copy-judge="${index}" title="copy judge call">${COPY_SVG}</button>` +
+        `<span class="entry-chev">›</span></summary>` +
+        `<div class="judge-call-grid"><section class="judge-request"><header>Judge prompt</header>${prompt}</section>` +
+        `<section class="judge-result"><header>Judge response</header><pre>${esc(responseText)}</pre></section>${parsed}</div>` +
+        `</details>`
+      );
+    })
+    .join("");
+  return (
+    `<div class="judging-divider"><span>Judging</span><span>${records.length} call${records.length === 1 ? "" : "s"}</span></div>` +
+    calls
+  );
+}
+
 function renderedTokensHtml(trace, branches) {
   const rendered = trace.rendered_tokens;
   const errors = errorBannersHtml(episodeErrors(currentEpisode, trace));
@@ -2837,6 +2921,15 @@ function renderMessages(ep, trace, branches) {
   const errorsHtml = errorBannersHtml(episodeErrors(ep, trace));
   if (!trace) {
     container.innerHTML = errorsHtml + emptyState("no traces", "this episode carries no trace data");
+    return;
+  }
+  if (currentEvidenceView === "task") {
+    container.innerHTML = errorsHtml + (taskEvidenceHtml(trace) || emptyState("no task data", "this trace carries no task-specific evidence"));
+    return;
+  }
+  if (currentEvidenceView === "judge") {
+    const judgesHtml = judgeEvidenceHtml(trace);
+    container.innerHTML = errorsHtml + (judgesHtml ? `<div class="judging-view">${judgesHtml}</div>` : emptyState("no judge calls", "this trace has no recorded judge evidence"));
     return;
   }
   if (state.traces.viewMode === "rendered") {
@@ -3037,6 +3130,8 @@ function renderMeta(ep, trace, branches) {
     parts.push(metaRow("turns", nodes.filter((n) => n.sampled).length));
     parts.push(metaRow("branches", branches.length));
     parts.push(metaRow("tool calls", nodes.reduce((acc, n) => acc + (n.message?.tool_calls?.length || 0), 0)));
+    const judgeRecords = Array.isArray(trace.info?.judge_calls) ? trace.info.judge_calls : [];
+    if (judgeRecords.length) parts.push(metaRow("judge calls", judgeRecords.length));
 
     const usage = { input: null, output: null, reasoning: null, cached: null, maxContext: null, cost: null };
     const addUsage = (field, value) => {
@@ -3238,24 +3333,39 @@ function renderEpisode() {
           .join("")
       : "";
   const branchTabs = $("#tm-branch-tabs");
-  branchTabs.hidden = branches.length <= 1;
+  const taskFields = Object.entries(trace?.task?.data || {}).filter(([key, value]) => !TASK_SCAFFOLD_FIELDS.has(key) && value != null);
+  const judgeCalls = Array.isArray(trace?.info?.judge_calls) ? trace.info.judge_calls : [];
+  const hasEvidence = taskFields.length > 0 || judgeCalls.length > 0;
+  branchTabs.hidden = branches.length <= 1 && !hasEvidence;
   branchTabs.innerHTML =
-    branches.length > 1
+    !branchTabs.hidden
       ? branches
-          .map((_, i) => `<button data-branch="${i}" class="${i === currentBranchIdx ? "active" : ""}">branch ${i}</button>`)
+          .map((_, i) => `<button data-branch="${i}" class="${currentEvidenceView == null && i === currentBranchIdx ? "active" : ""}">branch ${i}</button>`)
           .join("") +
-        `<button data-branch="-1" class="${currentBranchIdx === -1 ? "active" : ""}" title="all branches concatenated top to bottom">all</button>`
+        (branches.length > 1
+          ? `<button data-branch="-1" class="${currentEvidenceView == null && currentBranchIdx === -1 ? "active" : ""}" title="all branches concatenated top to bottom">all</button>`
+          : "")
       : "";
+  const evidenceTabs = $("#tm-evidence-tabs");
+  evidenceTabs.hidden = !hasEvidence;
+  evidenceTabs.innerHTML =
+    (taskFields.length
+      ? `<button data-evidence="task" class="${currentEvidenceView === "task" ? "active" : ""}">task data</button>`
+      : "") +
+    (judgeCalls.length
+      ? `<button data-evidence="judge" class="${currentEvidenceView === "judge" ? "active" : ""}">judging · ${judgeCalls.length}</button>`
+      : "");
   setActive("#trace-view-mode", "mode", state.traces.viewMode);
   renderRolloutList();
   const timeline = traceView === "timeline";
-  $("#tm-tabs-row").hidden = timeline || (traceTabs.hidden && branchTabs.hidden);
+  $("#tm-tabs-row").hidden = timeline || (traceTabs.hidden && branchTabs.hidden && evidenceTabs.hidden);
   $("#tm-messages").hidden = timeline;
   $("#tm-timeline").hidden = !timeline;
-  $("#token-signal").closest(".dd-select").hidden = timeline;
-  $("#trace-view-mode").hidden = timeline;
-  $("#tm-collapse").hidden = timeline;
-  $("#tm-expand").hidden = timeline;
+  const evidence = currentEvidenceView != null;
+  $("#token-signal").closest(".dd-select").hidden = timeline || evidence;
+  $("#trace-view-mode").hidden = timeline || evidence;
+  $("#tm-collapse").hidden = timeline || evidence;
+  $("#tm-expand").hidden = timeline || evidence;
   setActive("#tm-view", "view", traceView);
   if (timeline) renderTimeline();
   else renderMessages(ep, trace, branches);
@@ -4410,11 +4520,13 @@ $("#tm-timeline").addEventListener("click", async (e) => {
     const branches = trace ? traceBranches(trace) : [];
     const branch = branches.findIndex((path) => path.includes(node));
     currentBranchIdx = branch >= 0 ? branch : -1;
+    currentEvidenceView = null;
     pendingTimelineNode = node;
     pendingTimelineCall = call;
     state.traces.viewMode = "messages";
   } else {
     currentBranchIdx = 0;
+    currentEvidenceView = null;
     pendingTimelineNode = null;
     pendingTimelineCall = call;
     if (call != null) state.traces.viewMode = "messages";
@@ -4465,11 +4577,15 @@ $("#tm-timeline").addEventListener("mouseout", (e) => {
 });
 $("#tm-trace-tabs").addEventListener("click", (e) => {
   const btn = e.target.closest("[data-trace]");
-  if (btn) { currentTraceIdx = +btn.dataset.trace; currentBranchIdx = 0; renderEpisode(); }
+  if (btn) { currentTraceIdx = +btn.dataset.trace; currentBranchIdx = 0; currentEvidenceView = null; renderEpisode(); }
 });
 $("#tm-branch-tabs").addEventListener("click", (e) => {
   const btn = e.target.closest("[data-branch]");
-  if (btn) { currentBranchIdx = +btn.dataset.branch; renderEpisode(); }
+  if (btn) { currentBranchIdx = +btn.dataset.branch; currentEvidenceView = null; renderEpisode(); }
+});
+$("#tm-evidence-tabs").addEventListener("click", (e) => {
+  const btn = e.target.closest("[data-evidence]");
+  if (btn) { currentEvidenceView = btn.dataset.evidence; renderEpisode(); }
 });
 $("#tm-list").addEventListener("click", (e) => {
   const item = e.target.closest("[data-line]");
@@ -4482,7 +4598,9 @@ $("#tm-expand").addEventListener("click", () =>
   document.querySelectorAll("#tm-messages details").forEach((d) => (d.open = true))
 );
 $("#tm-messages").addEventListener("click", (e) => {
-  const btn = e.target.closest("[data-copy], [data-copy-tool], [data-copy-schema], [data-copy-tools], [data-copy-rendered]");
+  const btn = e.target.closest(
+    "[data-copy], [data-copy-tool], [data-copy-schema], [data-copy-tools], [data-copy-rendered], [data-copy-task], [data-copy-judge]"
+  );
   if (!btn) return;
   e.preventDefault();
   e.stopPropagation();
@@ -4491,6 +4609,16 @@ $("#tm-messages").addEventListener("click", (e) => {
   if (btn.dataset.copy != null) {
     const node = trace.nodes?.[+btn.dataset.copy];
     if (node) copyText(messageText(node.message), btn);
+    return;
+  }
+  if (btn.dataset.copyTask != null) {
+    const value = trace.task?.data?.[btn.dataset.copyTask];
+    if (value != null) copyText(evidenceText(value), btn);
+    return;
+  }
+  if (btn.dataset.copyJudge != null) {
+    const record = trace.info?.judge_calls?.[+btn.dataset.copyJudge];
+    if (record) copyText(JSON.stringify(record, null, 2), btn);
     return;
   }
   const tools = normalizedTools(trace.tools);

--- a/src/prime_rl/dashboard/static/index.html
+++ b/src/prime_rl/dashboard/static/index.html
@@ -254,6 +254,7 @@
     <div class="tm-head tm-tabs-row" id="tm-tabs-row" hidden>
       <div id="tm-trace-tabs" class="seg" hidden></div>
       <div id="tm-branch-tabs" class="seg" hidden></div>
+      <div id="tm-evidence-tabs" class="seg" hidden></div>
     </div>
     <div id="tm-messages"></div>
     <div id="tm-timeline" hidden></div>

--- a/src/prime_rl/dashboard/static/style.css
+++ b/src/prime_rl/dashboard/static/style.css
@@ -694,6 +694,9 @@ mark.hit {
   overflow-y: hidden;
   scrollbar-width: thin;
 }
+#tm-evidence-tabs [data-evidence="task"].active { color: var(--chart-3); }
+#tm-evidence-tabs [data-evidence="judge"].active { color: #7adfff; }
+#tm-evidence-tabs { margin-left: auto; }
 .tm-title { font-size: 12px; font-weight: 500; color: var(--grey-6); white-space: nowrap; }
 #tm-left { border-right: 1px solid var(--hairline); display: flex; flex-direction: column; min-height: 0; }
 #tm-left .search { margin: 10px 14px 6px; }
@@ -915,6 +918,80 @@ details.tool-definitions, .rendered-transcript {
   margin-bottom: 12px;
   background: rgba(183, 166, 250, 0.025);
 }
+.task-evidence {
+  border: 1px solid color-mix(in srgb, var(--chart-3) 42%, var(--grey-3));
+  margin-bottom: 12px;
+  background: color-mix(in srgb, var(--chart-3) 3%, transparent);
+}
+.task-evidence.standalone,
+.judging-view .judging-divider { margin-top: 0; }
+.task-evidence > summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 7px 12px;
+  background: var(--grey-2);
+}
+.task-evidence .context-label { color: var(--chart-3); }
+.task-evidence[open] > summary { border-bottom: 1px solid var(--hairline); }
+.task-evidence[open] > summary .entry-chev { transform: rotate(90deg); }
+.evidence-fields { display: grid; gap: 8px; padding: 10px 12px 12px; }
+.evidence-field { min-width: 0; border: 1px solid var(--hairline); background: rgba(0, 0, 0, 0.08); }
+.evidence-field > header {
+  display: flex;
+  align-items: center;
+  padding: 5px 9px;
+  border-bottom: 1px solid var(--hairline);
+  color: var(--chart-3);
+  font-size: 10px;
+  letter-spacing: var(--track-caps);
+  text-transform: uppercase;
+}
+.evidence-field > header .icon-btn { margin-left: auto; }
+.evidence-field > pre,
+.judge-result > pre {
+  max-height: 360px;
+  margin: 0;
+  overflow: auto;
+  padding: 9px 11px;
+  color: var(--grey-5);
+  font: 400 11px/1.55 var(--font-mono);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.judging-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 20px 0 8px;
+  color: #7adfff;
+  font-size: 10px;
+  letter-spacing: var(--track-caps);
+  text-transform: uppercase;
+}
+.judging-divider::after { content: ""; flex: 1; height: 1px; background: var(--hairline); }
+.judging-divider > :last-child { order: 2; color: var(--grey-4); }
+.judge-entry { border-color: color-mix(in srgb, #7adfff 38%, var(--grey-3)); }
+.judge-entry .entry-role { color: #7adfff; }
+.judge-call-grid { display: grid; grid-template-columns: minmax(0, 1fr); gap: 10px; padding: 10px 12px 12px; }
+.judge-request,
+.judge-result { min-width: 0; border: 1px solid var(--hairline); }
+.judge-request > header,
+.judge-result > header {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--hairline);
+  color: #7adfff;
+  font-size: 10px;
+  letter-spacing: var(--track-caps);
+  text-transform: uppercase;
+}
+.judge-result.parsed > header { color: var(--chart-2); }
+.judge-message { display: grid; grid-template-columns: 72px minmax(0, 1fr); border-bottom: 1px solid var(--hairline-faint); }
+.judge-message:last-child { border-bottom: 0; }
+.judge-message > header { display: flex; gap: 8px; padding: 9px 10px; color: var(--grey-4); font-size: 10px; }
+.judge-message > header strong { color: var(--grey-5); font-weight: 500; text-transform: uppercase; }
+.judge-message > div { min-width: 0; padding: 9px 11px; border-left: 1px solid var(--hairline); color: var(--grey-5); font-size: 11.5px; white-space: pre-wrap; overflow-wrap: anywhere; }
 details.tool-definitions > summary, details.rendered-transcript > summary,
 details.tool-definition > summary {
   display: flex;

--- a/uv.lock
+++ b/uv.lock
@@ -7648,16 +7648,16 @@ requires-dist = [{ name = "verifiers", specifier = ">=0.3.1" }]
 
 [[package]]
 name = "uvicorn"
-version = "0.48.0"
+version = "0.52.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
     { name = "click", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
 ]
 
 [package.optional-dependencies]
@@ -7705,7 +7705,9 @@ dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
     { name = "gepa" },
+    { name = "h11" },
     { name = "httpx" },
+    { name = "httpx2" },
     { name = "loguru" },
     { name = "math-verify" },
     { name = "mcp" },
@@ -7722,6 +7724,7 @@ dependencies = [
     { name = "tenacity" },
     { name = "tomli-w" },
     { name = "typing-extensions" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
@@ -7739,8 +7742,10 @@ requires-dist = [
     { name = "anthropic", specifier = ">=1.0.0" },
     { name = "datasets", marker = "extra == 'lean'", specifier = ">=3.3.0,<6.0.0" },
     { name = "gepa", specifier = ">=0.0.6" },
+    { name = "h11", specifier = ">=0.16.0" },
     { name = "harbor", marker = "python_full_version >= '3.12' and extra == 'harbor'", specifier = "==0.21.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "httpx2", specifier = ">=2.12.0" },
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "math-verify", specifier = ">=0.8.0" },
     { name = "mcp", specifier = "==2.0.0" },
@@ -7761,6 +7766,7 @@ requires-dist = [
     { name = "textarena", marker = "extra == 'ta'", specifier = "==0.7.4" },
     { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
+    { name = "uvicorn", specifier = ">=0.52.0" },
 ]
 provides-extras = ["harbor", "lean", "modal", "openenv", "ta"]
 


### PR DESCRIPTION
## Summary

- add right-aligned **Task Data** and **Judging** tabs beside branch navigation when a trace carries evidence
- show task-specific fields with `question` before `answer`, omit generic execution scaffolding, and provide per-field copy actions
- show every pluggable judge call with its name, exact request messages and model, assistant response, parsed verdict, usage, and a whole-call copy action
- expose the judge-call count in trace metadata and bump Verifiers to the merged strict judge-call trace contract

## Screenshots

Task data from a real RedSearcher rollout:

![Task Data tab on a real RedSearcher trace](https://github.com/user-attachments/assets/35a9771e-d481-4bc9-8026-a583bfcf2c78)

Full judge prompt and response from the same trace:

![Judging tab on a real RedSearcher trace](https://github.com/user-attachments/assets/53d30e54-cb13-466e-8133-1f6931f72139)

## Validation

- `node --check src/prime_rl/dashboard/static/app.js`
- `uv run --frozen pre-commit run --all-files`
- browser-tested branch, rendered, Task Data, Judging, trace, and timeline navigation
- exercised with two real, uninstrumented RedSearcher rollouts on `deepseek/deepseek-v4-flash` with nano-RLM default autocompaction enabled; both completed with reward `1.0`, four branches, three subagent calls, and a recorded judge call

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only UI and lockfile dependency updates; no server auth or training-path changes.
> 
> **Overview**
> The trace episode drawer gains **Task data** and **Judging** tabs (right-aligned next to branch tabs) when a trace has non-scaffold `trace.task.data` fields or `trace.info.judge_calls`.
> 
> Selecting **task data** replaces the message transcript with collapsible fields (`question` / `answer` first, scaffolding keys omitted) and per-field copy. **Judging** lists each judge call with name, model/usage chips, full prompt messages, raw response, optional parsed verdict, and whole-call JSON copy. Evidence mode clears branch highlighting, hides token-signal / view-mode / collapse controls, and can be opened via `openEpisode(..., { evidence: "task"|"judge" })`. Overview metadata adds **judge calls** when present.
> 
> `uv.lock` bumps **uvicorn** and extends **verifiers** deps (`h11`, `httpx2`, `uvicorn`) for the judge-call trace contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9643d4361a41662787d5f53ecef3a58ce3544472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->