### PR TITLE
feat: visualize compaction attempts and exclude rejected branches

### DIFF
--- a/src/prime_rl/dashboard/server.py
+++ b/src/prime_rl/dashboard/server.py
@@ -884,6 +884,7 @@ def activity_spans(
         if reasoning_tokens is None:
             reasoning_tokens = (usage.get("completion_tokens_details") or {}).get("reasoning_tokens")
         text = " ".join(message_text(node.get("message") or {}).split())
+        mask = node.get("mask")
         spans.append(
             {
                 "kind": "model_call",
@@ -901,6 +902,7 @@ def activity_spans(
                 "output_tokens": output_tokens,
                 "reasoning_tokens": reasoning_tokens,
                 "cost": usage.get("cost"),
+                "trainable": any(mask) if isinstance(mask, list) and mask else None,
             }
         )
     return sorted(spans, key=lambda span: span["started_at"] if span["started_at"] is not None else float("inf"))
@@ -1085,8 +1087,9 @@ def semantic_context_lanes(
     """Project continuation components as execution-context timeline lanes.
 
     ``continuation`` keeps calls in one context. ``subagent_call`` creates a child
-    agent, while ``compaction`` starts a new context for the same agent. Other edge
-    labels remain visible but do not invent session semantics.
+    agent, ``compaction_attempt`` creates a summary leaf beside its source context,
+    and ``compaction`` starts a new context for the same agent. Other edge labels
+    remain visible but do not invent session semantics.
     """
     nodes = trace.get("nodes") or []
     call_nodes = {
@@ -1139,7 +1142,9 @@ def semantic_context_lanes(
     ordered_components = sorted(components, key=lambda component: (component_start(component), component))
     cross_edges = [edge for edge in edges if component_for[edge["source_node"]] != component_for[edge["target_node"]]]
     created_components = {
-        component_for[edge["target_node"]] for edge in cross_edges if edge["type"] in {"subagent_call", "compaction"}
+        component_for[edge["target_node"]]
+        for edge in cross_edges
+        if edge["type"] in {"subagent_call", "compaction_attempt", "compaction"}
     }
     root_components = [component for component in ordered_components if component not in created_components]
 
@@ -1165,6 +1170,8 @@ def semantic_context_lanes(
             if edge["type"] == "subagent_call":
                 subagent_number += 1
                 identities[target] = (f"subagent {subagent_number}", depth + 1, 0)
+            elif edge["type"] == "compaction_attempt":
+                identities[target] = (agent_label, depth, context_index)
             elif edge["type"] == "compaction":
                 identities[target] = (agent_label, depth, context_index + 1)
             else:
@@ -1179,6 +1186,16 @@ def semantic_context_lanes(
             unlinked_components.add(component)
 
     lanes = []
+    accepted_attempt_nodes = {edge["source_node"] for edge in cross_edges if edge["type"] == "compaction"}
+    attempt_by_component = {
+        component_for[edge["target_node"]]: {
+            "source_node": edge["source_node"],
+            "target_node": edge["target_node"],
+            "accepted": edge["target_node"] in accepted_attempt_nodes,
+        }
+        for edge in cross_edges
+        if edge["type"] == "compaction_attempt"
+    }
     for component in ordered_components:
         agent_label, depth, context_index = identities[component]
         activities = component_activities[component]
@@ -1223,6 +1240,8 @@ def semantic_context_lanes(
         }
         if component in unlinked_components:
             lane["context"]["unlinked"] = True
+        if component in attempt_by_component:
+            lane["compaction_attempt"] = attempt_by_component[component]
         lanes.append(lane)
     return lanes
 

--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -3386,6 +3386,7 @@ function semanticEdgeKind(type) {
   if (type === "continuation") return "continuation";
   if (type === "subagent_call") return "subagent-call";
   if (type === "subagent_return") return "subagent-return";
+  if (type === "compaction_attempt") return "compaction-attempt";
   if (type === "compaction") return "compaction";
   return "custom";
 }
@@ -3455,6 +3456,12 @@ function semanticNodeTip(event) {
     ["end", span.ended_at == null ? "unknown" : timelineClock(span.ended_at)],
     ["duration", span.started_at == null || span.ended_at == null ? "—" : fmtDuration(span.ended_at - span.started_at)],
   ];
+  if (event.compactionAttempt) {
+    rows.splice(2, 0,
+      ["compaction", event.compactionAttempt.accepted ? "accepted" : "rejected"],
+      ["training", span.trainable === false ? "masked" : "included"]
+    );
+  }
   appendTimelineUsage(rows, {
     input_tokens: span.input_tokens,
     cached_tokens: span.cached_tokens,
@@ -3466,8 +3473,10 @@ function semanticNodeTip(event) {
     cost: span.cost,
   });
   return timelineTipAttr({
-    kind: "model call",
-    title: `${event.agent.label} — ${span.label}`,
+    kind: event.compactionAttempt ? "compaction attempt" : "model call",
+    title: event.compactionAttempt
+      ? `${event.agent.label} — attempt ${event.compactionAttemptIndex}`
+      : `${event.agent.label} — ${span.label}`,
     snippet: span.snippet || "",
     rows,
     hint: "Click to inspect this call. Exact wall-clock placement is available in Timeline.",
@@ -3521,6 +3530,7 @@ function renderSemanticGraph() {
       contextIndex: lane.context.index,
       unlinked: !!lane.context.unlinked,
       lane,
+      compactionAttempt: lane.compaction_attempt || null,
       events: [],
     };
     agent.segments.push(segment);
@@ -3536,6 +3546,7 @@ function renderSemanticGraph() {
         lane,
         agent,
         segment,
+        compactionAttempt: segment.compactionAttempt,
         span,
       };
       segment.events.push(event);
@@ -3550,11 +3561,31 @@ function renderSemanticGraph() {
   );
   for (const agent of agents) {
     agent.segments.sort((left, right) => left.contextIndex - right.contextIndex);
+    agent.contextSegments = agent.segments.filter((segment) => !segment.compactionAttempt);
     agent.usage = aggregateTimelineUsage(agent.segments.map((segment) => segment.lane.usage));
+    agent.contextUsage = new Map();
+    const segmentsByContext = new Map();
+    for (const segment of agent.segments) {
+      if (!segmentsByContext.has(segment.contextIndex)) {
+        segmentsByContext.set(segment.contextIndex, []);
+      }
+      segmentsByContext.get(segment.contextIndex).push(segment);
+    }
+    for (const [contextIndex, contextSegments] of segmentsByContext) {
+      agent.contextUsage.set(
+        contextIndex,
+        aggregateTimelineUsage(contextSegments.map((candidate) => candidate.lane.usage))
+      );
+    }
+    for (const segment of agent.contextSegments) {
+      segment.contextUsage = agent.contextUsage.get(segment.contextIndex);
+    }
     semanticScopeDetails.set(`agent:${agent.key}`, { kind: "agent", agent });
   }
   for (const segment of segments) {
-    semanticScopeDetails.set(`context:${segment.key}`, { kind: "context", segment });
+    if (!segment.compactionAttempt) {
+      semanticScopeDetails.set(`context:${segment.key}`, { kind: "context", segment });
+    }
   }
   events.sort(
     (left, right) =>
@@ -3600,7 +3631,7 @@ function renderSemanticGraph() {
   });
   for (const agent of agents) {
     const agentEvents = events
-      .filter((event) => event.agent === agent)
+      .filter((event) => event.agent === agent && !event.compactionAttempt)
       .sort(
         (left, right) =>
           (left.span.started_at ?? Infinity) - (right.span.started_at ?? Infinity) ||
@@ -3807,10 +3838,52 @@ function renderSemanticGraph() {
     semanticNodeDetails.set(event.key, event);
   }
 
+  const attemptsBySource = new Map();
+  for (const edge of edges) {
+    if (edge.type !== "compaction_attempt") continue;
+    const sourceKey = semanticNodeKey(edge.trace_index, edge.source_node);
+    const targetKey = semanticNodeKey(edge.trace_index, edge.target_node);
+    if (!attemptsBySource.has(sourceKey)) attemptsBySource.set(sourceKey, []);
+    attemptsBySource.get(sourceKey).push(targetKey);
+  }
+  const attemptSpread = Math.min(96, laneWidth * 0.27);
+  for (const [sourceKey, targetKeys] of attemptsBySource) {
+    const source = positions.get(sourceKey);
+    if (!source) continue;
+    targetKeys.sort((leftKey, rightKey) => {
+      const left = eventByKey.get(leftKey);
+      const right = eventByKey.get(rightKey);
+      return eventOrder(left.key, right.key);
+    });
+    const acceptedIndex = targetKeys.findIndex(
+      (key) => eventByKey.get(key)?.compactionAttempt?.accepted
+    );
+    let rejectedSlot = 0;
+    targetKeys.forEach((targetKey, index) => {
+      const event = eventByKey.get(targetKey);
+      const position = positions.get(targetKey);
+      if (!event || !position) return;
+      event.compactionAttemptIndex = index + 1;
+      let offset;
+      if (acceptedIndex >= 0 && index === acceptedIndex) {
+        offset = 0;
+      } else if (acceptedIndex >= 0) {
+        offset = rejectedSlot % 2 === 0
+          ? -(Math.floor(rejectedSlot / 2) + 1)
+          : Math.floor(rejectedSlot / 2) + 1;
+        rejectedSlot += 1;
+      } else {
+        offset = index - (targetKeys.length - 1) / 2;
+      }
+      positions.set(targetKey, { x: source.x + offset * attemptSpread, y: position.y });
+    });
+  }
+
   const markerColors = {
     continuation: "#767676",
     "subagent-call": "#4a9eff",
     "subagent-return": "#ff6b4a",
+    "compaction-attempt": "#b7a6fa",
     compaction: "#b7a6fa",
     custom: "#b6ff3c",
   };
@@ -3875,7 +3948,7 @@ function renderSemanticGraph() {
   }
   const lifelines = segments
     .map((segment) => {
-      if (!segment.firstEvent || !segment.lastEvent) return "";
+      if (segment.compactionAttempt || !segment.firstEvent || !segment.lastEvent) return "";
       const first = positions.get(segment.firstEvent.key);
       const last = positions.get(segment.lastEvent.key);
       const color = PALETTE[agents.indexOf(segment.agent) % PALETTE.length];
@@ -3907,6 +3980,7 @@ function renderSemanticGraph() {
   })
     .join("");
   const agentLabels = segments
+    .filter((segment) => !segment.compactionAttempt)
     .map((segment) => {
       if (!segment.firstEvent) return "";
       const position = positions.get(segment.firstEvent.key);
@@ -3928,14 +4002,14 @@ function renderSemanticGraph() {
         kind: "agent",
         title: agentLabel,
         snippet: "",
-        rows: [["contexts", fmtNum(segment.agent.segments.length)], ...semanticUsageRows(segment.agent.usage)],
+        rows: [["contexts", fmtNum(segment.agent.contextSegments.length)], ...semanticUsageRows(segment.agent.usage)],
         hint: "Current prompt is the latest model request. Click for exact usage.",
       });
       const contextTip = timelineTipAttr({
         kind: segment.unlinked ? "unlinked calls" : "context",
         title: segment.unlinked ? agentLabel : `${agentLabel} — context ${segment.contextIndex}`,
         snippet: "",
-        rows: semanticUsageRows(segment.lane.usage),
+        rows: semanticUsageRows(segment.contextUsage || segment.lane.usage),
         hint: segment.unlinked
           ? "The trace did not provide enough lineage to place these calls."
           : "Current prompt is the latest model request. Click for exact usage.",
@@ -3957,13 +4031,19 @@ function renderSemanticGraph() {
     .map((event) => {
       const position = positions.get(event.key);
       const color = PALETTE[agents.indexOf(event.agent) % PALETTE.length];
+      const attemptClass = event.compactionAttempt
+        ? ` compaction-attempt ${event.compactionAttempt.accepted ? "accepted" : "rejected"}`
+        : "";
+      const label = event.compactionAttempt
+        ? `a${event.compactionAttemptIndex}${event.compactionAttempt.accepted ? " ✓" : " ×"}`
+        : event.span.label.replace("turn ", "t");
       return (
-        `<button class="sg-turn" style="left:${position.x - turnHitWidth / 2}px;top:${position.y - turnHitHeight / 2}px;` +
+        `<button class="sg-turn${attemptClass}" style="left:${position.x - turnHitWidth / 2}px;top:${position.y - turnHitHeight / 2}px;` +
         `width:${turnHitWidth}px;height:${turnHitHeight}px;--turn-color:${color};--turn-mark-width:${turnMarkWidth}px;` +
         `--turn-mark-height:${turnMarkHeight}px;--turn-label-offset:${turnLabelOffset}px" ` +
         `data-sg-key="${esc(event.key)}" data-tl-trace="${event.traceIndex}" data-tl-node="${event.nodeIndex}" ` +
         `data-tl-call="${event.callIndex}"${semanticNodeTip(event)}>` +
-        `<span class="sg-turn-mark"></span><span class="sg-turn-index">${esc(event.span.label.replace("turn ", "t"))}</span></button>`
+        `<span class="sg-turn-mark"></span><span class="sg-turn-index">${esc(label)}</span></button>`
       );
     })
     .join("");
@@ -4032,7 +4112,15 @@ function openSemanticCallInspector(event) {
     ["cost", span.cost == null ? "n/a" : fmtCost(span.cost)],
   ];
   if (event.inferredContinuation) rows.splice(2, 0, ["lineage", "recovered from physical tool flow"]);
-  $("#sg-inspector-title").textContent = `${event.agent.label} · ${span.label}`;
+  if (event.compactionAttempt) {
+    rows.splice(2, 0,
+      ["compaction", event.compactionAttempt.accepted ? "accepted" : "rejected"],
+      ["training", span.trainable === false ? "masked" : "included"]
+    );
+  }
+  $("#sg-inspector-title").textContent = event.compactionAttempt
+    ? `${event.agent.label} · compaction attempt ${event.compactionAttemptIndex}`
+    : `${event.agent.label} · ${span.label}`;
   $("#sg-inspector-body").innerHTML =
     `<div class="sg-inspector-section">model call</div>` +
     semanticInspectorRows(rows) +
@@ -4051,14 +4139,14 @@ function openSemanticScopeInspector(scope) {
       `<div class="sg-inspector-section">current context</div>` +
       semanticInspectorRows(semanticContextRows(agent.usage, false)) +
       `<div class="sg-inspector-section">cumulative usage</div>` +
-      semanticInspectorRows([["contexts", fmtNum(agent.segments.length)], ...semanticCumulativeUsageRows(agent.usage, false)]) +
+      semanticInspectorRows([["contexts", fmtNum(agent.contextSegments.length)], ...semanticCumulativeUsageRows(agent.usage, false)]) +
       `<div class="sg-inspector-section">contexts</div>` +
       semanticInspectorRows(
-        agent.segments.map((segment) => [
+        agent.contextSegments.map((segment) => [
           `context ${segment.contextIndex}`,
-          segment.lane.usage?.latest_context_tokens == null
+          segment.contextUsage?.latest_context_tokens == null
             ? "n/a"
-            : `${Math.round(segment.lane.usage.latest_context_tokens).toLocaleString()} prompt · ${fmtNum(segment.lane.usage.model_calls || 0)} calls`,
+            : `${Math.round(segment.contextUsage.latest_context_tokens).toLocaleString()} prompt · ${fmtNum(segment.contextUsage.model_calls || 0)} calls`,
         ])
       );
   } else {
@@ -4068,9 +4156,9 @@ function openSemanticScopeInspector(scope) {
       : `${segment.agent.displayLabel} · context ${segment.contextIndex}`;
     $("#sg-inspector-body").innerHTML =
       `<div class="sg-inspector-section">context length</div>` +
-      semanticInspectorRows(semanticContextRows(segment.lane.usage, false)) +
+      semanticInspectorRows(semanticContextRows(segment.contextUsage || segment.lane.usage, false)) +
       `<div class="sg-inspector-section">cumulative usage</div>` +
-      semanticInspectorRows(semanticCumulativeUsageRows(segment.lane.usage, false));
+      semanticInspectorRows(semanticCumulativeUsageRows(segment.contextUsage || segment.lane.usage, false));
   }
   $("#sg-inspector").hidden = false;
 }

--- a/src/prime_rl/dashboard/static/app.js
+++ b/src/prime_rl/dashboard/static/app.js
@@ -3459,7 +3459,7 @@ function semanticNodeTip(event) {
   if (event.compactionAttempt) {
     rows.splice(2, 0,
       ["compaction", event.compactionAttempt.accepted ? "accepted" : "rejected"],
-      ["training", span.trainable === false ? "masked" : "included"]
+      ["training branch", event.compactionAttempt.accepted ? "included" : "excluded"]
     );
   }
   appendTimelineUsage(rows, {
@@ -4115,7 +4115,7 @@ function openSemanticCallInspector(event) {
   if (event.compactionAttempt) {
     rows.splice(2, 0,
       ["compaction", event.compactionAttempt.accepted ? "accepted" : "rejected"],
-      ["training", span.trainable === false ? "masked" : "included"]
+      ["training branch", event.compactionAttempt.accepted ? "included" : "excluded"]
     );
   }
   $("#sg-inspector-title").textContent = event.compactionAttempt

--- a/src/prime_rl/dashboard/static/style.css
+++ b/src/prime_rl/dashboard/static/style.css
@@ -784,6 +784,7 @@ mark.hit {
 }
 .tl-edge-key i.subagent-call { border-color: var(--infra); }
 .tl-edge-key i.subagent-return { border-color: var(--risk); }
+.tl-edge-key i.compaction-attempt { border-color: var(--chart-2); border-top-style: dotted; }
 .tl-edge-key i.compaction { border-color: var(--chart-2); border-top-style: dashed; }
 .tl-edge-key i.custom { border-color: var(--accent); border-top-style: dotted; }
 .tl-head, .tl-lane {
@@ -903,11 +904,13 @@ mark.hit {
 .sg-edge.continuation { opacity: 0.34; }
 .sg-edge.subagent-call { stroke: var(--infra); stroke-width: 2.2; opacity: 0.9; }
 .sg-edge.subagent-return { stroke: var(--risk); stroke-width: 2.2; opacity: 0.9; }
+.sg-edge.compaction-attempt { stroke: var(--chart-2); stroke-dasharray: 2 4; opacity: 0.66; }
 .sg-edge.compaction { stroke: var(--chart-2); stroke-dasharray: 5 4; opacity: 0.9; }
 .sg-edge.custom { stroke: var(--accent); stroke-dasharray: 2 4; opacity: 0.9; }
 #sg-arrow-continuation path { fill: var(--grey-4); }
 #sg-arrow-subagent-call path { fill: var(--infra); }
 #sg-arrow-subagent-return path { fill: var(--risk); }
+#sg-arrow-compaction-attempt path { fill: var(--chart-2); }
 #sg-arrow-compaction path { fill: var(--chart-2); }
 #sg-arrow-custom path { fill: var(--accent); }
 .sg-agent-label {
@@ -997,6 +1000,22 @@ mark.hit {
   background: var(--accent);
 }
 .sg-turn:focus-visible .sg-turn-mark { outline: 1px solid var(--grey-6); outline-offset: 2px; }
+.sg-turn.compaction-attempt.accepted .sg-turn-mark {
+  outline: 1px solid var(--chart-2);
+  outline-offset: 2px;
+}
+.sg-turn.compaction-attempt.rejected .sg-turn-mark {
+  border: 1px dashed var(--chart-2);
+  background: var(--grey-1);
+  opacity: 0.72;
+}
+.sg-turn.compaction-attempt.rejected .sg-turn-index { color: var(--grey-4); }
+.sg-turn.compaction-attempt.rejected:hover .sg-turn-mark,
+.sg-turn.compaction-attempt.rejected:focus-visible .sg-turn-mark {
+  border-color: var(--grey-6);
+  background: var(--grey-2);
+  opacity: 1;
+}
 .sg-turn-run {
   position: absolute;
   z-index: 5;

--- a/src/prime_rl/orchestrator/algo/routing.py
+++ b/src/prime_rl/orchestrator/algo/routing.py
@@ -9,8 +9,9 @@ from prime_rl.transports.batch import TrainingSample
 
 
 def assign_advantages(trace: vf.Trace, values: float | list[float]) -> None:
-    """Assign credit in compact sampled-token order across the trace graph."""
-    nodes = [node for node in trace.nodes if any(node.mask)]
+    """Assign credit in compact sampled-token order across trainable graph paths."""
+    trainable_nodes = {id(node) for branch in trace.branches if branch.trainable for node in branch.nodes}
+    nodes = [node for node in trace.nodes if id(node) in trainable_nodes and any(node.mask)]
     for node in nodes:
         if len(node.mask) != len(node.token_ids):
             raise ValueError(

--- a/src/prime_rl/orchestrator/annotations.py
+++ b/src/prime_rl/orchestrator/annotations.py
@@ -43,7 +43,7 @@ def stamp_batch(episodes: list[vf.Episode], step: int) -> list[dict[str, Any]]:
             branches = {
                 branch.index: {"advantages": advantages}
                 for branch in trace.branches
-                if (advantages := branch.advantages) is not None
+                if branch.trainable and (advantages := branch.advantages) is not None
             }
             updates.append(make_update(trace.id, info=info, branches=branches))
     return updates

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -91,6 +91,7 @@ def _encode_sampling_mask(mask: vf.SamplingMask | None, num_tokens: int) -> Samp
 def iter_trainable_branches(trace: vf.Trace) -> Iterator[tuple[vf.Branch, list[bool]]]:
     """Yield each branch that yields a training sample, with its trainable-token mask.
 
+    Branches excluded by trace semantics are skipped before shared-node accounting.
     The mask is `branch.sampled_mask` except that a sampled node shared by several branches
     (a mid-trajectory fork) is trainable only in the first branch containing it; later
     branches carry its tokens as context (mask False). Branches left with no trainable
@@ -99,6 +100,8 @@ def iter_trainable_branches(trace: vf.Trace) -> Iterator[tuple[vf.Branch, list[b
     """
     trained_nodes: set[int] = set()
     for branch in trace.branches:
+        if not branch.trainable:
+            continue
         mask: list[bool] = []
         for node in branch.nodes:
             if node.sampled and any(node.mask) and id(node) in trained_nodes:

--- a/tests/unit/orchestrator/test_algorithms.py
+++ b/tests/unit/orchestrator/test_algorithms.py
@@ -239,14 +239,16 @@ def test_compaction_retries_train_only_causally_used_generations():
         ),
         MessageNode(
             parent=2,
+            semantic_parents=[vf.ParentLink(node=1, type="compaction_attempt")],
             message=AssistantMessage(content="rejected tool call"),
             sampled=True,
             token_ids=[4],
-            mask=[False],
+            mask=[True],
             logprobs=[-0.2],
         ),
         MessageNode(
             parent=2,
+            semantic_parents=[vf.ParentLink(node=1, type="compaction_attempt")],
             message=AssistantMessage(content="accepted summary"),
             sampled=True,
             token_ids=[5],
@@ -262,6 +264,7 @@ def test_compaction_retries_train_only_causally_used_generations():
         ),
         MessageNode(
             parent=5,
+            semantic_parents=[vf.ParentLink(node=4, type="compaction")],
             message=AssistantMessage(content="answer"),
             sampled=True,
             token_ids=[7],
@@ -276,6 +279,16 @@ def test_compaction_retries_train_only_causally_used_generations():
         rewards={},
         ok=True,
     )
+    branches = {branch.nodes[-1].message.content: branch for branch in trace.branches}
+    assert branches["rejected tool call"].trainable is False
+    assert branches["accepted summary"].trainable is True
+    assert branches["answer"].trainable is True
+
+    assign_advantages(trace, 1.0)
+    assert trace.nodes[1].advantages == [1.0]
+    assert trace.nodes[3].advantages is None
+    assert trace.nodes[4].advantages == [1.0]
+    assert trace.nodes[6].advantages == [1.0]
 
     trainable_ids = [
         token_id

--- a/tests/unit/orchestrator/test_algorithms.py
+++ b/tests/unit/orchestrator/test_algorithms.py
@@ -213,6 +213,80 @@ def test_assign_advantages_full_length_stream():
     assert trace_to_samples(trace)[0].advantages == [0.0, 0.0, 0.5, -0.5, 0.0, 1.0]
 
 
+def test_compaction_retries_train_only_causally_used_generations():
+    nodes = [
+        MessageNode(
+            parent=None,
+            message=UserMessage(content="work"),
+            sampled=False,
+            token_ids=[1],
+            mask=[False],
+        ),
+        MessageNode(
+            parent=0,
+            message=AssistantMessage(content="evidence"),
+            sampled=True,
+            token_ids=[2],
+            mask=[True],
+            logprobs=[-0.1],
+        ),
+        MessageNode(
+            parent=1,
+            message=UserMessage(content="summarize"),
+            sampled=False,
+            token_ids=[3],
+            mask=[False],
+        ),
+        MessageNode(
+            parent=2,
+            message=AssistantMessage(content="rejected tool call"),
+            sampled=True,
+            token_ids=[4],
+            mask=[False],
+            logprobs=[-0.2],
+        ),
+        MessageNode(
+            parent=2,
+            message=AssistantMessage(content="accepted summary"),
+            sampled=True,
+            token_ids=[5],
+            mask=[True],
+            logprobs=[-0.3],
+        ),
+        MessageNode(
+            parent=None,
+            message=UserMessage(content="compacted context"),
+            sampled=False,
+            token_ids=[6],
+            mask=[False],
+        ),
+        MessageNode(
+            parent=5,
+            message=AssistantMessage(content="answer"),
+            sampled=True,
+            token_ids=[7],
+            mask=[True],
+            logprobs=[-0.4],
+        ),
+    ]
+    trace = vf.Trace(
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt=None)),
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        nodes=nodes,
+        rewards={},
+        ok=True,
+    )
+
+    trainable_ids = [
+        token_id
+        for sample in trace_to_samples(trace)
+        for token_id, trainable in zip(sample.token_ids, sample.mask, strict=True)
+        if trainable
+    ]
+
+    assert sorted(trainable_ids) == [2, 5, 7]
+
+
 def test_assign_advantages_slices_across_nodes():
     trace = _make_episode().traces[0]
     assign_advantages(trace, [1.0, 2.0, 3.0])

--- a/tests/unit/test_dashboard_timeline.py
+++ b/tests/unit/test_dashboard_timeline.py
@@ -156,6 +156,44 @@ def test_semantic_timeline_starts_new_context_after_compaction() -> None:
     ]
 
 
+def test_semantic_timeline_keeps_rejected_and_accepted_compaction_attempts() -> None:
+    nodes = [
+        _node(None, 0.0),
+        _node(0, 2.0),
+        _node(1, 4.0, [{"node": 1, "type": "compaction_attempt"}]),
+        _node(1, 5.0, [{"node": 1, "type": "compaction_attempt"}]),
+        _node(0, 7.0, [{"node": 3, "type": "compaction"}]),
+    ]
+    nodes[2]["mask"] = [False]
+    nodes[3]["mask"] = [True]
+    calls = [
+        _call(1, 1.0, 2.0),
+        _call(2, 3.0, 4.0),
+        _call(3, 4.0, 5.0),
+        _call(4, 6.0, 7.0),
+    ]
+
+    timeline = project_episode_timeline(_episode(nodes, calls))
+    attempts = [lane for lane in timeline["semantic_lanes"] if lane.get("compaction_attempt")]
+
+    assert [attempt["compaction_attempt"]["accepted"] for attempt in attempts] == [
+        False,
+        True,
+    ]
+    assert [attempt["spans"][1]["trainable"] for attempt in attempts] == [
+        False,
+        True,
+    ]
+    assert [attempt["context"] for attempt in attempts] == [
+        {"agent": "root", "index": 0},
+        {"agent": "root", "index": 0},
+    ]
+    assert timeline["semantic_lanes"][-1]["context"] == {
+        "agent": "root",
+        "index": 1,
+    }
+
+
 def test_semantic_timeline_falls_back_to_physical_only() -> None:
     nodes = [_node(None, 0.0), _node(0, 2.0)]
     timeline = project_episode_timeline(_episode(nodes, [_call(1, 1.0, 2.0)]))

--- a/tests/unit/test_dashboard_timeline.py
+++ b/tests/unit/test_dashboard_timeline.py
@@ -164,7 +164,7 @@ def test_semantic_timeline_keeps_rejected_and_accepted_compaction_attempts() -> 
         _node(1, 5.0, [{"node": 1, "type": "compaction_attempt"}]),
         _node(0, 7.0, [{"node": 3, "type": "compaction"}]),
     ]
-    nodes[2]["mask"] = [False]
+    nodes[2]["mask"] = [True]
     nodes[3]["mask"] = [True]
     calls = [
         _call(1, 1.0, 2.0),
@@ -181,7 +181,7 @@ def test_semantic_timeline_keeps_rejected_and_accepted_compaction_attempts() -> 
         True,
     ]
     assert [attempt["spans"][1]["trainable"] for attempt in attempts] == [
-        False,
+        True,
         True,
     ]
     assert [attempt["context"] for attempt in attempts] == [


### PR DESCRIPTION
## Summary

- render `compaction_attempt` edges as retry leaves beside their shared source context
- mark rejected attempts as hollow `×` nodes and the accepted summary as an outlined `✓` node
- show accepted/rejected and training-branch included/excluded status in hover and call inspection
- count compaction attempts in their source context usage without treating them as new contexts
- skip untrainable branches before advantage assignment and shared-node deduplication
- keep only the accepted summary connected to the resumed compacted context

Rejected attempt responses remain visible, sampled, and unmasked in the trace. Verifiers derives their dangling branches as untrainable; Prime-RL omits those branches before they can claim a shared prefix. The accepted summary, its shared pre-compaction work, and the resumed answer therefore train exactly once.

The Verifiers submodule is pinned to main commit `828488f`, which includes compaction-attempt branch trainability and nano-RLM `e384006`.

## Testing

- focused trainer, advantage-routing, and dashboard projection suite: 42 passed
- temporary serialized integration check: shared physical prefix, branch states `false/true/true`, trained token IDs `[2, 5, 7]`, dashboard attempts `×/✓`
- `uv run --frozen pre-commit run --all-files`
- PR CI: unit tests, slim install, Ruff, and CodeQL passed
- JavaScript syntax check passed
- live Redsearcher trace renders three rejected summaries as sibling `a1 ×`, `a2 ×`, and `a3 ×` leaves beneath one root context; the accepted-summary fixture renders `a3 ✓` and connects only it to the resumed context
