### PR TITLE
feat: accept max reasoning effort for evaluation

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -124,7 +124,7 @@ class EvalSamplingConfig(BaseConfig):
     max_completion_tokens: int | None = None
     """Maximum output tokens per turn. None defers to the inference server default."""
 
-    reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = None
+    reasoning_effort: Literal["minimal", "low", "medium", "high", "max"] | None = None
     """Reasoning effort constraint for reasoning models."""
 
     extra_body: dict[str, Any] = {}

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -124,7 +124,7 @@ class EvalSamplingConfig(BaseConfig):
     max_completion_tokens: int | None = None
     """Maximum output tokens per turn. None defers to the inference server default."""
 
-    reasoning_effort: Literal["minimal", "low", "medium", "high", "max"] | None = None
+    reasoning_effort: Literal["minimal", "low", "medium", "high", "xhigh", "max"] | None = None
     """Reasoning effort constraint for reasoning models."""
 
     extra_body: dict[str, Any] = {}


### PR DESCRIPTION
Allow `reasoning_effort = "xhigh"` and `reasoning_effort = "max"` in EvalSamplingConfig. Existing values and the None default are unchanged; this only passes through the provider value, not a model-specific mapping.

Validation: direct Pydantic parsing (xhigh, max, existing values, default) and train-rejection assertions pass; Ruff passes. Isolated from #3497.
