### PR TITLE
feat(rl): add experimental Total Router Recall

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -299,6 +299,69 @@ This however is not free, it adds a significant overhead to the HTTP requests as
 
 Currently this feature is also not supported with CPU KV cache offload, which can have negative impact on the inference throughput.
 
+### Total Router Recall (experimental)
+
+Total Router Recall replays **expert IDs and captured FP32 routing coefficients**.
+It requires a vLLM build that implements `enable_return_routed_expert_weights`;
+the stock vLLM 0.28.0 package does not provide coefficient export.
+
+Add to an existing single-turn Qwen3-MoE RL recipe:
+
+```toml
+[trainer]
+enable_router_replay = true
+router_replay_mode = "ids_and_weights"
+
+[trainer.model]
+impl = "custom"
+freeze_moe_router = true
+ep = 1
+cp = 1
+
+[inference.vllm]
+moe_backend = "triton"
+```
+
+The managed launcher also enables
+`inference.vllm.enable_return_routed_expert_weights = true` and the existing ID
+capture flag. A standalone patched server needs both
+`--enable-return-routed-experts` and `--enable-return-routed-expert-weights` and the
+V2 runner. The Prime tokens endpoint requires `stream=false` for this mode.
+
+**Initial scope:** custom text-only Qwen3-MoE with normalized top-k routing and
+route scale 1, a supported modular vLLM routing backend, one generation call per
+branch, and trainer CP=EP=1. Reused-prefix/multi-turn full-mode traces, monolithic
+capture backends, speculation, disaggregated P/D and external KV offload are not
+supported and must fail rather than silently recompute coefficients. Ordinary
+in-engine prefix-cache hits remain part of the capture implementation.
+
+Direct replay bypasses the parameter-bearing router module and treats recorded
+weights as constants. Frozen router parameters remain registered for checkpointing;
+their forward hooks are not entered by the direct MoE path. Expert paths remain
+differentiable, but derivatives through the
+gating coefficients (including into incoming hidden states) are removed. This
+is not an STE or an exact gradient of the ordinary recomputed-router policy.
+Routing-confidence metrics are omitted in this mode; load counts describe actual
+dispatch slots, including zero-weight terminal/padding rows. Full-mode FSDP
+policies preserve FP32 coefficient inputs instead of casting them to BF16.
+
+The wire record pairs ID bytes, FP32 weights and input-row validity. Packing and
+truncation transform them together. CPU ingress also requires distinct expert IDs
+and normalized coefficients on real captured rows (with FP32 roundoff tolerance,
+without renormalizing the payload). A missing final sampled-token input row is
+allowed only where it cannot affect any later trained prediction; missing real
+context rows are errors. The existing IDs-only format and mode remain supported.
+
+FP32 weights add `4 * token_rows * layer_slots * top_k` bytes. For 32K rows,
+48 layers and top-8, weights add 48 MiB before HTTP/base64 overhead. Capture
+history also grows over the engine's CPU KV-slot pool. No out-of-band blob store
+or reduced-precision coefficient encoding is included in this MVP.
+
+**Qualification:** GPU eager/graph, prefix-cache and trainer FSDP/checkpoint tests
+must pass on the intended GPU/backend before this experimental mode is used for
+training. CPU tests alone do not establish GPU correctness, throughput or
+training-quality improvements.
+
 ### Sampling Replay
 
 Truncated sampling (`top_p < 1`, `top_k`) renormalizes the sampling distribution over a sampling mask of surviving token ids. The rollout logprobs reflect that (`logprobs_mode = "processed_logprobs"`), so the trainer must renormalize over the same mask — otherwise every importance ratio is biased and training collapses (DeepSeek V3.2's "Keep Sampling Mask", [arXiv:2512.02556](https://arxiv.org/abs/2512.02556) §3.1; Cognition's [SWE-1.7 post](https://cognition.com/blog/swe-1-7)). prime-rl handles this automatically: vLLM records the sampling mask at sampling time (`--return-sampling-mask`, native since vLLM 0.28) and the trainer renormalizes its logprobs over it.

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -136,6 +136,11 @@ class VllmConfig(BaseConfig):
     enable_return_routed_experts: bool = False
     """Return routed experts in responses."""
 
+    enable_return_routed_expert_weights: bool = False
+    """Return FP32 coefficients paired with routed expert IDs. Requires the TRR-patched
+    vLLM V2 runner and enable_return_routed_experts=true; unsupported by stock vLLM 0.28.
+    """
+
     @model_validator(mode="before")
     @classmethod
     def parse_extra_values(cls, data: dict) -> dict:
@@ -484,6 +489,17 @@ class InferenceConfig(BaseConfig):
     def validate_multi_node_requires_slurm(self):
         if self.deployment.type in ("multi_node", "disaggregated") and self.slurm is None:
             raise ValueError("Must use SLURM for multi-node / disaggregated deployment.")
+        return self
+
+    @model_validator(mode="after")
+    def validate_router_weight_capture(self):
+        if self.vllm.enable_return_routed_expert_weights:
+            if not self.vllm.enable_return_routed_experts:
+                raise ValueError("Routing-weight capture requires enable_return_routed_experts=true")
+            if self.deployment.type == "disaggregated" or self.use_pd_kv_transfer:
+                raise ValueError("Routing-weight capture does not support disaggregated P/D")
+            if self.kv_cache_offload is not None:
+                raise ValueError("Routing-weight capture does not support external KV cache offload")
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -608,9 +608,15 @@ class RLConfig(BaseConfig):
                         stacklevel=2,
                     )
                 self.inference.vllm.enable_return_routed_experts = True
+                if self.trainer.router_replay_mode == "ids_and_weights":
+                    self.inference.vllm.enable_return_routed_expert_weights = True
+                    # InferenceConfig validators ran before these managed flags were set.
+                    self.inference.validate_router_weight_capture()
             else:
                 warnings.warn(
-                    "Router replay is enabled, but inference is not configured. When manually starting the inference server, make sure to pass `--enable-return-routed-experts` to the vLLM server.",
+                    "Router replay is enabled, but inference is not configured. Pass "
+                    "`--enable-return-routed-experts` to the vLLM server. For ids_and_weights, "
+                    "also pass `--enable-return-routed-expert-weights` to a TRR-patched vLLM V2 server.",
                     stacklevel=2,
                 )
         return self

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -664,6 +664,12 @@ class TrainerConfig(BaseConfig):
     enable_router_replay: bool = False
     """Return routed experts in the batch so the trainer can replay routing. Requires ``enable_return_routed_experts=true`` on the vLLM server (or ``--enable-return-routed-experts``) and is only supported for custom models."""
 
+    router_replay_mode: Literal["ids", "ids_and_weights"] = "ids"
+    """Replay expert IDs only, or IDs and recorded FP32 coefficients (Total Router Recall).
+    The initial coefficient mode requires a frozen custom Qwen3-MoE router, CP=EP=1,
+    and single-turn rollouts from the patched vLLM V2 runner. It is not an STE mode.
+    """
+
     memory_profiler_path: Path | None = None
     """Path to write the memory profile to."""
 
@@ -788,4 +794,17 @@ class TrainerConfig(BaseConfig):
         if self.enable_router_replay and self.model.impl not in ("custom", "auto"):
             raise ValueError("Router replay is only supported with the custom implementation or auto mode")
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_router_weight_replay(self):
+        if self.router_replay_mode == "ids_and_weights":
+            if not self.enable_router_replay:
+                raise ValueError("ids_and_weights requires enable_router_replay=true")
+            if not self.model.freeze_moe_router:
+                raise ValueError("ids_and_weights requires model.freeze_moe_router=true")
+            if self.model.cp != 1 or self.model.ep != 1:
+                raise ValueError("ids_and_weights currently requires model.cp=1 and model.ep=1")
+            if self.model.vlm is not None:
+                raise ValueError("ids_and_weights currently supports text-only Qwen3-MoE")
         return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,6 +225,7 @@ prime = false
 prime-sandboxes = false
 prime-tunnel = false
 prime-evals = false
+prime-runs = false
 verifiers = false
 renderers = false
 prime-pydantic-config = false

--- a/src/prime_rl/inference/server.py
+++ b/src/prime_rl/inference/server.py
@@ -14,7 +14,11 @@ def setup_vllm_env(config: InferenceConfig):
     # for sampling-mask capture, but router replay remains on V1 because vLLM
     # rejects routed-expert capture with KV connectors and prime-rl's stitching
     # patch is V1-only. setdefault keeps an explicit env-var choice authoritative.
-    if config.enable_return_sampling_mask:
+    if config.vllm.enable_return_routed_expert_weights:
+        if os.environ.get("VLLM_USE_V2_MODEL_RUNNER", "1") != "1":
+            raise ValueError("Total Router Recall requires the patched vLLM V2 model runner")
+        os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"
+    elif config.enable_return_sampling_mask:
         os.environ.setdefault("VLLM_USE_V2_MODEL_RUNNER", "1")
     elif config.vllm.enable_return_routed_experts:
         use_v2_runner = config.deployment.type != "disaggregated"

--- a/src/prime_rl/inference/vllm/routed_experts.py
+++ b/src/prime_rl/inference/vllm/routed_experts.py
@@ -1,48 +1,97 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pybase64
-from vllm.outputs import RequestOutput
+
+if TYPE_CHECKING:
+    from vllm.outputs import RequestOutput
 
 
-def serialize_routed_experts(routed_experts: Any, start: int = 0) -> dict[str, Any] | None:
+def serialize_routed_experts(
+    routed_experts: Any,
+    start: int = 0,
+    *,
+    weights: Any = None,
+    num_experts: int | None = None,
+) -> dict[str, Any] | None:
     if routed_experts is None:
+        if weights is not None:
+            raise ValueError("Routing coefficients require paired expert IDs")
         return None
 
     array = np.asarray(routed_experts)
-    assert array.ndim == 3
-    assert np.issubdtype(array.dtype, np.integer)
-    dtype = np.uint8
-    if array.size:
-        assert array.min() >= 0
-        if array.max() > np.iinfo(np.uint8).max:
-            # Models with >256 experts (e.g. NemotronH Super/Ultra: 512) need wider
-            # indices. The payload self-describes via "dtype" so consumers pick it up.
-            assert array.max() <= np.iinfo(np.uint16).max
-            dtype = np.uint16
+    if array.ndim != 3 or any(n <= 0 for n in array.shape[1:]):
+        raise ValueError("Routing IDs must have shape [tokens, layers > 0, top_k > 0]")
+    if not np.issubdtype(array.dtype, np.integer):
+        raise ValueError("Routing IDs must have an integer dtype")
+    if type(start) is not int or start < 0:
+        raise ValueError("Routing start must be a nonnegative integer")
+    if num_experts is not None and (type(num_experts) is not int or not 0 < num_experts <= 65536):
+        raise ValueError("Routing payloads support 1..65536 logical experts")
+    # Read each bound at most once before narrowing. Unsigned IDs cannot be negative.
+    minimum = int(array.min()) if array.size and np.issubdtype(array.dtype, np.signedinteger) else 0
+    maximum = int(array.max()) if array.size else 0
+    if minimum < 0 or maximum > 65535:
+        raise ValueError("Routing payload contains an invalid expert ID")
+    if num_experts is not None and (maximum >= num_experts or array.shape[-1] > num_experts):
+        raise ValueError("Routing expert ID/top_k exceeds the model's expert count")
+    dtype = np.uint8 if (num_experts if num_experts is not None else maximum + 1) <= 256 else np.uint16
 
     compact = np.ascontiguousarray(array.astype(dtype, copy=False))
-    return {
+    payload = {
         "data": pybase64.b64encode(memoryview(compact)).decode("ascii"),
         "shape": list(compact.shape),
         "start": start,
         "dtype": np.dtype(dtype).name,
     }
+    if weights is not None:
+        coefficients = np.asarray(weights)
+        if coefficients.shape != array.shape or coefficients.dtype != np.float32:
+            raise ValueError("Routing coefficients must be FP32 with the same shape as expert IDs")
+        if not (coefficients.min(initial=0) >= 0 and coefficients.max(initial=0) <= 1):
+            raise ValueError("Routing v1 coefficients must be finite and in [0, 1]")
+        coefficients = np.ascontiguousarray(coefficients, dtype="<f4")
+        payload["format_version"] = 1
+        payload["weights"] = {
+            "data": pybase64.b64encode(memoryview(coefficients)).decode("ascii"),
+            "dtype": "float32",
+        }
+    return payload
 
 
 class RoutedExpertsCapture:
-    def __init__(self, generator: AsyncIterator[RequestOutput], start: int = 0):
+    def __init__(
+        self,
+        generator: AsyncIterator[RequestOutput],
+        start: int = 0,
+        *,
+        require_weights: bool = False,
+        num_experts: int | None = None,
+    ):
         self._generator = generator
         self._start = start
+        self._require_weights = require_weights
+        self._num_experts = num_experts
         self.routed_experts: dict[int, dict[str, Any]] = {}
 
     async def __aiter__(self):
         async for request_output in self._generator:
             for output in request_output.outputs:
-                encoded = serialize_routed_experts(getattr(output, "routed_experts", None), start=self._start)
+                ids = getattr(output, "routed_experts", None)
+                weights = getattr(output, "routed_expert_weights", None) if self._require_weights else None
+                if self._require_weights and output.finished() and (ids is None or weights is None):
+                    raise ValueError("Total Router Recall response is missing paired routing IDs/coefficients")
+                encoded = serialize_routed_experts(
+                    ids, start=self._start, weights=weights, num_experts=self._num_experts
+                )
                 if encoded is not None:
                     self.routed_experts[output.index] = encoded
+                    # The upstream response's .npy/base64 field is replaced below.
+                    # Keep the already serialized private payload and avoid encoding it twice.
+                    output.routed_experts = None
+                    if self._require_weights:
+                        output.routed_expert_weights = None
             yield request_output

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -221,6 +221,15 @@ def server(config: InferenceConfig):
     if lora_target_modules and not any("expert" in m for m in lora_target_modules):
         os.environ["PRIME_NO_MOE_LORA"] = "1"
 
+    if config.vllm.enable_return_routed_expert_weights:
+        from vllm.engine.arg_utils import EngineArgs
+
+        if not hasattr(EngineArgs, "enable_return_routed_expert_weights"):
+            raise RuntimeError(
+                "Total Router Recall requires the TRR-patched vLLM build; "
+                "stock vLLM does not export routing coefficients."
+            )
+
     namespace = config.to_namespace()
 
     parser = FlexibleArgumentParser(description="vLLM OpenAI-Compatible RESTful API server.")

--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -74,6 +74,11 @@ class PrimeRlServingTokens(ServingTokens):
         request: GenerateRequest,
         raw_request: Request | None = None,
     ) -> GenerateResponse | ErrorResponse | AsyncGenerator[str, None]:
+        if getattr(self.model_config, "enable_return_routed_expert_weights", False) and request.stream:
+            return self.create_error_response(
+                "Total Router Recall currently requires stream=false on the tokens endpoint"
+            )
+
         # Upstream parses ``request.kv_transfer_params`` but never threads it
         # into the engine, so decode receives an empty NIXL handshake and
         # re-prefills the prompt locally (~100x slower under concurrency).
@@ -103,6 +108,8 @@ class PrimeRlServingTokens(ServingTokens):
             capture = _GenerateRoutedExpertsCapture(
                 result_generator,
                 start=request.sampling_params.routed_experts_prompt_start,
+                require_weights=getattr(self.model_config, "enable_return_routed_expert_weights", False),
+                num_experts=self.model_config.get_num_experts(),
             )
             result_generator = capture
 

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -19,6 +19,7 @@ from collections.abc import Iterator
 
 import numpy as np
 import verifiers.v1 as vf
+from verifiers.v1.routing import RoutingData
 
 from prime_rl.transports.batch import TrainingSample
 from prime_rl.transports.batch.types import EncodedTensor, RoutedExperts, SamplingMask
@@ -49,7 +50,7 @@ def _encode_mm_kwargs(mm_items: dict[str, list[dict]]) -> dict[str, EncodedTenso
     return encoded or None
 
 
-def _encode_routed_experts(arr: np.ndarray | None, num_tokens: int) -> RoutedExperts | None:
+def _encode_routed_experts(arr: np.ndarray | RoutingData | None, num_tokens: int) -> RoutedExperts | None:
     """The branch's router-replay array (`[tokens, layers, top_k]`) -> the transport
     `RoutedExperts` the trainer replays. Defensively realigns the token axis to `num_tokens`
     (the trainer asserts `routed_experts.shape[0] == len(token_ids)`): truncate if longer,
@@ -57,6 +58,19 @@ def _encode_routed_experts(arr: np.ndarray | None, num_tokens: int) -> RoutedExp
     is a backstop."""
     if arr is None:
         return None
+    if isinstance(arr, RoutingData):
+        if len(arr) != num_tokens:
+            raise ValueError("Full routing must align exactly with branch input tokens")
+        # The verifier owns terminal-row validity; never manufacture missing
+        # real coefficients with the legacy truncate/zero-pad fallback below.
+        return RoutedExperts(
+            data=arr.ids.tobytes(),
+            shape=list(arr.ids.shape),
+            dtype=str(arr.ids.dtype),
+            weights=arr.weights.tobytes(),
+            valid=arr.valid.tobytes(),
+            format_version=1,
+        )
     arr = np.ascontiguousarray(arr)
     if arr.shape[0] > num_tokens:
         arr = arr[:num_tokens]

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -6,6 +6,14 @@ from typing import Any
 
 import numpy as np
 
+from prime_rl.transports.batch.routing import (
+    concatenate_routed_experts,
+    copy_routed_experts,
+    pad_routed_experts,
+    routing_compatible,
+    slice_routed_experts,
+    validate_routed_experts,
+)
 from prime_rl.transports.batch.types import EncodedTensor, MicroBatch, RoutedExperts, SamplingMask, TrainingSample
 
 # Backfill value per component weight stream when a packed sample doesn't
@@ -250,11 +258,7 @@ def balanced_partition(weights: Sequence[int], num_partitions: int) -> list[list
 
 
 def _copy_routed_experts(routed_experts: RoutedExperts) -> RoutedExperts:
-    return RoutedExperts(
-        data=routed_experts.data,
-        shape=list(routed_experts.shape),
-        dtype=routed_experts.dtype,
-    )
+    return copy_routed_experts(routed_experts)
 
 
 def _routed_experts_row_size(routed_experts: RoutedExperts) -> int:
@@ -262,20 +266,12 @@ def _routed_experts_row_size(routed_experts: RoutedExperts) -> int:
 
 
 def _slice_routed_experts(routed_experts: RoutedExperts, seq_len: int) -> RoutedExperts:
-    row_size = _routed_experts_row_size(routed_experts)
-    return RoutedExperts(
-        data=routed_experts.data[: seq_len * row_size],
-        shape=[seq_len, routed_experts.shape[1], routed_experts.shape[2]],
-        dtype=routed_experts.dtype,
-    )
+    return slice_routed_experts(routed_experts, 0, seq_len)
 
 
 def _pad_routed_experts(micro_batch: MicroBatch, padding_size: int) -> None:
-    routed_experts = micro_batch.routed_experts
-    assert routed_experts is not None
-    row_size = _routed_experts_row_size(routed_experts)
-    routed_experts.data += b"\0" * (padding_size * row_size)
-    routed_experts.shape[0] += padding_size
+    assert micro_batch.routed_experts is not None
+    micro_batch.routed_experts = pad_routed_experts(micro_batch.routed_experts, padding_size)
 
 
 _SAMPLING_MASK_ITEMSIZE = np.dtype(np.int32).itemsize
@@ -408,6 +404,14 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
     routed_experts = (
         _copy_routed_experts(training_example.routed_experts) if training_example.routed_experts is not None else None
     )
+    if routed_experts is not None and routed_experts.weights is not None:
+        _, _, valid = validate_routed_experts(routed_experts)
+        if routed_experts.shape[0] != len(input_ids):
+            raise ValueError("Full routing must align exactly with the source sample's input tokens")
+        # Validate before truncation. A shorter crop must not conceal a missing
+        # interior input row from a malformed/multi-turn source record.
+        if not valid[:-1].all():
+            raise ValueError("Full routing source may omit only the final unforwarded token row")
     # No copy needed: SamplingMask holds immutable bytes, and _pad_sampling_mask only
     # ever mutates _materialize_bin's own accumulator.
     sampling_mask = training_example.sampling_mask
@@ -532,6 +536,10 @@ class _MicroBatchBin:
             return False
         if (first_sample.routed_experts is None) != (sample.routed_experts is None):
             return False
+        if first_sample.routed_experts is not None and not routing_compatible(
+            first_sample.routed_experts, sample.routed_experts
+        ):
+            return False
 
         sample_is_mm = _is_multimodal_sample(sample)
         existing_mm_sample = self.first_multimodal_sample
@@ -597,7 +605,7 @@ def _materialize_bin(bin_content: _MicroBatchBin) -> MicroBatch:
     mm_kwargs: dict[str, EncodedTensor] | None = None
     streams: dict[str, list[float] | None] = {name: ([] if has_stream[name] else None) for name in STREAM_FILL}
     seq_lens: list[int] = []
-    routed_experts: RoutedExperts | None = None
+    routing_parts: list[RoutedExperts] = []
     sampling_mask: SamplingMask | None = SamplingMask(ids=b"", counts=b"") if has_sampling_mask else None
     trace_ids: list[str] = []
     branch_indices: list[int] = []
@@ -623,13 +631,7 @@ def _materialize_bin(bin_content: _MicroBatchBin) -> MicroBatch:
                 sample.mm_token_type_ids if sample.mm_token_type_ids is not None else [0] * sample_len
             )
         if sample.routed_experts is not None:
-            if routed_experts is None:
-                routed_experts = _copy_routed_experts(sample.routed_experts)
-            else:
-                assert routed_experts.dtype == sample.routed_experts.dtype
-                assert routed_experts.shape[1:] == sample.routed_experts.shape[1:]
-                routed_experts.data += sample.routed_experts.data
-                routed_experts.shape[0] += sample.routed_experts.shape[0]
+            routing_parts.append(sample.routed_experts)
         if sample.mm_kwargs is not None:
             if mm_kwargs is None:
                 mm_kwargs = copy.deepcopy(sample.mm_kwargs)
@@ -645,6 +647,7 @@ def _materialize_bin(bin_content: _MicroBatchBin) -> MicroBatch:
         trace_ids.extend(sample.trace_ids or [""] * len(sample.sequence_lengths))
         branch_indices.extend(sample.branch_indices or [-1] * len(sample.sequence_lengths))
 
+    routed_experts = concatenate_routed_experts(routing_parts) if routing_parts else None
     sequence_lengths = [len(sample.input_ids) for sample in bin_content.samples]
     assert sum(sequence_lengths) == len(input_ids), (sequence_lengths, len(input_ids))
     assert sum(seq_lens) == len(input_ids), (seq_lens, len(input_ids))
@@ -833,6 +836,8 @@ def _assert_token_arrays_aligned(micro_batch: MicroBatch) -> None:
         assert micro_batch.routed_experts.shape[0] == num_tokens, (
             f"routed_experts misaligned after packing: {micro_batch.routed_experts.shape[0]} != {num_tokens} tokens"
         )
+        if micro_batch.routed_experts.weights is not None:
+            validate_routed_experts(micro_batch.routed_experts)
     if micro_batch.sampling_mask is not None:
         mask_counts = np.frombuffer(micro_batch.sampling_mask.counts, dtype=np.int32)
         assert len(mask_counts) == num_tokens, (

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -54,6 +54,7 @@ from prime_rl.trainer.models.layers.moe import MoE, TokenChoiceTopKRouter
 from prime_rl.trainer.models.layers.mxfp8_linear import replace_linear_with_mxfp8_linear
 from prime_rl.trainer.moe_runtime import configure_moe_runtime
 from prime_rl.trainer.parallel_dims import ParallelDims
+from prime_rl.trainer.routing_replay import RoutingReplay, validate_routing_replay
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
@@ -508,8 +509,44 @@ def is_tt_moe_model(model: nn.Module) -> bool:
     return hasattr(model.config, "num_experts") or hasattr(model.config, "n_routed_experts")
 
 
+def validate_full_router_replay_model(
+    model: nn.Module, *, cp_size: int = 1, ep_size: int = 1, has_vlm: bool = False
+) -> None:
+    """Fail closed for the MVP's frozen, normalized custom Qwen3-MoE objective."""
+    from prime_rl.trainer.models.qwen3_moe import Qwen3MoeForCausalLM
+
+    if cp_size != 1 or ep_size != 1 or has_vlm:
+        raise ValueError("Full routing replay does not support CP>1, EP>1, or VLM training")
+    if not isinstance(model, Qwen3MoeForCausalLM):
+        raise ValueError("Full routing replay only supports the custom Qwen3-MoE model")
+    if not model.config.norm_topk_prob:
+        raise ValueError("Full routing replay requires Qwen3 normalized top-k coefficients")
+    layers = model.model.layers
+    if not layers or len(layers) != model.config.num_hidden_layers:
+        raise ValueError("Full routing replay requires the complete Qwen3 MoE layer layout")
+    for layer in layers:
+        moe = layer.mlp
+        if not isinstance(moe, MoE):
+            raise ValueError("Full routing replay requires an MoE block in every Qwen3 layer")
+        router = moe.router
+        if (
+            not isinstance(router, TokenChoiceTopKRouter)
+            or router.score_func != "softmax"
+            or not router.route_norm
+            or router.route_scale != 1.0
+            or moe.score_before_experts
+        ):
+            raise ValueError("Full routing replay requires Qwen3 normalized top-k weights with route scale 1")
+        if any(parameter.requires_grad for parameter in router.parameters()):
+            raise ValueError("Full routing replay requires frozen MoE router parameters")
+
+
 def get_load_balance_stats(
-    model: nn.Module, reset_stats: bool = True, try_to_avoid_padding_experts: bool = True
+    model: nn.Module,
+    reset_stats: bool = True,
+    try_to_avoid_padding_experts: bool = True,
+    *,
+    include_routing_confidence: bool = True,
 ) -> dict[str, Tensor | None]:
     per_layer_max_vio = []
     per_layer_routing_confidence = []
@@ -527,8 +564,9 @@ def get_load_balance_stats(
         max_vio = (tokens_per_expert.max() - balanced_load) / balanced_load
         per_layer_max_vio.append(max_vio.detach())
 
-        routing_confidence = block_mlp.routing_confidence_sum / num_routed_tokens
-        per_layer_routing_confidence.append(routing_confidence.detach())
+        if include_routing_confidence:
+            routing_confidence = block_mlp.routing_confidence_sum / num_routed_tokens
+            per_layer_routing_confidence.append(routing_confidence.detach())
 
         if reset_stats:
             block_mlp.tokens_per_expert.zero_()
@@ -537,7 +575,7 @@ def get_load_balance_stats(
         return {"max_vio": None, "routing_confidence": None}
     return {
         "max_vio": torch.stack(per_layer_max_vio),
-        "routing_confidence": torch.stack(per_layer_routing_confidence),
+        "routing_confidence": torch.stack(per_layer_routing_confidence) if per_layer_routing_confidence else None,
     }
 
 
@@ -775,8 +813,18 @@ def setup_processor(config: ModelConfig):
     return processor
 
 
-def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims):
-    mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=DTYPE_MAP[config.reduce_dtype])
+def setup_fsdp(
+    model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims, *, preserve_routing_weights: bool = False
+):
+    # FSDP recursively casts floating forward inputs, including tensors inside a
+    # NamedTuple. Full replay must keep its recorded coefficients in FP32 at the
+    # root and every nested FSDP boundary. Qwen hidden states already have the
+    # parameter compute dtype; no blanket input cast is needed for this mode.
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16,
+        reduce_dtype=DTYPE_MAP[config.reduce_dtype],
+        cast_forward_inputs=not preserve_routing_weights,
+    )
     offload_policy: OffloadPolicy = CPUOffloadPolicy(pin_memory=True) if config.fsdp_cpu_offload else OffloadPolicy()
 
     shard_placement_fn = get_fsdp_shard_placement_fn(model) if config.fusions.shard_fused_on_dim1 else None
@@ -823,7 +871,11 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
             fully_shard(
                 block_mlp.router,
                 mesh=hsdp_mesh,
-                mp_policy=MixedPrecisionPolicy(param_dtype=torch.float32, reduce_dtype=torch.float32),
+                mp_policy=MixedPrecisionPolicy(
+                    param_dtype=torch.float32,
+                    reduce_dtype=torch.float32,
+                    cast_forward_inputs=not preserve_routing_weights,
+                ),
                 offload_policy=offload_policy,
                 reshard_after_forward=config.reshard_after_forward,
                 shard_placement_fn=shard_placement_fn,
@@ -1240,6 +1292,8 @@ def setup_model(
     config: ModelConfig,
     parallel_dims: ParallelDims,
     loading_from_checkpoint_later: bool = False,
+    *,
+    full_router_replay: bool = False,
 ) -> nn.Module:
     resolve_auto_attn(config)
 
@@ -1317,7 +1371,7 @@ def setup_model(
     if config.compile is not None:
         apply_compile(model, config.compile)
 
-    setup_fsdp(model, config, parallel_dims)
+    setup_fsdp(model, config, parallel_dims, preserve_routing_weights=full_router_replay)
 
     if not possible_to_load_to_meta:
         _move_buffers_to_cuda(model, config)
@@ -1357,7 +1411,7 @@ def forward(
     seq_lens: Int[Tensor, "segments"],
     labels: Int[Tensor, "batch seq"] | None = None,
     temperature: Tensor | None = None,
-    routed_experts: Int[Tensor, "batch seq layers topk"] | None = None,
+    routed_experts: Int[Tensor, "batch seq layers topk"] | RoutingReplay | None = None,
     sampling_mask: Int[Tensor, "batch seq mask"] | None = None,
     # Generic multimodal kwargs (e.g. {"pixel_values": ...,
     # "image_grid_thw": ...} for Qwen3-VL; just {"pixel_values": ...}
@@ -1397,6 +1451,15 @@ def forward(
         kwargs["seq_lens"] = seq_lens
         kwargs["seq_lens_are_pre_shard"] = seq_lens_are_pre_shard
 
+    if isinstance(routed_experts, RoutingReplay):
+        validate_full_router_replay_model(
+            model, cp_size=2 if seq_lens_are_pre_shard else 1, has_vlm=bool(mm_kwargs) or mm_token_type_ids is not None
+        )
+        validate_routing_replay(
+            routed_experts,
+            expected_shape=(*input_ids.shape, model.config.num_hidden_layers, model.config.num_experts_per_tok),
+            device=input_ids.device,
+        )
     if routed_experts is not None:
         kwargs["routed_experts"] = routed_experts
 

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -17,6 +17,7 @@ from prime_rl.trainer.models.fusions import fuse_gate_up_projections
 from prime_rl.trainer.models.layers.activations import ActivationDispatch, ActivationType
 from prime_rl.trainer.models.layers.grouped_gemm import BF16GroupedGemm, GroupedGemm
 from prime_rl.trainer.models.layers.mlp import ExpertType, FeedForward
+from prime_rl.trainer.routing_replay import RoutingReplay, replay_routing, validate_routing_replay
 
 ScoreFuncType = Literal["softmax", "sigmoid", "topk_softmax"]
 
@@ -229,12 +230,14 @@ class TokenChoiceTopKRouter(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        routed_experts: torch.Tensor | None = None,
+        routed_experts: torch.Tensor | RoutingReplay | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Args:
             x (torch.Tensor): Input tensor with shape ``(bs*slen, dim)``.
-            routed_experts (torch.Tensor | None, optional): Optional tensor with shape ``(bs * slen, top_k)``.
+            routed_experts (torch.Tensor | RoutingReplay | None, optional): Expert IDs, or paired IDs and
+                final FP32 coefficients, with shape ``(bs * slen, top_k)``. A pair skips all gate computation
+                and treats coefficients as constants. The loader must validate finite values and ID ranges.
 
         Returns:
             tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -243,10 +246,17 @@ class TokenChoiceTopKRouter(nn.Module):
                 - selected_experts_indices (torch.Tensor):
                     Expert indices selected for each token with shape ``(bs*slen, top_k)``.
                 - num_tokens_per_expert (torch.Tensor):
-                    Number of tokens assigned to each expert with shape ``(num_experts,)``.
+                    Number of dispatch assignments to each expert with shape ``(num_experts,)``.
+                    This includes zero-weight slots; RoutingReplay carries no captured-row validity mask.
                 - routing_confidence_sum (torch.Tensor):
                     Sum over tokens of the selected-expert probability mass before route normalization/scaling.
+                    NaN in direct replay: the trainer gate is not evaluated, so its confidence is unavailable.
         """
+        if isinstance(routed_experts, RoutingReplay):
+            return replay_routing(
+                routed_experts, num_tokens=x.shape[0], top_k=self.top_k, num_experts=self.num_experts, device=x.device
+            )
+
         # scores shape (bs*slen, num_experts)
         assert routed_experts is None or routed_experts.shape[-1] == self.top_k, (
             f"routed_experts shape: {routed_experts.shape}, top_k: {self.top_k}"
@@ -405,12 +415,13 @@ class MoE(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        routed_experts: torch.Tensor | None = None,
+        routed_experts: torch.Tensor | RoutingReplay | None = None,
     ) -> torch.Tensor:
         """
         Args:
             x (torch.Tensor): Input tensor with shape ``(bs, slen, dim)``.
-            routed_experts (torch.Tensor | None, optional): Optional tensor with shape ``(bs, slen, top_k)``.
+            routed_experts (torch.Tensor | RoutingReplay | None, optional): Expert IDs or paired IDs and
+                final FP32 coefficients with shape ``(bs, slen, top_k)``.
 
         Returns:
             out (torch.Tensor): Output tensor with shape ``(bs, slen, dim)``.
@@ -418,7 +429,15 @@ class MoE(nn.Module):
         bs, slen, dim = x.shape
         x = x.view(-1, dim)
 
-        if routed_experts is not None:
+        if isinstance(routed_experts, RoutingReplay):
+            validate_routing_replay(routed_experts, expected_shape=(bs, slen, self.router.top_k), device=x.device)
+            # Layer slices are non-contiguous. Flatten both streams in the same
+            # token order; checkpoint recomputation receives the same pair.
+            routed_experts = RoutingReplay(
+                routed_experts.ids.reshape(-1, self.router.top_k),
+                routed_experts.weights.reshape(-1, self.router.top_k),
+            )
+        elif routed_experts is not None:
             _, _, top_k = routed_experts.shape
             routed_experts = routed_experts.reshape(
                 -1, top_k
@@ -431,7 +450,17 @@ class MoE(nn.Module):
             selected_experts_indices,
             num_tokens_per_expert,
             routing_confidence_sum,
-        ) = self.router(x, routed_experts=routed_experts)
+        ) = (
+            replay_routing(
+                routed_experts,
+                num_tokens=x.shape[0],
+                top_k=self.router.top_k,
+                num_experts=self.router.num_experts,
+                device=x.device,
+            )
+            if isinstance(routed_experts, RoutingReplay)
+            else self.router(x, routed_experts=routed_experts)
+        )
 
         # Accumulate expert usage for selection-bias updates and metrics.
         with torch.no_grad():

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -35,6 +35,7 @@ from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
 from prime_rl.trainer.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
 from prime_rl.trainer.models.qwen3_moe.converting_qwen3_moe import conversion_chain
+from prime_rl.trainer.routing_replay import RoutingReplay, select_routing_layer
 from prime_rl.utils.sequence import get_cu_seqlens_from_seq_lens
 
 logger = logging.get_logger(__name__)
@@ -94,7 +95,7 @@ class Qwen3MoeDecoderLayer(GradientCheckpointingLayer):
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
-        routed_experts: Optional[torch.LongTensor] = None,
+        routed_experts: torch.Tensor | RoutingReplay | None = None,
     ) -> torch.FloatTensor:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
@@ -181,14 +182,16 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
-        routed_experts: Optional[torch.LongTensor] = None,
+        routed_experts: torch.Tensor | RoutingReplay | None = None,
         *,
         seq_lens: torch.LongTensor,
         seq_lens_are_pre_shard: bool = False,
     ) -> MoeModelOutputWithPast:
         """
-        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
-            Routed experts for each token in the sequence. Only used for router replay.
+        routed_experts (`torch.Tensor` or `RoutingReplay`, *optional*):
+            Expert IDs, or paired IDs and final FP32 coefficients, with shape
+            `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`.
+            A pair uses constant coefficients and skips the router gate.
         seq_lens (`torch.LongTensor` of shape `(num_documents,)`):
             Per-document lengths of the packed row (PrimeRL packed-batch contract).
         seq_lens_are_pre_shard (`bool`, *optional*, defaults to `False`):
@@ -210,7 +213,7 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
         for layer_idx, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
-            routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
+            routed_experts_layer = select_routing_layer(routed_experts, layer_idx)
             hidden_states = decoder_layer(
                 hidden_states,
                 position_embeddings=position_embeddings,
@@ -263,7 +266,7 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
         cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
-        routed_experts: Optional[torch.LongTensor] = None,
+        routed_experts: torch.Tensor | RoutingReplay | None = None,
         *,
         seq_lens: torch.LongTensor,
         seq_lens_are_pre_shard: bool = False,
@@ -284,8 +287,10 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
             (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Per-token temperatures for logprobs/entropy computation.
-        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
-            Routed experts for each token in the sequence. Only used for router replay.
+        routed_experts (`torch.Tensor` or `RoutingReplay`, *optional*):
+            Expert IDs, or paired IDs and final FP32 coefficients, with shape
+            `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`.
+            A pair uses constant coefficients and skips the router gate.
 
         Example:
 

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TypedDict
+from typing import Any, Literal, TypedDict
 
 import numpy as np
 import torch
@@ -7,6 +7,7 @@ from jaxtyping import Bool, Float, Int
 from torch import Tensor
 
 from prime_rl.configs.trainer import FakeDataLoaderConfig
+from prime_rl.trainer.routing_replay import RoutingReplay, validate_routing_replay
 from prime_rl.trainer.world import get_world
 from prime_rl.transports.batch import (
     BatchReceiver,
@@ -14,6 +15,7 @@ from prime_rl.transports.batch import (
     TransportConfig,
     setup_batch_receiver,
 )
+from prime_rl.transports.batch.routing import validate_routed_experts
 
 
 class TensorMicroBatch(TypedDict):
@@ -40,7 +42,7 @@ class TensorMicroBatch(TypedDict):
     seq_lens: Int[Tensor, "segments"]
 
     # MoE router replay
-    routed_experts: Int[Tensor, "batch seq layers topk"] | None
+    routed_experts: Int[Tensor, "batch seq layers topk"] | RoutingReplay | None
 
     # Sampling-mask token ids per position, padded with -1 to the micro batch's
     # maximum mask size. A row containing only -1 has no mask.
@@ -213,15 +215,18 @@ class DataLoader:
         routed_experts = None
         packed_routed_experts = micro_batch.routed_experts
         if packed_routed_experts is not None:
-            routed_experts = (
-                torch.frombuffer(
-                    packed_routed_experts.data,
-                    dtype=_torch_dtype(packed_routed_experts.dtype),
-                )
-                .reshape(packed_routed_experts.shape)
-                .to(torch.int32)
-                .unsqueeze(0)
-            )
+            ids, weights, valid = validate_routed_experts(packed_routed_experts)
+            if ids.shape[0] != len(micro_batch.input_ids):
+                raise ValueError("Routing rows must match the packed microbatch token count")
+            # Own the storage: bytes/NumPy views can be read-only or reused by a
+            # receiver while a previous microbatch awaits checkpoint backward.
+            id_tensor = torch.from_numpy(ids.astype(np.int32, copy=True)).unsqueeze(0)
+            if weights is not None:
+                _validate_packed_routing_validity(micro_batch, ids, weights, valid)
+                weight_tensor = torch.from_numpy(weights.astype(np.float32, copy=True)).unsqueeze(0)
+                routed_experts = RoutingReplay(id_tensor, weight_tensor)
+            else:
+                routed_experts = id_tensor
         sampling_mask = None
         packed_sampling_mask = micro_batch.sampling_mask
         if packed_sampling_mask is not None:
@@ -265,6 +270,106 @@ class DataLoader:
             if micro_batch.ref_kl_weights is not None
             else None,
         )
+
+
+def _validate_packed_routing_validity(
+    micro_batch: MicroBatch, ids: np.ndarray, weights: np.ndarray, valid: np.ndarray | None
+) -> None:
+    """Every input before a participating target needs captured routing.
+
+    A target token's loss uses its preceding input row. Thus the final target
+    row itself may be uncaptured, and zero-loss tails/padding need no routes.
+    Raw-sample ingress separately restricts missing captures to terminal rows;
+    this packed check protects the actual causal inputs of the training loss.
+    """
+    num_tokens = len(micro_batch.input_ids)
+    if valid is None or valid.shape != (num_tokens,):
+        raise ValueError("Full routing replay requires one validity flag per packed token")
+    if micro_batch.mm_kwargs or micro_batch.mm_token_type_ids is not None:
+        raise ValueError("Full routing replay does not support multimodal microbatches")
+    lengths = micro_batch.seq_lens
+    if (
+        not lengths
+        or any(length <= 0 for length in lengths)
+        or sum(lengths) != num_tokens
+        or lengths != micro_batch.sequence_lengths
+    ):
+        raise ValueError("Full routing replay requires aligned positive sequence_lengths and seq_lens")
+    for name in ("loss_mask", "rl_weights", "ce_weights", "ref_kl_weights"):
+        values = getattr(micro_batch, name)
+        if values is not None and len(values) != num_tokens:
+            raise ValueError(f"Full routing replay requires token-aligned {name}")
+    # The byte codec has already checked finite values and zero placeholders.
+    # Match the loss's actual RL membership; a zero-weight RL token is inactive.
+    participating = np.asarray(micro_batch.loss_mask, dtype=bool).copy()
+    if micro_batch.rl_weights is not None:
+        participating &= np.asarray(micro_batch.rl_weights) != 0
+    for stream in (micro_batch.ce_weights, micro_batch.ref_kl_weights):
+        if stream is not None:
+            participating |= np.asarray(stream) != 0
+    start = 0
+    for length in lengths:
+        end = start + length
+        targets = np.flatnonzero(participating[start:end])
+        if len(targets):
+            if targets[0] == 0:
+                raise ValueError("Full routing replay requires loss-masked sequence starts")
+            if not np.all(valid[start : start + int(targets[-1])]):
+                raise ValueError("Full routing replay is missing a causal input row before a participating target")
+        start = end
+
+    # Full v1 is normalized Qwen3 top-k, not arbitrary mixture coefficients.
+    # Check once at trainer ingress, while capture validity is still available.
+    # Do not renormalize/reorder the actual payload or inspect GPU values later.
+    if valid.any():
+        if not np.allclose(weights.sum(axis=-1)[valid], 1.0, rtol=1e-5, atol=1e-6):
+            raise ValueError("Captured full-replay rows must have normalized top-k coefficients")
+        ordered = np.sort(ids, axis=-1)
+        # K is small; check one slot pair at a time to bound temporary memory.
+        if any(
+            np.any((ordered[..., slot - 1] == ordered[..., slot]) & valid[:, None]) for slot in range(1, ids.shape[-1])
+        ):
+            raise ValueError("Captured full-replay rows must contain unique expert IDs")
+
+
+def prepare_router_replay(
+    micro_batch: TensorMicroBatch,
+    *,
+    enabled: bool,
+    mode: Literal["ids", "ids_and_weights"],
+    model_config: Any,
+) -> Tensor | RoutingReplay | None:
+    """Choose the objective and validate full routing bounds before any H2D copy."""
+    if mode not in ("ids", "ids_and_weights"):
+        raise ValueError(f"Unknown router replay mode: {mode}")
+    if mode == "ids_and_weights" and not enabled:
+        raise ValueError("ids_and_weights requires enable_router_replay=true")
+    if not enabled:
+        return None
+    replay = micro_batch["routed_experts"]
+    if replay is None:
+        raise ValueError("Router replay requires routed experts from inference (enable_return_routed_experts=True)")
+    if mode == "ids":
+        # Explicit IDs mode keeps the legacy recomputed-coefficient objective,
+        # even when the inference server supplied both streams.
+        return replay.ids if isinstance(replay, RoutingReplay) else replay
+    if not isinstance(replay, RoutingReplay):
+        raise ValueError("ids_and_weights requires captured routing weights; IDs-only data is insufficient")
+    if micro_batch.get("mm_kwargs") or micro_batch.get("mm_token_type_ids") is not None:
+        raise ValueError("Full routing replay does not support multimodal microbatches")
+    if getattr(model_config, "model_type", None) != "qwen3_moe":
+        raise ValueError("Full routing replay only supports custom Qwen3-MoE")
+    expected_shape = (
+        *micro_batch["input_ids"].shape,
+        model_config.num_hidden_layers,
+        model_config.num_experts_per_tok,
+    )
+    validate_routing_replay(replay, expected_shape=expected_shape, device=torch.device("cpu"))
+    if not torch.isfinite(replay.weights).all():
+        raise ValueError("Full routing replay weights must be finite")
+    if replay.ids.numel() and (replay.ids.min() < 0 or replay.ids.max() >= model_config.num_experts):
+        raise ValueError("Full routing replay expert IDs are outside the model's expert range")
+    return replay
 
 
 def _torch_dtype(name: str) -> torch.dtype:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -18,7 +18,7 @@ from prime_rl.trainer.ckpt import Progress, setup_ckpt_manager
 from prime_rl.trainer.optim import setup_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler
 from prime_rl.configs.trainer import TrainerConfig
-from prime_rl.trainer.rl.data import DataLoader, FakeDataLoader
+from prime_rl.trainer.rl.data import DataLoader, FakeDataLoader, prepare_router_replay
 from prime_rl.utils.cp import (
     gather_for_cp,
     gather_for_cp_wo_grad,
@@ -43,6 +43,7 @@ from prime_rl.trainer.model import (
     setup_model,
     is_tt_moe_model,
     get_load_balance_stats,
+    validate_full_router_replay_model,
 )
 from prime_rl.trainer.parallel_dims import get_parallel_dims, resolve_ep
 from prime_rl.trainer.perf import get_perf_counter
@@ -129,6 +130,12 @@ def train(config: TrainerConfig):
 
     # Initialize parallel dimensions
     parallel_dims = get_parallel_dims(config.model)
+    full_router_replay = config.router_replay_mode == "ids_and_weights"
+    if full_router_replay:
+        if not config.enable_router_replay or not config.model.freeze_moe_router:
+            raise ValueError("ids_and_weights requires enable_router_replay=true and model.freeze_moe_router=true")
+        if parallel_dims.cp != 1 or parallel_dims.ep != 1 or config.model.vlm is not None:
+            raise ValueError("Full routing replay does not support CP>1, EP>1, or VLM training")
 
     # Check for checkpoint to resume from
     checkpoint_step = None
@@ -147,7 +154,11 @@ def train(config: TrainerConfig):
     logger.info(f"Initializing model ({config.model})")
     t0 = time.perf_counter()
     loading_from_ckpt_later = checkpoint_step is not None
-    model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
+    model = setup_model(config.model, parallel_dims, loading_from_ckpt_later, full_router_replay=full_router_replay)
+    if full_router_replay:
+        validate_full_router_replay_model(
+            model, cp_size=parallel_dims.cp, ep_size=parallel_dims.ep, has_vlm=config.model.vlm is not None
+        )
     logger.debug(f"Initialized model in {format_time(time.perf_counter() - t0)}")
 
     if config.model.vlm is not None and not getattr(model, "supports_packed_multimodal_training", False):
@@ -352,6 +363,15 @@ def train(config: TrainerConfig):
         cp_size = parallel_dims.cp
 
         for micro_step, micro_batch in enumerate(micro_batches):
+            # Validate complete CPU routing inputs before transferring either
+            # stream. Full mode cannot silently degrade to IDs-only replay.
+            cpu_routing = prepare_router_replay(
+                micro_batch,
+                enabled=config.enable_router_replay,
+                mode=config.router_replay_mode,
+                model_config=model.config,
+            )
+            routed_experts = cpu_routing.to("cuda") if cpu_routing is not None else None
             input_ids = micro_batch["input_ids"].to("cuda")
             position_ids = micro_batch["position_ids"].to("cuda")
             advantages = micro_batch["advantages"].to("cuda")
@@ -363,19 +383,6 @@ def train(config: TrainerConfig):
             ref_kl_weights = (
                 micro_batch["ref_kl_weights"].to("cuda") if micro_batch["ref_kl_weights"] is not None else None
             )
-            routed_experts = (
-                micro_batch["routed_experts"].to("cuda") if micro_batch["routed_experts"] is not None else None
-            )
-
-            if routed_experts is None and config.enable_router_replay:
-                raise ValueError(
-                    "You must set `enable_return_routed_experts=True` in the inference config or pass `--enable-return-routed-experts` to vLLM server to use router replay."
-                )
-
-            if routed_experts is not None and not config.enable_router_replay:
-                # we could've gotten routed experts from the inference server, but we didn't enable router replay
-                routed_experts = None
-
             sampling_mask = (
                 micro_batch["sampling_mask"].to("cuda") if micro_batch["sampling_mask"] is not None else None
             )
@@ -561,7 +568,11 @@ def train(config: TrainerConfig):
             annotation_writer.export(micro_batch, out)
 
             if is_tt_moe_model(model):
-                load_balance_stats = get_load_balance_stats(model)
+                load_balance_stats = get_load_balance_stats(
+                    model,
+                    try_to_avoid_padding_experts=not full_router_replay,
+                    include_routing_confidence=not full_router_replay,
+                )
                 for k, v in load_balance_stats.items():
                     if v is not None:
                         tensors[k].append(v)

--- a/src/prime_rl/trainer/routing_replay.py
+++ b/src/prime_rl/trainer/routing_replay.py
@@ -1,0 +1,94 @@
+"""Immutable tensor inputs for direct routing replay.
+
+The loader owns validation of captured rows, finite coefficients and expert-ID
+ranges. These model-side helpers check tensor metadata without reading device
+values or adding per-layer host synchronizations.
+"""
+
+from typing import NamedTuple
+
+import torch
+
+
+class RoutingReplay(NamedTuple):
+    """Paired logical expert IDs and final FP32 coefficients, in recorded slot order.
+
+    The tuple is immutable, not its tensor storage. Callers must keep both tensors
+    unchanged until backward (including checkpoint recomputation) has finished.
+    Weights already include inference normalization/scaling. They are detached
+    when consumed by the router, not normalized or cast a second time.
+    """
+
+    ids: torch.Tensor
+    weights: torch.Tensor
+
+    def to(self, device: torch.device | str | int, *, non_blocking: bool = False) -> "RoutingReplay":
+        """Move both tensors together without changing their dtypes."""
+        return RoutingReplay(
+            self.ids.to(device=device, non_blocking=non_blocking),
+            self.weights.to(device=device, non_blocking=non_blocking),
+        )
+
+
+def validate_routing_replay(
+    replay: RoutingReplay,
+    *,
+    expected_shape: tuple[int, ...] | None = None,
+    device: torch.device | None = None,
+) -> None:
+    """Check metadata only; data-dependent validation belongs at loader ingress."""
+    if not isinstance(replay.ids, torch.Tensor) or not isinstance(replay.weights, torch.Tensor):
+        raise TypeError("RoutingReplay.ids and RoutingReplay.weights must be tensors")
+    if replay.ids.shape != replay.weights.shape:
+        raise ValueError("RoutingReplay IDs and weights must have the same shape")
+    if expected_shape is not None and replay.ids.shape != expected_shape:
+        raise ValueError(f"RoutingReplay shape {tuple(replay.ids.shape)} does not match expected {expected_shape}")
+    if replay.ids.dtype not in (torch.int32, torch.int64):
+        raise TypeError("RoutingReplay IDs must have dtype int32 or int64")
+    if replay.weights.dtype != torch.float32:
+        raise TypeError("RoutingReplay weights must have dtype float32")
+    if replay.ids.device != replay.weights.device:
+        raise ValueError("RoutingReplay IDs and weights must be on the same device")
+    if device is not None and replay.ids.device != device:
+        raise ValueError("RoutingReplay tensors must be on the same device as the hidden states")
+
+
+def replay_routing(
+    replay: RoutingReplay,
+    *,
+    num_tokens: int,
+    top_k: int,
+    num_experts: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Use captured coefficients without entering a parameter-bearing router module.
+
+    Bypassing the module call also avoids its FSDP pre-forward hooks. Parameters
+    remain registered for checkpointing. The loader validates values and ranges;
+    this hot path checks only metadata, preserves slot order and detaches weights.
+    """
+    validate_routing_replay(replay, expected_shape=(num_tokens, top_k), device=device)
+    weights = replay.weights.detach()
+    counts = torch.histc(replay.ids.reshape(-1).float(), bins=num_experts, min=0, max=num_experts).to(torch.int64)
+    # The trainer gate was not evaluated; its confidence is unavailable.
+    return weights, replay.ids, counts, weights.new_full((), float("nan"))
+
+
+def select_routing_layer(
+    routed_experts: torch.Tensor | RoutingReplay | None,
+    layer_idx: int,
+) -> torch.Tensor | RoutingReplay | None:
+    """Slice the layer axis of model inputs shaped ``[batch, sequence, layer, top_k]``."""
+    if routed_experts is None:
+        return None
+    if isinstance(routed_experts, RoutingReplay):
+        validate_routing_replay(routed_experts)
+        if routed_experts.ids.ndim != 4:
+            raise ValueError("Model RoutingReplay must have shape [batch, sequence, layer, top_k]")
+        return RoutingReplay(
+            routed_experts.ids[:, :, layer_idx, :],
+            routed_experts.weights[:, :, layer_idx, :],
+        )
+    if not isinstance(routed_experts, torch.Tensor):
+        raise TypeError("routed_experts must be a Tensor, RoutingReplay, or None")
+    return routed_experts[:, :, layer_idx, :]

--- a/src/prime_rl/transports/batch/routing.py
+++ b/src/prime_rl/transports/batch/routing.py
@@ -1,0 +1,153 @@
+"""Paired routing byte transforms, independent of the trainer/GPU runtime.
+
+Weights v1 are the Qwen3 captured FP32 coefficients (route scale 1), not logits.
+The arrays returned by validation are read-only views into immutable payload bytes.
+Token-causality validity is checked at sample/loader boundaries, not by this codec.
+"""
+
+import math
+from collections.abc import Sequence
+
+import numpy as np
+
+from prime_rl.transports.batch.types import RoutedExperts
+
+
+def validate_routed_experts(
+    routing: RoutedExperts,
+) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None]:
+    """Validate structure and values; return IDs, optional coefficients and validity.
+
+    Legacy integer dtypes remain accepted. Full mode requires compact little-endian
+    IDs. The actual model's expert/layer/top-k bounds must also be checked by the
+    trainer, which has the model configuration.
+    """
+    shape = routing.shape
+    if (
+        not isinstance(shape, list)
+        or len(shape) != 3
+        or any(type(n) is not int for n in shape)
+        or shape[0] < 0
+        or shape[1] <= 0
+        or shape[2] <= 0
+    ):
+        raise ValueError("routing shape must be [tokens >= 0, layers > 0, top_k > 0]")
+    try:
+        dtype = np.dtype(routing.dtype)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("invalid routing ID dtype") from exc
+    if not np.issubdtype(dtype, np.integer):
+        raise ValueError("routing IDs must have an integer dtype")
+    count = math.prod(shape)
+    if not isinstance(routing.data, bytes) or len(routing.data) != count * dtype.itemsize:
+        raise ValueError("routing ID byte count does not match shape/dtype")
+    ids = np.frombuffer(routing.data, dtype=dtype).reshape(shape)
+    if np.issubdtype(dtype, np.signedinteger) and ids.size and ids.min() < 0:
+        raise ValueError("routing IDs must be nonnegative")
+    if routing.weights is None:
+        if type(routing.format_version) is not int or routing.format_version != 0 or routing.valid is not None:
+            raise ValueError("legacy routing must have format_version=0 without coefficient validity")
+        return ids, None, None
+    if type(routing.format_version) is not int or routing.format_version != 1:
+        raise ValueError("routing coefficients require format_version=1")
+    if dtype not in (np.dtype("u1"), np.dtype("<u2")):
+        raise ValueError("routing v1 IDs must be little-endian uint8/uint16")
+    if not isinstance(routing.weights, bytes) or len(routing.weights) != count * 4:
+        raise ValueError("routing coefficient byte count does not match FP32 shape")
+    if not isinstance(routing.valid, bytes) or len(routing.valid) != shape[0]:
+        raise ValueError("routing validity must have one byte per token")
+    valid_bytes = np.frombuffer(routing.valid, dtype=np.uint8)
+    if np.any(valid_bytes > 1):
+        raise ValueError("routing validity bytes must be 0 or 1")
+    valid = valid_bytes.view(np.bool_)
+    weights = np.frombuffer(routing.weights, dtype="<f4").reshape(shape)
+    # NaNs propagate through min/max, so these scalar bounds also reject NaN
+    # and infinities without allocating coefficient-sized boolean temporaries.
+    if not (weights.min(initial=0) >= 0 and weights.max(initial=0) <= 1):
+        raise ValueError("routing v1 coefficients must be finite and in [0, 1]")
+    if np.any(weights[~valid] != 0):
+        raise ValueError("invalid routing rows must have zero placeholder coefficients")
+    return ids, weights, valid
+
+
+def routing_compatible(left: RoutedExperts, right: RoutedExperts) -> bool:
+    """Whether the two routing records can share one packed microbatch."""
+    return (
+        left.dtype == right.dtype
+        and left.shape[1:] == right.shape[1:]
+        and left.format_version == right.format_version
+        and (left.weights is None) == (right.weights is None)
+        and (left.valid is None) == (right.valid is None)
+    )
+
+
+def copy_routed_experts(routing: RoutedExperts) -> RoutedExperts:
+    """Own mutable shape metadata; reuse immutable byte storage."""
+    return RoutedExperts(
+        data=routing.data,
+        shape=list(routing.shape),
+        dtype=routing.dtype,
+        weights=routing.weights,
+        valid=routing.valid,
+        format_version=routing.format_version,
+    )
+
+
+def slice_routed_experts(routing: RoutedExperts, start: int, stop: int) -> RoutedExperts:
+    if not 0 <= start <= stop <= routing.shape[0]:
+        raise ValueError("routing slice is out of token range")
+    layer_slots = routing.shape[1] * routing.shape[2]
+    row_bytes = layer_slots * np.dtype(routing.dtype).itemsize
+    return RoutedExperts(
+        data=routing.data[start * row_bytes : stop * row_bytes],
+        shape=[stop - start, *routing.shape[1:]],
+        dtype=routing.dtype,
+        weights=(
+            routing.weights[start * layer_slots * 4 : stop * layer_slots * 4] if routing.weights is not None else None
+        ),
+        valid=routing.valid[start:stop] if routing.valid is not None else None,
+        format_version=routing.format_version,
+    )
+
+
+def concatenate_routed_experts(parts: Sequence[RoutedExperts]) -> RoutedExperts:
+    """Concatenate paired streams once, not repeated growing-prefix byte copies."""
+    if not parts:
+        raise ValueError("cannot concatenate empty routing list")
+    first = parts[0]
+    if not all(routing_compatible(first, part) for part in parts):
+        raise ValueError("cannot pack routing with different modes/dtypes/layouts")
+    return RoutedExperts(
+        data=b"".join(part.data for part in parts),
+        shape=[sum(part.shape[0] for part in parts), *first.shape[1:]],
+        dtype=first.dtype,
+        weights=b"".join(part.weights for part in parts) if first.weights is not None else None,
+        valid=b"".join(part.valid for part in parts) if first.valid is not None else None,
+        format_version=first.format_version,
+    )
+
+
+def pad_routed_experts(routing: RoutedExperts, count: int) -> RoutedExperts:
+    if count < 0:
+        raise ValueError("routing padding count must be nonnegative")
+    if count == 0:
+        return copy_routed_experts(routing)
+    ids, weights, valid = validate_routed_experts(routing)
+    shape = [count, *routing.shape[1:]]
+    if weights is None:
+        # Preserve legacy IDs-only padding behavior.
+        padding = RoutedExperts(data=bytes(math.prod(shape) * ids.dtype.itemsize), shape=shape, dtype=routing.dtype)
+    else:
+        # Spread zero-weight padding over a proven valid expert range. Avoid every
+        # padding slot dispatching to expert 0; actual model bounds are checked later.
+        upper = max(routing.shape[2], int(ids.max()) + 1 if ids.size else routing.shape[2])
+        padded_ids = (np.arange(math.prod(shape), dtype=np.int64) % upper).astype(ids.dtype).reshape(shape)
+        padding = RoutedExperts(
+            data=padded_ids.tobytes(),
+            shape=shape,
+            dtype=routing.dtype,
+            weights=bytes(math.prod(shape) * 4),
+            valid=bytes(count),
+            format_version=1,
+        )
+    return concatenate_routed_experts([routing, padding])

--- a/src/prime_rl/transports/batch/types.py
+++ b/src/prime_rl/transports/batch/types.py
@@ -16,6 +16,10 @@ class RoutedExperts(msgspec.Struct, array_like=True, gc=False, omit_defaults=Tru
     data: bytes
     shape: list[int]  # [seq_len, layers, topk]
     dtype: str
+    # Append-only for compatibility with positional legacy ID-only messages.
+    weights: bytes | None = None  # v1: little-endian FP32, same [tokens, layers, topk]
+    valid: bytes | None = None  # v1: one 0/1 byte per input-token row
+    format_version: int = 0  # 0 = legacy IDs-only; 1 = paired coefficients
 
 
 # Sampling masks for top-p/top-k replay: flat int32 token-id bytes plus an

--- a/tests/unit/inference/test_routed_expert_weights.py
+++ b/tests/unit/inference/test_routed_expert_weights.py
@@ -1,0 +1,136 @@
+import base64
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from verifiers.v1.routing import RoutingData, complete_routing_capture, decode_routing_payload
+
+from prime_rl.inference.vllm.routed_experts import RoutedExpertsCapture, serialize_routed_experts
+from prime_rl.orchestrator.trajectories import _encode_routed_experts
+from prime_rl.trainer.batch import prepare_sample
+from prime_rl.transports.batch.routing import validate_routed_experts
+from prime_rl.transports.batch.types import TrainingSample
+
+
+def arrays():
+    ids = (np.arange(3 * 2 * 2).reshape(3, 2, 2) % 8).astype(np.int32)
+    weights = np.broadcast_to(np.array([0.375, 0.625], dtype=np.float32), ids.shape).copy()
+    return ids, weights
+
+
+def test_serializer_legacy_payload_unchanged():
+    ids, _ = arrays()
+    payload = serialize_routed_experts(ids)
+    assert set(payload) == {"data", "shape", "start", "dtype"}
+    assert payload["dtype"] == "uint8"
+    assert base64.b64decode(payload["data"]) == ids.astype(np.uint8).tobytes()
+
+
+def test_serializer_dtype_stable_for_model_expert_range():
+    ids, weights = arrays()
+    payload = serialize_routed_experts(ids, weights=weights, num_experts=512)
+    assert payload["dtype"] == "uint16"
+    assert payload["format_version"] == 1
+    assert base64.b64decode(payload["weights"]["data"]) == weights.tobytes()
+
+
+@pytest.mark.parametrize("problem", ["no_ids", "wrong_shape", "bf16_like", "nan", "negative", "id_bound"])
+def test_serializer_rejects_unpaired_or_invalid_data(problem):
+    ids, weights = arrays()
+    if problem == "no_ids":
+        ids = None
+    if problem == "wrong_shape":
+        weights = weights[:-1]
+    if problem == "bf16_like":
+        weights = weights.astype(np.float16)
+    if problem == "nan":
+        weights[0, 0, 0] = float("nan")
+    if problem == "negative":
+        weights[0, 0, 0] = -0.5
+    if problem == "id_bound":
+        ids[0, 0, 0] = 8
+    with pytest.raises(ValueError):
+        serialize_routed_experts(ids, weights=weights, num_experts=8)
+
+
+def test_http_to_verifier_to_batch_preserves_exact_coefficients():
+    ids, weights = arrays()
+    payload = serialize_routed_experts(ids, weights=weights, num_experts=8)
+    routing, start = decode_routing_payload(payload, require_weights=True, num_experts=8)
+    assert start == 0 and isinstance(routing, RoutingData)
+    assert routing.weights.tobytes() == weights.tobytes()
+    routing = complete_routing_capture(routing, total_tokens=4, completion_tokens=2)
+    packed = _encode_routed_experts(routing, 4)
+    sample = TrainingSample(
+        token_ids=[10, 11, 12, 13],
+        mask=[False, False, True, True],
+        logprobs=[0, 0, -0.1, -0.2],
+        temperatures=[1] * 4,
+        advantages=[0, 0, 1, 1],
+        env_name="test",
+        routed_experts=packed,
+    )
+    micro = prepare_sample(sample, seq_len=4)
+    final_ids, final_weights, valid = validate_routed_experts(micro.routed_experts)
+    assert final_ids[:3].tobytes() == ids.astype(np.uint8).tobytes()
+    assert final_weights[:3].tobytes() == weights.tobytes()
+    assert valid.tolist() == [True, True, True, False]
+    assert not final_weights[-1].any()
+    with pytest.raises(ValueError, match="align exactly"):
+        _encode_routed_experts(routing, 3)
+
+
+@pytest.mark.asyncio
+async def test_capture_preserves_pair_and_avoids_discarded_encoding():
+    ids, weights = arrays()
+    output = SimpleNamespace(index=0, routed_experts=ids, routed_expert_weights=weights, finished=lambda: True)
+
+    async def stream():
+        yield SimpleNamespace(outputs=[output])
+
+    capture = RoutedExpertsCapture(stream(), require_weights=True, num_experts=8)
+    emitted = [item async for item in capture]
+    assert len(emitted) == 1
+    assert output.routed_experts is None
+    assert output.routed_expert_weights is None
+    assert base64.b64decode(capture.routed_experts[0]["weights"]["data"]) == weights.tobytes()
+
+
+@pytest.mark.asyncio
+async def test_capture_fails_when_finished_output_has_no_weights():
+    ids, _ = arrays()
+
+    async def stream():
+        yield SimpleNamespace(outputs=[SimpleNamespace(index=0, routed_experts=ids, finished=lambda: True)])
+
+    with pytest.raises(ValueError, match="missing paired"):
+        async for _ in RoutedExpertsCapture(stream(), require_weights=True):
+            pass
+
+
+@pytest.mark.parametrize("start", [-1, True, 0.5, "0"])
+def test_serializer_rejects_invalid_start_metadata(start):
+    ids, weights = arrays()
+    with pytest.raises(ValueError, match="nonnegative integer"):
+        serialize_routed_experts(ids, weights=weights, start=start)
+
+
+@pytest.mark.parametrize("num_experts", [0, 65537, True, 2.5, "8"])
+def test_serializer_rejects_invalid_model_expert_count(num_experts):
+    ids, weights = arrays()
+    with pytest.raises(ValueError, match="1..65536"):
+        serialize_routed_experts(ids, weights=weights, num_experts=num_experts)
+
+
+@pytest.mark.parametrize("ids", [np.zeros((2, 2)), np.zeros((2, 0, 2), dtype=np.int32), np.zeros((2, 2, 2))])
+def test_serializer_checks_id_metadata_without_asserts(ids):
+    with pytest.raises(ValueError, match="shape|integer dtype"):
+        serialize_routed_experts(ids)
+
+
+@pytest.mark.parametrize("value", [float("-inf"), float("inf"), float("nan"), 1.1])
+def test_serializer_rejects_invalid_full_v1_coefficients(value):
+    ids, weights = arrays()
+    weights[0, 0, 0] = value
+    with pytest.raises(ValueError, match="finite and in"):
+        serialize_routed_experts(ids, weights=weights)

--- a/tests/unit/inference/test_serving_tokens.py
+++ b/tests/unit/inference/test_serving_tokens.py
@@ -11,8 +11,11 @@ deltas here:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import numpy as np
 import pybase64
+import pytest
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
 from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateResponse, GenerateResponseChoice
 
@@ -88,3 +91,13 @@ def test_generate_response_post_process_replaces_upstream_routed_experts():
     payload = processed.model_dump(mode="json")
     assert payload["choices"][0]["routed_experts"] == compact_routed_experts
     assert payload["usage"]["total_tokens"] == 7
+
+
+@pytest.mark.asyncio
+async def test_full_routing_replay_rejects_streaming_before_upstream():
+    serving = SimpleNamespace(
+        model_config=SimpleNamespace(enable_return_routed_expert_weights=True),
+        create_error_response=lambda message: {"error": message},
+    )
+    response = await PrimeRlServingTokens.serve_tokens(serving, SimpleNamespace(stream=True))
+    assert "stream=false" in response["error"]

--- a/tests/unit/test_router_weight_configs.py
+++ b/tests/unit/test_router_weight_configs.py
@@ -1,0 +1,110 @@
+import os
+
+import pytest
+from pydantic import ValidationError
+
+from prime_rl.configs.inference import InferenceConfig
+from prime_rl.configs.rl import RLConfig
+from prime_rl.configs.trainer import TrainerConfig
+from prime_rl.inference.server import setup_vllm_env
+
+
+def full_trainer(**updates):
+    config = {
+        "enable_router_replay": True,
+        "router_replay_mode": "ids_and_weights",
+        "model": {"freeze_moe_router": True, "ep": 1, "cp": 1, "impl": "custom"},
+    }
+    config.update(updates)
+    return config
+
+
+def test_legacy_replay_defaults_unchanged():
+    config = TrainerConfig(enable_router_replay=True)
+    assert config.router_replay_mode == "ids"
+    assert not config.model.freeze_moe_router
+    assert not InferenceConfig().vllm.enable_return_routed_expert_weights
+
+
+def test_full_replay_config():
+    config = TrainerConfig.model_validate(full_trainer())
+    assert config.router_replay_mode == "ids_and_weights"
+    assert config.model.freeze_moe_router
+
+
+@pytest.mark.parametrize(
+    "override, message",
+    [
+        ({"enable_router_replay": False}, "enable_router_replay"),
+        ({"model": {"freeze_moe_router": False, "ep": 1}}, "freeze_moe_router"),
+        ({"model": {"freeze_moe_router": True, "ep": 2}}, "model.cp=1"),
+        ({"model": {"freeze_moe_router": True, "ep": 1, "cp": 2}}, "model.cp=1"),
+        ({"model": {"freeze_moe_router": True, "ep": 1, "impl": "hf"}}, "custom"),
+    ],
+)
+def test_full_replay_rejects_unsupported_config(override, message):
+    with pytest.raises(ValidationError, match=message):
+        TrainerConfig.model_validate(full_trainer(**override))
+
+
+def test_managed_full_replay_enables_paired_capture():
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": "Qwen/Qwen3-30B-A3B"},
+            "trainer": full_trainer(),
+            "orchestrator": {},
+            "inference": {},
+        }
+    )
+    assert config.inference.vllm.enable_return_routed_experts
+    assert config.inference.vllm.enable_return_routed_expert_weights
+
+
+def test_managed_ids_only_does_not_enable_weights():
+    config = RLConfig.model_validate(
+        {
+            "trainer": {"enable_router_replay": True},
+            "orchestrator": {},
+            "inference": {},
+        }
+    )
+    assert config.inference.vllm.enable_return_routed_experts
+    assert not config.inference.vllm.enable_return_routed_expert_weights
+
+
+def test_standalone_full_capture_requires_ids():
+    with pytest.raises(ValidationError, match="enable_return_routed_experts"):
+        InferenceConfig(vllm={"enable_return_routed_expert_weights": True})
+
+
+def test_weights_require_v2_and_reject_override(monkeypatch):
+    config = InferenceConfig(
+        vllm={
+            "enable_return_routed_experts": True,
+            "enable_return_routed_expert_weights": True,
+        }
+    )
+    monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
+    setup_vllm_env(config)
+    assert os.environ["VLLM_USE_V2_MODEL_RUNNER"] == "1"
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "0")
+    with pytest.raises(ValueError, match="V2"):
+        setup_vllm_env(config)
+
+
+def test_full_capture_rejects_pd_transfer():
+    with pytest.raises(ValidationError, match="disaggregated"):
+        InferenceConfig(
+            use_pd_kv_transfer=True,
+            vllm={"enable_return_routed_experts": True, "enable_return_routed_expert_weights": True},
+        )
+
+
+def test_full_capture_guard_rechecked_after_parent_auto_configuration():
+    # Parent config auto-enables fields after nested validation; the guard must
+    # still execute when the previously valid inference config has KV offload.
+    inference = InferenceConfig().model_copy(update={"kv_cache_offload": object()})
+    inference.vllm.enable_return_routed_experts = True
+    inference.vllm.enable_return_routed_expert_weights = True
+    with pytest.raises(ValueError, match="offload"):
+        inference.validate_router_weight_capture()

--- a/tests/unit/train/models/test_qwen3_moe_routing_replay.py
+++ b/tests/unit/train/models/test_qwen3_moe_routing_replay.py
@@ -1,0 +1,175 @@
+"""GPU integration coverage for Qwen3 direct routing replay.
+
+These tests require the native CUDA/FlashAttention/grouped-GEMM environment.
+They are not a claim that full-model GPU replay has been validated on a CPU host.
+"""
+
+import copy
+
+import pytest
+import torch
+
+from prime_rl.trainer.routing_replay import RoutingReplay
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="Qwen3 integration requires a CUDA GPU"),
+]
+
+
+def make_model():
+    from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
+    from prime_rl.trainer.models.layers.moe import MoE
+    from prime_rl.trainer.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalLM
+    from prime_rl.utils.utils import default_dtype
+
+    pytest.importorskip("flash_attn", reason="Qwen3 integration requires FlashAttention 2")
+    config = Qwen3MoeConfig(
+        vocab_size=128,
+        hidden_size=256,
+        intermediate_size=256,
+        moe_intermediate_size=256,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=64,
+        num_experts=4,
+        num_experts_per_tok=2,
+        num_hidden_layers=2,
+        max_position_embeddings=128,
+        norm_topk_prob=True,
+        load_balance_coeff=None,
+        attention_dropout=0.0,
+    )
+    config._attn_implementation = "flash_attention_2"
+    with torch.device("cuda"), default_dtype(torch.bfloat16):
+        model = Qwen3MoeForCausalLM._from_config(config)
+    # GroupedExperts owns raw parameters rather than nn.Linear modules.
+    for module in model.modules():
+        if isinstance(module, MoE):
+            module.init_weights(0.02, buffer_device=torch.device("cuda"))
+            module.router.gate.requires_grad_(False)
+    inject_prime_lm_head(model, chunk_size=None)
+    return model.train()
+
+
+@pytest.mark.parametrize("checkpoint_mode", [None, "full", "selective"])
+def test_qwen3_direct_replay_matches_detached_router_objective_and_checkpoint_gradients(checkpoint_mode):
+    from prime_rl.configs.trainer import ActivationCheckpointConfig
+    from prime_rl.trainer.activation_checkpointing import get_activation_checkpoint_wrapper
+
+    torch.manual_seed(31)
+    reference = make_model()
+    actual = copy.deepcopy(reference)
+    reference_moes = [layer.mlp for layer in reference.model.layers]
+    actual_moes = [layer.mlp for layer in actual.model.layers]
+    captured = {}
+
+    def capture_detached(layer_idx):
+        def hook(_module, _inputs, output):
+            scores, ids, counts, confidence = output
+            captured[layer_idx] = RoutingReplay(ids.detach().clone(), scores.detach().clone())
+            # This defines the same constant-coefficient objective as direct replay,
+            # including removal of the gate's hidden-state derivative.
+            return scores.detach(), ids, counts, confidence
+
+        return hook
+
+    hooks = [moe.router.register_forward_hook(capture_detached(i)) for i, moe in enumerate(reference_moes)]
+    input_ids = torch.randint(0, reference.config.vocab_size, (1, 16), device="cuda")
+    seq_lens = torch.tensor([input_ids.shape[1]], device="cuda")
+    expected = reference(input_ids=input_ids, seq_lens=seq_lens)["logits"]
+    for hook in hooks:
+        hook.remove()
+    replay = RoutingReplay(
+        torch.stack([captured[i].ids for i in range(len(reference_moes))], dim=1).unsqueeze(0),
+        torch.stack([captured[i].weights for i in range(len(reference_moes))], dim=1).unsqueeze(0).requires_grad_(),
+    )
+    original = RoutingReplay(replay.ids.clone(), replay.weights.detach().clone())
+
+    def fail_gate(*_args):
+        raise AssertionError("direct replay must not enter the router module, including during recomputation")
+
+    gate_hooks = [moe.router.register_forward_pre_hook(fail_gate) for moe in actual_moes]
+    if checkpoint_mode is not None:
+        wrapper = get_activation_checkpoint_wrapper(ActivationCheckpointConfig(mode=checkpoint_mode))
+        for i, layer in enumerate(actual.model.layers):
+            actual.model.layers[i] = wrapper(layer)
+
+    output = actual(input_ids=input_ids, seq_lens=seq_lens, routed_experts=replay)["logits"]
+    counts_after_forward = [moe.tokens_per_expert.clone() for moe in actual_moes]
+    torch.testing.assert_close(output, expected, rtol=1e-3, atol=1e-3)
+    output.float().square().mean().backward()
+    expected.float().square().mean().backward()
+    for hook in gate_hooks:
+        hook.remove()
+
+    torch.testing.assert_close(
+        actual.model.embed_tokens.weight.grad, reference.model.embed_tokens.weight.grad, rtol=2e-2, atol=1e-5
+    )
+    assert actual.model.embed_tokens.weight.grad.abs().sum() > 0
+    for reference_moe, actual_moe, counts in zip(reference_moes, actual_moes, counts_after_forward):
+        for name in ("gate_proj", "up_proj", "down_proj"):
+            actual_grad = getattr(actual_moe.experts, name).grad
+            reference_grad = getattr(reference_moe.experts, name).grad
+            torch.testing.assert_close(actual_grad, reference_grad, rtol=2e-2, atol=1e-5)
+            assert actual_grad is not None and actual_grad.abs().sum() > 0
+        assert actual_moe.router.gate.weight.grad is None
+        torch.testing.assert_close(actual_moe.tokens_per_expert, counts, rtol=0, atol=0)
+        torch.testing.assert_close(actual_moe.tokens_per_expert, reference_moe.tokens_per_expert, rtol=0, atol=0)
+        assert torch.isnan(actual_moe.routing_confidence_sum)
+    assert replay.weights.grad is None
+    torch.testing.assert_close(replay.ids, original.ids, rtol=0, atol=0)
+    torch.testing.assert_close(replay.weights, original.weights, rtol=0, atol=0)
+
+
+def test_qwen3_fsdp_preserves_fp32_coefficients_through_root_and_layer_boundaries(free_port):
+    import torch.distributed as dist
+
+    from prime_rl.configs.trainer import ModelConfig
+    from prime_rl.trainer.model import setup_fsdp, validate_full_router_replay_model
+    from prime_rl.trainer.parallel_dims import ParallelDims
+
+    if dist.is_initialized():
+        pytest.skip("This single-rank integration test requires its own process group")
+    dist.init_process_group("nccl", init_method=f"tcp://127.0.0.1:{free_port}", rank=0, world_size=1)
+    router_hooks = []
+    try:
+        model = make_model()
+        expected_router_state = {
+            f"model.layers.{i}.mlp.router.gate.weight": layer.mlp.router.gate.weight.detach().cpu().clone()
+            for i, layer in enumerate(model.model.layers)
+        }
+        config = ModelConfig(name="qwen3-moe-routing-replay-test", moe_router_dtype="float32")
+        parallel_dims = ParallelDims(dp_replicate=1, dp_shard=1, cp=1, pp=1, ep=1, world_size=1)
+        setup_fsdp(model, config, parallel_dims, preserve_routing_weights=True)
+        validate_full_router_replay_model(model)
+
+        def reject_router_forward(*_args):
+            raise AssertionError("TRR must not enter the separately sharded frozen router")
+
+        router_hooks = [
+            layer.mlp.router.register_forward_pre_hook(reject_router_forward) for layer in model.model.layers
+        ]
+        ids = torch.arange(64, device="cuda").reshape(1, 16, 2, 2) % model.config.num_experts
+        weights = torch.tensor([0.1, 0.9], device="cuda").expand_as(ids).clone().requires_grad_()
+        pair = RoutingReplay(ids, weights)
+        original = weights.detach().clone()
+        tokens = torch.randint(0, model.config.vocab_size, (1, 16), device="cuda")
+        output = model(input_ids=tokens, seq_lens=torch.tensor([16], device="cuda"), routed_experts=pair)["logits"]
+        output.float().square().mean().backward()
+        assert model.model.embed_tokens.weight.grad is not None
+        assert pair.weights.grad is None
+        assert pair.weights.dtype == torch.float32
+        torch.testing.assert_close(pair.weights, original, rtol=0, atol=0)
+        for layer in model.model.layers:
+            assert layer.mlp.router.gate.weight.grad is None
+        # Uncalled nested FSDP units must still own valid checkpoint parameters.
+        from torch.distributed.checkpoint.state_dict import StateDictOptions, get_model_state_dict
+
+        state = get_model_state_dict(model, options=StateDictOptions(full_state_dict=True, cpu_offload=True))
+        for name, expected in expected_router_state.items():
+            torch.testing.assert_close(state[name].float(), expected.float(), rtol=0, atol=0)
+    finally:
+        for handle in router_hooks:
+            handle.remove()
+        dist.destroy_process_group()

