### PR TITLE
Sami/add deepepv2

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -33,7 +33,7 @@ Most of the features are supported for all deployment shapes, with few exception
 
 Every deployment shape has the same client-facing layout: a single global router listens on `inference.server.port` and fronts all vLLM engines, which listen on `inference.backend_port` (+ rank offset). Clients always talk to one URL, regardless of how many engines run behind it.
 
-You can select the deployment shape with `InferenceDeploymentConfig` in your config file. This is a config-field that allows you to set the deployment shape and topology knobs such as `num_nodes` and `num_replicas`.
+You can select the deployment shape with `InferenceDeploymentConfig` in your config file. This is a config-field that allows you to set the deployment shape and topology knobs such as `num_nodes`, `nodes_per_replica`, and the P/D replica counts.
 
 ```toml
 [inference.deployment]
@@ -96,6 +96,7 @@ Parallelism configuration is the same as the single-node deployment. The shape i
 [inference.deployment]
 type = "multi_node"
 num_nodes = 2
+nodes_per_replica = 1
 
 [inference.vllm]
 model = "PrimeIntellect/INTELLECT-3"
@@ -103,7 +104,7 @@ tensor_parallel_size = 2
 data_parallel_size = 4
 ```
 
-This configuration will run 2 independent vLLM replicas, each with `tensor_parallel_size=2` and `data_parallel_size=4`. Routing is handled by a single global router running on the first inference node, fronting the per-rank endpoints of all replicas — either `vllm-router` (default) or the upstream `llm-d` EPP+Envoy, selected via the `[inference.router]` block. You can read more about the supported routing options in the [router](#router) section.
+This configuration will run 2 independent vLLM replicas, each with `tensor_parallel_size=2` and `data_parallel_size=4`. `nodes_per_replica = 1` is the default. Routing is handled by a single global router running on the first inference node, fronting the per-rank endpoints of all replicas — either `vllm-router` (default) or the upstream `llm-d` EPP+Envoy, selected via the `[inference.router]` block. You can read more about the supported routing options in the [router](#router) section.
 
 ### Wide-EP
 
@@ -113,6 +114,7 @@ For huge, 200B+ scale models, you might want to use multi-node expert parallelis
 [inference.deployment]
 type = "multi_node"
 num_nodes = 2
+nodes_per_replica = 2
 
 [inference.vllm]
 model = "PrimeIntellect/INTELLECT-3"
@@ -121,7 +123,12 @@ tensor_parallel_size = 2
 data_parallel_size = 8
 ```
 
-This configuration will run 2 vLLM processes, each with `data_parallel_size_local = 4` and `tensor_parallel_size = 2` and expert parallelism spanning 2 nodes. The requests are again routed to these processes via the `vllm-router`.
+This configuration runs one wide vLLM replica with `data_parallel_size_local = 4` per node, `tensor_parallel_size = 2`, and expert parallelism spanning both nodes. The requests are again routed to these processes via the `vllm-router`.
+
+`num_nodes` must be divisible by `nodes_per_replica`. For example,
+`num_nodes = 8` and `nodes_per_replica = 2` form four independent 2-node
+expert-parallel replicas; `nodes_per_replica = 4` forms two 4-node replicas.
+Cross-node grouping requires `enable_expert_parallel = true`.
 
 ## P/D Disaggregation
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -373,6 +373,22 @@ class MultiNodeInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
     num_nodes: int = Field(2, ge=1)
     """Inference nodes."""
 
+    nodes_per_replica: int = Field(1, ge=1)
+    """Nodes in each independent aggregate inference replica."""
+
+    @property
+    def num_replicas(self) -> int:
+        return self.num_nodes // self.nodes_per_replica
+
+    @model_validator(mode="after")
+    def validate_replica_shape(self):
+        if self.num_nodes % self.nodes_per_replica != 0:
+            raise ValueError(
+                "deployment.num_nodes must be divisible by deployment.nodes_per_replica "
+                f"({self.num_nodes} is not divisible by {self.nodes_per_replica})"
+            )
+        return self
+
 
 # Disaggregated prefill/decode inference. Each replica is split into separate
 # prefill and decode node groups. Requires NIXL for KV transfer and a router for
@@ -484,6 +500,12 @@ class InferenceConfig(BaseConfig):
     def validate_multi_node_requires_slurm(self):
         if self.deployment.type in ("multi_node", "disaggregated") and self.slurm is None:
             raise ValueError("Must use SLURM for multi-node / disaggregated deployment.")
+        if (
+            self.deployment.type == "multi_node"
+            and self.deployment.nodes_per_replica > 1
+            and not self.vllm.enable_expert_parallel
+        ):
+            raise ValueError("Multi-node aggregate replicas require inference.vllm.enable_expert_parallel = true.")
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -34,6 +34,7 @@ All2AllBackend = Literal[
     "allgather_reducescatter",
     "deepep_high_throughput",
     "deepep_low_latency",
+    "deepep_v2",
     "flashinfer_nvlink_one_sided",
     "flashinfer_nvlink_two_sided",
 ]

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -124,7 +124,7 @@ class EvalSamplingConfig(BaseConfig):
     max_completion_tokens: int | None = None
     """Maximum output tokens per turn. None defers to the inference server default."""
 
-    reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = None
+    reasoning_effort: Literal["minimal", "low", "medium", "high", "max"] | None = None
     """Reasoning effort constraint for reasoning models."""
 
     extra_body: dict[str, Any] = {}

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -115,6 +115,9 @@ class SlurmConfig(BaseConfig):
     shared_fs: bool = True
     """Whether the project filesystem (including the venv) is shared across nodes (e.g. NFS). When True, a single ``uv sync`` on the batch node suffices. Set to False when the venv is node-local (e.g. ``UV_PROJECT_ENVIRONMENT`` on ``/tmp``) so ``uv sync`` runs on every node via srun."""
 
+    infrastructure_nodes: int = Field(0, ge=0, le=1)
+    """Extra node reserved by the inference launcher for the router. It does not run model engines."""
+
     @property
     def template_vars(self) -> dict:
         """Common template variables for all SLURM templates."""
@@ -129,6 +132,7 @@ class SlurmConfig(BaseConfig):
             "pre_run_command": self.pre_run_command,
             "cleanup_grace_period": self.cleanup_grace_period,
             "shared_fs": self.shared_fs,
+            "infrastructure_nodes": self.infrastructure_nodes,
         }
 
     @model_validator(mode="after")

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -71,6 +71,8 @@ The `sft` entrypoint takes the same eval shape at the top level for online evals
 
 **vLLM pass-through** — `[inference.vllm]` uses vLLM's own argument names (`model`, `tensor_parallel_size`, `data_parallel_size`, `max_model_len`, ...) and forwards *any* key to the vLLM server, typed by prime-rl or not: `[inference.vllm] max_num_seqs = 256`, or `--inference.vllm.max-num-seqs 256` on the CLI. CLI values are JSON-coerced, so dict-valued vLLM args work as `--inference.vllm.compilation-config '{"cudagraph_mode": "NONE"}'`. Non-vLLM knobs (router, deployment, weight broadcast, kv-cache offload, env vars) stay on `[inference]` itself.
 
+**Grouped multi-node inference** — for `deployment.type = "multi_node"`, `num_nodes` is the total model-node count and `nodes_per_replica` is the width of each independent replica (default `1`). The total must divide evenly by the width. A width greater than one requires `vllm.enable_expert_parallel = true`; for example, eight nodes with width two launch four EP replicas.
+
 **Discriminated unions** — set the `type` field to pick the variant (`[orchestrator.algo] type = "max_rl"`). Omit `type` to keep the default variant.
 
 **RL loss** — `[trainer.loss]` defaults to IPO with `eps = 0.1`, `adv_tau = 1.0`, and `kl_tau = 1e-3`. Omit the section to use these defaults. Set `type = "custom"` with `import_path` and optional `kwargs` to load a custom RL loss. The `ce` and `ref_kl` components are fixed.

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -3,6 +3,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 from threading import Event, Thread
 from typing import Any
@@ -26,6 +27,42 @@ from prime_rl.utils.process import (
 
 INFERENCE_CONFIG = "inference.json"
 INFERENCE_SBATCH = "inference.sbatch"
+
+
+def wait_for_distributed_startup_barrier(config: InferenceConfig) -> None:
+    """Hold external-LB front ends until every DP rank has imported vLLM.
+
+    vLLM engine cores have a hard-coded five-minute front-end handshake. On a
+    large distributed launch, early ranks can spawn their cores while the
+    last ranks are still importing vLLM, causing otherwise healthy groups to
+    time out. The Slurm launcher opts into this file barrier and gives every
+    replica a separate group name.
+    """
+    barrier_root = os.environ.get("PRIME_INFERENCE_STARTUP_BARRIER_DIR")
+    barrier_group = os.environ.get("PRIME_INFERENCE_STARTUP_GROUP")
+    if not barrier_root or not barrier_group or config.vllm.data_parallel_size <= 1:
+        return
+
+    barrier_dir = Path(barrier_root) / barrier_group
+    barrier_dir.mkdir(parents=True, exist_ok=True)
+    rank = config.vllm.data_parallel_rank
+    (barrier_dir / f"rank-{rank}").touch()
+
+    expected = config.vllm.data_parallel_size
+    timeout = float(os.environ.get("PRIME_INFERENCE_STARTUP_BARRIER_TIMEOUT", "1800"))
+    deadline = time.monotonic() + timeout
+    logger = setup_logger(config.log.level, json_logging=config.log.json_logging)
+    while True:
+        arrived = sum(1 for path in barrier_dir.iterdir() if path.name.startswith("rank-"))
+        if arrived >= expected:
+            logger.info(f"Startup barrier {barrier_group}: {arrived}/{expected} ranks ready")
+            return
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"Startup barrier {barrier_group} timed out after {timeout}s "
+                f"with {arrived}/{expected} ranks ready."
+            )
+        time.sleep(1)
 
 
 def vllm_overrides_fragment(overrides: dict[str, Any]) -> str:
@@ -69,6 +106,8 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, log_dir: Path
 
     is_disaggregated = config.deployment.type == "disaggregated"
     dp_per_node = config.deployment.gpus_per_node // config.vllm.tensor_parallel_size
+    num_engine_nodes = getattr(config.deployment, "num_nodes", 1)
+    infrastructure_nodes = config.slurm.infrastructure_nodes
 
     offload = config.kv_cache_offload
     is_mooncake = offload is not None and offload.type == "mooncake"
@@ -82,7 +121,8 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, log_dir: Path
         launcher_log_dir=get_launcher_log_dir(config.output_dir),
         gpus_per_node=config.deployment.gpus_per_node,
         dp_per_node=dp_per_node,
-        num_nodes=getattr(config.deployment, "num_nodes", 1),
+        num_nodes=num_engine_nodes,
+        num_slurm_nodes=num_engine_nodes + infrastructure_nodes,
         port=config.server.port,
         router=config.router,
         router_port=config.server.port,
@@ -119,7 +159,8 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, log_dir: Path
             backend_port=config.backend_port,
             data_parallel_rpc_port=config.vllm.data_parallel_rpc_port,
             enable_expert_parallel=config.vllm.enable_expert_parallel,
-            infer_nodes_per_replica=config.deployment.num_nodes,
+            infer_nodes_per_replica=config.deployment.nodes_per_replica,
+            num_infer_replicas=config.deployment.num_replicas,
         )
 
     script = template.render(**template_vars)
@@ -228,6 +269,8 @@ def inference_local(config: InferenceConfig):
         logger.info(f"Starting inference on http://{host}:{port}/v1\n")
 
     from prime_rl.inference.vllm.server import server  # pyright: ignore
+
+    wait_for_distributed_startup_barrier(config)
 
     try:
         server(config)

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -20,6 +20,7 @@ def apply_shared_vllm_patches():
     monkey_patch_deepseek_v4_allowed_layer_types()
     monkey_patch_deepseek_v4_per_layer_rope()
     monkey_patch_deepseek_v4_bf16_o_proj()
+    monkey_patch_deepep_v2_empty_decode_metadata()
     monkey_patch_engine_handshake_timeout()
 
 
@@ -35,6 +36,86 @@ def monkey_patch_engine_handshake_timeout():
     from vllm.v1.engine import core
 
     core.HANDSHAKE_TIMEOUT_MINS = max(1, math.ceil(float(timeout) / 60))
+
+
+def monkey_patch_deepep_v2_empty_decode_metadata():
+    """Fix DeepEP v2 decode profiling with vLLM 0.28's DeepGEMM backend.
+
+    DeepEP v2 skips the CPU count sync on its cudagraph/decode path, so
+    ``num_recv_tokens_per_expert_list`` is empty. vLLM 0.28 turns that empty
+    list into a zero-length ``ExpertTokensMetadata`` tensor. DeepGEMM then
+    compares those zero global counts with the rank's local expert workspace
+    and aborts while profiling the KV cache (0 entries versus 16 for GLM-5.3).
+
+    Upstream vLLM treats the empty list as absent metadata so the expert kernel
+    derives local counts from ``topk_ids``. Keep this compatibility patch
+    limited to the affected 0.28 release; later versions carry the upstream
+    implementation and may attach additional decode metadata here.
+    """
+    from importlib.metadata import version
+    from importlib.util import find_spec
+
+    if version("vllm") != "0.28.0" or find_spec("deep_ep") is None:
+        return
+
+    # Older DeepEP builds do not provide the v2 API. Importing vLLM's v2
+    # prepare/finalize module against one of those builds fails while resolving
+    # its ``deep_ep.ElasticBuffer`` annotation, even for deployments using the
+    # v1 high-throughput/low-latency backends.
+    try:
+        import deep_ep
+    except (ImportError, OSError):
+        return
+
+    if not hasattr(deep_ep, "ElasticBuffer"):
+        return
+
+    from vllm.logger import init_logger
+    from vllm.model_executor.layers.fused_moe.prepare_finalize.deepep_v2 import (
+        DeepEPV2PrepareAndFinalize,
+    )
+
+    original_receiver = DeepEPV2PrepareAndFinalize._receiver
+    if getattr(original_receiver, "_prime_rl_handles_empty_decode_metadata", False):
+        return
+
+    def _receiver(
+        self,
+        event,
+        has_scales,
+        recv_x,
+        recv_topk_idx,
+        num_experts,
+        recv_expert_num_tokens,
+        recv_topk_weights,
+        psum_recv_per_rank,
+        a1_scale,
+        quant_config,
+        defer_input_quant,
+    ):
+        result = original_receiver(
+            self,
+            event,
+            has_scales,
+            recv_x,
+            recv_topk_idx,
+            num_experts,
+            recv_expert_num_tokens,
+            recv_topk_weights,
+            psum_recv_per_rank,
+            a1_scale,
+            quant_config,
+            defer_input_quant,
+        )
+        if not recv_expert_num_tokens:
+            result = (result[0], result[1], None, result[3], result[4])
+        return result
+
+    _receiver._prime_rl_handles_empty_decode_metadata = True
+    DeepEPV2PrepareAndFinalize._receiver = _receiver
+    init_logger(__name__).warning(
+        "Patched vLLM 0.28 DeepEP v2 empty decode expert metadata."
+    )
 
 
 def monkey_patch_deepseek_v4_allowed_layer_types():

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -20,6 +20,21 @@ def apply_shared_vllm_patches():
     monkey_patch_deepseek_v4_allowed_layer_types()
     monkey_patch_deepseek_v4_per_layer_rope()
     monkey_patch_deepseek_v4_bf16_o_proj()
+    monkey_patch_engine_handshake_timeout()
+
+
+def monkey_patch_engine_handshake_timeout():
+    """Honor prime-rl's engine-ready timeout in vLLM's spawned processes."""
+    import math
+    import os
+
+    timeout = os.environ.get("VLLM_ENGINE_READY_TIMEOUT_S")
+    if timeout is None:
+        return
+
+    from vllm.v1.engine import core
+
+    core.HANDSHAKE_TIMEOUT_MINS = max(1, math.ceil(float(timeout) / 60))
 
 
 def monkey_patch_deepseek_v4_allowed_layer_types():

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -20,6 +20,7 @@ from prime_rl.utils.logger import get_logger
 logger = get_logger()
 from prime_rl.inference.patches import (
     monkey_patch_dp_coordinator_startup_timeout,
+    monkey_patch_engine_handshake_timeout,
     monkey_patch_nano_v3_reasoning_parser,
     monkey_patch_strip_routed_experts_from_chat,
     monkey_patch_tokenize_params_validation,
@@ -41,6 +42,9 @@ monkey_patch_strip_routed_experts_from_chat()
 # API server blows through when all engine-core ranks on the node are loading
 # weights concurrently (multi-node disaggregated deployments).
 monkey_patch_dp_coordinator_startup_timeout()
+# vLLM 0.28 hard-codes the engine/front-end handshake to five minutes. Apply
+# prime-rl's configured timeout in the API process before it spawns engine cores.
+monkey_patch_engine_handshake_timeout()
 
 logger = init_logger("vllm.entrypoints.openai.api_server")
 

--- a/src/prime_rl/templates/_launch_rank.sh.j2
+++ b/src/prime_rl/templates/_launch_rank.sh.j2
@@ -15,13 +15,12 @@ rank_log() {
 # launch_inference_rank <port> <cuda_visible_devices> <dp> <rpc_port> <vllm_extra_json|""> <nixl_side_channel_port|""> <log_file>
 launch_inference_rank() {
     local port="$1" gpus="$2" dp="$3" rpc="$4" extra="$5" nixl="$6" log="$7"
-    # Per-rank dir for the mooncake-store lookup ipc socket. It must be unique per process:
-    # external-LB runs one engine per process, all with data_parallel_rank_local 0, so the
-    # lookup socket name collides on bind if the dir is shared node-wide. $port is unique per
-    # rank on the node. Node-local /tmp also avoids inheriting an absent submit-node TMPDIR.
+    # Per-rank runtime directory. External-LB runs one engine per process, all
+    # with data_parallel_rank_local 0, so connector IPC names can collide if
+    # the directory is shared node-wide. $port is unique per local rank.
     local rpcbase="/tmp/vllm-rpc-$USER-$SLURM_JOB_ID-$port"
     mkdir -p "$rpcbase"
-    local -a cmd=(uv run inference @ "$CONFIG_PATH"
+    local -a cmd=(uv run --no-sync inference @ "$CONFIG_PATH"
         --server.host 0.0.0.0 --server.port "$port"
         --vllm.data-parallel-size "$dp" --vllm.data-parallel-size-local 1 --vllm.api-server-count 1)
     [ -n "$rpc" ] && cmd+=(--vllm.data-parallel-rpc-port "$rpc")

--- a/src/prime_rl/templates/_launch_router.sh.j2
+++ b/src/prime_rl/templates/_launch_router.sh.j2
@@ -65,6 +65,7 @@ LLMD_EOF
     epp --pool-name prime-rl --pool-namespace slurm \
         --config-file "$LLMD_DIR/epp.yaml" \
         --grpc-port 9002 --grpc-health-port 9013 --metrics-port 9090 \
+        --refresh-metrics-interval 2s --metrics-staleness-threshold 10s \
         --secure-serving=false --metrics-endpoint-auth=false --tracing=false \
         >> "$log" 2>&1 &
     envoy -c "$LLMD_DIR/envoy.yaml" >> "$log" 2>&1 &

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #SBATCH --job-name={{ job_name }}
-#SBATCH --nodes={{ num_nodes }}
+#SBATCH --nodes={{ num_slurm_nodes }}
 #SBATCH --ntasks-per-node=1
 #SBATCH --gres=gpu:{{ gpus_per_node }}
 #SBATCH --partition={{ partition }}
@@ -27,6 +27,8 @@ set -e
 
 # Configs
 export NUM_NODES={{ num_nodes }}
+export NUM_SLURM_NODES={{ num_slurm_nodes }}
+export INFRA_NODES={{ infrastructure_nodes }}
 export GPUS_PER_NODE={{ gpus_per_node }}
 {% if is_disaggregated -%}
 export NUM_PREFILL_NODES={{ num_prefill_nodes }}
@@ -47,6 +49,8 @@ export DECODE_SIDECAR_PORT={{ router.decode_sidecar_port }}
 export ROUTER_PORT={{ router_port }}
 export BACKEND_PORT={{ backend_port }}
 export RPC_PORT={{ data_parallel_rpc_port }}
+export NODES_PER_INFER_REPLICA={{ infer_nodes_per_replica }}
+export NUM_INFER_REPLICAS={{ num_infer_replicas }}
 {%- endif %}
 
 # Paths
@@ -57,6 +61,10 @@ export OUTPUT_DIR={{ output_dir }}
 export LOG_DIR={{ log_dir }}
 export PRL_ATTEMPT_CONFIG_DIR=$CONFIG_DIR
 export PRL_ATTEMPT_LOG_DIR=$LOG_DIR
+# Keep vLLM's hard-coded five-minute engine/front-end handshake from expiring
+# while distributed API processes import. The Slurm restart count
+# prevents stale markers from an automatic requeue from opening the barrier.
+export PRIME_INFERENCE_STARTUP_BARRIER_DIR="$LOG_DIR/inference/startup-barrier-${SLURM_JOB_ID}-${SLURM_RESTART_COUNT:-0}"
 mkdir -p $LOG_DIR/inference
 ln -sfn inference/node_0.log $LOG_DIR/inference.log
 
@@ -74,16 +82,19 @@ srun --ntasks-per-node=1 bash -s <<'SYNC_SH'
 cd $PROJECT_DIR && { [ -f .env ] && source .env || true; } && uv sync --all-extras --all-packages
 SYNC_SH
 {% else %}
-# Shared (NFS) venv: one sync on the batch node populates it for all nodes.
-uv sync --all-extras --all-packages
+# Shared venv: validate that the already-installed environment is importable.
+# Launchers use uv --no-sync so allocated nodes never mutate the environment.
+python -c 'import prime_rl'
 {% endif %}
 
 # Print inference URLs
-export HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
+export ALL_HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
+export INFRA_HOST="${ALL_HOSTNAMES[0]}"
+export HOSTNAMES=( "${ALL_HOSTNAMES[@]:$INFRA_NODES}" )
 export HOSTNAMES_STR="${HOSTNAMES[*]}"
 {% if is_disaggregated -%}
 # Single global router on node 0 fronts every per-rank endpoint.
-INFER_URLS="http://${HOSTNAMES[0]}:${ROUTER_PORT}/v1"
+INFER_URLS="http://${INFRA_HOST}:${ROUTER_PORT}/v1"
 ROUTER_ARGS=""
 # External-LB: one --prefill/--decode endpoint per DP rank (PORT + k) on each node.
 for ((p=0; p<NUM_PREFILL_NODES; p++)); do
@@ -102,7 +113,7 @@ export INFER_URLS
 export ROUTER_ARGS
 {%- elif num_nodes > 1 %}
 # External LB: one router on node 0; one endpoint per DP rank (BACKEND_PORT + dp_local) on every node.
-INFER_URLS="http://${HOSTNAMES[0]}:${ROUTER_PORT}/v1"
+INFER_URLS="http://${INFRA_HOST}:${ROUTER_PORT}/v1"
 DP_PER_NODE={{ dp_per_node }}
 ROUTER_ARGS=""
 for host in ${HOSTNAMES[@]}; do
@@ -115,6 +126,7 @@ export ROUTER_ARGS
 {%- else %}
 INFER_URLS="http://${HOSTNAMES[0]}:{{ port }}/v1"
 {%- endif %}
+echo "INFRA_HOST=${INFRA_HOST}"
 echo "HOSTNAMES=${HOSTNAMES[@]}"
 echo "INFER_URLS=${INFER_URLS}"
 
@@ -180,7 +192,8 @@ srun --kill-on-bad-exit=1 bash -s <<'LAUNCH_SH'
     IB_HCA=$(ibv_devinfo 2>/dev/null | sed -n -e "/hca_id/p" -e "/link_layer:/p" | grep -B1 InfiniBand | grep hca_id | sed -e "s/^hca_id://g" | tr -d "[[:blank:]]" | paste -sd,)
     [ -n "$IB_HCA" ] && export NCCL_IB_HCA=$IB_HCA
 
-    INFER_NODE_RANK=$SLURM_PROCID
+    TASK_RANK=$SLURM_PROCID
+    INFER_NODE_RANK=$((TASK_RANK - INFRA_NODES))
     LOCAL_IP=$(hostname -I | awk "{print \$1}")
     # Inference env vars: launcher defaults + [inference.env_vars]
 {%- for key, value in inference_env_vars.items() %}
@@ -192,6 +205,15 @@ srun --kill-on-bad-exit=1 bash -s <<'LAUNCH_SH'
 {%- if kv_offload %}
     ulimit -l unlimited
 {%- endif %}
+    if [ "$TASK_RANK" -lt "$INFRA_NODES" ]; then
+        launch_router {{ "pd" if is_disaggregated else "regular" }} "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$LOG_DIR/inference/router.log"
+        echo "[infrastructure] $(hostname) serving router"
+        wait -n
+        EXIT_CODE=$?
+        echo "[$(hostname)] infrastructure component exited with code $EXIT_CODE"
+        for pid in $(jobs -p); do kill -TERM $pid 2>/dev/null || true; done
+        exit $EXIT_CODE
+    fi
 {%- if kv_offload_mooncake %}
 {% include "_mooncake_store.sh.j2" %}
 {%- endif %}
@@ -275,9 +297,10 @@ srun --kill-on-bad-exit=1 bash -s <<'LAUNCH_SH'
 
     echo "NODE_RANK=$INFER_NODE_RANK ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK DP=$DP PORT=$PORT LOCAL_IP=$LOCAL_IP" \
         | tee $LOG_DIR/inference/node_${INFER_NODE_RANK}.log
+    export PRIME_INFERENCE_STARTUP_GROUP="${ROLE}-${SUB_REPLICA}"
 
-    # Start the single global router on node 0 (external LB across all per-rank endpoints)
-    if [ "$INFER_NODE_RANK" -eq 0 ]; then
+    # Without a dedicated infrastructure node, model node 0 also hosts the router.
+    if [ "$INFRA_NODES" -eq 0 ] && [ "$INFER_NODE_RANK" -eq 0 ]; then
         launch_router pd "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$LOG_DIR/inference/router.log"
     fi
 {%- if router.type == "llm-d" %}
@@ -313,27 +336,40 @@ srun --kill-on-bad-exit=1 bash -s <<'LAUNCH_SH'
         launch_inference_rank "$((PORT + k))" "$RANK_GPUS" "$DP" "$RPC_PORT" "$RANK_EXTRA" "$((5600 + k))" "$(rank_log "$INFER_NODE_RANK" "$k")"
     done
 {%- elif num_nodes > 1 %}
-    echo "INFER_NODE_RANK=${INFER_NODE_RANK}, LOCAL_IP=${LOCAL_IP}" \
+    read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
+    REPLICA_IDX=$((INFER_NODE_RANK / NODES_PER_INFER_REPLICA))
+    ROLE_RANK=$((INFER_NODE_RANK % NODES_PER_INFER_REPLICA))
+    REPLICA_BASE=$((REPLICA_IDX * NODES_PER_INFER_REPLICA))
+    HEAD_HOST="${HOSTNAMES[$REPLICA_BASE]}"
+
+    GLOO_IFNAME=$(ip -o -4 addr show to "$LOCAL_IP" 2>/dev/null | awk "{print \$2; exit}")
+    if [ -n "$GLOO_IFNAME" ]; then export GLOO_SOCKET_IFNAME=$GLOO_IFNAME; fi
+
+    echo "INFER_NODE_RANK=${INFER_NODE_RANK}, REPLICA=${REPLICA_IDX}, ROLE_RANK=${ROLE_RANK}, LOCAL_IP=${LOCAL_IP}" \
         | tee $LOG_DIR/inference/node_${INFER_NODE_RANK}.log
 
     DP_PER_NODE={{ dp_per_node }}
     TP=$((GPUS_PER_NODE / DP_PER_NODE))
     EP={{ "1" if enable_expert_parallel else "0" }}
+    DP=$((NODES_PER_INFER_REPLICA * DP_PER_NODE))
+    export PRIME_INFERENCE_STARTUP_GROUP="aggregate-${REPLICA_IDX}"
 
     # Start the single global router on node 0 (balances across per-rank endpoints — no intra-node DP header)
-    if [ "$INFER_NODE_RANK" -eq 0 ]; then
+    if [ "$INFRA_NODES" -eq 0 ] && [ "$INFER_NODE_RANK" -eq 0 ]; then
         launch_router regular "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router.policy }}" "$LOG_DIR/inference/router.log"
     fi
 
-    # External-LB: one vLLM API server per DP rank on this node (BACKEND_PORT + dp_local),
-    # each pinned to its TP slice of GPUs. Each node is an independent replica, so any MoE EP
-    # group is node-local (rendezvous on LOCAL_IP); dense models run independent engines.
+    # External-LB: one vLLM API server per DP rank, pinned to its TP slice of GPUs.
+    # Expert-parallel ranks rendezvous within each aggregate replica; dense models
+    # continue to run independent engines.
     for ((d=0; d<DP_PER_NODE; d++)); do
         RANK_GPUS=$(seq -s, $((d * TP)) $((d * TP + TP - 1)))
         RANK_LOG=$(rank_log "$INFER_NODE_RANK" "$d")
-        if [ "$EP" -eq 1 ] && [ "$DP_PER_NODE" -gt 1 ]; then
-            RANK_EXTRA="{\"data_parallel_rank\": $d, \"data_parallel_address\": \"$LOCAL_IP\"}"
-            launch_inference_rank "$((BACKEND_PORT + d))" "$RANK_GPUS" "$DP_PER_NODE" "$RPC_PORT" "$RANK_EXTRA" "" "$RANK_LOG"
+        if [ "$EP" -eq 1 ] && [ "$DP" -gt 1 ]; then
+            GLOBAL_RANK=$((ROLE_RANK * DP_PER_NODE + d))
+            if [ "$ROLE_RANK" -eq 0 ]; then DP_ADDR=$LOCAL_IP; else DP_ADDR=$HEAD_HOST; fi
+            RANK_EXTRA="{\"data_parallel_rank\": $GLOBAL_RANK, \"data_parallel_address\": \"$DP_ADDR\"}"
+            launch_inference_rank "$((BACKEND_PORT + d))" "$RANK_GPUS" "$DP" "$RPC_PORT" "$RANK_EXTRA" "" "$RANK_LOG"
         else
             # Dense or single-DP-rank EP (dp=1, e.g. EP within one tp=8 group):
             # independent single-engine servers. vLLM rejects the external-LB DP
@@ -345,7 +381,7 @@ srun --kill-on-bad-exit=1 bash -s <<'LAUNCH_SH'
 {%- else %}
     echo "INFER_NODE_RANK=${INFER_NODE_RANK}, LOCAL_IP=${LOCAL_IP}" | tee $LOG_DIR/inference/node_${INFER_NODE_RANK}.log
 
-    uv run inference \
+    uv run --no-sync inference \
         @ $CONFIG_PATH \
         2>&1 | tee -a $LOG_DIR/inference/node_${INFER_NODE_RANK}.log &
 {%- endif %}


### PR DESCRIPTION
Superseded by focused draft PRs: #3498 (DeepEP v2), #3499 (Max effort), #3500 (engine handshake timeout), and #3501 (grouped inference launch).

Verifier changes are isolated in PrimeIntellect-ai/verifiers#2561 (local cache) and PrimeIntellect-ai/verifiers#2562 (explicit subprocess network-policy override). The verifier submodule integration pin should follow their merge.

Closing the omnibus to avoid duplicate merge paths. The original branch and deployed checkout are preserved.

this is vibe coded slop a bit, will clean later

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes multi-node SLURM allocation, router placement, and distributed vLLM startup timing; incorrect topology or barrier timeouts could fail large EP launches, but validation and env-gated patches limit blast radius.
> 
> **Overview**
> Adds **DeepEP v2** as an expert-parallel `all2all_backend` option and **vLLM 0.28 compatibility patches**: empty decode expert metadata for DeepEP v2 + DeepGEMM KV profiling, and configurable engine/front-end handshake timeout via `VLLM_ENGINE_READY_TIMEOUT_S`.
> 
> **Multi-node topology** gains `deployment.nodes_per_replica` (with divisibility validation and a requirement that width &gt; 1 use `enable_expert_parallel`). SLURM launch now treats `num_nodes` as engine nodes, computes replica count, and wires cross-node DP/EP within each aggregate replica (head-host rendezvous, per-replica startup barrier groups).
> 
> **SLURM ops**: optional `slurm.infrastructure_nodes` (0–1) reserves a node for the global router; client URL uses `INFRA_HOST`. Shared-venv jobs validate imports instead of `uv sync` on the batch node; rank launches use `uv run --no-sync`. llm-d EPP gets fresher metrics refresh flags.
> 
> Docs/skills and eval sampling add **`reasoning_effort = "max"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4d78a4bc413418d713a6f6302a52334da6b0f13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->