### PR TITLE
fix(wandb): use compatible GraphQL transport

### DIFF
--- a/src/prime_rl/monitors/wandb/overview.py
+++ b/src/prime_rl/monitors/wandb/overview.py
@@ -19,7 +19,7 @@ from typing import Literal
 import wandb
 import wandb_workspaces.reports.v2 as wr
 import wandb_workspaces.workspaces as ws
-from wandb_gql import gql
+from wandb_workspaces._graphql import execute_graphql
 
 from prime_rl.utils.logger import get_logger
 
@@ -185,16 +185,14 @@ def build_sections(
 
 def list_views(entity: str, project: str) -> list[tuple[str, str]]:
     """``(display_name, internal_name)`` for every saved view in the project."""
-    query = gql(
-        """
+    query = """
         query Views($entity: String!, $project: String!) {
           project(name: $project, entityName: $entity) {
             allViews(viewType: "project-view") { edges { node { name displayName } } }
           }
         }
         """
-    )
-    res = wandb.Api().client.execute(query, variable_values={"entity": entity, "project": project})
+    res = execute_graphql(wandb.Api(), query, {"entity": entity, "project": project})
     edges = ((res.get("project") or {}).get("allViews") or {}).get("edges") or []
     return [(e["node"]["displayName"], e["node"]["name"]) for e in edges if e.get("node")]
 

--- a/tests/unit/test_wandb_overview.py
+++ b/tests/unit/test_wandb_overview.py
@@ -1,0 +1,28 @@
+from prime_rl.monitors.wandb import overview
+
+
+def test_list_views_uses_workspace_graphql_transport(monkeypatch) -> None:
+    api = object()
+    response = {
+        "project": {
+            "allViews": {
+                "edges": [
+                    {"node": {"displayName": "overview", "name": "nw-overview-v"}},
+                    {"node": None},
+                ]
+            }
+        }
+    }
+
+    monkeypatch.setattr(overview.wandb, "Api", lambda: api)
+
+    def execute(received_api: object, query: str, variables: dict[str, str]) -> dict:
+        assert received_api is api
+        assert isinstance(query, str)
+        assert "query Views" in query
+        assert variables == {"entity": "prime", "project": "rl"}
+        return response
+
+    monkeypatch.setattr(overview, "execute_graphql", execute)
+
+    assert overview.list_views("prime", "rl") == [("overview", "nw-overview-v")]


### PR DESCRIPTION
## Summary

- replace the removed `wandb_gql` import and legacy `Api.client.execute()` call with the compatibility transport provided by the existing `wandb-workspaces>=0.4.3` dependency
- pass the GraphQL document as a raw string so `wandb-workspaces` can select either the legacy client or the newer W&B service transport
- add focused regression coverage for query dispatch and saved-view parsing

Fixes #3087.

## Validation

- `uv run --no-project --isolated --with 'ruff==0.15.14' ruff check src/prime_rl/monitors/wandb/overview.py tests/unit/test_wandb_overview.py`
- `uv run --no-project --isolated --with 'ruff==0.15.14' ruff format --check src/prime_rl/monitors/wandb/overview.py tests/unit/test_wandb_overview.py`
- focused `tests/unit/test_wandb_overview.py` under `wandb==0.27.0` + `wandb-workspaces==0.4.3` (`1 passed`)
- focused `tests/unit/test_wandb_overview.py` under `wandb==0.28.2` + `wandb-workspaces==0.4.3` (`1 passed`)
- isolated compatibility smoke with `wandb==0.27.0` + `wandb-workspaces==0.4.3` (legacy client transport)
- isolated compatibility smoke with `wandb==0.28.2` + `wandb-workspaces==0.4.3` (service transport)
- `git diff --check`

The full project test environment was not installed on this Windows host because the repository lock declares Linux/macOS resolution environments. The focused pytest runs isolated unrelated package initializers, while the separate transport smokes exercised both real compatibility branches without network calls.
