### PR TITLE
feat(trainer): shard packed parameters along dim 1 (alternative to explicit write-back)

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -42,7 +42,7 @@ from prime_rl.trainer.models import (
     get_custom_vlm_cls,
     supports_custom_impl,
 )
-from prime_rl.trainer.models.fusions import apply_model_fusions
+from prime_rl.trainer.models.fusions import apply_model_fusions, fsdp_shard_placement
 from prime_rl.trainer.models.glm_moe_dsa.sparse_mla_attention import Indexer
 from prime_rl.trainer.models.layers.fp8_linear import replace_linear_with_fp8_blockwise_linear
 from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
@@ -775,10 +775,12 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
     mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=DTYPE_MAP[config.reduce_dtype])
     offload_policy: OffloadPolicy = CPUOffloadPolicy(pin_memory=True) if config.fsdp_cpu_offload else OffloadPolicy()
 
+    shard_placement_fn = fsdp_shard_placement(model)
     fsdp_config = {
         "mp_policy": mp_policy,
         "offload_policy": offload_policy,
         "reshard_after_forward": config.reshard_after_forward,
+        "shard_placement_fn": shard_placement_fn,
     }
 
     hsdp_mesh = parallel_dims.get_mesh("hsdp")
@@ -820,6 +822,7 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
                 mp_policy=MixedPrecisionPolicy(param_dtype=torch.float32, reduce_dtype=torch.float32),
                 offload_policy=offload_policy,
                 reshard_after_forward=config.reshard_after_forward,
+                shard_placement_fn=shard_placement_fn,
             )
 
         fully_shard(
@@ -845,6 +848,7 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
             mp_policy=mp_policy,
             offload_policy=offload_policy,
             reshard_after_forward=False,
+            shard_placement_fn=shard_placement_fn,
         )
     else:
         get_logger().warning("Model uses tied word embeddings, so skipping the last-layer no-reshard optimization.")
@@ -855,6 +859,7 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
         mp_policy=mp_policy,
         offload_policy=offload_policy,
         reshard_after_forward=config.reshard_after_forward,
+        shard_placement_fn=shard_placement_fn,
     )
 
     if not parallel_dims.ep_enabled:

--- a/src/prime_rl/trainer/models/fusions.py
+++ b/src/prime_rl/trainer/models/fusions.py
@@ -3,6 +3,7 @@ from typing import Any, NamedTuple
 
 import torch
 from torch import nn
+from torch.distributed.tensor import Shard
 
 from prime_rl.utils.weights import resolve_fqn
 
@@ -154,6 +155,24 @@ def packed_parameters(model: nn.Module) -> Iterator[PackedParameterInfo]:
                 parameter=module.get_parameter(packed.name),
                 packed=packed,
             )
