### PR TITLE
fix(deepseek_v4): hardware guards for unrunnable gpu CI tests

### DIFF
--- a/tests/unit/train/models/test_deepseek_v4_kernels.py
+++ b/tests/unit/train/models/test_deepseek_v4_kernels.py
@@ -180,52 +180,39 @@ V4FLASH_MODEL = dict(
     },
 )
 
-# The hand-built tensors of the first section describe the same CSA layer `V4FLASH_MODEL` does, so
-# they are read off it rather than written out again: 64 heads over 512 channels, each query
-# gathering `sliding_window + index_topk = 128 + 512` slots from a single KV group, in bfloat16.
+# Read off `V4FLASH_MODEL` so the hand-built tensors below describe the same CSA layer it does.
 HEADS = V4FLASH_MODEL["num_attention_heads"]
 DIM = V4FLASH_MODEL["head_dim"]
 KV_GROUP = V4FLASH_MODEL["num_key_value_heads"]
 TOPK = V4FLASH_MODEL["sliding_window"] + V4FLASH_MODEL["index_topk"]
 SM_SCALE = DIM**-0.5
 
-# Three shapes. The first is aligned to both of the backward's tile sizes and the second to
-# neither: `preprocess` tiles the query axis at 32 and `postprocess` tiles the KV axis at 64, so a
-# remainder tile in either is a distinct code path. `200 % 32 = 8` and `1000 % 64 = 40`. The third
-# carries a batch, which nothing else here does: `Q` and `Indices` are indexed by batch and the
-# `dKV[by, Indices[by, ...]]` atomics scatter per batch entry, so a batch stride dropped anywhere
-# in that chain is invisible at batch 1. Sequence lengths stay modest because the float32 oracle
-# materializes a `(batch, seq_len, topk, head_dim)` gather, roughly 640 KB per token even before
-# its backward.
+# The first is aligned to both of the backward's tile sizes (32 in `preprocess`, 64 in
+# `postprocess`), the second to neither, and the third carries a batch, which nothing else here
+# does. Sequence lengths stay modest because the float32 oracle materializes the whole gather.
 SHAPES = [(1, 256, 1024), (1, 200, 1000), (3, 128, 768)]
 SHAPE_IDS = ["aligned", "misaligned", "batched"]
 
-# A quarter of the gather slots are masked, which is what a real query with a short window or a
-# saturated top-k looks like: the masked slots still cost a GEMM column.
+# What a real query with a short window or a saturated top-k looks like; a masked slot still
+# costs a GEMM column.
 MASKED_FRACTION = 0.25
 
-# Bounds on the largest absolute deviation against each tensor's own scale, not element-wise:
-# every entry is a sum over hundreds of terms, so the near-zero entries are the ones whose
-# summands cancelled, and an element-wise relative bound would read out that cancellation noise.
-# The kernel returns bfloat16, so its output cannot agree with a float32 oracle any more closely
-# than bfloat16 rounding allows: one ulp at full scale is 2**-8 = 3.9e-3.
+# Bounds on the largest deviation against each tensor's own scale, not element-wise: every entry
+# sums hundreds of terms, so an element-wise bound would read out the near-zero entries'
+# cancellation noise. The kernel returns bfloat16, one ulp of which is 2**-8 at full scale.
 OUT_RTOL = 1e-2
 # The LSE is float32 throughout on both sides.
 LSE_RTOL = 5e-7
 DQ_RTOL = 1e-2
 # The vendored kernel this one forked from rounds `P` and `dP` to bfloat16 before the `dKV` GEMMs
-# while the float32 oracle keeps them in float32. The rest is the bfloat16 `kv` the two sides
-# share. Neither effect needs a looser bound than the other gradients get: what used to need one
-# was the oracle's own bfloat16 leaf, see `_float32_leaves`.
+# while the oracle keeps them in float32, on top of the bfloat16 `kv` both sides share.
 DKV_RTOL = 1e-2
 # The sink gradient is a full reduction over every query in the row, so it cancels harder than
 # anything else here.
 DSINK_RTOL = 1e-2
 
-# Compiled against eager. The forward and the log-sum-exp are bit-identical, but `dKV` is not
-# comparable that way on either side: the backward scatters it with `atomic_addx4`, so its
-# summation order is whatever the scheduler picks and the same eager call against itself moves by
-# the same amount.
+# Compiled against eager, where the forward and the log-sum-exp are bit-identical. `dKV` is not,
+# because `atomic_addx4` leaves its summation order to the scheduler, on both sides.
 COMPILE_RTOL = 1e-2
 
 

--- a/tests/unit/train/models/test_deepseek_v4_kernels.py
+++ b/tests/unit/train/models/test_deepseek_v4_kernels.py
@@ -31,6 +31,14 @@ requires_sparse_attn_kernel = pytest.mark.skipif(
     reason="the fused sparse attention kernel did not import; tilelang ships in the `gpu` extra, on linux only",
 )
 
+# The kernels' shared tiles fit only the datacenter Hopper and Blackwell SMs. The opt-in limit does
+# not follow capability order, so this enumerates rather than compares: sm120 allows well under half
+# of what sm90 does.
+requires_datacenter_gpu = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] not in (9, 10),
+    reason="the fused sparse attention kernels need the shared memory of a datacenter Hopper or Blackwell GPU",
+)
+
 
 @pytest.fixture(autouse=True)
 def _seed_rng():
