### PR TITLE
fix(inference): support vLLM skip-gather logits

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -774,6 +774,8 @@ def monkey_patch_fp32_lm_head():
     Per @Jackmin801 on PR #2438, native ``out_dtype=fp32`` mm is more efficient
     and just as correct.
     """
+    from inspect import signature
+
     import torch
     from vllm.config import get_current_vllm_config
     from vllm.logger import init_logger
@@ -783,6 +785,7 @@ def monkey_patch_fp32_lm_head():
 
     _original_init = LogitsProcessor.__init__
     _original_get_logits = LogitsProcessor._get_logits
+    _original_supports_skip_gather = "skip_gather" in signature(_original_get_logits).parameters
 
     def _patched_init(self, *args, **kwargs):
         _original_init(self, *args, **kwargs)
@@ -792,8 +795,10 @@ def monkey_patch_fp32_lm_head():
         if self._fp32_lm_head_enabled:
             logger.warning("fp32 lm_head ENABLED for this LogitsProcessor instance.")
 
-    def _patched_get_logits(self, hidden_states, lm_head, embedding_bias):
+    def _patched_get_logits(self, hidden_states, lm_head, embedding_bias, skip_gather=False):
         if not getattr(self, "_fp32_lm_head_enabled", False):
+            if _original_supports_skip_gather:
+                return _original_get_logits(self, hidden_states, lm_head, embedding_bias, skip_gather)
             return _original_get_logits(self, hidden_states, lm_head, embedding_bias)
 
         # Native bf16xbf16 -> fp32 GEMM. torch.mm requires 2D inputs; vLLM v1's
@@ -806,7 +811,10 @@ def monkey_patch_fp32_lm_head():
         if hidden_states.dim() > 2:
             logits = logits.reshape(*hidden_states.shape[:-1], -1)
 
-        logits = self._gather_logits(logits)
+        if skip_gather:
+            return logits
+        if lm_head.tp_size > 1:
+            logits = self._gather_logits(logits)
         if logits is not None:
             logits = logits[..., : self.org_vocab_size]
         return logits

--- a/tests/unit/inference/test_patches.py
+++ b/tests/unit/inference/test_patches.py
@@ -64,7 +64,10 @@ def test_fp32_lm_head_patch_delegates_across_vllm_signatures(monkeypatch, suppor
     lm_head = object()
     embedding_bias = object()
 
-    result = processor._get_logits(hidden_states, lm_head, embedding_bias, skip_gather=True)
+    if supports_skip_gather:
+        result = processor._get_logits(hidden_states, lm_head, embedding_bias, skip_gather=True)
+    else:
+        result = processor._get_logits(hidden_states, lm_head, embedding_bias)
 
     assert result == "original"
     expected = (

--- a/tests/unit/inference/test_patches.py
+++ b/tests/unit/inference/test_patches.py
@@ -1,0 +1,116 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from prime_rl.inference.patches import monkey_patch_fp32_lm_head
+
+
+def _install_fake_vllm(monkeypatch, *, fp32_enabled: bool, supports_skip_gather: bool):
+    class LogitsProcessor:
+        def __init__(self):
+            self.org_vocab_size = 2
+            self.gather_calls = 0
+
+        def _gather_logits(self, logits):
+            self.gather_calls += 1
+            return logits
+
+    if supports_skip_gather:
+
+        def _get_logits(self, hidden_states, lm_head, embedding_bias, skip_gather=False):
+            self.original_call = (hidden_states, lm_head, embedding_bias, skip_gather)
+            return "original"
+
+    else:
+
+        def _get_logits(self, hidden_states, lm_head, embedding_bias):
+            self.original_call = (hidden_states, lm_head, embedding_bias)
+            return "original"
+
+    LogitsProcessor._get_logits = _get_logits
+
+    modules = {
+        "vllm": ModuleType("vllm"),
+        "vllm.config": ModuleType("vllm.config"),
+        "vllm.logger": ModuleType("vllm.logger"),
+        "vllm.model_executor": ModuleType("vllm.model_executor"),
+        "vllm.model_executor.layers": ModuleType("vllm.model_executor.layers"),
+        "vllm.model_executor.layers.logits_processor": ModuleType("vllm.model_executor.layers.logits_processor"),
+    }
+    modules["vllm.config"].get_current_vllm_config = lambda: SimpleNamespace(
+        additional_config={"fp32_lm_head": fp32_enabled}
+    )
+    modules["vllm.logger"].init_logger = lambda _name: MagicMock()
+    modules["vllm.model_executor.layers.logits_processor"].LogitsProcessor = LogitsProcessor
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    monkey_patch_fp32_lm_head()
+    return LogitsProcessor
+
+
+@pytest.mark.parametrize("supports_skip_gather", [False, True])
+def test_fp32_lm_head_patch_delegates_across_vllm_signatures(monkeypatch, supports_skip_gather):
+    processor_type = _install_fake_vllm(
+        monkeypatch,
+        fp32_enabled=False,
+        supports_skip_gather=supports_skip_gather,
+    )
+    processor = processor_type()
+    hidden_states = object()
+    lm_head = object()
+    embedding_bias = object()
+
+    result = processor._get_logits(hidden_states, lm_head, embedding_bias, skip_gather=True)
+
+    assert result == "original"
+    expected = (
+        (hidden_states, lm_head, embedding_bias, True)
+        if supports_skip_gather
+        else (
+            hidden_states,
+            lm_head,
+            embedding_bias,
+        )
+    )
+    assert processor.original_call == expected
+
+
+@pytest.mark.parametrize("supports_skip_gather", [False, True])
+def test_fp32_lm_head_patch_skips_gather_across_vllm_signatures(monkeypatch, supports_skip_gather):
+    processor_type = _install_fake_vllm(
+        monkeypatch,
+        fp32_enabled=True,
+        supports_skip_gather=supports_skip_gather,
+    )
+    processor = processor_type()
+    local_logits = torch.tensor([[1.0, 2.0, 3.0]])
+    monkeypatch.setattr(torch, "mm", MagicMock(return_value=local_logits))
+    hidden_states = torch.ones(1, 2, dtype=torch.bfloat16)
+    lm_head = SimpleNamespace(weight=torch.ones(3, 2, dtype=torch.bfloat16), tp_size=2)
+
+    result = processor._get_logits(hidden_states, lm_head, None, skip_gather=True)
+
+    assert result is local_logits
+    assert processor.gather_calls == 0
+
+
+def test_fp32_lm_head_patch_gathers_and_trims_by_default(monkeypatch):
+    processor_type = _install_fake_vllm(
+        monkeypatch,
+        fp32_enabled=True,
+        supports_skip_gather=True,
+    )
+    processor = processor_type()
+    logits = torch.tensor([[1.0, 2.0, 3.0]])
+    monkeypatch.setattr(torch, "mm", MagicMock(return_value=logits))
+    hidden_states = torch.ones(1, 2, dtype=torch.bfloat16)
+    lm_head = SimpleNamespace(weight=torch.ones(3, 2, dtype=torch.bfloat16), tp_size=2)
+
+    result = processor._get_logits(hidden_states, lm_head, None)
+
+    assert processor.gather_calls == 1
+    assert torch.equal(result, logits[..., :2])


### PR DESCRIPTION
## Summary

- Make Prime-RL's fp32 lm-head wrapper compatible with both vLLM 0.28.0 and 0.29.0.
- Preserve the vLLM 0.28.0 call path, whose `_get_logits` method has no `skip_gather` parameter.
- Forward vLLM 0.29.0's `skip_gather` flag and return shard-local fp32 logits before gather and vocabulary trimming when requested.
- Preserve normal vLLM behavior by gathering only when tensor parallel size is greater than one.

## Motivation

Prime-RL currently resolves vLLM 0.28.0. Its `_get_logits` signature accepts `hidden_states`, `lm_head`, and `embedding_bias`. vLLM 0.29.0 adds `skip_gather=False` for batch-sharded sampling and calls `_get_logits` with that fourth argument.

Prime-RL installs its fp32 lm-head wrapper as a vLLM plugin regardless of whether fp32 lm-head mode is enabled. Without this compatibility change, using Prime-RL with vLLM 0.29.0 fails when the newer call reaches the older wrapper signature:

```text
TypeError: monkey_patch_fp32_lm_head.<locals>._patched_get_logits() got an unexpected keyword argument 'skip_gather'
```

The wrapper detects support from the captured method signature instead of branching on a version string. With vLLM 0.28.0 it calls the original three-argument method. With vLLM 0.29.0 it forwards `skip_gather`; when fp32 mode is enabled, `skip_gather=True` returns shard-local logits without gathering or vocabulary trimming, matching upstream semantics.

This is a vLLM API compatibility fix, not a Dynamo- or multimodal-specific behavior change.

## Validation

- `PYTHONPATH=src uv run --no-project --python <prime-rl-venv>/bin/python pytest -q tests/unit/inference/test_patches.py` — 5 passed.
- `uv run --no-project --python <prime-rl-venv>/bin/python ruff check src/prime_rl/inference/patches.py tests/unit/inference/test_patches.py` — passed.
- `uv run --no-project --python <prime-rl-venv>/bin/python ruff format --check src/prime_rl/inference/patches.py tests/unit/inference/test_patches.py` — passed.
- Focused tests cover the vLLM 0.28.0 and 0.29.0 method signatures with fp32 mode enabled and disabled, including normal gather-and-trim behavior and `skip_gather=True`.
- Reproduced the pre-fix failure against a newer vLLM signature.
- Completed a five-step Qwen3.5-4B Dynamo VLM run against the newer vLLM signature with this implementation: five orchestrator steps, five trainer steps, and six NCCL weight receives passed.

The five-step vLLM 0.28.0 baseline used unmodified Prime-RL main. The compatibility behavior for 0.28.0 is covered by focused tests; a main-plus-this-PR 0.28.0 end-to-end rerun has not yet been performed.
