### PR TITLE
fix(orchestrator): zero-output guard ignores errored episodes, gets a config knob

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -59,6 +59,7 @@ A condensed view of the knobs you'll most often tune. For trainer-side paralleli
 |---|---|
 | `orchestrator.batch_size` | Tasks per trainer step. |
 | `orchestrator.constant_trainer_batch_size` | Keep trainer batches constant when samples have no training signal, such as zero advantage on all tokens. Enabled by default. Disable it for faster collection with variable trainer batch sizes. |
+| `orchestrator.max_zero_output_batches` | Abort after this many consecutive batch-equivalents of clean, error-free episodes with no training signal (default 10). Errored episodes and dispatch failures never count, so an environment or sandbox outage stalls the run instead of killing it. `None` disables the abort. |
 | `orchestrator.group_size` | Rollouts generated per task. |
 | `orchestrator.max_off_policy_steps` | Maximum staleness of a trained rollout (default 8): the version a batch trains on minus the oldest version that generated the rollout, queue time included. Episodes past the bound are dropped; a group shares one dispatch version, so its episodes age out together. The main off-policy dial on long agentic rollouts — bump for throughput, lower for tighter on-policyness. Watch `off_policy/*` and `mismatch_kl/all/mean` when tuning. |
 | `[orchestrator.algo]` | Training algorithm — its `type` names it (`grpo` default, `max_rl`, `rae`, `hierarchical_grpo`, `opd`, `opsd`, `sft`, `echo`). See [Algorithms](#algorithms). |

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -554,6 +554,9 @@ class OrchestratorConfig(BaseConfig):
     constant_trainer_batch_size: bool = True
     """Require each batch to reach its effective sample target."""
 
+    max_zero_output_batches: int | None = Field(10, ge=1)
+    """Abort after this many consecutive batch-equivalents of clean finalized episodes (completed without error) that produced no trainable sample — all-equal rewards, curriculum rejections, or staleness drops. Errored episodes and dispatch failures do not count, so an environment or sandbox outage stalls the run instead of killing it. ``None`` disables the abort; the warning still fires."""
+
     token_batch_size: int | None = Field(None, ge=1)
     """Tokens to train on per step (token-based batching). Set this OR ``batch_size``."""
 

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -25,7 +25,72 @@ from prime_rl.orchestrator.utils import episode_env_name, episode_group_id, min_
 from prime_rl.transports.batch import TrainingSample
 from prime_rl.utils.logger import get_logger
 
-MAX_CONSECUTIVE_ZERO_OUTPUT_BATCH_EQUIVALENTS = 10
+
+class ZeroOutputBudget:
+    """Abort a run that keeps finalizing groups without ever shipping a sample.
+
+    Only CLEAN finalized units advance the budget: completed, error-free episodes (or their
+    tokens) that produced no admitted payload — all-equal rewards, curriculum rejections,
+    staleness drops. Errored episodes and dispatch failures never count: they mean the
+    environment or its infrastructure is down, not that the task mix carries no signal, and an
+    outage must stall the run rather than kill it. ``max_windows=None`` disables the abort; the
+    warning still fires once per batch equivalent.
+    """
+
+    def __init__(self, target: int, max_windows: int | None) -> None:
+        assert target > 0
+        self.target = target
+        self.max_windows = max_windows
+        self.units = 0
+        self.reported_windows = 0
+
+    def record(self, units: int) -> None:
+        self.units += units
+        windows = self.units // self.target
+        if windows <= self.reported_windows:
+            return
+        self.reported_windows = windows
+        limit = f"{windows}/{self.max_windows}" if self.max_windows is not None else f"{windows}, abort disabled"
+        get_logger().warning(
+            f"No admitted train payload after {self.units} clean finalized units "
+            f"(consecutive zero-output batch equivalents: {limit}); errored episodes and dispatch "
+            "failures are not counted"
+        )
+        if self.max_windows is not None and windows >= self.max_windows:
+            raise RuntimeError(
+                f"{windows} consecutive zero-output batch equivalents — "
+                "check the curriculum admission policy, task difficulty, and staleness drops."
+            )
+
+    def reset(self) -> None:
+        self.units = 0
+        self.reported_windows = 0
+
+
+def zero_output_units(
+    group: list[vf.Episode],
+    survivors: list[vf.Trace],
+    *,
+    n_owed: int,
+    n_errored: int,
+    batch_mode: bool,
+    seq_len: int,
+) -> int:
+    """Clean finalized units a payload-less group contributes to the zero-output budget.
+
+    ``n_owed`` is the group's full episode budget (arrived + failed to dispatch + cancelled), so
+    dropped groups advance the budget at the same rate as fully-delivered ones; ``n_errored``
+    (errored traces, errored empty episodes, dispatch failures) is excluded. Trainable survivors
+    are error-free by construction and count first; otherwise the arrived error-free traces; and
+    for a group that delivered nothing clean, the still-owed clean episodes (e.g. a stale drop).
+    """
+    clean_traces = [trace for episode in group for trace in episode.traces if not trace.has_error]
+    clean_owed = max(n_owed - n_errored, 0)
+    if batch_mode:
+        return len(survivors) or len(clean_traces) or clean_owed
+    survivor_tokens = sum(trace.num_total_tokens for trace in survivors)
+    clean_tokens = sum(trace.num_total_tokens for trace in clean_traces)
+    return survivor_tokens or clean_tokens or seq_len * clean_owed
 
 
 def payload_tokens(samples: list[TrainingSample], trace: vf.Trace | None = None) -> int:
@@ -104,8 +169,9 @@ class TrainSink:
         # Step of the last full staleness sweep — queued traces only age when
         # ``progress.step`` advances, so one full sweep per step suffices.
         self._swept_step = 0
-        self.zero_output_units = 0
-        self.reported_zero_output_windows = 0
+        target = batch_size if batch_size is not None else token_batch_size
+        assert target is not None
+        self.zero_output = ZeroOutputBudget(target, config.max_zero_output_batches)
 
     def group_size_for(self, env_name: str) -> int:
         return self.train_envs.get(env_name).config.group_size
@@ -256,7 +322,7 @@ class TrainSink:
         # decision is not a task result.
         if cancellation is not None and cancellation.reason == "stale":
             self.pending_episodes.extend(group, admitted=False, cancelled=True)
-            self._record_zero_output(group, [], n_owed)
+            self._record_zero_output(group, [], n_owed=n_owed, n_errored=num_errored)
             get_logger().debug(
                 f"Dropped group | env={env_name} task_idx={task_idx} | "
                 f"episodes={len(group)} traces={len(traces)} (errored={num_errored}) | reason=cancelled (stale)"
@@ -269,7 +335,7 @@ class TrainSink:
         admitted = self._admit(group) if group else False
         if not survivors or not admitted:
             self.pending_episodes.extend(group, admitted=admitted)
-            self._record_zero_output(group, survivors, n_owed)
+            self._record_zero_output(group, survivors, n_owed=n_owed, n_errored=num_errored)
             reason = "no trainable survivors" if not survivors else "rejected by curriculum"
             get_logger().debug(
                 f"Dropped group | env={env_name} task_idx={task_idx} | "
@@ -300,7 +366,7 @@ class TrainSink:
 
         self.pending_episodes.extend(group, sampled_trace_ids=set(samples_by_trace), admitted=True)
         if not samples_by_trace:
-            self._record_zero_output(group, survivors, n_owed)
+            self._record_zero_output(group, survivors, n_owed=n_owed, n_errored=num_errored)
             return
 
         self.pending_batch.update(samples_by_trace)
@@ -319,10 +385,9 @@ class TrainSink:
         # trainer plus a tight bound could void groups forever without ever
         # tripping the abort.
         if not any(trace_id in self.pending_batch for trace_id in samples_by_trace):
-            self._record_zero_output(group, [], n_owed)
+            self._record_zero_output(group, [], n_owed=n_owed, n_errored=num_errored)
             return
-        self.zero_output_units = 0
-        self.reported_zero_output_windows = 0
+        self.zero_output.reset()
 
     def _trace(self, trace_id: str) -> vf.Trace:
         episode = self.episode_by_trace[trace_id]
@@ -331,36 +396,19 @@ class TrainSink:
     def _admit(self, group: list[vf.Episode]) -> bool:
         return self.on_result(group) if self.on_result is not None else True
 
-    def _record_zero_output(self, group: list[vf.Episode], survivors: list[vf.Trace], n_owed: int) -> None:
-        """``n_owed`` counts the group's full episode budget (arrived +
-        cancelled), so dropped groups advance the zero-output budget at the
-        same rate as fully-delivered ones."""
-        if self.batch_size is not None:
-            returned_traces = sum(len(episode.traces) for episode in group)
-            self.zero_output_units += len(survivors) or returned_traces or n_owed
-        else:
-            survivor_tokens = sum(trace.num_total_tokens for trace in survivors)
-            episode_tokens = sum(episode.num_total_tokens for episode in group)
-            self.zero_output_units += survivor_tokens or episode_tokens or self.config.seq_len * n_owed
-        self._check_zero_output_budget()
-
-    def _check_zero_output_budget(self) -> None:
-        target = self.batch_size if self.batch_size is not None else self.token_batch_size
-        assert target is not None
-        windows = self.zero_output_units // target
-        if windows <= self.reported_zero_output_windows:
-            return
-        self.reported_zero_output_windows = windows
-        get_logger().warning(
-            f"No admitted train payload after {self.zero_output_units} finalized units "
-            f"(consecutive zero-output batch equivalents: "
-            f"{windows}/{MAX_CONSECUTIVE_ZERO_OUTPUT_BATCH_EQUIVALENTS})"
-        )
-        if windows >= MAX_CONSECUTIVE_ZERO_OUTPUT_BATCH_EQUIVALENTS:
-            raise RuntimeError(
-                f"{windows} consecutive zero-output batch equivalents — "
-                "check the curriculum admission policy, task difficulty, and staleness drops."
+    def _record_zero_output(
+        self, group: list[vf.Episode], survivors: list[vf.Trace], *, n_owed: int, n_errored: int
+    ) -> None:
+        self.zero_output.record(
+            zero_output_units(
+                group,
+                survivors,
+                n_owed=n_owed,
+                n_errored=n_errored,
+                batch_mode=self.batch_size is not None,
+                seq_len=self.config.seq_len,
             )
+        )
 
     def process_batch(self) -> TrainBatch:
         items = list(self.pending_batch.items())

--- a/tests/unit/orchestrator/test_zero_output_budget.py
+++ b/tests/unit/orchestrator/test_zero_output_budget.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import pytest
+
+from prime_rl.orchestrator.train_sink import ZeroOutputBudget, zero_output_units
+
+
+def trace(tokens: int = 100, error: bool = False):
+    return SimpleNamespace(has_error=error, num_total_tokens=tokens)
+
+
+def episode(*traces):
+    return SimpleNamespace(traces=list(traces), ok=not any(t.has_error for t in traces))
+
+
+def units(group, survivors, *, n_owed, n_errored, batch_mode=True):
+    return zero_output_units(group, survivors, n_owed=n_owed, n_errored=n_errored, batch_mode=batch_mode, seq_len=1000)
+
+
+def test_all_equal_reward_group_counts_its_survivors():
+    # Eight clean rollouts with identical rewards: trainable survivors, but every advantage is 0.
+    group = [episode(trace()) for _ in range(8)]
+    survivors = [ep.traces[0] for ep in group]
+    assert units(group, survivors, n_owed=8, n_errored=0) == 8
+
+
+def test_errored_group_does_not_advance_the_budget():
+    # An outage: every rollout failed, no trainable survivors.
+    group = [episode(trace(tokens=0, error=True)) for _ in range(8)]
+    assert units(group, [], n_owed=8, n_errored=8) == 0
+    # Same for token-based batching, which used to fall back to seq_len * n_owed.
+    assert units(group, [], n_owed=8, n_errored=8, batch_mode=False) == 0
+
+
+def test_dispatch_failures_do_not_advance_the_budget():
+    # Nothing arrived at all: the whole group failed to dispatch.
+    assert units([], [], n_owed=8, n_errored=8) == 0
+    assert units([], [], n_owed=8, n_errored=8, batch_mode=False) == 0
+
+
+def test_mixed_group_counts_only_clean_units():
+    group = [episode(trace()) for _ in range(5)] + [episode(trace(error=True)) for _ in range(3)]
+    # Five clean rollouts with identical rewards survive; the three errors are excluded.
+    survivors = [ep.traces[0] for ep in group[:5]]
+    assert units(group, survivors, n_owed=8, n_errored=3) == 5
+    # If nothing is trainable, the clean arrived traces still count, the errored ones do not.
+    assert units(group, [], n_owed=8, n_errored=3) == 5
+
+
+def test_stale_drop_still_counts_as_a_pipeline_decision():
+    # Three rollouts arrived clean, five were cancelled as stale: the owed clean budget counts.
+    arrived = [episode(trace()) for _ in range(3)]
+    assert units(arrived, [], n_owed=8, n_errored=0) == 3
+    assert units([], [], n_owed=8, n_errored=0) == 8
+    assert units([], [], n_owed=8, n_errored=0, batch_mode=False) == 8 * 1000
+
+
+def test_budget_warns_per_window_and_aborts_at_the_limit():
+    budget = ZeroOutputBudget(target=128, max_windows=3)
+    budget.record(128)
+    budget.record(128)
+    assert budget.reported_windows == 2
+    with pytest.raises(RuntimeError, match="3 consecutive zero-output batch equivalents"):
+        budget.record(128)
+
+
+def test_budget_reset_and_disabled_limit():
+    budget = ZeroOutputBudget(target=128, max_windows=1)
+    budget.record(100)
+    budget.reset()
+    budget.record(100)  # 200 units total would have aborted without the reset
+    assert budget.units == 100 and budget.reported_windows == 0
+
+    unlimited = ZeroOutputBudget(target=128, max_windows=None)
+    for _ in range(50):
+        unlimited.record(128)  # warns, never raises
+    assert unlimited.reported_windows == 50


### PR DESCRIPTION
## Problem

The train sink aborts a run after 10 consecutive batch-equivalents of finalized groups that shipped no sample (`RuntimeError: 10 consecutive zero-output batch equivalents — check the curriculum admission policy, task difficulty, and staleness drops`). The guard is meant for a dead curriculum, an all-equal reward, or a staleness bound that drops everything.

Its budget, however, advanced for every finalized unit with no payload, including errored episodes and dispatch failures. During a sandbox/environment outage every rollout fails fast (provisioning timeout, retries exhausted), so with a few hundred episodes in flight the 10 windows fill in about 20 minutes with zero training steps in between. The run dies instead of stalling until the infrastructure is back, and only a checkpoint saves the progress.

Observed on a live run: a ~75-minute sandbox provisioning outage produced 1280 errored episodes, `1/10 … 10/10` warnings within 23 minutes, and the abort.

## Fix

- Only clean finalized units advance the budget: trainable survivors, else the arrived error-free traces, else the still-owed clean episodes (a stale drop is still a pipeline decision and still counts). Errored traces, errored empty episodes and dispatch failures are subtracted via the `num_errored` the sink already computes, for both rollout- and token-based batching (the token branch used to fall back to `seq_len * n_owed` for an all-error group).
- The accounting moves into a small `ZeroOutputBudget` helper; the warning names the unit definition and the limit.
- New `orchestrator.max_zero_output_batches` (default 10 = the previous hard-coded constant). `None` disables the abort while keeping the per-window warning. Documented in `docs/training.md`.

## Tests

`tests/unit/orchestrator/test_zero_output_budget.py`: all-equal-reward groups count their survivors, all-error groups and dispatch failures count zero (both batching modes), mixed groups count only clean units, stale drops still count, the budget warns per window and aborts at the limit, reset and the disabled limit behave.

`tests/unit/orchestrator/{test_batch,test_curriculum}.py` and `tests/unit/test_configs.py` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestrator train-sink abort semantics and run-stall behavior during outages; mis-tuned limits could hide a dead curriculum longer, but default matches prior behavior for genuine zero-signal cases.
> 
> **Overview**
> Fixes the train sink **zero-output abort** so long **environment or sandbox outages** no longer trip `RuntimeError` after 10 batch-equivalents of failed rollouts.
> 
> **Budget accounting** now advances only on **clean** finalized work with no admitted training payload (equal rewards, curriculum rejection, staleness drops). **Errored traces, empty errored episodes, and dispatch failures** are excluded via `n_errored`, including the token-batching path that previously used `seq_len * n_owed` for all-error groups. Logic lives in **`ZeroOutputBudget`** and **`zero_output_units`**, with clearer warnings.
> 
> Adds **`orchestrator.max_zero_output_batches`** (default **10**, same as the old constant; **`None`** keeps warnings but disables abort). Documented in **`docs/training.md`**. Unit tests cover the new accounting and budget behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 103df426f315aeeea8cf8181ca5ddd6f249d9e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->