--- a/tests/unit/train/models/test_routing_replay.py
+++ b/tests/unit/train/models/test_routing_replay.py
@@ -1,0 +1,362 @@
+"""CPU tests for immutable routing inputs and the native direct-replay router.
+
+MoE tests inject a small CPU reference dispatcher/expert implementation through
+its supported interfaces. They do not test CUDA grouped GEMM or permutation.
+"""
+
+import copy
+from unittest.mock import Mock
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.utils._pytree import tree_flatten, tree_unflatten
+
+from prime_rl.configs.trainer import ActivationCheckpointConfig
+from prime_rl.trainer.activation_checkpointing import get_activation_checkpoint_wrapper
+from prime_rl.trainer.models.layers.moe import MoE, TokenChoiceTopKRouter
+from prime_rl.trainer.routing_replay import RoutingReplay, select_routing_layer
+
+
+def make_router(**kwargs):
+    return TokenChoiceTopKRouter(
+        dim=4,
+        num_experts=3,
+        top_k=2,
+        score_func=kwargs.pop("score_func", "softmax"),
+        route_norm=kwargs.pop("route_norm", True),
+        route_scale=kwargs.pop("route_scale", 1.0),
+        **kwargs,
+    )
+
+
+def test_routing_replay_is_an_immutable_paired_tensor_input():
+    ids = torch.arange(24).reshape(1, 3, 4, 2)
+    weights = torch.arange(24, dtype=torch.float32).reshape(1, 3, 4, 2) / 31
+    replay = RoutingReplay(ids, weights)
+    with pytest.raises(AttributeError):
+        replay.ids = ids.clone()
+    leaves, structure = tree_flatten(replay)
+    assert leaves[0] is ids and leaves[1] is weights
+    rebuilt = tree_unflatten(leaves, structure)
+    assert isinstance(rebuilt, RoutingReplay)
+    assert rebuilt.ids is ids and rebuilt.weights is weights
+    moved = replay.to("cpu", non_blocking=True)
+    assert isinstance(moved, RoutingReplay)
+    assert moved.ids.dtype == ids.dtype
+    assert moved.weights.dtype == torch.float32
+    torch.testing.assert_close(moved.ids, ids, rtol=0, atol=0)
+    torch.testing.assert_close(moved.weights, weights, rtol=0, atol=0)
+
+
+def test_select_layer_preserves_noncontiguous_pair_and_legacy_inputs():
+    ids = torch.arange(48).reshape(2, 3, 4, 2)
+    weights = torch.arange(48, dtype=torch.float32).reshape(2, 3, 4, 2) / 53
+    replay = RoutingReplay(ids, weights)
+    selected = select_routing_layer(replay, 2)
+    assert isinstance(selected, RoutingReplay)
+    assert not selected.ids.is_contiguous() and not selected.weights.is_contiguous()
+    torch.testing.assert_close(selected.ids, ids[:, :, 2, :], rtol=0, atol=0)
+    torch.testing.assert_close(selected.weights, weights[:, :, 2, :], rtol=0, atol=0)
+    torch.testing.assert_close(select_routing_layer(ids, 2), selected.ids, rtol=0, atol=0)
+    assert select_routing_layer(None, 2) is None
+    with pytest.raises(IndexError):
+        select_routing_layer(replay, 4)
+    with pytest.raises(TypeError, match="Tensor, RoutingReplay, or None"):
+        select_routing_layer((ids, weights), 0)
+    with pytest.raises(ValueError, match="same shape"):
+        select_routing_layer(RoutingReplay(ids, weights[:, :-1]), 0)
+    with pytest.raises(ValueError, match="Model RoutingReplay"):
+        select_routing_layer(RoutingReplay(ids[0], weights[0]), 0)
+
+
+@pytest.mark.parametrize("score_func", ["softmax", "sigmoid", "topk_softmax"])
+@pytest.mark.parametrize("fp32_gate", [False, True])
+def test_direct_router_skips_gate_and_uses_exact_detached_final_coefficients(monkeypatch, score_func, fp32_gate):
+    router = make_router(score_func=score_func, route_norm=True, route_scale=7.0, selection_bias=True)
+    router.fp32_gate = fp32_gate
+    router.force_balanced = True  # Recorded routes take priority over selection controls.
+    x = torch.randn(3, 4, requires_grad=True)
+    ids = torch.tensor([[2, 0], [1, 2], [0, 1]], dtype=torch.int32)
+    # Intentionally not all normalized: detect accidental normalization or scaling.
+    weights = torch.tensor([[0.1, 0.7], [1.125, 0.3], [0.0, 0.0]], requires_grad=True)
+    gate = Mock(side_effect=AssertionError("gate must not execute in direct replay"))
+    monkeypatch.setattr(router.gate, "forward", gate)
+    monkeypatch.setattr(F, "linear", Mock(side_effect=AssertionError("FP32 gate must not execute")))
+    monkeypatch.setattr(F, "softmax", Mock(side_effect=AssertionError("scores must not be recomputed")))
+    monkeypatch.setattr(torch, "sigmoid", Mock(side_effect=AssertionError("scores must not be recomputed")))
+
+    scores, selected, counts, confidence = router(x, RoutingReplay(ids, weights))
+
+    assert selected is ids
+    assert scores.data_ptr() == weights.data_ptr()
+    assert not scores.requires_grad and scores.grad_fn is None
+    assert scores.dtype == torch.float32
+    assert torch.equal(scores.view(torch.int32), weights.detach().view(torch.int32))
+    torch.testing.assert_close(counts, torch.tensor([2, 2, 2]), rtol=0, atol=0)
+    assert torch.isnan(confidence)  # Captured coefficient mass is NOT trainer confidence.
+    gate.assert_not_called()
+    (x.unsqueeze(1) * scores.unsqueeze(-1)).sum().backward()
+    assert weights.grad is None
+    assert router.gate.weight.grad is None
+    assert x.grad is not None and x.grad[:2].abs().sum() > 0
+
+
+@pytest.mark.parametrize("score_func", ["softmax", "sigmoid", "topk_softmax"])
+@pytest.mark.parametrize("route_norm", [False, True])
+def test_legacy_ids_only_retains_recomputed_coefficients_and_gradients(score_func, route_norm):
+    torch.manual_seed(3)
+    router = make_router(score_func=score_func, route_norm=route_norm, route_scale=1.7)
+    x = torch.randn(4, 4, requires_grad=True)
+    reference_x = x.detach().clone().requires_grad_()
+    reference_gate = router.gate.weight.detach().clone().requires_grad_()
+    ids = torch.tensor([[2, 0], [1, 0], [0, 1], [2, 1]])
+    call_count = []
+    hook = router.gate.register_forward_hook(lambda *args: call_count.append(1))
+    actual, selected, counts, confidence = router(x, ids)
+    hook.remove()
+    assert call_count == [1]
+
+    logits = F.linear(reference_x, reference_gate).float()
+    if score_func == "topk_softmax":
+        expected = F.softmax(logits.gather(1, ids), dim=-1)
+        expected_confidence = expected.sum()
+    else:
+        probabilities = F.softmax(logits, dim=1) if score_func == "softmax" else torch.sigmoid(logits)
+        expected = probabilities.gather(1, ids)
+        mass = expected if score_func == "softmax" else expected / (probabilities.sum(-1, keepdim=True) + 1e-20)
+        expected_confidence = mass.sum()
+    if route_norm:
+        expected = expected / (expected.sum(-1, keepdim=True) + 1e-20)
+    expected = expected * 1.7
+
+    assert selected is ids
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(confidence, expected_confidence.detach(), rtol=0, atol=0)
+    torch.testing.assert_close(counts, torch.tensor([3, 3, 2]), rtol=0, atol=0)
+    factor = torch.arange(8).reshape(4, 2)
+    (actual * factor).sum().backward()
+    (expected * factor).sum().backward()
+    torch.testing.assert_close(x.grad, reference_x.grad)
+    torch.testing.assert_close(router.gate.weight.grad, reference_gate.grad)
+    assert router.gate.weight.grad.abs().sum() > 0
+
+
+def test_no_replay_and_legacy_replay_of_selected_ids_match():
+    torch.manual_seed(11)
+    router = make_router()
+    x = torch.randn(7, 4)
+    scores, ids, counts, confidence = router(x)
+    replayed = router(x, ids)
+    for actual, expected in zip(replayed, (scores, ids, counts, confidence)):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    ("ids", "weights", "error", "message"),
+    [
+        (torch.zeros(3, 2), torch.ones(3, 2), TypeError, "IDs must have dtype"),
+        (torch.zeros(3, 2, dtype=torch.bool), torch.ones(3, 2), TypeError, "IDs must have dtype"),
+        (torch.zeros(3, 2, dtype=torch.long), torch.ones(3, 2).half(), TypeError, "weights must have dtype"),
+        (torch.zeros(3, 2, dtype=torch.long), torch.ones(3, 1), ValueError, "same shape"),
+        (torch.zeros(3, 1, dtype=torch.long), torch.ones(3, 1), ValueError, "does not match expected"),
+        (torch.zeros(2, 2, dtype=torch.long), torch.ones(2, 2), ValueError, "does not match expected"),
+        (torch.zeros(1, 3, 2, dtype=torch.long), torch.ones(1, 3, 2), ValueError, "does not match expected"),
+        (torch.zeros(3, 2, dtype=torch.long), torch.ones(3, 2, device="meta"), ValueError, "same device"),
+        (torch.zeros(3, 2, dtype=torch.long), None, TypeError, "must be tensors"),
+    ],
+)
+def test_direct_router_rejects_malformed_pair_metadata(ids, weights, error, message):
+    router = make_router()
+    with pytest.raises(error, match=message):
+        router(torch.randn(3, 4), RoutingReplay(ids, weights))
+
+
+def test_direct_router_rejects_hidden_state_device_mismatch():
+    replay = RoutingReplay(torch.zeros(3, 2, dtype=torch.long), torch.ones(3, 2))
+    with pytest.raises(ValueError, match="same device as the hidden states"):
+        make_router()(torch.empty(3, 4, device="meta"), replay)
+
+
+def test_direct_router_accepts_empty_token_batch():
+    scores, ids, counts, confidence = make_router()(
+        torch.empty(0, 4), RoutingReplay(torch.empty(0, 2, dtype=torch.long), torch.empty(0, 2))
+    )
+    assert scores.shape == ids.shape == (0, 2)
+    assert counts.sum() == 0
+    assert torch.isnan(confidence)
+
+
+class CPUScaleExperts(nn.Module):
+    num_experts = 3
+    token_group_alignment = 1
+
+    def __init__(self):
+        super().__init__()
+        self.scales = nn.Parameter(torch.arange(1, 13, dtype=torch.float32).reshape(3, 4) / 5)
+
+    def forward(self, x, counts):
+        scales = torch.repeat_interleave(self.scales, counts, dim=0, output_size=x.shape[0])
+        return x.square() * scales
+
+
+class CPUReferenceDispatcher:
+    """Small CPU backend, injected instead of the CUDA-oriented permutation path."""
+
+    def run(self, x, scores, ids, experts, *, score_before_experts):
+        # These are the production local dispatch ordering and coefficient-application
+        # functions. Only the padding/permutation backend is omitted in this CPU test.
+        from prime_rl.trainer.distributed.token_dispatcher import _local_reorder, _scatter_routed_output
+
+        routed, indices, sorted_scores, counts = _local_reorder(
+            x, scores, ids, num_experts=experts.num_experts, top_k=ids.shape[-1]
+        )
+        if score_before_experts:
+            routed = (routed.float() * sorted_scores[:, None]).to(x.dtype)
+        output = experts(routed, counts)
+        return _scatter_routed_output(
+            output,
+            num_tokens=x.shape[0],
+            token_indices_experts_sorted=indices,
+            scores_after_experts=None if score_before_experts else sorted_scores,
+        )
+
+    def synchronize(self):
+        pass
+
+
+def make_cpu_moe(score_before_experts=False):
+    moe = MoE(
+        router=make_router(),
+        experts=CPUScaleExperts(),
+        shared_expert=None,
+        score_before_experts=score_before_experts,
+        load_balance_coeff=None,
+    )
+    moe.set_token_dispatcher(CPUReferenceDispatcher())
+    return moe
+
+
+@pytest.mark.parametrize("score_before_experts", [False, True])
+def test_moe_flattens_paired_layer_and_preserves_expert_and_input_gradients(score_before_experts):
+    torch.manual_seed(7)
+    moe = make_cpu_moe(score_before_experts)
+    x = torch.randn(2, 3, 4, requires_grad=True)
+    ref_x = x.detach().clone().requires_grad_()
+    ref_scales = moe.experts.scales.detach().clone().requires_grad_()
+    ids = torch.arange(24).reshape(2, 3, 2, 2) % 3
+    weights = (torch.arange(24, dtype=torch.float32).reshape(2, 3, 2, 2) / 29).requires_grad_()
+    pair = select_routing_layer(RoutingReplay(ids, weights), 1)
+    output = moe(x, pair)
+
+    chosen_scales = ref_scales[pair.ids]
+    expert_inputs = ref_x.unsqueeze(-2)
+    if score_before_experts:
+        expert_inputs = expert_inputs * pair.weights.detach().unsqueeze(-1)
+    contributions = expert_inputs.square() * chosen_scales
+    if not score_before_experts:
+        contributions = contributions * pair.weights.detach().unsqueeze(-1)
+    expected = contributions.sum(-2)
+    torch.testing.assert_close(output, expected)
+    output.square().sum().backward()
+    expected.square().sum().backward()
+    torch.testing.assert_close(x.grad, ref_x.grad)
+    torch.testing.assert_close(moe.experts.scales.grad, ref_scales.grad)
+    assert x.grad.abs().sum() > 0 and moe.experts.scales.grad.abs().sum() > 0
+    assert moe.router.gate.weight.grad is None and weights.grad is None
+    torch.testing.assert_close(moe.tokens_per_expert, torch.bincount(pair.ids.reshape(-1), minlength=3).float())
+    assert torch.isnan(moe.routing_confidence_sum)
+
+
+def test_moe_rejects_pair_with_wrong_batch_axes_even_when_token_count_matches():
+    pair = RoutingReplay(torch.zeros(3, 2, 2, dtype=torch.long), torch.ones(3, 2, 2))
+    with pytest.raises(ValueError, match="does not match expected"):
+        make_cpu_moe()(torch.randn(2, 3, 4), pair)
+
+
+@pytest.mark.parametrize("mode", ["full", "selective"])
+def test_checkpoint_reuses_immutable_pairs_across_queued_microbatches_and_records_counts_once(mode):
+    torch.manual_seed(19)
+    moe = make_cpu_moe()
+    reference = copy.deepcopy(moe)
+    checkpointed = get_activation_checkpoint_wrapper(ActivationCheckpointConfig(mode=mode))(moe)
+    inputs = [torch.randn(1, 3, 4, requires_grad=True) for _ in range(2)]
+    ref_inputs = [x.detach().clone().requires_grad_() for x in inputs]
+    pairs = [
+        RoutingReplay(
+            (torch.arange(6).reshape(1, 3, 2) + i) % 3,
+            (torch.arange(1, 7, dtype=torch.float32).reshape(1, 3, 2) / (7 + i)).requires_grad_(),
+        )
+        for i in range(2)
+    ]
+    originals = [RoutingReplay(p.ids.clone(), p.weights.detach().clone()) for p in pairs]
+    outputs = [checkpointed(x, routed_experts=p) for x, p in zip(inputs, pairs)]
+    expected_outputs = [reference(x, routed_experts=p) for x, p in zip(ref_inputs, pairs)]
+    counts_after_forward = moe.tokens_per_expert.clone()
+    for output, expected in reversed(list(zip(outputs, expected_outputs))):
+        torch.testing.assert_close(output, expected)
+        output.square().sum().backward()
+        expected.square().sum().backward()
+    torch.testing.assert_close(moe.tokens_per_expert, counts_after_forward, rtol=0, atol=0)
+    assert counts_after_forward.sum() == 12
+    assert torch.isnan(moe.routing_confidence_sum)
+    for x, ref_x, p, original in zip(inputs, ref_inputs, pairs, originals):
+        torch.testing.assert_close(x.grad, ref_x.grad)
+        torch.testing.assert_close(p.ids, original.ids, rtol=0, atol=0)
+        torch.testing.assert_close(p.weights, original.weights, rtol=0, atol=0)
+        assert p.weights.grad is None
+    torch.testing.assert_close(moe.experts.scales.grad, reference.experts.scales.grad)
+    assert moe.router.gate.weight.grad is None
+
+
+def test_direct_router_and_paired_layer_slice_compile_with_eager_backend():
+    router = make_router()
+
+    def forward(x, pair):
+        layer = select_routing_layer(pair, 1)
+        flat = RoutingReplay(layer.ids.reshape(-1, 2), layer.weights.reshape(-1, 2))
+        return router(x, flat)
+
+    compiled = torch.compile(forward, backend="eager", fullgraph=True)
+    x = torch.randn(3, 4)
+    pair = RoutingReplay(torch.arange(12).reshape(1, 3, 2, 2) % 3, torch.rand(1, 3, 2, 2))
+    expected = forward(x, pair)
+    actual = compiled(x, pair)
+    for result, reference in zip(actual, expected):
+        torch.testing.assert_close(result, reference, rtol=0, atol=0, equal_nan=True)
+
+
+def test_full_moe_bypasses_router_module_hooks_but_legacy_replay_keeps_them():
+    moe = make_cpu_moe()
+    moe.router.requires_grad_(False)
+    calls = []
+    handle = moe.router.register_forward_pre_hook(lambda *args: calls.append("router"))
+    x = torch.randn(1, 3, 4, requires_grad=True)
+    pair = RoutingReplay(torch.arange(6).reshape(1, 3, 2) % 3, torch.full((1, 3, 2), 0.5))
+    try:
+        moe(x, pair).sum().backward()
+        assert not calls
+        assert x.grad is not None and moe.experts.scales.grad is not None
+        # Registered/frozen router parameters remain available for checkpointing.
+        assert "router.gate.weight" in moe.state_dict()
+        moe(x.detach(), pair.ids)
+        assert calls == ["router"]
+    finally:
+        handle.remove()
+
+
+def test_full_moe_helper_compiles_with_eager_backend():
+    model = make_cpu_moe()
+    reference = copy.deepcopy(model)
+    compiled = torch.compile(model, backend="eager", fullgraph=True)
+    x = torch.randn(1, 3, 4, requires_grad=True)
+    ref_x = x.detach().clone().requires_grad_()
+    pair = RoutingReplay(torch.arange(6).reshape(1, 3, 2) % 3, torch.full((1, 3, 2), 0.5))
+    actual = compiled(x, pair)
+    expected = reference(ref_x, pair)
+    torch.testing.assert_close(actual, expected)
+    actual.sum().backward()
+    expected.sum().backward()
+    torch.testing.assert_close(x.grad, ref_x.grad)
+    torch.testing.assert_close(model.experts.scales.grad, reference.experts.scales.grad)

