### PR TITLE
fix: configure router request timeout for long agentic generations

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -306,6 +306,9 @@ class VllmRouterConfig(BaseConfig):
     policy: str = "consistent_hash"
     """Routing policy, e.g. ``consistent_hash`` or ``round_robin``."""
 
+    request_timeout_secs: int = Field(default=1800, gt=0)
+    """Per-request router timeout. Long agentic generations may need this aligned with the rollout timeout."""
+
 
 class LlmdRouterConfig(BaseConfig):
     """llm-d router backend (EPP + Envoy)."""

--- a/skills/training/start-run/SKILL.md
+++ b/skills/training/start-run/SKILL.md
@@ -95,6 +95,14 @@ curl http://localhost:8000/v1/chat/completions \
 - Entrypoint: `src/prime_rl/entrypoints/inference.py`
 - SLURM: single-node, multi-node, and disaggregated deployments
 
+For long agentic generations, check the transport timeout as well as the rollout timeout.
+`[inference.router] request_timeout_secs` in RL configs (or `[router]` in standalone inference)
+controls the vllm-router per-request timeout for both local and SLURM launches; include
+`type = "vllm-router"` in that table to select the router variant. The timeout defaults to
+1,800 seconds. Set it to accommodate the intended longest generation; a four-hour rollout budget
+does not automatically extend the router's thirty-minute request limit. Keep circuit breakers
+enabled and investigate request failures separately from engine KV pressure.
+
 ## `evals` — multi-env evals
 
 Runs the configured eval sources against a live inference server. Standalone (no `[online]` block): one epoch of every source against the served weights, then exit. Add `[ckpt]` (`interval` counts completed task groups in the eval-source order) to make the run interruptible, then use `--resume`, `--resume.step N`, or `--resume.dir path/to/checkpoints/step_N`; for standalone evals, checkpoint step N means resume from task cursor N. Checkpoints store only the cursor, not generated episode records; partially completed groups and groups beyond the durable cursor are retried. Resume loads without `[ckpt]` but does not save new checkpoints. Checkpoint/resume is rejected with `[online]` because that process is coupled to the trainer's live broadcast handshake. With `[online]` (`broadcasts_dir`, `max_steps`, `resume_step`): watch the broadcasts dir for stable `step_{n}` weight broadcasts and evaluate each — the `sft` launcher writes this config for online evals. By default a newer checkpoint cancels unfinished episodes from the prior eval. Set `eval.cancel_on_new_checkpoint = false` to drain every epoch. The trainer can idle while it waits for slow evals. Launcher-managed SFT evals use NCCL weight broadcast by default, including multi-node SLURM deployments. LoRA and external inference use filesystem broadcast.

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -181,6 +181,8 @@ def start_router(config: InferenceConfig) -> subprocess.Popen:
         str(config.vllm.data_parallel_size_local or config.vllm.data_parallel_size),
         "--request-id-headers",
         "x-session-id",
+        "--request-timeout-secs",
+        str(config.router.request_timeout_secs),
         "--worker-startup-timeout-secs",
         "4200",
         "--prometheus-port",

--- a/src/prime_rl/templates/_launch_router.sh.j2
+++ b/src/prime_rl/templates/_launch_router.sh.j2
@@ -73,6 +73,7 @@ LLMD_EOF
     echo "Starting $tag on $LOCAL_IP:$port" | tee "$log"
     local -a cmd=(vllm-router --policy "$policy" --host 0.0.0.0 --port "$port"
         --request-id-headers x-session-id
+        --request-timeout-secs {{ router.request_timeout_secs }}
         --prometheus-port "$((port + 21000))"
         --worker-startup-timeout-secs 4200 --log-level debug)
     if [ "$mode" = pd ]; then

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -9,7 +9,7 @@ from pydantic_config import ConfigFileError
 
 from prime_rl.configs.env_server import EnvServerConfig
 from prime_rl.configs.evals import EvalsConfig
-from prime_rl.configs.inference import InferenceConfig
+from prime_rl.configs.inference import InferenceConfig, VllmRouterConfig
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.configs.rl import RLConfig
 from prime_rl.configs.sft import SFTConfig
@@ -27,6 +27,33 @@ CONFIG_CLASSES = [
     EnvServerConfig,
     EvalsConfig,
 ]
+
+
+@pytest.mark.parametrize("timeout", [1800, 14400])
+def test_vllm_router_request_timeout_launch_paths(timeout, monkeypatch):
+    from jinja2 import Environment, FileSystemLoader
+
+    from prime_rl.entrypoints import inference
+
+    router = VllmRouterConfig(request_timeout_secs=timeout)
+    assert VllmRouterConfig().request_timeout_secs == 1800
+    config = InferenceConfig(router=router)
+    commands = []
+    monkeypatch.setattr(inference.subprocess, "Popen", lambda cmd: commands.append(cmd))
+    inference.start_router(config)
+    cmd = commands[0]
+    assert cmd[cmd.index("--request-timeout-secs") + 1] == str(timeout)
+
+    templates = Path(inference.__file__).parent.parent / "templates"
+    env = Environment(loader=FileSystemLoader(templates))
+    script = env.get_template("_launch_router.sh.j2").render(router=router)
+    assert f"--request-timeout-secs {timeout}" in script
+
+
+@pytest.mark.parametrize("timeout", [0, -1])
+def test_vllm_router_request_timeout_rejects_nonpositive(timeout):
+    with pytest.raises(ValidationError, match="request_timeout_secs"):
+        VllmRouterConfig(request_timeout_secs=timeout)
 
 
 def get_config_files() -> list[Path]:


### PR DESCRIPTION
## Summary

Expose `VllmRouterConfig.request_timeout_secs` and forward it through both local inference and
the shared SLURM router template. Keep the existing 1,800-second default and reject nonpositive
values. Longer rollout budgets do not otherwise extend the router's per-request timeout.

Includes focused config/launch-path tests and launch documentation. No changes to circuit
breakers, sampling, training precision, or model behavior.

## Validation

The companion dependency stack containing this exact router patch passed all 141 tests in
`tests/unit/test_configs.py`, including local command construction, SLURM template forwarding,
default preservation, and nonpositive-value rejection. A canonical RL dry-run generated a valid
SLURM script with the configured timeout. No GPU training was launched.

This is the base of dependency-pin companion #3496; it does not include experiment traces
or evaluation results.