@@ -320,6 +328,7 @@ def _reference_lse(q: torch.Tensor, kv: torch.Tensor, indices: torch.Tensor, sin
 
 @pytest.mark.parametrize(("batch", "seq_len", "seq_len_kv"), SHAPES, ids=SHAPE_IDS)
 @requires_sparse_attn_kernel
+@requires_datacenter_gpu
 def test_kernel_forward_matches_the_dense_reference(batch, seq_len, seq_len_kv):
     """Output and log-sum-exp against the float32 gather oracle, which has identical semantics."""
     q, kv, indices, sinks = _inputs(batch, seq_len, seq_len_kv)
@@ -339,6 +348,7 @@ def test_kernel_forward_matches_the_dense_reference(batch, seq_len, seq_len_kv):
 
 
 @requires_sparse_attn_kernel
+@requires_datacenter_gpu
 def test_kernel_pads_a_slot_count_its_tile_does_not_divide():
     """A caller states the slots it means and the kernel covers the difference to its own tile.
 
@@ -363,6 +373,7 @@ def test_kernel_pads_a_slot_count_its_tile_does_not_divide():
 
 
 @requires_sparse_attn_kernel
+@requires_datacenter_gpu
 def test_fully_masked_query_reads_as_zero_keys():
     """A query with no keys at all must emit exactly zero, on the sink term alone.
 
@@ -440,6 +451,7 @@ def test_tilelang_zero_fills_an_out_of_range_gather():
 
 @pytest.mark.parametrize(("batch", "seq_len", "seq_len_kv"), SHAPES, ids=SHAPE_IDS)
 @requires_sparse_attn_kernel
+@requires_datacenter_gpu
 def test_kernel_backward_matches_autograd_through_the_reference(batch, seq_len, seq_len_kv):
     """All three differentiable inputs, each against its own bound.
 
@@ -468,6 +480,7 @@ def test_kernel_backward_matches_autograd_through_the_reference(batch, seq_len, 
 
 
 @requires_sparse_attn_kernel
+@requires_datacenter_gpu
 def test_kernel_traces_under_torch_compile():
     """`torch.compile(fullgraph=True)` through the op, forward and backward.
 
@@ -633,6 +646,7 @@ def _selected_positions(indices: torch.Tensor, n_positions: int) -> torch.Tensor
 
 
 @requires_sparse_attn_kernel
+@requires_datacenter_gpu
 @pytest.mark.parametrize("doc_lens", V4FLASH_DOC_LENS, ids=V4FLASH_DOC_IDS)
 @pytest.mark.parametrize("layer_idx", V4FLASH_LAYERS, ids=V4FLASH_LAYER_IDS)
 def test_sparse_indices_address_exactly_the_keys_the_dense_mask_admits(doc_lens, layer_idx, monkeypatch):
@@ -690,6 +704,7 @@ def test_sparse_indices_address_exactly_the_keys_the_dense_mask_admits(doc_lens,
 
 
 @requires_sparse_attn_kernel
+@requires_datacenter_gpu
 @pytest.mark.parametrize("doc_lens", V4FLASH_DOC_LENS, ids=V4FLASH_DOC_IDS)
 @pytest.mark.parametrize("layer_idx", V4FLASH_LAYERS, ids=V4FLASH_LAYER_IDS)
 def test_sparse_indices_are_in_range_and_never_repeat_a_key(doc_lens, layer_idx, monkeypatch):
@@ -730,6 +745,7 @@ def test_sparse_indices_are_in_range_and_never_repeat_a_key(doc_lens, layer_idx,
 
 
 @requires_sparse_attn_kernel
+@requires_datacenter_gpu
 @pytest.mark.parametrize("doc_lens", V4FLASH_DOC_LENS, ids=V4FLASH_DOC_IDS)
 def test_absent_slots_are_marked_negative_rather_than_pointed_at_a_pad_row(doc_lens, monkeypatch):
     """An unused gather slot must hold `IGNORE_SLOT` (-1), never a position that `kv_buf` actually has.
@@ -806,6 +822,7 @@ EAGER_KERNEL_RTOL, EAGER_KERNEL_GRAD_RTOL = 1e-2, 5e-2
 
 @pytest.mark.parametrize("doc_lens", EAGER_KERNEL_DOC_LENS, ids=EAGER_KERNEL_DOC_IDS)
 @requires_sparse_attn_kernel
+@requires_datacenter_gpu
 def test_sparse_attention_kernel_matches_eager(doc_lens, monkeypatch):
     """The fused kernel against the naive dense softmax, single-document and packed.
 
@@ -865,6 +882,7 @@ def test_sparse_attention_kernel_matches_eager(doc_lens, monkeypatch):
 
 
 @requires_sparse_attn_kernel
+@requires_datacenter_gpu
 def test_sparse_attention_kernel_packed_matches_unpacked(monkeypatch):
     """The fused kernel path, end to end through one CSA layer, must respect documents.
 
@@ -915,6 +933,7 @@ def test_sparse_attention_kernel_packed_matches_unpacked(monkeypatch):
 
 
 @requires_sparse_attn_kernel
+@requires_datacenter_gpu
 def test_sparse_attention_kernel_trains_every_parameter(monkeypatch):
     """Every parameter of a CSA layer that can train does, with the kernel in the path.
 
@@ -1068,6 +1087,7 @@ def _assert_within_the_bfloat16_floor(
 
 
 @requires_sparse_attn_kernel
+@requires_datacenter_gpu
 @pytest.mark.parametrize("doc_lens", PARITY_DOC_LENS, ids=PARITY_DOC_IDS)
 @pytest.mark.parametrize("layer_idx", V4FLASH_LAYERS, ids=V4FLASH_LAYER_IDS)
 def test_kernel_and_eager_consumers_agree_on_shared_weights(layer_idx, doc_lens):


### PR DESCRIPTION
Custom deepseek v4 flash attention requires more SMEM than some gpus (like the current CI runners) have. Skip the tests in those cases. 