+
+
+def fsdp_shard_placement(model: nn.Module) -> Callable[[nn.Parameter], Shard | None]:
+    """FSDP placement that keeps every packed parameter's packing dimension unsharded.
+
+    Splitting a DTensor along an unsharded dimension is a local view, so the canonical
+    state-dict entries alias the packed storage and in-place loads reach it. FSDP's default
+    ``Shard(0)`` is kept for everything else, including parameters packed along dim 0 that
+    have no other dimension to shard.
+    """
+    packing_dims = {id(info.parameter): info.packed.dim for info in packed_parameters(model)}
+
+    def shard_placement(parameter: nn.Parameter) -> Shard | None:
+        if packing_dims.get(id(parameter)) == 0 and parameter.ndim > 1:
+            return Shard(1)
+        return None
+
+    return shard_placement
 
 
 def optimizer_state_dict_for_checkpoint(model: nn.Module, state_dict: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Alternative to the explicit write-back fix in #3451 (`965fdaa40`), opened separately for comparison. Based on the fusions branch **without** that commit.

Shards packed parameters along dim 1 instead of FSDP's default dim 0. A DTensor `split` along its sharded dimension unshards first, so with the default placement the canonical q/k/v state-dict entries of a `qkv`-fused layer were replicated copies; sharding on dim 1 keeps the packing dimension local, so the entries are views of the packed storage and in-place loads reach the parameter again.

`fsdp_shard_placement(model)` returns a `shard_placement_fn` for `fully_shard` that answers `Shard(1)` for any parameter packed along dim 0 with a second dimension, and `None` (default `Shard(0)`) otherwise. `setup_fsdp` passes it to every `fully_shard` call. 25 lines, no loader changes.

## Measurements

All on `samsja/mini-glm-moe`, 2×H200, EP=2, Muon, compile + AC. "write-back" is #3451 with `965fdaa40`; "Shard(1)" is this PR alone; "both" is this PR stacked on the write-back.

**`model.state_dict()` under FSDP, fused `gate_up`+`qkv`** (24 layers, 2 ranks):

| placement | q/k/v entries aliasing packed storage | extra memory held by `state_dict()` |
|---|---|---|
| `Shard(0)` (base, and write-back) | 0 / 144 | 72.1 MiB (full replicated qkv weights + biases on every rank) |
| `Shard(1)` | 72 / 72 weights, 0 / 72 biases | 0.1 MiB |

For Qwen3-30B-A3B the `Shard(0)` copies are ~1 GB bf16 weights + ~2 GB fp32 Muon momentum per rank, transient at load and checkpoint time.

**Correctness** (lr = 0 runs, checkpoint compared against the source weights; momentum after a resume must be 1.95× the saved value with `mu = 0.95`):

| check | base | write-back | Shard(1) alone | both |
|---|---|---|---|---|
| q/k/v weights loaded | ❌ all 0 | ✅ 144/144 bit-exact | ✅ 72/72 | ✅ |
| q/k/v biases loaded | ❌ all 0 | ✅ | ❌ all 0 | ✅ |
| resume, no offload: packed momentum | ❌ lost | ✅ | weights ✅ · biases ❌ | ✅ |
| resume, optimizer CPU offload (default): packed momentum | ❌ lost | ✅ | ❌ all lost (weights, biases, gate/up) | ✅ |
| fused ↔ unfused checkpoint resume (DCP reshards `Shard(1)` ↔ `Shard(0)`) | — | ✅ | ✅ | ✅ |
| fused vs unfused 10-step loss | 34% apart | ≤ 5e-4 rel. | ≤ 3e-3 rel. (bias missing) | ≤ 5e-4 rel. |
| fused vs unfused throughput, steps 3–10 | — | 6.3k vs 5.9k tok/s | 6.0k vs 5.9k tok/s | 6.3k vs 5.8k tok/s |

Muon handles the `Shard(1)` parameter: it reads the shard dim from the placements and concatenates shards along it, and packed parameters form their own batches via `matrix_partitions`, so mixed placements never share a batch.

## Trade-offs

**Where `Shard(1)` alone falls short.**
- **Biases.** A packed 1-D bias has no other dimension to shard, so its entries stay replicated copies: zero after load, momentum lost on resume. Every model with `attention_bias = true` (Qwen2/3 families, GLM-4.5) hits this.
- **Optimizer CPU offload.** `AppState.state_dict()` builds the DCP template and then `finish_checkpoint_save()` moves the state to CPU, which *replaces* the state tensors (`copy.copy(dtensor)` with a new local). The unpacked entries survive because the template holds the optimizer's own per-parameter dicts and sees the replacement; the packed entries are views of the old GPU tensors and go stale. Aliasing alone cannot fix this; the write-back can, and does.
- **Assumption-based.** Correctness rests on "the state dict aliases the parameter", which nothing checks. Any future wrapper, dtype cast, or `redistribute` silently breaks it the same way. The write-back is correct regardless of aliasing.
- **Even sharding.** FSDP2 requires `hidden_size % dp_shard == 0` for non-dim-0 sharding; it raises otherwise.
- **All-gather cost.** FSDP2 reassembles non-dim-0 shards with an extra chunk-cat per unshard of the qkv weight. Not visible at this model size; worth measuring at scale.

**Where it wins.**
- Removes the replicated copies: 0.1 MiB vs 72 MiB here, ~3 GB per rank on a 30B MoE, at every checkpoint save.
- No transient `cat` + `copy_` per packed parameter at load.
- Smaller diff.

**Recommendation.** Keep the write-back in #3451 as the correctness fix; adopt this placement on top of it (the "both" column) if the checkpoint-time memory matters. Alone it is not a fix.
