### PR TITLE
fix: propagate engine startup timeout to vLLM workers

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -20,6 +20,21 @@ def apply_shared_vllm_patches():
     monkey_patch_deepseek_v4_allowed_layer_types()
     monkey_patch_deepseek_v4_per_layer_rope()
     monkey_patch_deepseek_v4_bf16_o_proj()
+    monkey_patch_engine_handshake_timeout()
+
+
+def monkey_patch_engine_handshake_timeout():
+    """Honor prime-rl's engine-ready timeout in vLLM's spawned processes."""
+    import math
+    import os
+
+    timeout = os.environ.get("VLLM_ENGINE_READY_TIMEOUT_S")
+    if timeout is None:
+        return
+
+    from vllm.v1.engine import core
+
+    core.HANDSHAKE_TIMEOUT_MINS = max(1, math.ceil(float(timeout) / 60))
 
 
 def monkey_patch_deepseek_v4_allowed_layer_types():

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -20,6 +20,7 @@ from prime_rl.utils.logger import get_logger
 logger = get_logger()
 from prime_rl.inference.patches import (
     monkey_patch_dp_coordinator_startup_timeout,
+    monkey_patch_engine_handshake_timeout,
     monkey_patch_nano_v3_reasoning_parser,
     monkey_patch_strip_routed_experts_from_chat,
     monkey_patch_tokenize_params_validation,
@@ -41,6 +42,9 @@ monkey_patch_strip_routed_experts_from_chat()
 # API server blows through when all engine-core ranks on the node are loading
 # weights concurrently (multi-node disaggregated deployments).
 monkey_patch_dp_coordinator_startup_timeout()
+# vLLM 0.28 hard-codes the engine/front-end handshake to five minutes. Apply
+# prime-rl's configured timeout in the API process before it spawns engine cores.
+monkey_patch_engine_handshake_timeout()
 
 logger = init_logger("vllm.entrypoints.openai.api_server")
 


### PR DESCRIPTION
THIS IS SLOP not sure we want this


Propagate prime-rl's configured engine startup timeout to spawned vLLM processes through VLLM_ENGINE_READY_TIMEOUT_S, and translate seconds to the engine handshake's minute granularity.

Validation: Ruff passes; used on the combined production deployment. Standalone GPU validation of this isolated branch remains outstanding. Split from #3497.