### PR TITLE
perf(deepseek_v4): score the Lightning Indexer with the fused FP8 kernel

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -42,6 +42,7 @@ from prime_rl.trainer.models import (
     get_custom_vlm_cls,
     supports_custom_impl,
 )
+from prime_rl.trainer.models.deepseek_v4.attention import DeepseekV4Indexer
 from prime_rl.trainer.models.fusions import (
     apply_model_fusions,
     get_fsdp_shard_placement_fn,
@@ -461,20 +462,22 @@ def get_full_offload_dtype_policy(
 
 
 def freeze_sparse_indexer(model: nn.Module) -> None:
-    """Freeze DSA sparse-attention indexer parameters.
+    """Freeze sparse-attention indexer parameters.
 
-    The indexer's `compute_sparse_indices` forward runs under `torch.no_grad()`, so its
-    params never receive a gradient and cannot be trained. Left with requires_grad=True
-    they stay stateless in the optimizer, which breaks strict checkpoint resume: DCP
-    materializes optimizer state for every requires_grad param at load time, but the
-    stateless params were never saved -> "Missing key in checkpoint state_dict". Freezing
-    them keeps the saved and loaded optimizer state symmetric.
+    An indexer forward runs under `torch.no_grad()`, so its params never receive a gradient
+    and cannot be trained. Left with requires_grad=True they stay stateless in the optimizer,
+    which breaks strict checkpoint resume: DCP materializes optimizer state for every
+    requires_grad param at load time, but the stateless params were never saved -> "Missing
+    key in checkpoint state_dict". Freezing them keeps the saved and loaded optimizer state
+    symmetric.
     """
+    # TODO: no model here trains its indexer. DeepSeek's auxiliary KL objective, which supervises
+    # the top-k selection, is unimplemented, so these params are frozen rather than learned.
     logger = get_logger()
     num_frozen = 0
 
     for module in model.modules():
-        if isinstance(module, Indexer):
+        if isinstance(module, (Indexer, DeepseekV4Indexer)):
             for param in module.parameters():
                 param.requires_grad = False
                 num_frozen += 1
@@ -1290,9 +1293,9 @@ def setup_model(
     if config.moe_router_dtype == "float32":
         apply_fp32_moe_router(model)
 
-    # The DSA sparse-attention indexer runs its forward under torch.no_grad(), so it is
-    # never trainable. Freeze it so optimizer state stays symmetric across checkpoint
-    # save/resume. No-op for models without a sparse indexer.
+    # A sparse-attention indexer runs its forward under torch.no_grad(), so it is never
+    # trainable. Freeze it so optimizer state stays symmetric across checkpoint save/resume.
+    # No-op for models without a sparse indexer.
     freeze_sparse_indexer(model)
 
     if config.debug.force_balanced_routing:

--- a/src/prime_rl/trainer/models/deepseek_v4/attention.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/attention.py
@@ -483,14 +483,6 @@ class DeepseekV4Compressor(nn.Module):
 class DeepseekV4Indexer(nn.Module):
     """Lightning Indexer: picks the `index_topk` compressed entries each query may read.
 
-    It owns a compressor at the narrow `index_head_dim` and scores each query against its entries
-    with `fp8_indexer`, a fused Triton kernel that quantizes queries and keys to FP8 (UE8M0) and
-    never materializes a `(seq, heads, entries)` score tensor. GLM DSA runs the same kernel as its
-    only indexer path, unconditional and ungated, and this mirrors that. The indices this returns
-    address the entries of the compressor that owns it: both share `compress_rate` and the
-    `compress` RoPE base, so entry `e` in one covers the same source tokens as entry `e` in the
-    other, and the scores depend only on the query-key distance.
-
     Every query gets `index_topk` picks, the width the kernel pads to. An early query has fewer
     entries whose source tokens all lie at or before it, and its surplus picks come back as
     `IGNORE_SLOT` (-1).
@@ -513,28 +505,21 @@ class DeepseekV4Indexer(nn.Module):
         compressed_kv = self.compressor.compress(hidden_states, packed)
         n_entries = compressed_kv.shape[1]
 
-        # The token-position table for this rope type is already on `packed`; the compressor's own
-        # rotary is only ever evaluated at entry positions.
         cos, sin = packed.position_embeddings[self.compressor.rope_layer_type]
         q = self.q_b_proj(q_residual).view(batch, seq_len, -1, self.head_dim).transpose(1, 2)
         q = apply_rotary_pos_emb_interleaved(q, cos, sin).transpose(1, 2)
         w = self.weights_proj(hidden_states)
 
-        # The kernel wants a per-query contiguous readable range in the entry axis, `[ks, ke)`:
-        # `first_entry_of_doc` locates where the query's own document starts, and the number of
-        # entries closed so far advances that into the document.
         layout = packed.compression_layouts[self.compressor.compress_rate]
-        ks = layout.first_entry_of_doc[packed.tok_doc_idx].int()
-        ke = (ks + self.compressor.causal_threshold(packed.position_ids)[0]).int()
+        entry_start = layout.first_entry_of_doc[packed.tok_doc_idx].int()
+        entry_stop = (entry_start + self.compressor.causal_threshold(packed.position_ids)[0]).int()
 
-        # The kernel has no batch axis, and `ks`/`ke` come from the row's shared `PackedContext`,
-        # so every batch entry indexes the same ranges.
+        # fp8_indexer has no batch axis
         top_k_indices = torch.stack(
-            [fp8_indexer(q[b], compressed_kv[b], w[b], ks, ke, self.index_topk) for b in range(batch)]
+            [fp8_indexer(q[b], compressed_kv[b], w[b], entry_start, entry_stop, self.index_topk) for b in range(batch)]
         )
-        # The kernel's sentinel for "no valid pick" is `n_entries`; DS V4's own is `IGNORE_SLOT`.
-        # This also covers `n_entries == 0` for free: every query's range is empty, so the kernel's
-        # own out-of-range cleanup already maps every pick to its sentinel.
+
+        # Mark indices-to-ignore with IGNORE_SLOT
         in_range = top_k_indices < n_entries
         top_k_indices = torch.where(in_range, top_k_indices, torch.full_like(top_k_indices, IGNORE_SLOT))
         return top_k_indices.long()

--- a/src/prime_rl/trainer/models/deepseek_v4/attention.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/attention.py
@@ -502,9 +502,7 @@ class DeepseekV4Indexer(nn.Module):
     @torch.no_grad()  # Returns non-differentiable integer indices.
     def forward(self, hidden_states: torch.Tensor, q_residual: torch.Tensor, packed: PackedContext) -> torch.Tensor:
         batch, seq_len, _ = hidden_states.shape
-        if batch != 1:
-            # The causal thresholds below come from sample 0 only.
-            raise ValueError(f"the indexer needs a packed batch of size 1, got {batch}")
+        assert batch == 1, f"the indexer needs a packed batch of size 1, got {batch}"
         compressed_kv = self.compressor.compress(hidden_states, packed)
         n_entries = compressed_kv.shape[1]
 

--- a/src/prime_rl/trainer/models/deepseek_v4/attention.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/attention.py
@@ -324,27 +324,6 @@ class PackedContext:
                 "substitutes (see `prime_rl.trainer.models.layers.lm_head`), which this rejects."
             )
 
-    def token_entry_causal_mask(self, compress_rate: int, threshold: Tensor) -> Tensor:
-        """`(1, seq_len, n_entries)` bool: which compressed entries each query token may read.
-
-        Element `[0, t, e]` is true when query token `t` may read entry `e` of the rate's layout.
-        Both of these have to hold:
-
-        - `e` belongs to `t`'s own document, so no query reads another document's history;
-        - `e` closed before `t` arrived, i.e. its index within that document is below
-          `threshold[0, t]`, the count of entries the query's position has completed.
-
-        One `seq_lens` describes one packed row, so the leading axis is 1 and broadcasts over the
-        batch, as `threshold` does.
-
-        `threshold` counts per document, so it is compared against `entry_local_idx` and not
-        against the sequence-global entry number; those two coordinate systems disagree for every
-        document after the first.
-        """
-        layout = self.compression_layouts[compress_rate]
-        same_document = self.tok_doc_idx[None, :, None] == layout.entry_doc_idx[None, None, :]
-        return same_document & (threshold.unsqueeze(-1) > layout.entry_local_idx[None, None, :])
-
 
 @dataclass(frozen=True)
 class SparseAttnInputs:

--- a/src/prime_rl/trainer/models/deepseek_v4/attention.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/attention.py
@@ -113,16 +113,15 @@ All three layer types reach their keys the same way. `SparseAttnInputs` lays out
                          nothing else: an absent key needs no position of its own
 
 and one int32 index tensor addressing that position axis, `sliding_window + picks` slots per
-query: the local window first, the picks after. `picks` is the indexer's
-`min(index_topk, entries)` for CSA, `max_entries_per_doc` for HCA, and zero for a sliding layer,
-which reads its window alone. A slot with nothing to read holds `IGNORE_SLOT` (-1), which the
-kernel masks on, so a short window and a surplus pick cost only their loads.
+query: the local window first, the picks after. `picks` is the indexer's `index_topk` for CSA,
+`max_entries_per_doc` for HCA, and zero for a sliding layer, which reads its window alone. A slot
+with nothing to read holds `IGNORE_SLOT` (-1), which the kernel masks on, so a short window and a
+surplus pick cost only their loads.
 """
 
 from dataclasses import dataclass
 
 import torch
-import torch.nn.functional as F
 from torch import Tensor, nn
 
 from prime_rl.trainer.models.deepseek_v4.configuration_deepseek_v4 import DeepseekV4Config
@@ -130,6 +129,7 @@ from prime_rl.trainer.models.deepseek_v4.eager_reference import dense_mask_from_
 from prime_rl.trainer.models.deepseek_v4.hyperconnections import DeepseekV4UnweightedRMSNorm
 from prime_rl.trainer.models.deepseek_v4.rotary import DeepseekV4RotaryEmbedding, apply_rotary_pos_emb_interleaved
 from prime_rl.trainer.models.kernels.deepseek_v4 import IGNORE_SLOT
+from prime_rl.trainer.models.kernels.fp8_indexer import fp8_indexer
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
@@ -501,49 +501,20 @@ class DeepseekV4Compressor(nn.Module):
         nn.init.zeros_(self.position_bias)
 
 
-class DeepseekV4IndexerScorer(nn.Module):
-    """Lightning-Indexer score `score[t,e] = sum_h w[t,h] * ReLU(q[t,h,d] * k[e,d])`.
-
-    Query token `t` against compressed entry `e`, over indexer heads `h` and `index_head_dim`
-    channels `d`. The per-head weights `w[t,h]` come off the hidden state directly rather than
-    from a query-key interaction, which keeps the scorer one matmul deep. It runs in fp32: the
-    scores only feed a top-k, so the width costs little and near-ties are not decided by bf16
-    rounding.
-    """
-
-    def __init__(self, config: DeepseekV4Config):
-        super().__init__()
-        self.softmax_scale = config.index_head_dim**-0.5
-        self.weights_scaling = config.index_n_heads**-0.5
-        self.weights_proj = nn.Linear(config.hidden_size, config.index_n_heads, bias=False)
-
-    def forward(self, q: torch.Tensor, compressed_kv: torch.Tensor, hidden_states: torch.Tensor) -> torch.Tensor:
-        """Score `q` `(batch, seq, heads, dim)` against `compressed_kv` `(batch, entries, dim)`.
-
-        The `(batch, seq, heads, entries)` intermediate is 4 GB at 8192 tokens, so it is mutated in
-        place instead of copied. That is only correct with grad disabled, which the caller
-        `DeepseekV4Indexer.forward` guarantees.
-        """
-        scores = torch.matmul(q.float(), compressed_kv.transpose(-1, -2).float().unsqueeze(1))
-        F.relu_(scores)
-        # Both scales are positive constants and cannot change the selection, so they ride along on
-        # the per-head weights rather than costing a second pass over the intermediate.
-        weights = self.weights_proj(hidden_states).float() * (self.weights_scaling * self.softmax_scale)
-        scores *= weights.unsqueeze(-1)
-        return scores.sum(dim=2)
-
-
 class DeepseekV4Indexer(nn.Module):
     """Lightning Indexer: picks the `index_topk` compressed entries each query may read.
 
-    It owns a compressor at the narrow `index_head_dim` and scores each query against its
-    entries. The indices it returns address the entries of the compressor that owns it: both
-    share `compress_rate` and the `compress` RoPE base, so entry `e` in one covers the same
-    source tokens as entry `e` in the other, and the scores depend only on the query-key
-    distance.
+    It owns a compressor at the narrow `index_head_dim` and scores each query against its entries
+    with `fp8_indexer`, a fused Triton kernel that quantizes queries and keys to FP8 (UE8M0) and
+    never materializes a `(seq, heads, entries)` score tensor. GLM DSA runs the same kernel as its
+    only indexer path, unconditional and ungated, and this mirrors that. The indices this returns
+    address the entries of the compressor that owns it: both share `compress_rate` and the
+    `compress` RoPE base, so entry `e` in one covers the same source tokens as entry `e` in the
+    other, and the scores depend only on the query-key distance.
 
-    Each query gets `min(index_topk, entries)` picks. An early query has fewer entries whose
-    source tokens all lie at or before it, and its surplus picks come back as `IGNORE_SLOT` (-1).
+    Every query gets `index_topk` picks, the width the kernel pads to. An early query has fewer
+    entries whose source tokens all lie at or before it, and its surplus picks come back as
+    `IGNORE_SLOT` (-1).
     """
 
     def __init__(self, config: DeepseekV4Config):
@@ -555,34 +526,39 @@ class DeepseekV4Indexer(nn.Module):
             config, self.head_dim, config.compress_rates["compressed_sparse_attention"], n_series=2
         )
         self.q_b_proj = nn.Linear(config.q_lora_rank, self.num_heads * self.head_dim, bias=False)
-        self.scorer = DeepseekV4IndexerScorer(config)
+        self.weights_proj = nn.Linear(config.hidden_size, self.num_heads, bias=False)
 
-    @torch.no_grad() # Returns non-differentiable integer indices.
+    @torch.no_grad()  # Returns non-differentiable integer indices.
     def forward(self, hidden_states: torch.Tensor, q_residual: torch.Tensor, packed: PackedContext) -> torch.Tensor:
         batch, seq_len, _ = hidden_states.shape
         compressed_kv = self.compressor.compress(hidden_states, packed)
-        compressed_len = compressed_kv.shape[1]
-        top_k = min(self.index_topk, compressed_len)
+        n_entries = compressed_kv.shape[1]
 
         # The token-position table for this rope type is already on `packed`; the compressor's own
         # rotary is only ever evaluated at entry positions.
         cos, sin = packed.position_embeddings[self.compressor.rope_layer_type]
         q = self.q_b_proj(q_residual).view(batch, seq_len, -1, self.head_dim).transpose(1, 2)
         q = apply_rotary_pos_emb_interleaved(q, cos, sin).transpose(1, 2)
+        w = self.weights_proj(hidden_states)
 
-        scores = self.scorer(q, compressed_kv, hidden_states)
-        if compressed_len == 0:
-            return scores.topk(top_k, dim=-1).indices
+        # The kernel wants a per-query contiguous readable range in the entry axis, `[ks, ke)`:
+        # `first_entry_of_doc` locates where the query's own document starts, and the number of
+        # entries closed so far advances that into the document.
+        layout = packed.compression_layouts[self.compressor.compress_rate]
+        ks = layout.first_entry_of_doc[packed.tok_doc_idx].int()
+        ke = (ks + self.compressor.causal_threshold(packed.position_ids)[0]).int()
 
-        threshold = self.compressor.causal_threshold(packed.position_ids)
-        readable = packed.token_entry_causal_mask(self.compressor.compress_rate, threshold).expand_as(scores)
-        scores = scores.masked_fill(~readable, float("-inf"))
-        top_k_indices = scores.topk(top_k, dim=-1).indices
-        # An early query has fewer than `top_k` readable entries, so top-k still hands back
-        # masked-out ones. Mark those `IGNORE_SLOT` (-1) rather than letting them leak into attention.
-        return torch.where(
-            readable.gather(-1, top_k_indices), top_k_indices, torch.full_like(top_k_indices, IGNORE_SLOT)
+        # The kernel has no batch axis, and `ks`/`ke` come from the row's shared `PackedContext`,
+        # so every batch entry indexes the same ranges.
+        top_k_indices = torch.stack(
+            [fp8_indexer(q[b], compressed_kv[b], w[b], ks, ke, self.index_topk) for b in range(batch)]
         )
+        # The kernel's sentinel for "no valid pick" is `n_entries`; DS V4's own is `IGNORE_SLOT`.
+        # This also covers `n_entries == 0` for free: every query's range is empty, so the kernel's
+        # own out-of-range cleanup already maps every pick to its sentinel.
+        in_range = top_k_indices < n_entries
+        top_k_indices = torch.where(in_range, top_k_indices, torch.full_like(top_k_indices, IGNORE_SLOT))
+        return top_k_indices.long()
 
     def init_weights(self, init_std: float) -> None:
         self.compressor.init_weights(init_std)
@@ -801,7 +777,6 @@ __all__ = [
     "DeepseekV4GroupedLinear",
     "DeepseekV4HCACompressor",
     "DeepseekV4Indexer",
-    "DeepseekV4IndexerScorer",
     "PackedContext",
     "SparseAttnInputs",
     "dense_mask_from_indices",

--- a/src/prime_rl/trainer/models/deepseek_v4/attention.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/attention.py
@@ -518,11 +518,19 @@ class DeepseekV4IndexerScorer(nn.Module):
         self.weights_proj = nn.Linear(config.hidden_size, config.index_n_heads, bias=False)
 
     def forward(self, q: torch.Tensor, compressed_kv: torch.Tensor, hidden_states: torch.Tensor) -> torch.Tensor:
-        """Score `q` `(batch, seq, heads, dim)` against `compressed_kv` `(batch, entries, dim)`."""
+        """Score `q` `(batch, seq, heads, dim)` against `compressed_kv` `(batch, entries, dim)`.
+
+        The `(batch, seq, heads, entries)` intermediate is 4 GB at 8192 tokens, so it is mutated in
+        place instead of copied. That is only correct with grad disabled, which the caller
+        `DeepseekV4Indexer.forward` guarantees.
+        """
         scores = torch.matmul(q.float(), compressed_kv.transpose(-1, -2).float().unsqueeze(1))
-        scores = F.relu(scores) * self.softmax_scale
-        weights = self.weights_proj(hidden_states).float() * self.weights_scaling
-        return (scores * weights.unsqueeze(-1)).sum(dim=2)
+        F.relu_(scores)
+        # Both scales are positive constants and cannot change the selection, so they ride along on
+        # the per-head weights rather than costing a second pass over the intermediate.
+        weights = self.weights_proj(hidden_states).float() * (self.weights_scaling * self.softmax_scale)
+        scores *= weights.unsqueeze(-1)
+        return scores.sum(dim=2)
 
 
 class DeepseekV4Indexer(nn.Module):
@@ -549,6 +557,7 @@ class DeepseekV4Indexer(nn.Module):
         self.q_b_proj = nn.Linear(config.q_lora_rank, self.num_heads * self.head_dim, bias=False)
         self.scorer = DeepseekV4IndexerScorer(config)
 
+    @torch.no_grad() # Returns non-differentiable integer indices.
     def forward(self, hidden_states: torch.Tensor, q_residual: torch.Tensor, packed: PackedContext) -> torch.Tensor:
         batch, seq_len, _ = hidden_states.shape
         compressed_kv = self.compressor.compress(hidden_states, packed)

--- a/src/prime_rl/trainer/models/deepseek_v4/attention.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/attention.py
@@ -502,6 +502,9 @@ class DeepseekV4Indexer(nn.Module):
     @torch.no_grad()  # Returns non-differentiable integer indices.
     def forward(self, hidden_states: torch.Tensor, q_residual: torch.Tensor, packed: PackedContext) -> torch.Tensor:
         batch, seq_len, _ = hidden_states.shape
+        if batch != 1:
+            # The causal thresholds below come from sample 0 only.
+            raise ValueError(f"the indexer needs a packed batch of size 1, got {batch}")
         compressed_kv = self.compressor.compress(hidden_states, packed)
         n_entries = compressed_kv.shape[1]
 
@@ -515,9 +518,7 @@ class DeepseekV4Indexer(nn.Module):
         entry_stop = (entry_start + self.compressor.causal_threshold(packed.position_ids)[0]).int()
 
         # fp8_indexer has no batch axis
-        top_k_indices = torch.stack(
-            [fp8_indexer(q[b], compressed_kv[b], w[b], entry_start, entry_stop, self.index_topk) for b in range(batch)]
-        )
+        top_k_indices = fp8_indexer(q[0], compressed_kv[0], w[0], entry_start, entry_stop, self.index_topk).unsqueeze(0)
 
         # Mark indices-to-ignore with IGNORE_SLOT
         in_range = top_k_indices < n_entries

--- a/src/prime_rl/trainer/models/deepseek_v4/converting_deepseek_v4.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/converting_deepseek_v4.py
@@ -77,7 +77,7 @@ def _layer_ops(layer_idx: int, layer_type: str) -> list[ConvOp]:
         idx, prime_idx = f"{attn}.indexer", f"{prime_attn}.compressor.indexer"
         ops += [
             Rename(f"{idx}.wq_b.weight", f"{prime_idx}.q_b_proj.weight"),
-            Rename(f"{idx}.weights_proj.weight", f"{prime_idx}.scorer.weights_proj.weight"),
+            Rename(f"{idx}.weights_proj.weight", f"{prime_idx}.weights_proj.weight"),
             Rename(f"{idx}.compressor.wkv.weight", f"{prime_idx}.compressor.kv_proj.weight"),
             Rename(f"{idx}.compressor.wgate.weight", f"{prime_idx}.compressor.gate_proj.weight"),
             Rename(f"{idx}.compressor.norm.weight", f"{prime_idx}.compressor.kv_norm.weight"),

--- a/src/prime_rl/trainer/models/deepseek_v4/eager_reference.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/eager_reference.py
@@ -57,6 +57,31 @@ def build_sliding_window_mask(*, tok_doc_idx: Tensor, sliding_window: int, dtype
     return mask.masked_fill_(~readable, torch.finfo(dtype).min)[None, None]
 
 
+def token_entry_causal_mask(
+    *, tok_doc_idx: Tensor, entry_doc_idx: Tensor, entry_local_idx: Tensor, threshold: Tensor
+) -> Tensor:
+    """`(1, seq_len, n_entries)` bool: which compressed entries each query token may read.
+
+    Element `[0, t, e]` is true when query token `t` may read entry `e`. Both of these have to
+    hold:
+
+    - `e` belongs to `t`'s own document, so no query reads another document's history;
+    - `e` closed before `t` arrived, i.e. its index within that document is below
+      `threshold[0, t]`, the count of entries the query's position has completed.
+
+    One `seq_lens` describes one packed row, so the leading axis is 1 and broadcasts over the
+    batch, as `threshold` does.
+
+    `threshold` counts per document, so it is compared against `entry_local_idx` and not against
+    the sequence-global entry number; those two coordinate systems disagree for every document
+    after the first. That is the whole reason this exists: the indexer hands its kernel one
+    contiguous `[ks, ke)` range per query instead, and this is the dense statement of the same
+    rule to measure that range against.
+    """
+    same_document = tok_doc_idx[None, :, None] == entry_doc_idx[None, None, :]
+    return same_document & (threshold.unsqueeze(-1) > entry_local_idx[None, None, :])
+
+
 def block_bias_from_indices(top_k_indices: Tensor, n_entries: int, dtype: torch.dtype) -> Tensor:
     """Render the indexer's picks as the dense additive `(batch, 1, seq_len, n_entries)` bias.
 

--- a/src/prime_rl/trainer/models/deepseek_v4/eager_reference.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/eager_reference.py
@@ -91,3 +91,20 @@ def dense_mask_from_indices(indices: Tensor, n_positions: int, dtype: torch.dtyp
     mask = torch.full((batch, 1, seq_len, n_positions + 1), float("-inf"), dtype=dtype, device=indices.device)
     mask.scatter_(-1, safe, 0.0)
     return mask[..., :n_positions].contiguous()
+
+
+def indexer_scores(q: Tensor, compressed_kv: Tensor, weights: Tensor) -> Tensor:
+    """Lightning-Indexer score `score[b,t,e] = sum_h w[b,t,h] * relu(sum_d q[b,t,h,d] k[b,e,d])`.
+
+    `q` is `(batch, seq_len, heads, dim)`, `compressed_kv` is `(batch, n_entries, dim)`, `weights`
+    is `(batch, seq_len, heads)`, and the result is `(batch, seq_len, n_entries)`, in float32.
+
+    This is the standard `fp8_indexer` is measured against: the same formula, in float32 and
+    through the `(batch, seq_len, heads, n_entries)` intermediate the kernel exists to avoid, so
+    the only difference between the two is the kernel's FP8 quantization. Both constant scales the
+    model applies, `index_head_dim ** -0.5` and `index_n_heads ** -0.5`, are dropped here because
+    the kernel drops them too, and being positive they cannot change which entries a top-k selects.
+    """
+    scores = q.float() @ compressed_kv.transpose(-1, -2).float().unsqueeze(1)
+    scores = F.relu(scores) * weights.float().unsqueeze(-1)
+    return scores.sum(dim=2)

--- a/src/prime_rl/trainer/models/deepseek_v4/eager_reference.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/eager_reference.py
@@ -68,18 +68,10 @@ def token_entry_causal_mask(
     - `e` belongs to `t`'s own document, so no query reads another document's history;
     - `e` closed before `t` arrived, i.e. its index within that document is below
       `threshold[0, t]`, the count of entries the query's position has completed.
-
-    One `seq_lens` describes one packed row, so the leading axis is 1 and broadcasts over the
-    batch, as `threshold` does.
-
-    `threshold` counts per document, so it is compared against `entry_local_idx` and not against
-    the sequence-global entry number; those two coordinate systems disagree for every document
-    after the first. That is the whole reason this exists: the indexer hands its kernel one
-    contiguous `[ks, ke)` range per query instead, and this is the dense statement of the same
-    rule to measure that range against.
     """
     same_document = tok_doc_idx[None, :, None] == entry_doc_idx[None, None, :]
-    return same_document & (threshold.unsqueeze(-1) > entry_local_idx[None, None, :])
+    closed_before_query = threshold.unsqueeze(-1) > entry_local_idx[None, None, :]
+    return same_document & closed_before_query
 
 
 def block_bias_from_indices(top_k_indices: Tensor, n_entries: int, dtype: torch.dtype) -> Tensor:
@@ -116,20 +108,3 @@ def dense_mask_from_indices(indices: Tensor, n_positions: int, dtype: torch.dtyp
     mask = torch.full((batch, 1, seq_len, n_positions + 1), float("-inf"), dtype=dtype, device=indices.device)
     mask.scatter_(-1, safe, 0.0)
     return mask[..., :n_positions].contiguous()
-
-
-def indexer_scores(q: Tensor, compressed_kv: Tensor, weights: Tensor) -> Tensor:
-    """Lightning-Indexer score `score[b,t,e] = sum_h w[b,t,h] * relu(sum_d q[b,t,h,d] k[b,e,d])`.
-
-    `q` is `(batch, seq_len, heads, dim)`, `compressed_kv` is `(batch, n_entries, dim)`, `weights`
-    is `(batch, seq_len, heads)`, and the result is `(batch, seq_len, n_entries)`, in float32.
-
-    This is the standard `fp8_indexer` is measured against: the same formula, in float32 and
-    through the `(batch, seq_len, heads, n_entries)` intermediate the kernel exists to avoid, so
-    the only difference between the two is the kernel's FP8 quantization. Both constant scales the
-    model applies, `index_head_dim ** -0.5` and `index_n_heads ** -0.5`, are dropped here because
-    the kernel drops them too, and being positive they cannot change which entries a top-k selects.
-    """
-    scores = q.float() @ compressed_kv.transpose(-1, -2).float().unsqueeze(1)
-    scores = F.relu(scores) * weights.float().unsqueeze(-1)
-    return scores.sum(dim=2)

--- a/src/prime_rl/trainer/models/deepseek_v4/eager_reference.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/eager_reference.py
@@ -57,23 +57,6 @@ def build_sliding_window_mask(*, tok_doc_idx: Tensor, sliding_window: int, dtype
     return mask.masked_fill_(~readable, torch.finfo(dtype).min)[None, None]
 
 
-def token_entry_causal_mask(
-    *, tok_doc_idx: Tensor, entry_doc_idx: Tensor, entry_local_idx: Tensor, threshold: Tensor
-) -> Tensor:
-    """`(1, seq_len, n_entries)` bool: which compressed entries each query token may read.
-
-    Element `[0, t, e]` is true when query token `t` may read entry `e`. Both of these have to
-    hold:
-
-    - `e` belongs to `t`'s own document, so no query reads another document's history;
-    - `e` closed before `t` arrived, i.e. its index within that document is below
-      `threshold[0, t]`, the count of entries the query's position has completed.
-    """
-    same_document = tok_doc_idx[None, :, None] == entry_doc_idx[None, None, :]
-    closed_before_query = threshold.unsqueeze(-1) > entry_local_idx[None, None, :]
-    return same_document & closed_before_query
-
-
 def block_bias_from_indices(top_k_indices: Tensor, n_entries: int, dtype: torch.dtype) -> Tensor:
     """Render the indexer's picks as the dense additive `(batch, 1, seq_len, n_entries)` bias.
 

--- a/tests/unit/train/models/test_deepseek_v4.py
+++ b/tests/unit/train/models/test_deepseek_v4.py
@@ -45,8 +45,10 @@ MODEL = dict(
         "sliding_attention",
     ],
     compress_rates={"compressed_sparse_attention": 4, "heavily_compressed_attention": 8},
-    index_n_heads=4,
-    index_head_dim=24,
+    # The real V4-Flash Lightning Indexer shapes. `fp8_indexer` is the only indexer path and it
+    # does `tl.arange(0, index_head_dim)`, so the dimension has to be a power of two.
+    index_n_heads=64,
+    index_head_dim=128,
     # Smaller than the number of compressed entries the sequence yields, so the Lightning
     # Indexer's selection has to actually discard some of them.
     index_topk=2,

--- a/tests/unit/train/models/test_deepseek_v4_kernels.py
+++ b/tests/unit/train/models/test_deepseek_v4_kernels.py
@@ -782,44 +782,6 @@ def test_absent_slots_are_marked_negative_rather_than_pointed_at_a_pad_row(doc_l
     )
 
 
-@pytest.mark.parametrize("doc_lens", V4FLASH_DOC_LENS, ids=V4FLASH_DOC_IDS)
-def test_indexer_picks_match_the_dense_causal_mask(doc_lens):
-    """Every pick the FP8 indexer returns is one the dense per-document causal mask admits.
-
-    The kernel is handed a contiguous `[ks, ke)` range rather than that mask, so this pins the
-    range arithmetic in `DeepseekV4Indexer.forward` against the mask it is meant to reproduce.
-    """
-    module = v4flash_attention(V4FLASH_CSA_LAYER, dtype=torch.bfloat16)
-    indexer = module.compressor.indexer
-    packed = _packed_context(doc_lens, torch.bfloat16, _v4flash_config())
-    with torch.device("cuda"):
-        hidden_states = torch.randn(1, sum(doc_lens), V4FLASH_MODEL["hidden_size"], dtype=torch.bfloat16)
-
-    with torch.no_grad():
-        q_residual = module.q_a_norm(module.q_a_proj(hidden_states))
-        picks = indexer(hidden_states, q_residual, packed)
-
-    layout = packed.compression_layouts[V4FLASH_COMPRESS_RATE]
-    readable = eager_reference.token_entry_causal_mask(
-        tok_doc_idx=packed.tok_doc_idx,
-        entry_doc_idx=layout.entry_doc_idx,
-        entry_local_idx=layout.entry_local_idx,
-        threshold=indexer.compressor.causal_threshold(packed.position_ids),
-    )[0]
-    n_entries = readable.shape[-1]
-    selected = eager_reference.block_bias_from_indices(picks, n_entries, torch.float32)[0, 0] == 0
-
-    stray = selected & ~readable
-    assert not stray.any(), f"{int(stray.sum())} picks name an entry the causal mask forbids"
-
-    # A query whose readable entries all fit in `index_topk` has nothing to rank away, so the two
-    # sides must agree exactly. `(2600,)` saturates and contributes only to the check above.
-    unsaturated = readable.sum(-1) <= indexer.index_topk
-    assert torch.equal(selected[unsaturated], readable[unsaturated]), (
-        "a query that could hold every entry it may read did not pick them all"
-    )
-
-
 # One CSA layer in bfloat16, so `PACKED_RTOL` (float32, and three orders of magnitude tighter than a kernel
 # accumulating bfloat16 inputs) does not apply, but neither does the whole-model bound `test_deepseek_v4.py`
 # carries, which is sized for four hyper-connected layers amplifying a bfloat16 expert floor.

--- a/tests/unit/train/models/test_deepseek_v4_kernels.py
+++ b/tests/unit/train/models/test_deepseek_v4_kernels.py
@@ -580,14 +580,17 @@ def _entry_counts(doc_lens: tuple[int, ...], compress_rate: int) -> list[int]:
 
 
 def _expected_picks(layer_type: str, doc_lens: tuple[int, ...]) -> int:
-    """How many pick slots every query of this layer type gets, on top of its local window."""
+    """How many pick slots every query of this layer type gets, on top of its local window.
+
+    CSA gets `index_topk` whatever the row holds, because `fp8_indexer` pads its output to the
+    requested width and the surplus comes back as `IGNORE_SLOT`. HCA's tracks the longest document.
+    """
     rate = V4FLASH_MODEL["compress_rates"].get(layer_type)
     if rate is None:
         return 0
-    counts = _entry_counts(doc_lens, rate)
     if layer_type == "heavily_compressed_attention":
-        return max(counts)
-    return min(V4FLASH_MODEL["index_topk"], sum(counts))
+        return max(_entry_counts(doc_lens, rate))
+    return V4FLASH_MODEL["index_topk"]
 
 
 def _hca_entries_admitted(doc_lens: tuple[int, ...]) -> torch.Tensor:
@@ -776,6 +779,44 @@ def test_absent_slots_are_marked_negative_rather_than_pointed_at_a_pad_row(doc_l
     )
     assert (first_query[first_query < 0] == IGNORE_SLOT).all(), (
         "an absent slot is negative but is not the `IGNORE_SLOT` marker"
+    )
+
+
+@pytest.mark.parametrize("doc_lens", V4FLASH_DOC_LENS, ids=V4FLASH_DOC_IDS)
+def test_indexer_picks_match_the_dense_causal_mask(doc_lens):
+    """Every pick the FP8 indexer returns is one the dense per-document causal mask admits.
+
+    The kernel is handed a contiguous `[ks, ke)` range rather than that mask, so this pins the
+    range arithmetic in `DeepseekV4Indexer.forward` against the mask it is meant to reproduce.
+    """
+    module = v4flash_attention(V4FLASH_CSA_LAYER, dtype=torch.bfloat16)
+    indexer = module.compressor.indexer
+    packed = _packed_context(doc_lens, torch.bfloat16, _v4flash_config())
+    with torch.device("cuda"):
+        hidden_states = torch.randn(1, sum(doc_lens), V4FLASH_MODEL["hidden_size"], dtype=torch.bfloat16)
+
+    with torch.no_grad():
+        q_residual = module.q_a_norm(module.q_a_proj(hidden_states))
+        picks = indexer(hidden_states, q_residual, packed)
+
+    layout = packed.compression_layouts[V4FLASH_COMPRESS_RATE]
+    readable = eager_reference.token_entry_causal_mask(
+        tok_doc_idx=packed.tok_doc_idx,
+        entry_doc_idx=layout.entry_doc_idx,
+        entry_local_idx=layout.entry_local_idx,
+        threshold=indexer.compressor.causal_threshold(packed.position_ids),
+    )[0]
+    n_entries = readable.shape[-1]
+    selected = eager_reference.block_bias_from_indices(picks, n_entries, torch.float32)[0, 0] == 0
+
+    stray = selected & ~readable
+    assert not stray.any(), f"{int(stray.sum())} picks name an entry the causal mask forbids"
+
+    # A query whose readable entries all fit in `index_topk` has nothing to rank away, so the two
+    # sides must agree exactly. `(2600,)` saturates and contributes only to the check above.
+    unsaturated = readable.sum(-1) <= indexer.index_topk
+    assert torch.equal(selected[unsaturated], readable[unsaturated]), (
+        "a query that could hold every entry it may read did not pick them all"
     )
 
 

--- a/tests/unit/train/models/test_fp8_indexer.py
+++ b/tests/unit/train/models/test_fp8_indexer.py
@@ -1,0 +1,232 @@
+from typing import NamedTuple
+
+import pytest
+import torch
+
+from prime_rl.trainer.models.deepseek_v4.eager_reference import indexer_scores
+from prime_rl.trainer.models.kernels.fp8_indexer import fp8_indexer
+
+# Plain tensors rather than a model: the modeling path around this kernel is covered in
+# test_deepseek_v4_kernels.py, and the kernel also serves GLM DSA, which has no DeepSeek V4 in it.
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9,
+        reason="the indexer kernel quantizes to Triton fp8e4nv (e4m3), only supported on Hopper (SM90) and newer",
+    ),
+]
+
+# The real DeepSeek V4 Flash Lightning Indexer shapes.
+HEADS, DIM, TOPK, COMPRESS_RATE = 64, 128, 512, 4
+
+# Twice as many entries as TOPK, so the selection has to actually discard some of them.
+SEQ_LEN = 2 * TOPK * COMPRESS_RATE
+N_ENTRIES = SEQ_LEN // COMPRESS_RATE
+
+# One document, then the same tokens split into three of uneven length, where `ks` stops being
+# zero. Every length is a multiple of COMPRESS_RATE, so both layouts yield exactly N_ENTRIES
+# entries and the two runs differ only in how the range is laid out.
+DOC_LENS = [(SEQ_LEN,), (1500, 500, 2096)]
+DOC_IDS = ["one-doc", "three-docs"]
+
+# FP8 quantization can only move a pick across the top-k boundary, so the two selections agree on
+# nearly every entry; the floor allows a query whose scores cluster at that boundary.
+AGREEMENT_MEAN, AGREEMENT_FLOOR = 0.95, 0.5
+
+# How far from the cutoff a disagreement may sit, against the score tensor's own scale.
+NEAR_TIE_RTOL = 5e-2
+
+
+@pytest.fixture(autouse=True)
+def _seed_rng():
+    torch.manual_seed(0)
+
+
+class _Layout(NamedTuple):
+    tok_doc: torch.Tensor  # (seq_len,) int64 - which document each token belongs to
+    tok_pos: torch.Tensor  # (seq_len,) int64 - position of each token within its own document
+    entry_doc: torch.Tensor  # (n_entries,) int64 - which document each entry belongs to
+    entry_local: torch.Tensor  # (n_entries,) int64 - entry index within its own document
+    first_entry: torch.Tensor  # (n_docs,) int64 - global index of each document's first entry
+
+
+def _layout(doc_lens: tuple[int, ...], device: torch.device) -> _Layout:
+    """Document bookkeeping for a packed row, which a single document is the one-element case of."""
+    docs = torch.arange(len(doc_lens), device=device)
+    lengths = torch.tensor(doc_lens, device=device)
+    counts = lengths // COMPRESS_RATE
+    return _Layout(
+        tok_doc=torch.repeat_interleave(docs, lengths),
+        tok_pos=torch.cat([torch.arange(length, device=device) for length in doc_lens]),
+        entry_doc=torch.repeat_interleave(docs, counts),
+        entry_local=torch.cat([torch.arange(int(count), device=device) for count in counts]),
+        first_entry=counts.cumsum(0) - counts,
+    )
+
+
+def _causal_range(layout: _Layout) -> tuple[torch.Tensor, torch.Tensor]:
+    """The half-open entry range `[ks, ke)` each query may read, in the global entry axis.
+
+    A document's entries are numbered consecutively, so the readable set is contiguous: it starts
+    at that document's first entry and runs as far as the query's position has closed windows.
+    """
+    ks = layout.first_entry[layout.tok_doc]
+    return ks, ks + (layout.tok_pos + 1) // COMPRESS_RATE
+
+
+def _readable_mask(ks: torch.Tensor, ke: torch.Tensor, n_entries: int) -> torch.Tensor:
+    """`(seq_len, n_entries)` bool: entry `e` is in query `t`'s range `[ks[t], ke[t])`."""
+    entry_idx = torch.arange(n_entries, device=ks.device)
+    return (entry_idx[None, :] >= ks[:, None]) & (entry_idx[None, :] < ke[:, None])
+
+
+def _isin_rows(query: torch.Tensor, table: torch.Tensor, sentinel_at: int) -> torch.Tensor:
+    """Per row: whether `query[row, i]` appears in `table[row, :]`.
+
+    Sorts `table` and binary-searches it rather than the simpler `query[..., None] ==
+    table[..., None, :]` broadcast, whose `(rows, len(query), len(table))` intermediate these
+    shapes cannot afford. A value `>= sentinel_at` never matches, since both sides pad unused
+    slots with a sentinel and two sentinels are not agreement.
+    """
+    sorted_table, _ = table.sort(dim=-1)
+    pos = torch.searchsorted(sorted_table, query.contiguous()).clamp(max=sorted_table.shape[-1] - 1)
+    found = torch.gather(sorted_table, -1, pos) == query
+    return found & (query < sentinel_at)
+
+
+class _Selections(NamedTuple):
+    # The raw kernel marks "no pick" with `N_ENTRIES`, not with the layer's `IGNORE_SLOT`; the
+    # conversion between the two lives in `DeepseekV4Indexer.forward`, downstream of this file.
+    readable: torch.Tensor  # (SEQ_LEN, N_ENTRIES) bool
+    score_ref: torch.Tensor  # (SEQ_LEN, N_ENTRIES) float32
+    score_ref_masked: torch.Tensor  # score_ref with unreadable entries set to -inf
+    ref_idx: torch.Tensor  # (SEQ_LEN, TOPK) int64, the float32 reference's picks
+    ref_idx_sentinel: torch.Tensor  # ref_idx, with picks the query can't actually read replaced by N_ENTRIES
+    kernel_idx: torch.Tensor  # (SEQ_LEN, TOPK) int64, the FP8 kernel's picks, sentinel = N_ENTRIES
+
+
+def _selections(doc_lens: tuple[int, ...]) -> _Selections:
+    """Build q/k/w at real shapes and compare the kernel's picks against the float32 reference.
+
+    Both sides read the same bfloat16 tensors, so the only difference the comparison measures is
+    the kernel's own FP8 quantization.
+    """
+    device = torch.device("cuda")
+    ks, ke = _causal_range(_layout(doc_lens, device))
+    readable = _readable_mask(ks, ke, N_ENTRIES)
+
+    q_bf16 = torch.randn(SEQ_LEN, HEADS, DIM, device=device).bfloat16()
+    k_bf16 = torch.randn(N_ENTRIES, DIM, device=device).bfloat16()
+    w_bf16 = torch.randn(SEQ_LEN, HEADS, device=device).bfloat16()
+
+    score_ref = indexer_scores(q_bf16.unsqueeze(0), k_bf16.unsqueeze(0), w_bf16.unsqueeze(0))[0]
+    score_ref_masked = score_ref.masked_fill(~readable, float("-inf"))
+
+    ref_idx = score_ref_masked.topk(TOPK, dim=-1).indices
+    ref_valid = readable.gather(-1, ref_idx)
+    ref_idx_sentinel = torch.where(ref_valid, ref_idx, torch.full_like(ref_idx, N_ENTRIES))
+
+    kernel_idx = fp8_indexer(q_bf16, k_bf16, w_bf16, ks.int(), ke.int(), TOPK).long()
+
+    return _Selections(readable, score_ref, score_ref_masked, ref_idx, ref_idx_sentinel, kernel_idx)
+
+
+@pytest.mark.parametrize("doc_lens", DOC_LENS, ids=DOC_IDS)
+def test_causal_range_matches_entry_span(doc_lens):
+    """`[ks, ke)` must equal a causality check derived independently, from each entry's token span.
+
+    On a packed row the two coordinate systems disagree for every document after the first, which
+    is where a range-based mask would go wrong.
+    """
+    layout = _layout(doc_lens, torch.device("cuda"))
+    ks, ke = _causal_range(layout)
+
+    entry_last_token = (layout.entry_local + 1) * COMPRESS_RATE - 1
+    same_document = layout.entry_doc[None, :] == layout.tok_doc[:, None]
+    expected = same_document & (entry_last_token[None, :] <= layout.tok_pos[:, None])
+
+    assert torch.equal(_readable_mask(ks, ke, N_ENTRIES), expected), (
+        "the readable range disagrees with the entries' token spans"
+    )
+
+
+@pytest.mark.parametrize("doc_lens", DOC_LENS, ids=DOC_IDS)
+def test_selection_agreement(doc_lens):
+    """Set agreement between the FP8 kernel and the float32 reference, mean/p1/min over queries.
+
+    The denominator is each query's own number of readable entries, capped at `TOPK`: an early
+    query may have only a handful of entries to pick from, and comparing it against the fixed
+    `TOPK` would read a mostly-empty selection as near-total disagreement.
+    """
+    s = _selections(doc_lens)
+
+    matches = _isin_rows(s.kernel_idx, s.ref_idx_sentinel, N_ENTRIES)
+    valid_count = (s.ref_idx_sentinel < N_ENTRIES).sum(-1)
+    agreement = matches.float().sum(-1) / valid_count.clamp(min=1)
+    # A query with no readable entries has no selection to agree or disagree on.
+    agreement = agreement[valid_count > 0]
+
+    mean, p1, minimum = agreement.mean().item(), agreement.quantile(0.01).item(), agreement.min().item()
+    assert mean > AGREEMENT_MEAN, f"mean set agreement {mean} below {AGREEMENT_MEAN}"
+    assert p1 > AGREEMENT_FLOOR, f"p1 set agreement {p1} below {AGREEMENT_FLOOR}"
+    assert minimum > AGREEMENT_FLOOR, f"min set agreement {minimum} below {AGREEMENT_FLOOR}"
+
+
+@pytest.mark.parametrize("doc_lens", DOC_LENS, ids=DOC_IDS)
+@pytest.mark.parametrize("restrict_to", [8, 32])
+def test_selection_agreement_restricted_to_strongest_picks(restrict_to, doc_lens):
+    """Agreement restricted to the strongest fp32-ranked picks, where a miss matters more."""
+    s = _selections(doc_lens)
+
+    strongest = s.ref_idx[:, :restrict_to]
+    valid_strongest = s.readable.gather(-1, strongest)
+    matches = _isin_rows(strongest, s.kernel_idx, N_ENTRIES) & valid_strongest
+
+    denom = valid_strongest.sum(-1).clamp(min=1)
+    agreement = matches.float().sum(-1) / denom
+    agreement = agreement[valid_strongest.any(-1)]
+
+    mean, minimum = agreement.mean().item(), agreement.min().item()
+    assert mean > AGREEMENT_MEAN, f"mean top-{restrict_to} agreement {mean} below {AGREEMENT_MEAN}"
+    assert minimum > AGREEMENT_FLOOR, f"min top-{restrict_to} agreement {minimum} below {AGREEMENT_FLOOR}"
+
+
+@pytest.mark.parametrize("doc_lens", DOC_LENS, ids=DOC_IDS)
+def test_disagreements_are_near_ties(doc_lens):
+    """Where the kernel and the reference disagree, the entry each picked scores almost the same.
+
+    Both are scored by the float32 reference, so the disagreement sits at the top-k boundary, which
+    is all quantization noise can move. Whether a boundary swap changes the layer's output is a
+    separate question score proximity cannot settle.
+    """
+    s = _selections(doc_lens)
+    scale = s.score_ref.abs().max().clamp(min=1.0)
+
+    sorted_scores, _ = s.score_ref_masked.sort(dim=-1, descending=True)
+    boundary_score = sorted_scores[:, TOPK - 1]
+    next_score = sorted_scores[:, TOPK]  # N_ENTRIES > TOPK, so there is always a next entry.
+
+    dropped_mask = s.readable.gather(-1, s.ref_idx)
+    dropped_mask &= ~_isin_rows(s.ref_idx, s.kernel_idx, N_ENTRIES)
+    dropped_scores = torch.gather(s.score_ref, -1, s.ref_idx).masked_fill(~dropped_mask, float("-inf"))
+    max_dropped_score = dropped_scores.max(dim=-1).values
+
+    kernel_valid = s.kernel_idx < N_ENTRIES
+    added_mask = kernel_valid & ~_isin_rows(s.kernel_idx, s.ref_idx_sentinel, N_ENTRIES)
+    # The sentinel is out of range for this gather; clamped here and masked out immediately below.
+    added_scores = torch.gather(s.score_ref, -1, s.kernel_idx.clamp(max=N_ENTRIES - 1)).masked_fill(
+        ~added_mask, float("inf")
+    )
+    min_added_score = added_scores.min(dim=-1).values
+
+    # The near-cutoff comparison only means anything once a query has TOPK candidates to rank;
+    # `test_selection_agreement` already covers the shorter ones, whose selection is every entry.
+    fully_ranked = torch.isfinite(boundary_score)
+    gap_drop = (max_dropped_score - boundary_score).clamp(min=0)[fully_ranked]
+    gap_add = (next_score - min_added_score).clamp(min=0)[fully_ranked]
+    gap = torch.maximum(gap_drop, gap_add)
+
+    relative_gap = (gap / scale).max().item()
+    assert relative_gap < NEAR_TIE_RTOL, (
+        f"the largest disagreement sits {relative_gap} of score scale past the cutoff, over {NEAR_TIE_RTOL}"
+    )

--- a/tests/unit/train/models/test_fp8_indexer.py
+++ b/tests/unit/train/models/test_fp8_indexer.py
@@ -1,5 +1,3 @@
-from typing import NamedTuple
-
 import pytest
 import torch
 
@@ -29,14 +27,7 @@ SEGMENT_IDS = ["one-segment", "three-segments"]
 # FP8 quantization can only move a pick across the top-k boundary, so the two selections agree on
 # nearly every key. `p1` is the 1st percentile over queries: a whole tile of queries going wrong
 # is more than one percent of them, so it shows up there rather than hiding in the mean.
-AGREEMENT_MEAN, AGREEMENT_P1 = 0.99, 0.97
-
-# The strongest picks sit nowhere near the boundary, so quantization does not reorder them out of
-# the selection at all. These leave room for a handful of queries to lose one anyway.
-STRONGEST_MEAN, STRONGEST_P1 = 0.999, 0.99
-
-# How far from the cutoff a disagreement may sit, against the score tensor's own scale.
-NEAR_TIE_RTOL = 5e-2
+AGREEMENT_MEAN, AGREEMENT_P1 = 0.98, 0.97
 
 
 @pytest.fixture(autouse=True)
@@ -61,143 +52,60 @@ def ranges(segments: tuple[tuple[int, int], ...]) -> tuple[torch.Tensor, torch.T
 
 
 def eager_score_reference(q: torch.Tensor, k: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
-    """`score[t,s] = sum_h w[t,h] relu(sum_d q[t,h,d] k[s,d])`, in float32."""
-    per_head = torch.relu(q.float() @ k.float().T)
+    """`score[t,s] = sum_h w[t,h] relu(sum_d q[t,h,d] k[s,d])`, in float32.
+
+    The kernel's own formula, through the `(NUM_Q, HEADS, NUM_K)` intermediate the kernel exists to
+    avoid, so the only difference between the two is the kernel's FP8 quantization. The ReLU is
+    in place because a second buffer that size is most of a gigabyte.
+    """
+    per_head = (q.float() @ k.float().T).relu_()
     return torch.einsum("th,ths->ts", w.float(), per_head)
 
 
-def readable_mask(ks: torch.Tensor, ke: torch.Tensor, num_k: int) -> torch.Tensor:
+def readable_mask(ks: torch.Tensor, ke: torch.Tensor) -> torch.Tensor:
     """`(NUM_Q, NUM_K)` bool: key `s` is in query `t`'s range `[ks[t], ke[t])`."""
-    key_idx = torch.arange(num_k, device=ks.device)
+    key_idx = torch.arange(NUM_K, device=ks.device)
     return (key_idx[None, :] >= ks[:, None]) & (key_idx[None, :] < ke[:, None])
 
 
-def isin_rows(query: torch.Tensor, table: torch.Tensor, sentinel_at: int) -> torch.Tensor:
-    """Per row: whether `query[row, i]` appears in `table[row, :]`.
+def selected_mask(picks: torch.Tensor) -> torch.Tensor:
+    """`(NUM_Q, NUM_K)` bool: which keys each query's picks name.
 
-    Sorts `table` and binary-searches it rather than the simpler `query[..., None] ==
-    table[..., None, :]` broadcast, whose `(rows, len(query), len(table))` intermediate these
-    shapes cannot afford. A value `>= sentinel_at` never matches, since both sides pad unused
-    slots with a sentinel and two sentinels are not agreement.
+    A query's unused slots come back holding `NUM_K`, the kernel's "no pick" sentinel, so they
+    scatter into one throwaway column that is sliced back off.
     """
-    sorted_table, _ = table.sort(dim=-1)
-    pos = torch.searchsorted(sorted_table, query.contiguous()).clamp(max=sorted_table.shape[-1] - 1)
-    found = torch.gather(sorted_table, -1, pos) == query
-    return found & (query < sentinel_at)
-
-
-class Selections(NamedTuple):
-    readable: torch.Tensor  # (NUM_Q, NUM_K) bool
-    score_ref: torch.Tensor  # (NUM_Q, NUM_K) float32
-    score_ref_masked: torch.Tensor  # score_ref with unreadable keys set to -inf
-    ref_idx: torch.Tensor  # (NUM_Q, TOPK) int64, the float32 reference's picks
-    ref_idx_sentinel: torch.Tensor  # ref_idx, with picks the query can't actually read replaced by NUM_K
-    kernel_idx: torch.Tensor  # (NUM_Q, TOPK) int64, the FP8 kernel's picks, sentinel = NUM_K
-
-
-def selections(segments: tuple[tuple[int, int], ...]) -> Selections:
-    """Build q/k/w at real shapes and compare the kernel's picks against the float32 reference.
-
-    Both sides read the same bfloat16 tensors, so the only difference the comparison measures is
-    the kernel's own FP8 quantization.
-    """
-    device = torch.device("cuda")
-    ks, ke = ranges(segments)
-    readable = readable_mask(ks, ke, NUM_K)
-
-    q_bf16 = torch.randn(NUM_Q, HEADS, DIM, device=device).bfloat16()
-    k_bf16 = torch.randn(NUM_K, DIM, device=device).bfloat16()
-    w_bf16 = torch.randn(NUM_Q, HEADS, device=device).bfloat16()
-
-    score_ref = eager_score_reference(q_bf16, k_bf16, w_bf16)
-    score_ref_masked = score_ref.masked_fill(~readable, float("-inf"))
-
-    ref_idx = score_ref_masked.topk(TOPK, dim=-1).indices
-    ref_valid = readable.gather(-1, ref_idx)
-    ref_idx_sentinel = torch.where(ref_valid, ref_idx, torch.full_like(ref_idx, NUM_K))
-
-    kernel_idx = fp8_indexer(q_bf16, k_bf16, w_bf16, ks.int(), ke.int(), TOPK).long()
-
-    return Selections(readable, score_ref, score_ref_masked, ref_idx, ref_idx_sentinel, kernel_idx)
+    mask = torch.zeros(NUM_Q, NUM_K + 1, dtype=torch.bool, device=picks.device)
+    return mask.scatter_(1, picks, True)[:, :NUM_K]
 
 
 @pytest.mark.parametrize("segments", SEGMENTS, ids=SEGMENT_IDS)
 def test_selection_agreement(segments):
-    """Set agreement between the FP8 kernel and the float32 reference, mean and p1 over queries.
+    """The FP8 kernel's picks against the float32 reference's, as sets, per query.
 
-    The denominator is each query's own number of readable keys, capped at `TOPK`: an early query
-    may have only a handful of keys to pick from, and comparing it against the fixed `TOPK` would
-    read a mostly-empty selection as near-total disagreement.
+    Both sides read the same bfloat16 tensors, so the only difference measured is the kernel's own
+    FP8 quantization. A query with no more than `TOPK` readable keys has nothing to rank away and
+    must name that whole set exactly; the statistics cover the saturated queries, the only ones a
+    pick can move across the top-k boundary of.
     """
-    s = selections(segments)
+    ks, ke = ranges(segments)
+    readable = readable_mask(ks, ke)
 
-    matches = isin_rows(s.kernel_idx, s.ref_idx_sentinel, NUM_K)
-    valid_count = (s.ref_idx_sentinel < NUM_K).sum(-1)
-    agreement = matches.float().sum(-1) / valid_count.clamp(min=1)
-    # A query with no readable keys has no selection to agree or disagree on.
-    agreement = agreement[valid_count > 0]
+    q = torch.randn(NUM_Q, HEADS, DIM, device="cuda").bfloat16()
+    k = torch.randn(NUM_K, DIM, device="cuda").bfloat16()
+    w = torch.randn(NUM_Q, HEADS, device="cuda").bfloat16()
 
+    scores = eager_score_reference(q, k, w).masked_fill(~readable, float("-inf"))
+    # A query with fewer than TOPK readable keys fills its surplus picks from the -inf columns.
+    ref_selected = selected_mask(scores.topk(TOPK, dim=-1).indices) & readable
+    kernel_selected = selected_mask(fp8_indexer(q, k, w, ks.int(), ke.int(), TOPK).long())
+
+    saturated = readable.sum(-1) > TOPK
+    assert torch.equal(kernel_selected[~saturated], ref_selected[~saturated]), (
+        "a query that could hold every key it may read did not pick them all"
+    )
+    assert saturated.any(), "vacuous probe: no query has more readable keys than it can pick"
+
+    agreement = (ref_selected & kernel_selected).sum(-1)[saturated] / TOPK
     mean, p1 = agreement.mean().item(), agreement.quantile(0.01).item()
     assert mean > AGREEMENT_MEAN, f"mean set agreement {mean} below {AGREEMENT_MEAN}"
     assert p1 > AGREEMENT_P1, f"p1 set agreement {p1} below {AGREEMENT_P1}"
-
-
-@pytest.mark.parametrize("segments", SEGMENTS, ids=SEGMENT_IDS)
-@pytest.mark.parametrize("n_strongest", [8, 32])
-def test_selection_agreement_restricted_to_strongest_picks(n_strongest, segments):
-    """Agreement restricted to the strongest fp32-ranked picks, where a miss matters more."""
-    s = selections(segments)
-
-    strongest = s.ref_idx[:, :n_strongest]
-    valid_strongest = s.readable.gather(-1, strongest)
-    matches = isin_rows(strongest, s.kernel_idx, NUM_K) & valid_strongest
-
-    denom = valid_strongest.sum(-1).clamp(min=1)
-    agreement = matches.float().sum(-1) / denom
-    agreement = agreement[valid_strongest.any(-1)]
-
-    mean, p1 = agreement.mean().item(), agreement.quantile(0.01).item()
-    assert mean > STRONGEST_MEAN, f"mean top-{n_strongest} agreement {mean} below {STRONGEST_MEAN}"
-    assert p1 > STRONGEST_P1, f"p1 top-{n_strongest} agreement {p1} below {STRONGEST_P1}"
-
-
-@pytest.mark.parametrize("segments", SEGMENTS, ids=SEGMENT_IDS)
-def test_disagreements_are_near_ties(segments):
-    """Where the kernel and the reference disagree, the key each picked scores almost the same.
-
-    Both are scored by the float32 reference, so the disagreement sits at the top-k boundary, which
-    is all quantization noise can move. Whether a boundary swap changes the layer's output is a
-    separate question score proximity cannot settle.
-    """
-    s = selections(segments)
-    scale = s.score_ref.abs().max().clamp(min=1.0)
-
-    sorted_scores, _ = s.score_ref_masked.sort(dim=-1, descending=True)
-    boundary_score = sorted_scores[:, TOPK - 1]
-    next_score = sorted_scores[:, TOPK]  # NUM_K > TOPK, so there is always a next key.
-
-    dropped_mask = s.readable.gather(-1, s.ref_idx)
-    dropped_mask &= ~isin_rows(s.ref_idx, s.kernel_idx, NUM_K)
-    dropped_scores = torch.gather(s.score_ref, -1, s.ref_idx).masked_fill(~dropped_mask, float("-inf"))
-    max_dropped_score = dropped_scores.max(dim=-1).values
-
-    kernel_valid = s.kernel_idx < NUM_K
-    added_mask = kernel_valid & ~isin_rows(s.kernel_idx, s.ref_idx_sentinel, NUM_K)
-    # The sentinel is out of range for this gather; clamped here and masked out immediately below.
-    added_scores = torch.gather(s.score_ref, -1, s.kernel_idx.clamp(max=NUM_K - 1)).masked_fill(
-        ~added_mask, float("inf")
-    )
-    min_added_score = added_scores.min(dim=-1).values
-
-    # The near-cutoff comparison only means anything once a query has TOPK candidates to rank;
-    # `test_selection_agreement` already covers the shorter ones, whose selection is every key.
-    fully_ranked = torch.isfinite(boundary_score)
-    assert fully_ranked.any(), "vacuous probe: no query reads TOPK keys, so no selection ranks any of them away"
-    gap_drop = (max_dropped_score - boundary_score).clamp(min=0)[fully_ranked]
-    gap_add = (next_score - min_added_score).clamp(min=0)[fully_ranked]
-    gap = torch.maximum(gap_drop, gap_add)
-
-    relative_gap = (gap / scale).max().item()
-    assert relative_gap < NEAR_TIE_RTOL, (
-        f"the largest disagreement sits {relative_gap} of score scale past the cutoff, over {NEAR_TIE_RTOL}"
-    )

--- a/tests/unit/train/models/test_fp8_indexer.py
+++ b/tests/unit/train/models/test_fp8_indexer.py
@@ -3,11 +3,8 @@ from typing import NamedTuple
 import pytest
 import torch
 
-from prime_rl.trainer.models.deepseek_v4.eager_reference import indexer_scores
 from prime_rl.trainer.models.kernels.fp8_indexer import fp8_indexer
 
-# Plain tensors rather than a model: the modeling path around this kernel is covered in
-# test_deepseek_v4_kernels.py, and the kernel also serves GLM DSA, which has no DeepSeek V4 in it.
 pytestmark = [
     pytest.mark.gpu,
     pytest.mark.skipif(
@@ -16,71 +13,66 @@ pytestmark = [
     ),
 ]
 
-# The real DeepSeek V4 Flash Lightning Indexer shapes.
-HEADS, DIM, TOPK, COMPRESS_RATE = 64, 128, 512, 4
+HEADS, DIM, TOPK = 64, 128, 512
 
-# Twice as many entries as TOPK, so the selection has to actually discard some of them.
-SEQ_LEN = 2 * TOPK * COMPRESS_RATE
-N_ENTRIES = SEQ_LEN // COMPRESS_RATE
+# How many queries and keys, the kernel's `S_q` and `S_k`. NUM_K >= 2 * TOPK, so the selection has
+# to discard some, and neither axis is a whole number of the kernel's widest tile, so its
+# ragged-tail masking runs.
+NUM_Q, NUM_K = 3000, 1060
 
-# One document, then the same tokens split into three of uneven length, where `ks` stops being
-# zero. Every length is a multiple of COMPRESS_RATE, so both layouts yield exactly N_ENTRIES
-# entries and the two runs differ only in how the range is laid out.
-DOC_LENS = [(SEQ_LEN,), (1500, 500, 2096)]
-DOC_IDS = ["one-doc", "three-docs"]
+# A segment is a run of queries over a run of keys. One segment, then three uneven ones, where
+# `ks` stops being zero. One segment holds more than TOPK keys, which is what it takes for a query
+# to have a full ranking to disagree about.
+SEGMENTS = [((NUM_Q, NUM_K),), ((700, 200), (500, 260), (1800, 600))]
+SEGMENT_IDS = ["one-segment", "three-segments"]
 
 # FP8 quantization can only move a pick across the top-k boundary, so the two selections agree on
-# nearly every entry; the floor allows a query whose scores cluster at that boundary.
-AGREEMENT_MEAN, AGREEMENT_FLOOR = 0.95, 0.5
+# nearly every key. `p1` is the 1st percentile over queries: a whole tile of queries going wrong
+# is more than one percent of them, so it shows up there rather than hiding in the mean.
+AGREEMENT_MEAN, AGREEMENT_P1 = 0.99, 0.97
+
+# The strongest picks sit nowhere near the boundary, so quantization does not reorder them out of
+# the selection at all. These leave room for a handful of queries to lose one anyway.
+STRONGEST_MEAN, STRONGEST_P1 = 0.999, 0.99
 
 # How far from the cutoff a disagreement may sit, against the score tensor's own scale.
 NEAR_TIE_RTOL = 5e-2
 
 
 @pytest.fixture(autouse=True)
-def _seed_rng():
+def seed_rng():
     torch.manual_seed(0)
 
 
-class _Layout(NamedTuple):
-    tok_doc: torch.Tensor  # (seq_len,) int64 - which document each token belongs to
-    tok_pos: torch.Tensor  # (seq_len,) int64 - position of each token within its own document
-    entry_doc: torch.Tensor  # (n_entries,) int64 - which document each entry belongs to
-    entry_local: torch.Tensor  # (n_entries,) int64 - entry index within its own document
-    first_entry: torch.Tensor  # (n_docs,) int64 - global index of each document's first entry
+def ranges(segments: tuple[tuple[int, int], ...]) -> tuple[torch.Tensor, torch.Tensor]:
+    """The half-open key range `[ks, ke)` each query may read, one segment after another.
 
-
-def _layout(doc_lens: tuple[int, ...], device: torch.device) -> _Layout:
-    """Document bookkeeping for a packed row, which a single document is the one-element case of."""
-    docs = torch.arange(len(doc_lens), device=device)
-    lengths = torch.tensor(doc_lens, device=device)
-    counts = lengths // COMPRESS_RATE
-    return _Layout(
-        tok_doc=torch.repeat_interleave(docs, lengths),
-        tok_pos=torch.cat([torch.arange(length, device=device) for length in doc_lens]),
-        entry_doc=torch.repeat_interleave(docs, counts),
-        entry_local=torch.cat([torch.arange(int(count), device=device) for count in counts]),
-        first_entry=counts.cumsum(0) - counts,
-    )
-
-
-def _causal_range(layout: _Layout) -> tuple[torch.Tensor, torch.Tensor]:
-    """The half-open entry range `[ks, ke)` each query may read, in the global entry axis.
-
-    A document's entries are numbered consecutively, so the readable set is contiguous: it starts
-    at that document's first entry and runs as far as the query's position has closed windows.
+    A segment's keys are contiguous, so its queries read a growing prefix of them: the first reads
+    none of the segment at all, the last reads all of it.
     """
-    ks = layout.first_entry[layout.tok_doc]
-    return ks, ks + (layout.tok_pos + 1) // COMPRESS_RATE
+    assert sum(n_q for n_q, _ in segments) == NUM_Q
+    assert sum(n_k for _, n_k in segments) == NUM_K
+    ks, ke, base = [], [], 0
+    for n_q, n_k in segments:
+        ks.append(torch.full((n_q,), base, device="cuda"))
+        ke.append(base + torch.arange(n_q, device="cuda") * n_k // (n_q - 1))
+        base += n_k
+    return torch.cat(ks), torch.cat(ke)
 
 
-def _readable_mask(ks: torch.Tensor, ke: torch.Tensor, n_entries: int) -> torch.Tensor:
-    """`(seq_len, n_entries)` bool: entry `e` is in query `t`'s range `[ks[t], ke[t])`."""
-    entry_idx = torch.arange(n_entries, device=ks.device)
-    return (entry_idx[None, :] >= ks[:, None]) & (entry_idx[None, :] < ke[:, None])
+def eager_score_reference(q: torch.Tensor, k: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+    """`score[t,s] = sum_h w[t,h] relu(sum_d q[t,h,d] k[s,d])`, in float32."""
+    per_head = torch.relu(q.float() @ k.float().T)
+    return torch.einsum("th,ths->ts", w.float(), per_head)
 
 
-def _isin_rows(query: torch.Tensor, table: torch.Tensor, sentinel_at: int) -> torch.Tensor:
+def readable_mask(ks: torch.Tensor, ke: torch.Tensor, num_k: int) -> torch.Tensor:
+    """`(NUM_Q, NUM_K)` bool: key `s` is in query `t`'s range `[ks[t], ke[t])`."""
+    key_idx = torch.arange(num_k, device=ks.device)
+    return (key_idx[None, :] >= ks[:, None]) & (key_idx[None, :] < ke[:, None])
+
+
+def isin_rows(query: torch.Tensor, table: torch.Tensor, sentinel_at: int) -> torch.Tensor:
     """Per row: whether `query[row, i]` appears in `table[row, :]`.
 
     Sorts `table` and binary-searches it rather than the simpler `query[..., None] ==
@@ -94,134 +86,113 @@ def _isin_rows(query: torch.Tensor, table: torch.Tensor, sentinel_at: int) -> to
     return found & (query < sentinel_at)
 
 
-class _Selections(NamedTuple):
-    # The raw kernel marks "no pick" with `N_ENTRIES`, not with the layer's `IGNORE_SLOT`; the
-    # conversion between the two lives in `DeepseekV4Indexer.forward`, downstream of this file.
-    readable: torch.Tensor  # (SEQ_LEN, N_ENTRIES) bool
-    score_ref: torch.Tensor  # (SEQ_LEN, N_ENTRIES) float32
-    score_ref_masked: torch.Tensor  # score_ref with unreadable entries set to -inf
-    ref_idx: torch.Tensor  # (SEQ_LEN, TOPK) int64, the float32 reference's picks
-    ref_idx_sentinel: torch.Tensor  # ref_idx, with picks the query can't actually read replaced by N_ENTRIES
-    kernel_idx: torch.Tensor  # (SEQ_LEN, TOPK) int64, the FP8 kernel's picks, sentinel = N_ENTRIES
+class Selections(NamedTuple):
+    readable: torch.Tensor  # (NUM_Q, NUM_K) bool
+    score_ref: torch.Tensor  # (NUM_Q, NUM_K) float32
+    score_ref_masked: torch.Tensor  # score_ref with unreadable keys set to -inf
+    ref_idx: torch.Tensor  # (NUM_Q, TOPK) int64, the float32 reference's picks
+    ref_idx_sentinel: torch.Tensor  # ref_idx, with picks the query can't actually read replaced by NUM_K
+    kernel_idx: torch.Tensor  # (NUM_Q, TOPK) int64, the FP8 kernel's picks, sentinel = NUM_K
 
 
-def _selections(doc_lens: tuple[int, ...]) -> _Selections:
+def selections(segments: tuple[tuple[int, int], ...]) -> Selections:
     """Build q/k/w at real shapes and compare the kernel's picks against the float32 reference.
 
     Both sides read the same bfloat16 tensors, so the only difference the comparison measures is
     the kernel's own FP8 quantization.
     """
     device = torch.device("cuda")
-    ks, ke = _causal_range(_layout(doc_lens, device))
-    readable = _readable_mask(ks, ke, N_ENTRIES)
+    ks, ke = ranges(segments)
+    readable = readable_mask(ks, ke, NUM_K)
 
-    q_bf16 = torch.randn(SEQ_LEN, HEADS, DIM, device=device).bfloat16()
-    k_bf16 = torch.randn(N_ENTRIES, DIM, device=device).bfloat16()
-    w_bf16 = torch.randn(SEQ_LEN, HEADS, device=device).bfloat16()
+    q_bf16 = torch.randn(NUM_Q, HEADS, DIM, device=device).bfloat16()
+    k_bf16 = torch.randn(NUM_K, DIM, device=device).bfloat16()
+    w_bf16 = torch.randn(NUM_Q, HEADS, device=device).bfloat16()
 
-    score_ref = indexer_scores(q_bf16.unsqueeze(0), k_bf16.unsqueeze(0), w_bf16.unsqueeze(0))[0]
+    score_ref = eager_score_reference(q_bf16, k_bf16, w_bf16)
     score_ref_masked = score_ref.masked_fill(~readable, float("-inf"))
 
     ref_idx = score_ref_masked.topk(TOPK, dim=-1).indices
     ref_valid = readable.gather(-1, ref_idx)
-    ref_idx_sentinel = torch.where(ref_valid, ref_idx, torch.full_like(ref_idx, N_ENTRIES))
+    ref_idx_sentinel = torch.where(ref_valid, ref_idx, torch.full_like(ref_idx, NUM_K))
 
     kernel_idx = fp8_indexer(q_bf16, k_bf16, w_bf16, ks.int(), ke.int(), TOPK).long()
 
-    return _Selections(readable, score_ref, score_ref_masked, ref_idx, ref_idx_sentinel, kernel_idx)
+    return Selections(readable, score_ref, score_ref_masked, ref_idx, ref_idx_sentinel, kernel_idx)
 
 
-@pytest.mark.parametrize("doc_lens", DOC_LENS, ids=DOC_IDS)
-def test_causal_range_matches_entry_span(doc_lens):
-    """`[ks, ke)` must equal a causality check derived independently, from each entry's token span.
+@pytest.mark.parametrize("segments", SEGMENTS, ids=SEGMENT_IDS)
+def test_selection_agreement(segments):
+    """Set agreement between the FP8 kernel and the float32 reference, mean and p1 over queries.
 
-    On a packed row the two coordinate systems disagree for every document after the first, which
-    is where a range-based mask would go wrong.
+    The denominator is each query's own number of readable keys, capped at `TOPK`: an early query
+    may have only a handful of keys to pick from, and comparing it against the fixed `TOPK` would
+    read a mostly-empty selection as near-total disagreement.
     """
-    layout = _layout(doc_lens, torch.device("cuda"))
-    ks, ke = _causal_range(layout)
+    s = selections(segments)
 
-    entry_last_token = (layout.entry_local + 1) * COMPRESS_RATE - 1
-    same_document = layout.entry_doc[None, :] == layout.tok_doc[:, None]
-    expected = same_document & (entry_last_token[None, :] <= layout.tok_pos[:, None])
-
-    assert torch.equal(_readable_mask(ks, ke, N_ENTRIES), expected), (
-        "the readable range disagrees with the entries' token spans"
-    )
-
-
-@pytest.mark.parametrize("doc_lens", DOC_LENS, ids=DOC_IDS)
-def test_selection_agreement(doc_lens):
-    """Set agreement between the FP8 kernel and the float32 reference, mean/p1/min over queries.
-
-    The denominator is each query's own number of readable entries, capped at `TOPK`: an early
-    query may have only a handful of entries to pick from, and comparing it against the fixed
-    `TOPK` would read a mostly-empty selection as near-total disagreement.
-    """
-    s = _selections(doc_lens)
-
-    matches = _isin_rows(s.kernel_idx, s.ref_idx_sentinel, N_ENTRIES)
-    valid_count = (s.ref_idx_sentinel < N_ENTRIES).sum(-1)
+    matches = isin_rows(s.kernel_idx, s.ref_idx_sentinel, NUM_K)
+    valid_count = (s.ref_idx_sentinel < NUM_K).sum(-1)
     agreement = matches.float().sum(-1) / valid_count.clamp(min=1)
-    # A query with no readable entries has no selection to agree or disagree on.
+    # A query with no readable keys has no selection to agree or disagree on.
     agreement = agreement[valid_count > 0]
 
-    mean, p1, minimum = agreement.mean().item(), agreement.quantile(0.01).item(), agreement.min().item()
+    mean, p1 = agreement.mean().item(), agreement.quantile(0.01).item()
     assert mean > AGREEMENT_MEAN, f"mean set agreement {mean} below {AGREEMENT_MEAN}"
-    assert p1 > AGREEMENT_FLOOR, f"p1 set agreement {p1} below {AGREEMENT_FLOOR}"
-    assert minimum > AGREEMENT_FLOOR, f"min set agreement {minimum} below {AGREEMENT_FLOOR}"
+    assert p1 > AGREEMENT_P1, f"p1 set agreement {p1} below {AGREEMENT_P1}"
 
 
-@pytest.mark.parametrize("doc_lens", DOC_LENS, ids=DOC_IDS)
-@pytest.mark.parametrize("restrict_to", [8, 32])
-def test_selection_agreement_restricted_to_strongest_picks(restrict_to, doc_lens):
+@pytest.mark.parametrize("segments", SEGMENTS, ids=SEGMENT_IDS)
+@pytest.mark.parametrize("n_strongest", [8, 32])
+def test_selection_agreement_restricted_to_strongest_picks(n_strongest, segments):
     """Agreement restricted to the strongest fp32-ranked picks, where a miss matters more."""
-    s = _selections(doc_lens)
+    s = selections(segments)
 
-    strongest = s.ref_idx[:, :restrict_to]
+    strongest = s.ref_idx[:, :n_strongest]
     valid_strongest = s.readable.gather(-1, strongest)
-    matches = _isin_rows(strongest, s.kernel_idx, N_ENTRIES) & valid_strongest
+    matches = isin_rows(strongest, s.kernel_idx, NUM_K) & valid_strongest
 
     denom = valid_strongest.sum(-1).clamp(min=1)
     agreement = matches.float().sum(-1) / denom
     agreement = agreement[valid_strongest.any(-1)]
 
-    mean, minimum = agreement.mean().item(), agreement.min().item()
-    assert mean > AGREEMENT_MEAN, f"mean top-{restrict_to} agreement {mean} below {AGREEMENT_MEAN}"
-    assert minimum > AGREEMENT_FLOOR, f"min top-{restrict_to} agreement {minimum} below {AGREEMENT_FLOOR}"
+    mean, p1 = agreement.mean().item(), agreement.quantile(0.01).item()
+    assert mean > STRONGEST_MEAN, f"mean top-{n_strongest} agreement {mean} below {STRONGEST_MEAN}"
+    assert p1 > STRONGEST_P1, f"p1 top-{n_strongest} agreement {p1} below {STRONGEST_P1}"
 
 
-@pytest.mark.parametrize("doc_lens", DOC_LENS, ids=DOC_IDS)
-def test_disagreements_are_near_ties(doc_lens):
-    """Where the kernel and the reference disagree, the entry each picked scores almost the same.
+@pytest.mark.parametrize("segments", SEGMENTS, ids=SEGMENT_IDS)
+def test_disagreements_are_near_ties(segments):
+    """Where the kernel and the reference disagree, the key each picked scores almost the same.
 
     Both are scored by the float32 reference, so the disagreement sits at the top-k boundary, which
     is all quantization noise can move. Whether a boundary swap changes the layer's output is a
     separate question score proximity cannot settle.
     """
-    s = _selections(doc_lens)
+    s = selections(segments)
     scale = s.score_ref.abs().max().clamp(min=1.0)
 
     sorted_scores, _ = s.score_ref_masked.sort(dim=-1, descending=True)
     boundary_score = sorted_scores[:, TOPK - 1]
-    next_score = sorted_scores[:, TOPK]  # N_ENTRIES > TOPK, so there is always a next entry.
+    next_score = sorted_scores[:, TOPK]  # NUM_K > TOPK, so there is always a next key.
 
     dropped_mask = s.readable.gather(-1, s.ref_idx)
-    dropped_mask &= ~_isin_rows(s.ref_idx, s.kernel_idx, N_ENTRIES)
+    dropped_mask &= ~isin_rows(s.ref_idx, s.kernel_idx, NUM_K)
     dropped_scores = torch.gather(s.score_ref, -1, s.ref_idx).masked_fill(~dropped_mask, float("-inf"))
     max_dropped_score = dropped_scores.max(dim=-1).values
 
-    kernel_valid = s.kernel_idx < N_ENTRIES
-    added_mask = kernel_valid & ~_isin_rows(s.kernel_idx, s.ref_idx_sentinel, N_ENTRIES)
+    kernel_valid = s.kernel_idx < NUM_K
+    added_mask = kernel_valid & ~isin_rows(s.kernel_idx, s.ref_idx_sentinel, NUM_K)
     # The sentinel is out of range for this gather; clamped here and masked out immediately below.
-    added_scores = torch.gather(s.score_ref, -1, s.kernel_idx.clamp(max=N_ENTRIES - 1)).masked_fill(
+    added_scores = torch.gather(s.score_ref, -1, s.kernel_idx.clamp(max=NUM_K - 1)).masked_fill(
         ~added_mask, float("inf")
     )
     min_added_score = added_scores.min(dim=-1).values
 
     # The near-cutoff comparison only means anything once a query has TOPK candidates to rank;
-    # `test_selection_agreement` already covers the shorter ones, whose selection is every entry.
+    # `test_selection_agreement` already covers the shorter ones, whose selection is every key.
     fully_ranked = torch.isfinite(boundary_score)
+    assert fully_ranked.any(), "vacuous probe: no query reads TOPK keys, so no selection ranks any of them away"
     gap_drop = (max_dropped_score - boundary_score).clamp(min=0)[fully_ranked]
     gap_add = (next_score - min_added_score).clamp(min=0)[fully_ranked]
     gap = torch.maximum(gap_drop, gap_add)


### PR DESCRIPTION
Second of three stacked PRs, builds on #3479.

Scores the DeepSeek V4 Lightning Indexer with `fp8_indexer`, the fused Triton kernel GLM DSA already runs, dropping the eager float32 `(batch, seq_len, heads, entries)` intermediate.

The indexer now rejects a batch larger than 1 instead of looping over the batch axis: the entry ranges it hands the kernel are built from sample 0's causal thresholds, so every other sample would have been scored against the wrong range.
