### PR TITLE
fix(sft): preserve tool definitions in nullable columns

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -151,7 +151,7 @@ Two accepted layouts:
 
 If both columns are present, `messages` takes precedence.
 
-**Tool definitions and renderer controls.** For tool-use SFT, add a `tools` column (OpenAI function-calling format) or `tool_defs` ([`verifiers`](https://github.com/PrimeIntellect-ai/verifiers) rollout format). Each row's value can be either a list of dicts or a JSON-encoded string of a list — both are accepted, and `tool_defs` rows are auto-converted to OAI shape before being passed into the renderer.
+**Tool definitions and renderer controls.** For tool-use SFT, add a `tools` column (OpenAI function-calling format) or `tool_defs` ([`verifiers`](https://github.com/PrimeIntellect-ai/verifiers) rollout format). Each row's value can be either a list of dicts or a JSON-encoded string of a list — both are accepted, and `tool_defs` rows are auto-converted to OAI shape before being passed into the renderer. When both columns exist, a non-null `tools` value takes precedence; a null or absent `tools` value falls back to `tool_defs`. An explicit empty list in `tools` means no tools.
 
 Renderer-backed SFT reads template controls from the typed `[renderer]` config in the SFT TOML. For example:
 

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -69,6 +69,7 @@ uv run sft @ examples/basic/reverse-text/sft.toml --dry-run
 
 - Config: `SFTConfig` (`packages/prime-rl-configs/src/prime_rl/configs/sft.py`)
 - Entrypoint: `src/prime_rl/entrypoints/sft.py`
+- Tool-use data may contain `tools` or `tool_defs`. Null/absent `tools` falls back to `tool_defs`; a non-null `tools` value, including an empty list, takes precedence. See `docs/training.md` for accepted formats.
 - SLURM: single- and multi-node
 - Multi-node online evals use one SLURM job with `num_train_nodes + num_infer_nodes` nodes. The generated `launcher/sft.sbatch` assigns inference nodes first, then trainer nodes.
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -267,7 +267,9 @@ class SFTDataset(StatefulIterableDataset):
         # `tools` or `tool_defs` (the verifiers rollout format), as either a
         # JSON-encoded string of a list or a list of dicts; verifiers-shaped
         # tools are converted to OAI form for the chat template.
-        raw_tools = example.get("tools", example.get("tool_defs"))
+        raw_tools = example.get("tools")
+        if raw_tools is None:
+            raw_tools = example.get("tool_defs")
         if not raw_tools:
             tools = []
         else:

--- a/tests/unit/train/sft/test_sft_tool_columns.py
+++ b/tests/unit/train/sft/test_sft_tool_columns.py
@@ -1,0 +1,61 @@
+import json
+
+import pytest
+from datasets import Dataset, concatenate_datasets, load_dataset
+from renderers.qwen3 import Qwen3Renderer
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from tokenizers.pre_tokenizers import Whitespace
+from transformers import PreTrainedTokenizerFast
+
+from prime_rl.trainer.sft.data import SFTDataset
+
+
+@pytest.mark.parametrize("encoded", [False, True])
+@pytest.mark.parametrize("column", ["tools", "tool_defs", "mixed", "both", "empty_tools"])
+def test_mixed_tool_columns_keep_definitions(tmp_path, encoded, column):
+    special = [
+        "<|im_start|>",
+        "<|im_end|>",
+        "<|endoftext|>",
+        "<tool_call>",
+        "</tool_call>",
+        "<tool_response>",
+        "</tool_response>",
+        "<think>",
+        "</think>",
+    ]
+    vocab = ["[UNK]", "user", "assistant", "weather", "Question", "Answer", *special]
+    backend = Tokenizer(WordLevel(dict(zip(vocab, range(len(vocab)))), unk_token="[UNK]"))
+    backend.pre_tokenizer = Whitespace()
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=backend, unk_token="[UNK]", eos_token="<|im_end|>", additional_special_tokens=special
+    )
+    definition = {"name": "weather", "description": "Forecast", "parameters": {"type": "object"}}
+    messages = [{"role": "user", "content": "Question"}, {"role": "assistant", "content": "Answer"}]
+    native = [{"type": "function", "function": definition}]
+    verifier = [definition]
+    if encoded:
+        native, verifier = json.dumps(native), json.dumps(verifier)
+    native_data = Dataset.from_list([{"messages": messages, "tools": native}])
+    verifier_data = Dataset.from_list([{"messages": messages, "tool_defs": verifier}])
+    alternate = [{**definition, "name": "different_tool"}]
+    if column in ("both", "empty_tools"):
+        chosen = native if column == "both" else ("[]" if encoded else [])
+        alternate = json.dumps(alternate) if encoded else alternate
+        source = Dataset.from_list([{"messages": messages, "tools": chosen, "tool_defs": alternate}])
+    elif column == "mixed":
+        source = concatenate_datasets([native_data, verifier_data])
+        assert source[1]["tools"] is None
+    else:
+        source = native_data if column == "tools" else verifier_data
+    parquet_path = tmp_path / "data.parquet"
+    source.to_parquet(parquet_path)
+    source = load_dataset("parquet", data_files=str(parquet_path), split="train")
+    dataset = SFTDataset(source, Qwen3Renderer(tokenizer), shuffle=False, max_epochs=1, seq_len=1024)
+    samples = list(dataset)
+    assert len(samples) == (2 if column == "mixed" else 1)
+    weather_id = tokenizer.convert_tokens_to_ids("weather")
+    for sample in samples:
+        assert (weather_id in sample["input_ids"]) == (column != "empty_tools")
+        assert sample == samples[0]


### PR DESCRIPTION
Null `tools` values introduced when concatenating datasets currently hide valid `tool_defs` entries, so SFT samples lose their tool definitions. Fall back to `tool_defs` when `tools` is absent or null, while preserving the priority of populated `tools` and explicit empty lists. Update the training guide and launch skill with that precedence.

Regression coverage concatenates real Hugging Face datasets, round-trips them through Parquet, and iterates the actual SFTDataset with a real Qwen3Renderer and a local tokenizer. Both list and JSON-encoded inputs are covered, including single-column, mixed-column, populated-tools and empty-tools controls.

Validation (CPU, Python 3.12.14, Torch 2.13.0, Transformers 5.6.2; renderer/verifier submodules at the checkout's pinned commits):

- Baseline regression: **2 failed, 8 passed**, specifically the two mixed-column cases lose their tool name in the rendered token IDs.
- Fixed regression and existing FakeDataset tests: **18 passed**, no skips.
- Both configured pre-commit hooks passed; the actual commit hooks passed too.

```bash
uv run pytest tests/unit/train/sft/test_sft_tool_columns.py tests/unit/train/sft/test_fake_dataset.py -q
uv run pre-commit run --files src/prime_rl/trainer/sft/data.py tests/unit/train/sft/test_sft_tool_columns.py docs/training.md skills/training/start-run/SKILL.md
```

Local commands used an isolated component dependency environment via `uv run --no-project --active`; no model weights were downloaded, and no GPU/full training run was performed. The new regression does not substitute the dataset, renderer or tokenization implementation.

Duplicate checks: reviewed all open PRs and all-state `tool_defs` searches. #2494 introduced support for this alternate column; #2795 implements static SFT in the orchestrator and does not change the affected SFTDataset code. This fixes null fallback in the existing trainer path.

AI assistance: OpenAI Codex assisted with investigation, implementation and validation. Opened as a draft per AGENTS.md.
