### PR TITLE
chore: simplify pathing and sequence helpers

### DIFF
--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -121,16 +121,14 @@ def format_log_message(
     if train_env_names or eval_env_names:
         env_log_dir = log_dir / "envs"
         log_lines.append(f"{i1}{'Envs:':<{col}}tail -F {env_log_dir}/*/*.log")
-        if train_env_names:
-            log_lines.append(f"{i2}{'Train:':<{col - 1}}tail -F {env_log_dir}/train/*.log")
-            for name in train_env_names:
+        for split, names in (("train", train_env_names), ("eval", eval_env_names)):
+            if not names:
+                continue
+            label = f"{split.title()}:"
+            log_lines.append(f"{i2}{label:<{col - 1}}tail -F {env_log_dir}/{split}/*.log")
+            for name in names:
                 short = name if len(name) <= max_name else name[: max_name - 3] + "..."
-                log_lines.append(f"{i3}{f'{short}:':<{col - 2}}tail -F {env_log_dir}/train/{name}.log")
-        if eval_env_names:
-            log_lines.append(f"{i2}{'Eval:':<{col - 1}}tail -F {env_log_dir}/eval/*.log")
-            for name in eval_env_names:
-                short = name if len(name) <= max_name else name[: max_name - 3] + "..."
-                log_lines.append(f"{i3}{f'{short}:':<{col - 2}}tail -F {env_log_dir}/eval/{name}.log")
+                log_lines.append(f"{i3}{f'{short}:':<{col - 2}}tail -F {env_log_dir}/{split}/{name}.log")
     return "Logs:\n" + "\n".join(log_lines)
 
 
@@ -228,19 +226,17 @@ def get_step_path(path: Path, step: int) -> Path:
 
 def get_all_ckpt_steps(ckpt_dir: Path) -> list[int]:
     """Gets all checkpoint steps from the checkpoint directory, sorted in ascending order."""
-    step_dirs = list(ckpt_dir.glob("step_*"))
-    return sorted([int(step_dir.name.split("_")[-1]) for step_dir in step_dirs])
+    return sorted(int(step_dir.name.split("_")[-1]) for step_dir in ckpt_dir.glob("step_*"))
 
 
 def resolve_latest_ckpt_step(ckpt_dir: Path) -> int | None:
     """Gets the latest checkpoint step from the checkpoint directory. Returns None if no checkpoints are found."""
+    logger = get_logger()
     steps = get_all_ckpt_steps(ckpt_dir)
-    if len(steps) == 0:
-        logger = get_logger()
+    if not steps:
         logger.warning(f"No checkpoints found in {ckpt_dir}. Starting from scratch.")
         return None
     latest_step = steps[-1]
-    logger = get_logger()
     logger.info(f"Found latest checkpoint in {ckpt_dir}: {latest_step}")
     return latest_step
 
@@ -260,9 +256,8 @@ def has_run_artifacts(run_dir: Path) -> bool:
     """Check if the run directory contains artifacts beyond what the launcher pre-writes."""
     if not run_dir.exists():
         return False
-    launcher_entries = {entry for pattern in LAUNCHER_ARTIFACTS for entry in run_dir.glob(pattern)}
     for entry in run_dir.iterdir():
-        if entry in launcher_entries:
+        if entry.name in LAUNCHER_ARTIFACTS:
             continue
         if entry.name == "logs" and entry.is_dir() and not any(path.is_file() for path in entry.rglob("*")):
             continue

--- a/src/prime_rl/utils/sequence.py
+++ b/src/prime_rl/utils/sequence.py
@@ -20,19 +20,8 @@ def get_cu_seqlens_from_position_ids(position_ids: torch.Tensor) -> tuple[torch.
         [torch.zeros(1, dtype=zero_starts.dtype, device=zero_starts.device), zero_starts]
     ).unique_consecutive()
 
-    ends = torch.cat(
-        [
-            starts[1:],
-            torch.tensor([total_tokens], dtype=starts.dtype, device=starts.device),
-        ]
-    )
-    seqlens = ends - starts
-
-    cu_seqlens = torch.empty(seqlens.numel() + 1, dtype=torch.int32, device=position_ids.device)
-    cu_seqlens[0] = 0
-    cu_seqlens[1:] = seqlens.cumsum(dim=0, dtype=torch.int32)
-
-    return cu_seqlens, seqlens.max().item()
+    boundaries = torch.cat([starts, starts.new_tensor([total_tokens])])
+    return boundaries.to(dtype=torch.int32), boundaries.diff().max().item()
 
 
 def get_cu_seqlens_from_seq_lens(seq_lens: torch.Tensor, total_tokens: int | None = None) -> tuple[torch.Tensor, int]:

--- a/tests/unit/utils/test_sequence.py
+++ b/tests/unit/utils/test_sequence.py
@@ -10,6 +10,9 @@ from prime_rl.utils.sequence import (
 @pytest.mark.parametrize(
     ("position_ids", "expected_cu_seqlens", "expected_max_seqlen"),
     [
+        (torch.tensor([[0]]), [0, 1], 1),
+        (torch.tensor([[5]]), [0, 1], 1),
+        (torch.tensor([[0, 0, 0]]), [0, 1, 2, 3], 1),
         (torch.arange(8).unsqueeze(0), [0, 8], 8),
         (torch.arange(8, 16).unsqueeze(0), [0, 8], 8),
         (torch.tensor([[0, 1, 2, 3, 0, 1, 2]]), [0, 4, 7], 4),


### PR DESCRIPTION
Simplify path and sequence helpers without changing their outputs: share train/eval log formatting, check launcher artifact names directly, remove intermediate checkpoint lists, and construct cumulative sequence offsets from the boundaries already computed.

Extend the existing sequence test cases to cover single-token inputs and consecutive sequence starts.

Validation: 20 targeted unit tests passed; Ruff lint and formatting passed. Log formatting matched the original implementation across 1,152 combinations.