--- a/tests/unit/train/rl/test_routing_replay_data.py
+++ b/tests/unit/train/rl/test_routing_replay_data.py
@@ -1,0 +1,249 @@
+"""CPU checks for batch-to-trainer full-routing replay admission."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from prime_rl.trainer.rl.data import DataLoader, prepare_router_replay
+from prime_rl.trainer.routing_replay import RoutingReplay
+from prime_rl.transports.batch.types import MicroBatch, RoutedExperts
+
+
+def packed_batch(*, valid=(True, True, False), lengths=None, loss_mask=None, full=True):
+    count = len(valid)
+    ids = (np.arange(count * 4).reshape(count, 2, 2) % 4).astype(np.uint8)
+    weights = np.broadcast_to(np.array([0.25, 0.75], dtype="<f4"), ids.shape).copy()
+    weights[~np.asarray(valid)] = 0
+    payload = RoutedExperts(data=ids.tobytes(), shape=list(ids.shape), dtype="uint8")
+    if full:
+        payload.weights = weights.tobytes()
+        payload.valid = np.asarray(valid, dtype=np.uint8).tobytes()
+        payload.format_version = 1
+    lengths = lengths or [count]
+    if loss_mask is None:
+        loss_mask = [False] * count
+        offset = 0
+        for length in lengths:
+            if length > 1:
+                loss_mask[offset + length - 1] = True
+            offset += length
+    return (
+        MicroBatch(
+            input_ids=list(range(10, 10 + count)),
+            loss_mask=loss_mask,
+            advantages=[1.0] * count,
+            inference_logprobs=[-1.0] * count,
+            position_ids=[position for length in lengths for position in range(length)],
+            sequence_lengths=list(lengths),
+            temperatures=[1.0] * count,
+            env_names=["test"] * count,
+            seq_lens=list(lengths),
+            routed_experts=payload,
+        ),
+        ids,
+        weights,
+    )
+
+
+def decode(batch):
+    # Exercise the real conversion method without opening a transport receiver.
+    return DataLoader.__new__(DataLoader)._micro_batch_to_tensor(batch)
+
+
+def model_config(**changes):
+    fields = dict(model_type="qwen3_moe", num_hidden_layers=2, num_experts_per_tok=2, num_experts=4)
+    return SimpleNamespace(**(fields | changes))
+
+
+def prepare(batch, **changes):
+    arguments = dict(enabled=True, mode="ids_and_weights", model_config=model_config()) | changes
+    return prepare_router_replay(batch, **arguments)
+
+
+def test_loader_materializes_owned_exact_pair_and_keeps_legacy_ids():
+    batch, ids, weights = packed_batch()
+    first = decode(batch)
+    second = decode(batch)
+    pair = first["routed_experts"]
+    assert isinstance(pair, RoutingReplay)
+    assert pair.ids.dtype == torch.int32 and pair.weights.dtype == torch.float32
+    assert pair.ids.shape == pair.weights.shape == (1, 3, 2, 2)
+    torch.testing.assert_close(pair.ids, torch.from_numpy(ids.astype(np.int32)).unsqueeze(0), rtol=0, atol=0)
+    assert np.array_equal(pair.weights.numpy()[0].view(np.uint32), weights.view(np.uint32))
+    pair.ids.zero_()
+    pair.weights.zero_()
+    assert np.array_equal(second["routed_experts"].weights.numpy()[0], weights)
+    assert batch.routed_experts.weights == weights.tobytes()
+    legacy, legacy_ids, _ = packed_batch(full=False)
+    tensor = decode(legacy)["routed_experts"]
+    assert isinstance(tensor, torch.Tensor)
+    torch.testing.assert_close(tensor[0], torch.from_numpy(legacy_ids.astype(np.int32)), rtol=0, atol=0)
+
+
+def test_loader_keeps_final_target_loss_when_only_its_input_row_is_uncaptured():
+    batch, _, _ = packed_batch()
+    tensor_batch = decode(batch)
+    assert tensor_batch["loss_mask"][0, -1]
+    assert isinstance(prepare(tensor_batch), RoutingReplay)
+
+
+@pytest.mark.parametrize("terminal_valid", [False, True])
+def test_loader_accepts_both_terminal_capture_states_followed_by_actual_packer_padding(terminal_valid):
+    from prime_rl.trainer.batch import pad_micro_batch
+
+    batch, _, _ = packed_batch(valid=(True, True, terminal_valid))
+    padded = pad_micro_batch(batch, pad_to_multiple_of=8)
+    pair = decode(padded)["routed_experts"]
+    assert padded.sequence_lengths == padded.seq_lens == [8]
+    assert pair.weights.shape == (1, 8, 2, 2)
+    assert pair.weights[0, 3:].count_nonzero() == 0
+    assert padded.routed_experts.valid[3:] == bytes(5)
+
+
+def test_loader_accepts_terminal_placeholders_for_each_packed_document():
+    batch, _, _ = packed_batch(valid=(True, True, False, True, True, False), lengths=[3, 3])
+    pair = decode(batch)["routed_experts"]
+    assert pair.weights[0, 2].count_nonzero() == pair.weights[0, 5].count_nonzero() == 0
+
+
+@pytest.mark.parametrize("valid", [(False, True, False), (True, False, False)])
+def test_loader_rejects_missing_causal_context_even_when_that_row_has_no_loss(valid):
+    batch, _, _ = packed_batch(valid=valid, loss_mask=[False, False, True])
+    with pytest.raises(ValueError, match="causal input row"):
+        decode(batch)
+
+
+def test_loader_allows_inactive_suffix_and_zero_loss_dummy_without_inventing_validity():
+    batch, _, _ = packed_batch(valid=(True, False, False, False), loss_mask=[False, True, False, False])
+    assert isinstance(decode(batch)["routed_experts"], RoutingReplay)
+    dummy, _, _ = packed_batch(valid=(False, False, False), loss_mask=[False] * 3)
+    pair = decode(dummy)["routed_experts"]
+    assert pair.weights.count_nonzero() == 0
+
+
+@pytest.mark.parametrize("stream", ["ce_weights", "ref_kl_weights"])
+def test_loader_checks_non_rl_loss_streams_independent_of_loss_mask(stream):
+    batch, _, _ = packed_batch(valid=(True, False, False), loss_mask=[False] * 3)
+    setattr(batch, stream, [0.0, 0.0, 1.0])
+    with pytest.raises(ValueError, match="causal input row"):
+        decode(batch)
+
+
+def test_loader_rejects_training_across_packed_document_boundary():
+    batch, _, _ = packed_batch(valid=(True, True, False, True, True, False), lengths=[3, 3])
+    batch.loss_mask[3] = True
+    with pytest.raises(ValueError, match="loss-masked sequence starts"):
+        decode(batch)
+
+
+def test_loader_rejects_misaligned_attention_and_loss_boundaries():
+    batch, _, _ = packed_batch()
+    batch.seq_lens = [1, 2]
+    with pytest.raises(ValueError, match="aligned positive sequence_lengths"):
+        decode(batch)
+
+
+def test_loader_rejects_nonzero_placeholder_weights():
+    batch, _, weights = packed_batch()
+    weights[-1] = 0.5
+    batch.routed_experts.weights = weights.tobytes()
+    with pytest.raises(ValueError, match="[Uu]ncaptured|[Ii]nvalid|placeholder"):
+        decode(batch)
+
+
+def test_loader_rejects_multimodal_full_replay():
+    batch, _, _ = packed_batch()
+    batch.mm_token_type_ids = [0, 0, 0]
+    with pytest.raises(ValueError, match="multimodal"):
+        decode(batch)
+
+
+def test_prepare_selects_explicit_objective_without_implicit_fallback():
+    batch, _, _ = packed_batch()
+    tensor_batch = decode(batch)
+    pair = tensor_batch["routed_experts"]
+    assert prepare(tensor_batch) is pair
+    assert prepare(tensor_batch, mode="ids") is pair.ids
+    assert prepare(tensor_batch, enabled=False, mode="ids") is None
+    with pytest.raises(ValueError, match="requires enable_router_replay"):
+        prepare(tensor_batch, enabled=False)
+    tensor_batch["routed_experts"] = pair.ids
+    with pytest.raises(ValueError, match="IDs-only data is insufficient"):
+        prepare(tensor_batch)
+    assert prepare(tensor_batch, mode="ids") is pair.ids
+    tensor_batch["routed_experts"] = None
+    with pytest.raises(ValueError, match="requires routed experts"):
+        prepare(tensor_batch)
+
+
+@pytest.mark.parametrize("changes", [{"num_hidden_layers": 3}, {"num_experts_per_tok": 1}])
+def test_prepare_checks_model_layer_and_topk_bounds_on_cpu(changes):
+    batch, _, _ = packed_batch()
+    with pytest.raises(ValueError, match="does not match expected"):
+        prepare(decode(batch), model_config=model_config(**changes))
+
+
+@pytest.mark.parametrize("bad_id", [-1, 4])
+def test_prepare_checks_actual_model_expert_range_on_cpu(bad_id):
+    batch, _, _ = packed_batch()
+    tensor_batch = decode(batch)
+    tensor_batch["routed_experts"].ids[0, 0, 0, 0] = bad_id
+    with pytest.raises(ValueError, match="outside the model's expert range"):
+        prepare(tensor_batch)
+
+
+def test_prepare_rejects_mutated_nonfinite_coefficients_and_unsupported_model():
+    batch, _, _ = packed_batch()
+    tensor_batch = decode(batch)
+    with pytest.raises(ValueError, match="only supports custom Qwen3"):
+        prepare(tensor_batch, model_config=model_config(model_type="llama"))
+    tensor_batch["routed_experts"].weights[0, 0, 0, 0] = float("nan")
+    with pytest.raises(ValueError, match="must be finite"):
+        prepare(tensor_batch)
+
+
+@pytest.mark.parametrize("row_weights", [[0.0, 0.0], [0.2, 0.3], [0.8, 0.8]])
+def test_loader_rejects_unnormalized_real_routing_rows(row_weights):
+    batch, _, weights = packed_batch()
+    weights[0, 0] = row_weights
+    batch.routed_experts.weights = weights.tobytes()
+    with pytest.raises(ValueError, match="normalized top-k"):
+        decode(batch)
+
+
+def test_loader_accepts_float32_normalization_roundoff_without_changing_values():
+    batch, _, weights = packed_batch()
+    weights[0, 0, 0] += np.spacing(np.float32(1.0))
+    assert weights[0, 0].sum(dtype=np.float32) != 1.0
+    batch.routed_experts.weights = weights.tobytes()
+    pair = decode(batch)["routed_experts"]
+    assert pair.weights.numpy()[0].tobytes() == weights.tobytes()
+
+
+def test_loader_rejects_duplicate_real_experts_but_allows_terminal_placeholders():
+    batch, ids, _ = packed_batch()
+    ids[-1] = 0
+    batch.routed_experts.data = ids.tobytes()
+    decode(batch)  # Repeated dummy IDs are legal only on uncaptured zero-weight rows.
+    ids[0, 0] = [1, 1]
+    batch.routed_experts.data = ids.tobytes()
+    with pytest.raises(ValueError, match="unique expert IDs"):
+        decode(batch)
+
+
+def test_loader_uses_actual_rl_membership_for_causal_validity():
+    batch, _, _ = packed_batch(valid=(False, False, False), loss_mask=[True, True, True])
+    batch.rl_weights = [0.0, 0.0, 0.0]
+    assert isinstance(decode(batch)["routed_experts"], RoutingReplay)
+    batch.rl_weights[-1] = 1.0
+    with pytest.raises(ValueError, match="causal input row"):
+        decode(batch)
+
+
+def test_loader_rejects_misaligned_rl_weight_stream():
+    batch, _, _ = packed_batch()
+    batch.rl_weights = [0.0]
+    with pytest.raises(ValueError, match="token-aligned rl_weights"):
+        decode(batch)

--- a/tests/unit/train/test_model_routing_replay.py
+++ b/tests/unit/train/test_model_routing_replay.py
@@ -1,0 +1,138 @@
+"""CPU admission/forward-plumbing checks; not full Qwen3 numerical tests."""
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+from torch import nn
+
+from prime_rl.trainer.model import forward, get_load_balance_stats, validate_full_router_replay_model
+from prime_rl.trainer.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalLM
+from prime_rl.trainer.routing_replay import RoutingReplay
+
+
+def tiny_model():
+    config = Qwen3MoeConfig(
+        vocab_size=16,
+        hidden_size=8,
+        intermediate_size=16,
+        moe_intermediate_size=8,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=4,
+        num_experts=4,
+        num_experts_per_tok=2,
+        num_hidden_layers=2,
+        max_position_embeddings=32,
+        norm_topk_prob=True,
+        load_balance_coeff=None,
+    )
+    config._attn_implementation = "flash_attention_2"
+    model = Qwen3MoeForCausalLM._from_config(config)
+    for layer in model.model.layers:
+        layer.mlp.router.requires_grad_(False)
+    return model
+
+
+def test_full_replay_guard_accepts_only_frozen_custom_qwen3_convention():
+    model = tiny_model()
+    validate_full_router_replay_model(model)
+    model.model.layers[0].mlp.router.gate.weight.requires_grad_(True)
+    with pytest.raises(ValueError, match="frozen MoE router"):
+        validate_full_router_replay_model(model)
+    model.model.layers[0].mlp.router.requires_grad_(False)
+    model.model.layers[0].mlp.router.route_scale = 2.0
+    with pytest.raises(ValueError, match="route scale 1"):
+        validate_full_router_replay_model(model)
+    model.model.layers[0].mlp.router.route_scale = 1.0
+    model.config.norm_topk_prob = False
+    with pytest.raises(ValueError, match="normalized top-k coefficients"):
+        validate_full_router_replay_model(model)
+    with pytest.raises(ValueError, match="custom Qwen3"):
+        validate_full_router_replay_model(nn.Linear(2, 2))
+
+
+@pytest.mark.parametrize("kwargs", [{"cp_size": 2}, {"ep_size": 2}, {"has_vlm": True}])
+def test_full_replay_guard_rejects_unsupported_parallel_and_multimodal_modes(kwargs):
+    with pytest.raises(ValueError, match="CP>1, EP>1, or VLM"):
+        validate_full_router_replay_model(tiny_model(), **kwargs)
+
+
+def test_unified_forward_passes_exact_pair_and_rejects_unsupported_call_shapes(monkeypatch):
+    model = tiny_model()
+    capture = Mock(return_value={"logits": torch.zeros(1, 3, 16)})
+    monkeypatch.setattr(model, "forward", capture)
+    ids = torch.tensor([[1, 2, 3]])
+    positions = torch.arange(3).unsqueeze(0)
+    pair = RoutingReplay(torch.zeros(1, 3, 2, 2, dtype=torch.int32), torch.ones(1, 3, 2, 2) / 2)
+    forward(model, ids, positions, seq_lens=torch.tensor([3]), routed_experts=pair)
+    assert capture.call_args.kwargs["routed_experts"] is pair
+    assert "seq_lens" in capture.call_args.kwargs
+    capture.reset_mock()
+    with pytest.raises(ValueError, match="CP>1, EP>1, or VLM"):
+        forward(model, ids, positions, seq_lens=torch.tensor([3]), routed_experts=pair, seq_lens_are_pre_shard=True)
+    capture.assert_not_called()
+    with pytest.raises(ValueError, match="does not match expected"):
+        forward(model, ids[:, :-1], positions[:, :-1], seq_lens=torch.tensor([2]), routed_experts=pair)
+    capture.assert_not_called()
+
+
+def test_full_replay_metrics_omit_unavailable_confidence_and_reset_counts():
+    model = tiny_model()
+    for layer in model.model.layers:
+        layer.mlp.tokens_per_expert.fill_(2)
+        layer.mlp.routing_confidence_sum.fill_(float("nan"))
+    stats = get_load_balance_stats(model, try_to_avoid_padding_experts=False, include_routing_confidence=False)
+    assert stats["routing_confidence"] is None
+    torch.testing.assert_close(stats["max_vio"], torch.zeros(2), rtol=0, atol=0)
+    for layer in model.model.layers:
+        assert layer.mlp.tokens_per_expert.sum() == 0
+        assert layer.mlp.routing_confidence_sum == 0
+    for layer in model.model.layers:
+        layer.mlp.tokens_per_expert.fill_(2)
+        layer.mlp.routing_confidence_sum.fill_(3)
+    legacy_stats = get_load_balance_stats(model, try_to_avoid_padding_experts=False)
+    torch.testing.assert_close(legacy_stats["routing_confidence"], torch.full((2,), 0.75), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("preserve", [False, True])
+def test_fsdp_policy_preserves_full_pair_dtypes_without_changing_legacy_policy(monkeypatch, preserve):
+    from types import SimpleNamespace
+
+    import prime_rl.trainer.model as model_module
+
+    model = tiny_model()
+    policies = []
+    monkeypatch.setattr(model_module, "fully_shard", lambda *args, **kwargs: policies.append(kwargs["mp_policy"]))
+    from prime_rl.configs.trainer import ModelConfig
+
+    config = ModelConfig(
+        reduce_dtype="float32",
+        fsdp_cpu_offload=False,
+        reshard_after_forward=True,
+        vlm=None,
+        moe_router_dtype="float32",
+        fusions={"shard_fused_on_dim1": False},
+    )
+    parallel_dims = SimpleNamespace(ep_enabled=False, get_mesh=lambda name: None)
+    model_module.setup_fsdp(model, config, parallel_dims, preserve_routing_weights=preserve)
+    assert policies
+    assert all(policy.cast_forward_inputs is (not preserve) for policy in policies)
+    assert any(policy.param_dtype == torch.float32 for policy in policies)
+    assert any(policy.param_dtype == torch.bfloat16 for policy in policies)
+
+
+def test_full_replay_guard_checks_layer_list_without_recursive_module_walk(monkeypatch):
+    model = tiny_model()
+    monkeypatch.setattr(model, "modules", Mock(side_effect=AssertionError("no recursive model traversal")))
+    validate_full_router_replay_model(model)
+    model.model.layers[0].mlp = nn.Identity()
+    with pytest.raises(ValueError, match="MoE block in every"):
+        validate_full_router_replay_model(model)
+
+
+def test_full_replay_guard_rejects_incomplete_layer_layout():
+    model = tiny_model()
+    del model.model.layers[-1]
+    with pytest.raises(ValueError, match="complete Qwen3 MoE layer layout"):
+        validate_full_router_replay_model(model)

--- a/tests/unit/train/test_routing_replay_imports.py
+++ b/tests/unit/train/test_routing_replay_imports.py
@@ -1,0 +1,16 @@
+"""Keep tensor metadata/loader imports independent of optional model kernels."""
+
+import subprocess
+import sys
+
+
+def test_routing_data_import_does_not_load_model_registry():
+    code = """
+import sys
+from prime_rl.trainer.rl.data import DataLoader
+from prime_rl.trainer.routing_replay import RoutingReplay
+for name in ("prime_rl.trainer.models", "ring_flash_attn", "flash_attn"):
+    assert name not in sys.modules, name
+"""
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=90)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/unit/transports/test_routing_payload.py
+++ b/tests/unit/transports/test_routing_payload.py
@@ -1,0 +1,189 @@
+import copy
+
+import msgspec
+import numpy as np
+import pytest
+
+from prime_rl.trainer.batch import build_bin_cost, prepare_batch, prepare_sample
+from prime_rl.transports.batch.routing import (
+    concatenate_routed_experts,
+    copy_routed_experts,
+    pad_routed_experts,
+    routing_compatible,
+    slice_routed_experts,
+    validate_routed_experts,
+)
+from prime_rl.transports.batch.types import RoutedExperts, TrainingSample
+
+
+def paired(n=4, dtype=np.uint8, terminal=True):
+    ids = (np.arange(n * 2 * 2).reshape(n, 2, 2) % 8).astype(dtype)
+    weights = np.broadcast_to(np.array([0.375, 0.625], dtype="<f4"), ids.shape).copy()
+    valid = np.ones(n, dtype=np.bool_)
+    if terminal and n:
+        valid[-1] = False
+        weights[-1] = 0
+    return RoutedExperts(
+        data=ids.tobytes(),
+        shape=list(ids.shape),
+        dtype=str(ids.dtype),
+        weights=weights.tobytes(),
+        valid=valid.tobytes(),
+        format_version=1,
+    )
+
+
+def sample(routing):
+    n = routing.shape[0]
+    return TrainingSample(
+        token_ids=list(range(10, 10 + n)),
+        mask=[False] + [True] * (n - 1),
+        logprobs=[0.0] * n,
+        temperatures=[1.0] * n,
+        advantages=[0.0] + [1.0] * (n - 1),
+        env_name="test",
+        routed_experts=routing,
+    )
+
+
+def test_legacy_positional_wire_is_compatible():
+    raw = msgspec.msgpack.encode([b"\x01\x02", [2, 1, 1], "uint8"])
+    decoded = msgspec.msgpack.decode(raw, type=RoutedExperts)
+    assert decoded.weights is None and decoded.valid is None and decoded.format_version == 0
+    ids, weights, valid = validate_routed_experts(decoded)
+    assert ids.flatten().tolist() == [1, 2]
+    assert weights is valid is None
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16])
+def test_pair_exact_wire_roundtrip(dtype):
+    record = paired(dtype=dtype)
+    restored = msgspec.msgpack.decode(msgspec.msgpack.encode(record), type=RoutedExperts)
+    assert restored == record
+    ids, weights, valid = validate_routed_experts(restored)
+    assert weights.tobytes() == record.weights
+    assert not ids.flags.writeable and not weights.flags.writeable and not valid.flags.writeable
+    assert valid.tolist() == [True, True, True, False]
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("shape", [4, 2]),
+        ("shape", [4, 0, 2]),
+        ("shape", [True, 2, 2]),
+        ("data", b""),
+        ("dtype", "object"),
+        ("weights", b""),
+        ("valid", None),
+        ("valid", b"\x01\x02\x01\x00"),
+        ("format_version", 2),
+    ],
+)
+def test_malformed_pair_rejected(field, value):
+    record = paired()
+    setattr(record, field, value)
+    with pytest.raises(ValueError):
+        validate_routed_experts(record)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -0.1, 1.1])
+def test_invalid_coefficients_rejected(value):
+    record = paired()
+    weights = np.frombuffer(record.weights, dtype="<f4").copy()
+    weights[0] = value
+    record.weights = weights.tobytes()
+    with pytest.raises(ValueError, match="finite"):
+        validate_routed_experts(record)
+
+
+def test_invalid_row_cannot_have_nonzero_coefficient():
+    record = paired()
+    record.valid = bytes(4)
+    with pytest.raises(ValueError, match="placeholder"):
+        validate_routed_experts(record)
+
+
+def test_pair_copy_slice_concat_keep_axes_and_storage():
+    source = paired(6)
+    copied = copy_routed_experts(source)
+    assert copied.data is source.data and copied.weights is source.weights
+    assert copied.shape is not source.shape
+    a = slice_routed_experts(source, 0, 3)
+    b = slice_routed_experts(source, 3, 6)
+    assert concatenate_routed_experts([a, b]) == source
+    ids, weights, valid = validate_routed_experts(b)
+    original_ids, original_weights, original_valid = validate_routed_experts(source)
+    assert ids.tobytes() == original_ids[3:].tobytes()
+    assert weights.tobytes() == original_weights[3:].tobytes()
+    assert valid.tobytes() == original_valid[3:].tobytes()
+
+
+def test_mixed_modes_and_layouts_are_not_packed_together():
+    full = paired()
+    legacy = RoutedExperts(full.data, list(full.shape), full.dtype)
+    assert not routing_compatible(full, legacy)
+    with pytest.raises(ValueError, match="different"):
+        concatenate_routed_experts([full, legacy])
+    groups = prepare_batch(
+        [sample(full), sample(legacy)], seq_len=8, num_train_workers=1, bin_cost=build_bin_cost(None)
+    )
+    assert len(groups[0]) == 2
+
+
+def test_full_padding_does_not_modify_source_or_concentrate_every_slot_on_zero():
+    source = paired()
+    before = copy.deepcopy(source)
+    padded = pad_routed_experts(source, 4)
+    ids, weights, valid = validate_routed_experts(padded)
+    assert source == before
+    assert ids.shape == (8, 2, 2)
+    assert np.all(weights[4:] == 0) and not valid[4:].any()
+    assert (ids[4:] < 8).all() and np.unique(ids[4:]).size == 8
+    assert np.all(ids[4:, :, 0] != ids[4:, :, 1])
+    assert padded.weights[: len(source.weights)] == source.weights
+
+
+def test_legacy_padding_is_unchanged():
+    full = paired()
+    legacy = RoutedExperts(full.data, list(full.shape), full.dtype)
+    padded = pad_routed_experts(legacy, 2)
+    ids, weights, valid = validate_routed_experts(padded)
+    assert np.all(ids[4:] == 0)
+    assert weights is valid is None
+
+
+def test_crop_preserves_pair_and_rejects_missing_interior_before_crop():
+    source = paired(6)
+    cropped = prepare_sample(sample(source), seq_len=3)
+    ids, weights, valid = validate_routed_experts(cropped.routed_experts)
+    assert ids.shape == (3, 2, 2) and valid.all()
+    assert weights.tobytes() == source.weights[: 3 * 2 * 2 * 4]
+    source.valid = b"\x01\x00\x01\x01\x01\x00"
+    weights = np.frombuffer(source.weights, dtype="<f4").copy().reshape(source.shape)
+    weights[1] = 0
+    source.weights = weights.tobytes()
+    with pytest.raises(ValueError, match="final unforwarded"):
+        prepare_sample(sample(source), seq_len=1)
+
+
+def test_pack_roundtrip_and_padding_keep_per_sequence_validity():
+    a, b = paired(3), paired(4)
+    batches = prepare_batch(
+        [sample(a), sample(b)], seq_len=12, num_train_workers=1, bin_cost=build_bin_cost(None), pad_to_multiple_of=8
+    )[0]
+    assert len(batches) == 1
+    batch = batches[0]
+    ids, weights, valid = validate_routed_experts(batch.routed_experts)
+    assert len(batch.input_ids) == len(valid) == 8
+    assert sum(batch.sequence_lengths) == sum(batch.seq_lens) == 8
+    assert not valid[-1]
+    # Order is packing-dependent. Every source contribution remains an exact pair.
+    offset = 0
+    for length in batch.sequence_lengths:
+        real_len = length - 1 if offset + length == 8 else length
+        expected = a if real_len == 3 else b
+        row = slice_routed_experts(batch.routed_experts, offset, offset + real_len)
+        assert row == expected
+        offset += length
+    assert np.all(weights[-1] == 0)

--- a/uv.lock
+++ b/uv.lock
@@ -17,25 +17,26 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-vllm = false
-verifiers = false
-harbor = "2026-08-11T00:00:00Z"
-prime-pydantic-config = false
-vllm-router = false
+deep-ep = false
+deep-gemm = false
 dion = false
 fastokens = false
 flash-attn-3 = false
-prime-tunnel = false
-deep-gemm = false
-prime-evals = false
-torchao = false
-tokenspeed-mla = false
+harbor = "2026-08-11T00:00:00Z"
 nixl-cu13 = false
-deep-ep = false
-prime-sandboxes = false
-renderers = false
-prime-kernels = false
 prime = false
+prime-evals = false
+prime-kernels = false
+prime-pydantic-config = false
+prime-runs = false
+prime-sandboxes = false
+prime-tunnel = false
+renderers = false
+tokenspeed-mla = false
+torchao = false
+verifiers = false
+vllm = false
+vllm-router = false
 
 [manifest]
 members = [
@@ -5197,6 +5198,19 @@ requires-dist = [
 ]
 
 [[package]]
+name = "prime-runs"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "prime-traces" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/db/3d5a9362f0d373d10145eaee3ac255cf227bf4164b36d04119b18e226607/prime_runs-0.1.1.tar.gz", hash = "sha256:0be97dcc95b3f1648ca25475efa45a5892fb12a775bf1f61728baec73a0088bb", size = 61110, upload-time = "2026-09-04T17:01:33.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/52/3fa41ac5e3c8bfa8eb33520f86634ae56474228f85c59b16aa04875efd7d/prime_runs-0.1.1-py3-none-any.whl", hash = "sha256:d512753ff84159a1234d1ea93091857f0a59fba12ef7ab2f69bfb579deb5ce75", size = 43006, upload-time = "2026-09-04T17:01:31.821Z" },
+]
+
+[[package]]
 name = "prime-sandboxes"
 version = "0.2.39"
 source = { registry = "https://pypi.org/simple" }
@@ -5213,6 +5227,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/59/8c/0bf89180addb74f75e41fbf6fa06c5401ea802b69ec0b565330562270be2/prime_sandboxes-0.2.39.tar.gz", hash = "sha256:7ff6c23aa2c96985a9129d977d532c0ae2fb6afb6d394dac746393ce0c53b597", size = 103161, upload-time = "2026-08-19T23:09:27.921Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/a5/8a2a1aefecfc58ca926d6b21e8302a127884bf2a45952ed390b5f702eeda/prime_sandboxes-0.2.39-py3-none-any.whl", hash = "sha256:3ea355158473c1697f9ef6ec2a07f3189e9a2555c80d1c88e1f7e22979772e0a", size = 58161, upload-time = "2026-08-19T23:09:26.69Z" },
+]
+
+[[package]]
+name = "prime-traces"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/77/13fa99c0fb71909f2f35d048d9724efb9ae432484e47f12386b1542815e8/prime_traces-0.0.3.tar.gz", hash = "sha256:4071833db77a606ccbb718e5c73f2dfaf63982fe801aa096daed0bc605da554f", size = 50874, upload-time = "2026-08-27T19:46:44.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/9a/5a917de29a3a839c0ba36d445e3af562f744d9716b509571be643a01476c/prime_traces-0.0.3-py3-none-any.whl", hash = "sha256:0838f60651f1ed38371e383bd88b954e461d20ac424874e694bc83358934f5f3", size = 38345, upload-time = "2026-08-27T19:46:43.396Z" },
 ]
 
 [[package]]
@@ -7715,6 +7742,7 @@ dependencies = [
     { name = "numpy" },
     { name = "openai" },
     { name = "prime-pydantic-config", extra = ["toml"] },
+    { name = "prime-runs" },
     { name = "prime-sandboxes" },
     { name = "prime-tunnel" },
     { name = "pydantic" },
@@ -7756,6 +7784,7 @@ requires-dist = [
     { name = "openai", specifier = ">=2.54.0,<3.0.0" },
     { name = "openenv", marker = "extra == 'openenv'", specifier = ">=0.4.1" },
     { name = "prime-pydantic-config", extras = ["toml"], specifier = ">=0.4.3" },
+    { name = "prime-runs", specifier = ">=0.1.1" },
     { name = "prime-sandboxes", specifier = ">=0.2.39" },
     { name = "prime-tunnel", specifier = ">=0.1.8" },
     { name = "pydantic", specifier = ">=2.12.3" },


### PR DESCRIPTION
## Summary

Add opt-in Total Router Recall for the custom Qwen3-MoE trainer: replay inference-selected expert IDs **and their captured FP32 coefficients**, instead of recomputing coefficients from trainer logits.

- Carry one paired routing record through serving, trace conversion, packing, and the trainer.
- Validate shape, dtype, row validity, expert bounds, and normalized/distinct real-token routes.
- Bypass the frozen router module during direct replay; keep its parameters registered for checkpointing and preserve FP32 inputs through FSDP.
- Keep IDs-only replay as the default mode and reject unsupported full-replay paths explicitly.

## Experimental scope

One generation call per branch, custom text-only Qwen3-MoE, normalized top-k, trainer CP=EP=1, modular vLLM V2 routing, non-streaming token requests. No multi-turn full replay, P/D, external KV offload, monolithic capture, new metadata store, or general backend qualification.

Recorded coefficients are constants. The normal gradient through the router and its input-dependent coefficients is removed; expert paths remain trainable. This is not a straight-through estimator or a claim of zero numerical mismatch.

<!-- trr-dependencies:start -->
## Dependencies

- Renderer paired-payload support: https://github.com/PrimeIntellect-ai/renderers/pull/154 (`fa5624c`).
- Verifier paired trace support: https://github.com/PrimeIntellect-ai/verifiers/pull/2568 (`036c828`).
- A matching vLLM coefficient-capture build is required for the opt-in mode. Upstream vLLM submission is held pending its required human review/testing/DCO steps. Stock vLLM 0.28 does not export these weights.

The parent submodule pins will reference the companion PR heads. These dependencies and GPU qualification must be resolved before merge.
<!-- trr-dependencies:end -->

## Validation

Ported onto current main `6a360c302938c5ab16791bc7ee3d97ba968d1228` and tested with renderer `fa5624ceff7072fe2c3cad2d6e3b5bf318347329` and verifier `036c828d0021a8c1ce901aed07879ba749dae16f`.

```sh
UV_PROJECT_ENVIRONMENT=.venv-ci uv run --no-sync -m pytest tests/unit/transports/test_routing_payload.py tests/unit/orchestrator/test_batch.py tests/unit/test_router_weight_configs.py tests/unit/test_configs.py tests/unit/inference/test_routed_expert_weights.py tests/unit/inference/test_serving_tokens.py tests/unit/train/models/test_routing_replay.py tests/unit/train/models/test_qwen3_moe_routing_replay.py tests/unit/train/rl/test_routing_replay_data.py tests/unit/train/test_model_routing_replay.py tests/unit/train/test_routing_replay_imports.py tests/unit/train/test_model.py tests/unit/train/test_model_forward.py -m "not gpu" -k "not load_configs" -q
```

**235 passed, 80 deselected.** The excluded cases include GPU tests and the configuration-file matrix; neither is claimed as passing. A mainline FSDP test fixture was updated to use the current `ModelConfig`/fusion settings; its focused rerun passed 10 tests.

The companion verifier now requires first-party `prime-runs`; this PR adds it to the existing first-party cooldown exceptions and refreshes the lock for `prime-runs`/`prime-traces`. Existing version requirements and numerical dtype defaults are unchanged.

No actual GPU execution, end-to-end sampler/trainer parity, throughput, or training-quality result is claimed. Full replay still requires a compatible coefficient-capture vLLM build; the stock pinned wheel is intentionally rejected for that opt-in mode.

## AI assistance

AI assistance was used for implementation, review, and local test execution. This is a draft for human review; model-quality, CUDA graph, cache, FSDP/checkpoint, and end-to-end sampler-to-trainer qualification remain required.
