### PR TITLE
chore(deepseek_v4): production attention path cleanup

### DIFF
--- a/src/prime_rl/trainer/models/deepseek_v4/attention.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/attention.py
@@ -125,7 +125,6 @@ import torch
 from torch import Tensor, nn
 
 from prime_rl.trainer.models.deepseek_v4.configuration_deepseek_v4 import DeepseekV4Config
-from prime_rl.trainer.models.deepseek_v4.eager_reference import dense_mask_from_indices, eager_attention_with_sinks
 from prime_rl.trainer.models.deepseek_v4.hyperconnections import DeepseekV4UnweightedRMSNorm
 from prime_rl.trainer.models.deepseek_v4.rotary import DeepseekV4RotaryEmbedding, apply_rotary_pos_emb_interleaved
 from prime_rl.trainer.models.kernels.deepseek_v4 import IGNORE_SLOT
@@ -637,56 +636,14 @@ class DeepseekV4Attention(nn.Module):
         )
         self.o_b_proj = nn.Linear(config.o_groups * config.o_lora_rank, config.hidden_size, bias=False)
         self.sinks = nn.Parameter(torch.zeros(self.num_heads))
-        self.attn_impl = config._attn_impl
         # Raised here rather than from the first forward, where it would surface as an ImportError
         # or a tilelang compile failure a long way from the config that caused it.
-        blocker = _kernel_blocker(self.num_heads, self.head_dim) if self.attn_impl == "kernel" else None
+        blocker = _kernel_blocker(self.num_heads, self.head_dim)
         if blocker is not None:
             raise ValueError(f"DeepSeek V4 cannot run the fused sparse-attention kernel: {blocker}")
+        assert config.attention_dropout == 0.0, "the fused sparse attention kernel implements no dropout"
         compressor_class = COMPRESSOR_CLASSES[self.layer_type]
         self.compressor = compressor_class(config) if compressor_class is not None else None
-
-    def _eager(self, q: Tensor, kv: Tensor, attention_mask: Tensor) -> Tensor:
-        return eager_attention_with_sinks(
-            q,
-            kv,
-            kv,
-            self.sinks,
-            attention_mask,
-            scaling=self.scaling,
-            dropout=self.attention_dropout,
-            training=self.training,
-        )
-
-    def _attend(self, q: Tensor, kv: Tensor, compressed: tuple[Tensor, Tensor] | None, packed: PackedContext) -> Tensor:
-        """Attend `q` (b, h, t, d) over the local KV `kv` (b, 1, t, d), plus any compressed entries.
-
-        Returns (b, t, h, d). A sliding layer sees only its window and passes `compressed` as
-        `None`; a compressed layer reaches further through its compressor's output, the entries
-        paired with the per-query indices selecting among them.
-
-        Every layer lays its slots out once, in `SparseAttnInputs`, and then differs only in the
-        attention core it hands them to, so the eager consumer is an oracle for the kernel rather
-        than a second answer to which keys a query reads.
-        """
-        compressed_kv, top_k_indices = compressed if compressed is not None else (None, None)
-        inputs = SparseAttnInputs.build(
-            kv=kv,
-            compressed_kv=compressed_kv,
-            top_k_indices=top_k_indices,
-            window_indices=packed.window_indices,
-        )
-        if self.attn_impl == "eager":
-            n_positions = inputs.kv_buf.shape[1]
-            attention_mask = dense_mask_from_indices(inputs.indices, n_positions, q.dtype)
-            return self._eager(q, inputs.kv_buf.transpose(1, 2), attention_mask)
-
-        # `eager_attention_with_sinks` drops attention weights and the kernel does not, so the
-        # two only agree at zero. The default is 0.0 but a config may set it.
-        assert self.attention_dropout == 0.0, "the fused sparse attention kernel implements no dropout"
-        q = q.transpose(1, 2).contiguous()  # the kernel asserts contiguity
-        out, _ = dsv4_sparse_attn(q, inputs.kv_buf, inputs.indices, self.sinks, self.scaling)
-        return out
 
     def forward(self, hidden_states: torch.Tensor, packed: PackedContext) -> tuple[torch.Tensor, None]:
         """`packed` carries the document boundaries every pathway below is clipped at."""
@@ -715,7 +672,20 @@ class DeepseekV4Attention(nn.Module):
         kv = apply_rotary_pos_emb_interleaved(kv, cos, sin)
 
         compressed = self.compressor(hidden_states, q_residual, packed) if self.compressor is not None else None
-        attn_output = self._attend(q, kv, compressed, packed)  # (b, t, h, d)
+        compressed_kv, top_k_indices = compressed if compressed is not None else (None, None)
+        inputs = SparseAttnInputs.build(
+            kv=kv,
+            compressed_kv=compressed_kv,
+            top_k_indices=top_k_indices,
+            window_indices=packed.window_indices,
+        )
+        attn_output, _ = dsv4_sparse_attn(
+            q.transpose(1, 2).contiguous(),
+            inputs.kv_buf,
+            inputs.indices,
+            self.sinks,
+            self.scaling,
+        )  # (b, t, h, d)
 
         # The value stream is the key stream, so it arrived rotated. Rotating the output
         # by the conjugate angle at the query position cancels that out.
@@ -742,6 +712,4 @@ __all__ = [
     "DeepseekV4Indexer",
     "PackedContext",
     "SparseAttnInputs",
-    "dense_mask_from_indices",
-    "eager_attention_with_sinks",
 ]

--- a/src/prime_rl/trainer/models/deepseek_v4/configuration_deepseek_v4.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/configuration_deepseek_v4.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any
 
 from huggingface_hub.dataclasses import strict
 from transformers.configuration_utils import PretrainedConfig
@@ -125,7 +125,6 @@ class DeepseekV4Config(PretrainedConfig):
         index_n_heads: int = 64,
         index_head_dim: int = 128,
         index_topk: int = 512,
-        _attn_impl: Literal["kernel", "eager"] = "kernel",
         num_experts_per_tok: int = 6,
         n_routed_experts: int = 256,
         n_shared_experts: int = 1,
@@ -182,9 +181,6 @@ class DeepseekV4Config(PretrainedConfig):
         self.index_n_heads = index_n_heads
         self.index_head_dim = index_head_dim
         self.index_topk = index_topk
-        # Exists so tests can run toy shapes the kernel rejects; no shipped config may set it,
-        # and `to_dict` drops it so it never reaches disk.
-        self._attn_impl = _attn_impl
 
         self.partial_rotary_factor = (
             partial_rotary_factor
@@ -324,18 +320,15 @@ class DeepseekV4Config(PretrainedConfig):
                 self.rope_parameters = rope_parameters_dict
 
     def to_dict(self) -> dict[str, Any]:
-        """Drop the in-memory-only fields before serializing.
+        """Drop the in-memory-only field before serializing.
 
         `num_hash_layers` is the on-disk source of truth (matching the real checkpoint);
         `mlp_layer_types` only exists in memory so HF's real `DeepseekV4SparseMoeBlock`
         (which reads `config.mlp_layer_types[layer_idx]` directly) still works when this
-        config is handed to it, e.g. in HF-parity tests. `_attn_impl` is a test knob: an
-        underscore prefix alone would not keep it out, since the base method strips an
-        explicit list of names.
+        config is handed to it, e.g. in HF-parity tests.
         """
         output = super().to_dict()
         output.pop("mlp_layer_types", None)
-        output.pop("_attn_impl", None)
         return output
 
     def validate_layer_type(self) -> None:

--- a/src/prime_rl/trainer/models/deepseek_v4/eager_reference.py
+++ b/src/prime_rl/trainer/models/deepseek_v4/eager_reference.py
@@ -1,13 +1,19 @@
 """Naive DeepSeek V4 attention reference.
 
 Nothing in the production path calls these. They exist for the tests, where a dense, obviously
-correct implementation is the standard the fused kernel is measured against. They take plain
-tensors, so this module imports nothing from `attention.py` and the dependency runs one way only.
+correct implementation is the standard the fused kernel is measured against, and where it is the
+only implementation that runs at shapes the kernel cannot tile. The dependency runs one way only:
+this module reads `attention.py`, which is kernel-only and never reads back.
 """
+
+import types
 
 import torch
 import torch.nn.functional as F
-from torch import Tensor
+from torch import Tensor, nn
+
+from prime_rl.trainer.models.deepseek_v4.attention import DeepseekV4Attention, PackedContext, SparseAttnInputs
+from prime_rl.trainer.models.deepseek_v4.rotary import apply_rotary_pos_emb_interleaved
 
 
 def eager_attention_with_sinks(
@@ -91,3 +97,61 @@ def dense_mask_from_indices(indices: Tensor, n_positions: int, dtype: torch.dtyp
     mask = torch.full((batch, 1, seq_len, n_positions + 1), float("-inf"), dtype=dtype, device=indices.device)
     mask.scatter_(-1, safe, 0.0)
     return mask[..., :n_positions].contiguous()
+
+
+def eager_attention_forward(
+    module: DeepseekV4Attention, hidden_states: Tensor, packed: PackedContext
+) -> tuple[Tensor, None]:
+    """`DeepseekV4Attention.forward` with a dense softmax where the fused kernel goes.
+
+    The projections and the RoPE are reimplemented rather than called through, so a change to that
+    method has to be mirrored here. The slot layout is not: both consumers read the same
+    `SparseAttnInputs`, which is what makes a disagreement between them one about attention math.
+    """
+    input_shape = hidden_states.shape[:-1]
+    hidden_shape = (*input_shape, -1, module.head_dim)
+    cos, sin = packed.position_embeddings[module.rope_layer_type]
+
+    q_residual = module.q_a_norm(module.q_a_proj(hidden_states))
+    q = module.q_b_proj(q_residual).view(*hidden_shape).transpose(1, 2)
+    q = apply_rotary_pos_emb_interleaved(module.q_b_norm(q), cos, sin)
+
+    kv = module.kv_norm(module.kv_proj(hidden_states)).view(*hidden_shape).transpose(1, 2)
+    kv = apply_rotary_pos_emb_interleaved(kv, cos, sin)
+
+    compressed = module.compressor(hidden_states, q_residual, packed) if module.compressor is not None else None
+    compressed_kv, top_k_indices = compressed if compressed is not None else (None, None)
+    inputs = SparseAttnInputs.build(
+        kv=kv,
+        compressed_kv=compressed_kv,
+        top_k_indices=top_k_indices,
+        window_indices=packed.window_indices,
+    )
+
+    attention_mask = dense_mask_from_indices(inputs.indices, inputs.kv_buf.shape[1], q.dtype)
+    keys = inputs.kv_buf.transpose(1, 2)
+    attn_output = eager_attention_with_sinks(
+        q,
+        keys,
+        keys,
+        module.sinks,
+        attention_mask,
+        scaling=module.scaling,
+        dropout=module.attention_dropout,
+        training=module.training,
+    )
+
+    attn_output = apply_rotary_pos_emb_interleaved(attn_output, cos, -sin, unsqueeze_dim=2)
+    grouped = module.o_a_proj(attn_output.reshape(*input_shape, module.config.o_groups, -1)).flatten(2)
+    return module.o_b_proj(grouped), None
+
+
+def use_eager_attention(module: nn.Module) -> None:
+    """Rebind every `DeepseekV4Attention` under `module` to the dense reference consumer.
+
+    `modules()` yields `module` itself, so this covers a lone attention layer as well as a model
+    holding several of them.
+    """
+    for submodule in module.modules():
+        if isinstance(submodule, DeepseekV4Attention):
+            submodule.forward = types.MethodType(eager_attention_forward, submodule)

--- a/tests/unit/train/models/test_deepseek_v4.py
+++ b/tests/unit/train/models/test_deepseek_v4.py
@@ -26,6 +26,11 @@ pytestmark = [
     ),
 ]
 
+requires_fp8_indexer = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9,
+    reason="the indexer kernel quantizes to Triton fp8e4nv (e4m3), only supported on Hopper (SM90) and newer",
+)
+
 # Deliberately heterogeneous: one layer of every attention type, hash-routed bootstrap
 # layers ahead of standard MoE ones, and a sliding window narrow enough that the compressed
 # branches are what carries any long-range signal.
@@ -197,6 +202,7 @@ def _packed_context(doc_lens: tuple[int, ...], dtype: torch.dtype) -> PackedCont
     )
 
 
+@requires_fp8_indexer
 def test_deepseek_v4_hash_layers_route_on_token_ids():
     """The bootstrap layers read `input_ids`, so identical hidden states still route apart."""
     prime_model = get_prime_model()
@@ -220,6 +226,7 @@ def test_deepseek_v4_hash_layers_route_on_token_ids():
     torch.testing.assert_close(counts[0][0], expected)
 
 
+@requires_fp8_indexer
 def test_deepseek_v4_backward():
     """Every parameter that can train does, and the Lightning Indexer's still cannot."""
     with torch.device("cuda"), default_dtype(torch.bfloat16):
@@ -672,6 +679,7 @@ def _compare_accumulated_grads(
         _assert_relative(param.grad, expected[name], rtol, name)
 
 
+@requires_fp8_indexer
 def test_packed_sliding_window_mask_respects_documents(_torch_rms_norm, monkeypatch):  # noqa: F811
     """The local window stops at document boundaries, on every layer.
 
@@ -710,6 +718,7 @@ def test_packed_sliding_window_mask_respects_documents(_torch_rms_norm, monkeypa
         assert torch.equal(local, expected), f"layer {layer_idx}: the local window crosses a document boundary"
 
 
+@requires_fp8_indexer
 def test_model_packed_matches_unpacked(_torch_rms_norm):  # noqa: F811
     """The invariant that makes the trainer agree with vLLM, which serves each rollout alone.
 
@@ -843,7 +852,7 @@ def test_compressor_packed_matches_per_document(layer_idx, compress_rate, expect
 @pytest.mark.parametrize(
     ("layer_idx", "doc_lens"),
     [
-        (CSA_LAYER, MID_WINDOW_DOCS),
+        pytest.param(CSA_LAYER, MID_WINDOW_DOCS, marks=requires_fp8_indexer),
         (HCA_LAYER, EXACT_MULTIPLE_DOCS),
         (SLIDING_LAYER, MID_WINDOW_DOCS),
     ],

--- a/tests/unit/train/models/test_deepseek_v4.py
+++ b/tests/unit/train/models/test_deepseek_v4.py
@@ -65,8 +65,9 @@ MODEL = dict(
     rms_norm_eps=1e-6,
 )
 
-MODEL_BATCH, MODEL_SEQ = 2, 32
-MODULE_BATCH = 2
+# The Lightning Indexer scores one packed row, which makes every batch axis here 1.
+BATCH = 1
+MODEL_SEQ = 32
 
 SLIDING_LAYER, CSA_LAYER, HCA_LAYER = 0, 1, 2
 COMPRESS_RATE = MODEL["compress_rates"]["compressed_sparse_attention"]
@@ -193,7 +194,7 @@ def test_deepseek_v4_hash_layers_route_on_token_ids():
 
     counts = []
     for token_id in (0, 1):
-        input_ids = torch.full((MODEL_BATCH, MODEL_SEQ), token_id, device="cuda", dtype=torch.long)
+        input_ids = torch.full((BATCH, MODEL_SEQ), token_id, device="cuda", dtype=torch.long)
         for layer in hash_layers:
             layer.mlp.tokens_per_expert.zero_()
         position_ids, seq_lens = _single_doc(input_ids)
@@ -204,7 +205,7 @@ def test_deepseek_v4_hash_layers_route_on_token_ids():
     assert set(table[0].tolist()) != set(table[1].tolist()), "the two table rows must differ for this to bite"
     assert not torch.equal(counts[0], counts[1]), "a hash layer must route the two token ids to different experts"
     expected = torch.zeros_like(counts[0][0])
-    expected[table[0]] = MODEL_BATCH * MODEL_SEQ
+    expected[table[0]] = BATCH * MODEL_SEQ
     torch.testing.assert_close(counts[0][0], expected)
 
 
@@ -216,7 +217,7 @@ def test_deepseek_v4_backward():
     _randomize(model)
     inject_prime_lm_head(model)
 
-    input_ids = torch.randint(0, MODEL["vocab_size"], (MODEL_BATCH, MODEL_SEQ), device="cuda")
+    input_ids = torch.randint(0, MODEL["vocab_size"], (BATCH, MODEL_SEQ), device="cuda")
     position_ids, seq_lens = _single_doc(input_ids)
     output = model(input_ids, position_ids=position_ids, seq_lens=seq_lens)
     output["logits"].sum().backward()
@@ -638,7 +639,7 @@ def _entry_counts(doc_lens: tuple[int, ...], compress_rate: int) -> list[int]:
 def _fp32_hidden_states(seq_len: int) -> tuple[torch.Tensor, torch.Tensor]:
     """Two leaves carrying identical values, one for the packed run and one for the lone runs."""
     with torch.device("cuda"):
-        hidden = torch.randn(MODULE_BATCH, seq_len, MODEL["hidden_size"])
+        hidden = torch.randn(BATCH, seq_len, MODEL["hidden_size"])
     return hidden.clone().requires_grad_(True), hidden.clone().requires_grad_(True)
 
 
@@ -806,7 +807,7 @@ def test_compressor_packed_matches_per_document(layer_idx, compress_rate, expect
     packed_input, alone_input = _fp32_hidden_states(sum(doc_lens))
 
     packed_entries = compressor.compress(packed_input, packed)
-    assert packed_entries.shape == (MODULE_BATCH, sum(counts), compressor.head_dim)
+    assert packed_entries.shape == (BATCH, sum(counts), compressor.head_dim)
 
     with torch.device("cuda"):
         weight = torch.randn_like(packed_entries)
@@ -819,9 +820,7 @@ def test_compressor_packed_matches_per_document(layer_idx, compress_rate, expect
         alone = compressor.compress(
             alone_input[:, _doc_slice(doc_lens, index)], _packed_context((doc_lens[index],), torch.float32)
         )
-        assert alone.shape == (MODULE_BATCH, count, compressor.head_dim), (
-            f"document {index} compressed to the wrong count"
-        )
+        assert alone.shape == (BATCH, count, compressor.head_dim), f"document {index} compressed to the wrong count"
         torch.testing.assert_close(
             packed_entries[:, entries],
             alone,

--- a/tests/unit/train/models/test_deepseek_v4.py
+++ b/tests/unit/train/models/test_deepseek_v4.py
@@ -75,6 +75,10 @@ MODEL = dict(
     rms_norm_eps=1e-6,
 )
 
+# Shared: model construction only writes transformers' private `_attn_implementation_internal`
+# and `_experts_implementation_internal`, idempotently, so deep-copy before any other mutation.
+MODEL_CONFIG = DeepseekV4Config(**MODEL)
+
 # The Lightning Indexer scores one packed row, which makes every batch axis here 1.
 BATCH = 1
 MODEL_SEQ = 32
@@ -138,14 +142,10 @@ def _randomize(module: nn.Module) -> None:
                 buffer.copy_(_tid2eid(buffer.shape[0], router.num_experts, router.top_k))
 
 
-def _prime_config() -> DeepseekV4Config:
-    return DeepseekV4Config(**MODEL)
-
-
 def get_prime_model(dtype: torch.dtype = torch.bfloat16) -> nn.Module:
     """A prime-rl model with non-degenerate weights and the LM head training code wraps it in."""
     with torch.device("cuda"), default_dtype(dtype):
-        model = DeepseekV4ForCausalLM._from_config(_prime_config())
+        model = DeepseekV4ForCausalLM._from_config(MODEL_CONFIG)
     _randomize(model)
     eager_reference.use_eager_attention(model)
     inject_prime_lm_head(model, chunk_size=None)
@@ -159,7 +159,7 @@ def prime_attention(layer_idx: int, dtype: torch.dtype = torch.bfloat16) -> nn.M
     bit-identical to one from a config carrying only the attention keys.
     """
     with torch.device("cuda"), default_dtype(dtype):
-        module = DeepseekV4Attention(_prime_config(), layer_idx=layer_idx)
+        module = DeepseekV4Attention(MODEL_CONFIG, layer_idx=layer_idx)
     _randomize(module)
     eager_reference.use_eager_attention(module)
     return module
@@ -188,7 +188,7 @@ def _packed_context(doc_lens: tuple[int, ...], dtype: torch.dtype) -> PackedCont
     be the one the caller runs at.
     """
     with torch.device("cuda"), default_dtype(dtype):
-        rotary = DeepseekV4RotaryEmbedding(_prime_config())
+        rotary = DeepseekV4RotaryEmbedding(MODEL_CONFIG)
     return PackedContext.build(
         rotary_emb=rotary,
         seq_lens=torch.tensor(doc_lens, device="cuda"),
@@ -222,9 +222,8 @@ def test_deepseek_v4_hash_layers_route_on_token_ids():
 
 def test_deepseek_v4_backward():
     """Every parameter that can train does, and the Lightning Indexer's still cannot."""
-    prime_config = _prime_config()
     with torch.device("cuda"), default_dtype(torch.bfloat16):
-        model = DeepseekV4ForCausalLM(prime_config)
+        model = DeepseekV4ForCausalLM(MODEL_CONFIG)
     _randomize(model)
     eager_reference.use_eager_attention(model)
     inject_prime_lm_head(model)
@@ -253,8 +252,7 @@ def test_deepseek_v4_backward():
 
 
 def test_deepseek_v4_weight_conversion_roundtrip():
-    prime_config = _prime_config()
-    model = DeepseekV4ForCausalLM(prime_config).to("cuda")
+    model = DeepseekV4ForCausalLM(MODEL_CONFIG).to("cuda")
     original = {name: tensor.clone() for name, tensor in model.state_dict().items()}
 
     state_dict = model.state_dict()
@@ -299,8 +297,7 @@ def test_deepseek_v4_hash_table_survives_the_load_path(tmp_path, monkeypatch):
     so getting it to reset one buffer too many is an easy mistake with no symptom other than every
     bootstrap token routing to expert 0.
     """
-    prime_config = _prime_config()
-    model = DeepseekV4ForCausalLM(prime_config).to("cuda")
+    model = DeepseekV4ForCausalLM(MODEL_CONFIG).to("cuda")
     tables = _fill_hash_tables(model)
 
     state_dict = model.convert_to_hf(dict(model.state_dict()))
@@ -312,15 +309,13 @@ def test_deepseek_v4_hash_table_survives_the_load_path(tmp_path, monkeypatch):
         assert torch.equal(state_dict[f"layers.{layer_idx}.ffn.gate.tid2eid"], table)
 
     model.convert_to_prime(state_dict)
-    reloaded = DeepseekV4ForCausalLM(prime_config).to("cuda")
+    reloaded = DeepseekV4ForCausalLM(MODEL_CONFIG).to("cuda")
     reloaded.load_state_dict(state_dict)
     for layer_idx, table in tables.items():
         assert torch.equal(reloaded.model.layers[layer_idx].mlp.router.tid2eid, table)
 
-    # And now the loading path itself, on a meta-device model, with the name `load_dcp_from_hf`
-    # asks the checkpoint for raising a `KeyError` in the stub below if the buffer ever moves.
     with torch.device("meta"):
-        meta_model = DeepseekV4ForCausalLM(prime_config)
+        meta_model = DeepseekV4ForCausalLM(MODEL_CONFIG)
     expected = tables[0]
 
     def fake_dcp_load(state_dict, storage_reader=None):
@@ -406,7 +401,7 @@ def test_deepseek_v4_on_disk_keys_map_to_the_names_vllm_expects():
     from vllm.models.deepseek_v4.nvidia.model import _make_deepseek_v4_weights_mapper
 
     with torch.device("meta"):
-        model = DeepseekV4ForCausalLM._from_config(_prime_config())
+        model = DeepseekV4ForCausalLM._from_config(MODEL_CONFIG)
     on_disk_state_dict = model.convert_to_hf(dict(model.state_dict()))
     assert on_disk_state_dict, "vacuous probe: the model produced no weights to map"
 
@@ -422,14 +417,13 @@ def test_deepseek_v4_on_disk_keys_map_to_the_names_vllm_expects():
 
 def test_deepseek_v4_init_buffers_post_meta_restores_every_rotary():
     """Rotary tables are non-persistent and computed eagerly, so meta loading loses them."""
-    prime_config = _prime_config()
     with torch.device("meta"):
-        model = DeepseekV4ForCausalLM(prime_config)
+        model = DeepseekV4ForCausalLM(MODEL_CONFIG)
     model.to_empty(device="cuda")
 
     model.init_buffers_post_meta()
 
-    reference = 1.0 / (prime_config.rope_theta ** (torch.arange(0, 16, 2, device="cuda", dtype=torch.float) / 16))
+    reference = 1.0 / (MODEL_CONFIG.rope_theta ** (torch.arange(0, 16, 2, device="cuda", dtype=torch.float) / 16))
     torch.testing.assert_close(model.model.rotary_emb.main_inv_freq, reference)
     compressors = [layer.self_attn.compressor for layer in model.model.layers if layer.self_attn.compressor]
     assert compressors, "config must contain a compressed attention layer"

--- a/tests/unit/train/models/test_deepseek_v4.py
+++ b/tests/unit/train/models/test_deepseek_v4.py
@@ -8,7 +8,7 @@ from torch import nn
 
 from prime_rl.configs.trainer import ModelConfig
 from prime_rl.trainer.model import load_dcp_from_hf
-from prime_rl.trainer.models.deepseek_v4 import DeepseekV4Config, DeepseekV4ForCausalLM
+from prime_rl.trainer.models.deepseek_v4 import DeepseekV4Config, DeepseekV4ForCausalLM, eager_reference
 from prime_rl.trainer.models.deepseek_v4 import attention as dsv4_attention
 from prime_rl.trainer.models.deepseek_v4.attention import DeepseekV4Attention, PackedContext
 from prime_rl.trainer.models.deepseek_v4.rotary import DeepseekV4RotaryEmbedding
@@ -16,7 +16,15 @@ from prime_rl.trainer.models.layers import norms
 from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
 from prime_rl.utils.utils import default_dtype
 
-pytestmark = [pytest.mark.gpu]
+# Every layer is built through `DeepseekV4Attention.__init__`, which refuses to construct without
+# the kernel it would dispatch to, so the whole file needs tilelang even though nothing here calls it.
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        dsv4_attention.dsv4_sparse_attn is None,
+        reason="the fused sparse attention kernel did not import; tilelang ships in the `gpu` extra, on linux only",
+    ),
+]
 
 # Deliberately heterogeneous: one layer of every attention type, hash-routed bootstrap
 # layers ahead of standard MoE ones, and a sliding window narrow enough that the compressed
@@ -26,7 +34,9 @@ MODEL = dict(
     hidden_size=128,
     moe_intermediate_size=64,
     num_hidden_layers=5,
-    num_attention_heads=4,
+    # The smallest head count `DeepseekV4Attention.__init__` accepts: the kernel's tiler pads the
+    # head axis to a power of two and its backward GEMM needs 32 rows.
+    num_attention_heads=32,
     num_key_value_heads=1,
     head_dim=32,
     q_lora_rank=64,
@@ -128,29 +138,30 @@ def _randomize(module: nn.Module) -> None:
                 buffer.copy_(_tid2eid(buffer.shape[0], router.num_experts, router.top_k))
 
 
-def _prime_config(attn_impl: str = "eager") -> DeepseekV4Config:
-    """The toy config. It defaults to eager because the kernel cannot tile 4 attention heads."""
-    return DeepseekV4Config(**MODEL, _attn_impl=attn_impl)
+def _prime_config() -> DeepseekV4Config:
+    return DeepseekV4Config(**MODEL)
 
 
-def get_prime_model(dtype: torch.dtype = torch.bfloat16, attn_impl: str = "eager") -> nn.Module:
+def get_prime_model(dtype: torch.dtype = torch.bfloat16) -> nn.Module:
     """A prime-rl model with non-degenerate weights and the LM head training code wraps it in."""
     with torch.device("cuda"), default_dtype(dtype):
-        model = DeepseekV4ForCausalLM._from_config(_prime_config(attn_impl))
+        model = DeepseekV4ForCausalLM._from_config(_prime_config())
     _randomize(model)
+    eager_reference.use_eager_attention(model)
     inject_prime_lm_head(model, chunk_size=None)
     return model
 
 
-def prime_attention(layer_idx: int, dtype: torch.dtype = torch.bfloat16, attn_impl: str = "eager") -> nn.Module:
+def prime_attention(layer_idx: int, dtype: torch.dtype = torch.bfloat16) -> nn.Module:
     """One attention layer of the same config the whole-model tests use.
 
     `DeepseekV4Attention` reads no MoE or hyper-connection field, so the layer this builds is
     bit-identical to one from a config carrying only the attention keys.
     """
     with torch.device("cuda"), default_dtype(dtype):
-        module = DeepseekV4Attention(_prime_config(attn_impl), layer_idx=layer_idx)
+        module = DeepseekV4Attention(_prime_config(), layer_idx=layer_idx)
     _randomize(module)
+    eager_reference.use_eager_attention(module)
     return module
 
 
@@ -215,6 +226,7 @@ def test_deepseek_v4_backward():
     with torch.device("cuda"), default_dtype(torch.bfloat16):
         model = DeepseekV4ForCausalLM(prime_config)
     _randomize(model)
+    eager_reference.use_eager_attention(model)
     inject_prime_lm_head(model)
 
     input_ids = torch.randint(0, MODEL["vocab_size"], (BATCH, MODEL_SEQ), device="cuda")
@@ -674,19 +686,19 @@ def test_packed_sliding_window_mask_respects_documents(_torch_rms_norm, monkeypa
     `sliding_window` packed positions whatever document they belong to, which at the production
     `sliding_window = 128` against 77-token rollouts spans roughly two neighbours on all 43 layers.
 
-    Captured from the mask the model actually applies rather than by calling the builder, so it
-    keeps holding if the masking ever moves.
+    Captured from the dense mask the reference consumer applies to production's own
+    `window_indices`, rather than by calling the builder, so it keeps holding if the masking moves.
     """
     recorded = []
-    real_attention = dsv4_attention.eager_attention_with_sinks
+    real_attention = eager_reference.eager_attention_with_sinks
 
     def record(query, key, value, sinks, attention_mask, **kwargs):
         recorded.append(attention_mask)
         return real_attention(query, key, value, sinks, attention_mask, **kwargs)
 
-    monkeypatch.setattr(dsv4_attention, "eager_attention_with_sinks", record)
+    monkeypatch.setattr(eager_reference, "eager_attention_with_sinks", record)
 
-    # The dense mask is an eager-path artifact; the count below is one call per layer.
+    # The dense mask is a reference-path artifact; the count below is one call per layer.
     prime_model = get_prime_model(torch.float32)
     input_ids, position_ids, seq_lens = _packed_inputs(DOC_LENS)
     prime_model(input_ids, position_ids=position_ids, seq_lens=seq_lens)

--- a/tests/unit/train/models/test_deepseek_v4_kernels.py
+++ b/tests/unit/train/models/test_deepseek_v4_kernels.py
@@ -168,6 +168,9 @@ V4FLASH_MODEL = dict(
     },
 )
 
+# Shared by every test here: `DeepseekV4Attention` and `PackedContext.build` only read it.
+V4FLASH_CONFIG = DeepseekV4Config(**V4FLASH_MODEL)
+
 # Read off `V4FLASH_MODEL` so the hand-built tensors below describe the same CSA layer it does.
 HEADS = V4FLASH_MODEL["num_attention_heads"]
 DIM = V4FLASH_MODEL["head_dim"]
@@ -511,14 +514,10 @@ V4FLASH_DOC_LENS = [(517, 1019), (3,), (300,), (3, 129, 1021), (2600,)]
 V4FLASH_DOC_IDS = ["two-docs", "no-entries", "one-short-doc", "three-docs", "saturated-topk"]
 
 
-def _v4flash_config() -> DeepseekV4Config:
-    return DeepseekV4Config(**V4FLASH_MODEL)
-
-
 def v4flash_attention(layer_idx: int, dtype: torch.dtype = torch.float32, eager: bool = False) -> nn.Module:
     """One attention layer at the real DeepSeek V4 Flash shapes, 126M parameters of it."""
     with torch.device("cuda"), default_dtype(dtype):
-        module = DeepseekV4Attention(_v4flash_config(), layer_idx=layer_idx)
+        module = DeepseekV4Attention(V4FLASH_CONFIG, layer_idx=layer_idx)
     _randomize(module)
     if eager:
         eager_reference.use_eager_attention(module)
@@ -651,7 +650,7 @@ def test_sparse_indices_address_exactly_the_keys_the_dense_mask_admits(doc_lens,
     """
     module = v4flash_attention(layer_idx, dtype=torch.bfloat16)
     layer_type = V4FLASH_MODEL["layer_types"][layer_idx]
-    packed = _packed_context(doc_lens, torch.bfloat16, _v4flash_config())
+    packed = _packed_context(doc_lens, torch.bfloat16, V4FLASH_CONFIG)
     hidden_states = _v4flash_hidden_states(sum(doc_lens))[0].detach().to(torch.bfloat16)
     recorded = _record_attention(monkeypatch)
 
@@ -700,7 +699,7 @@ def test_sparse_indices_are_in_range_and_never_repeat_a_key(doc_lens, layer_idx,
     """
     module = v4flash_attention(layer_idx, dtype=torch.bfloat16)
     layer_type = V4FLASH_MODEL["layer_types"][layer_idx]
-    packed = _packed_context(doc_lens, torch.bfloat16, _v4flash_config())
+    packed = _packed_context(doc_lens, torch.bfloat16, V4FLASH_CONFIG)
     hidden_states = _v4flash_hidden_states(sum(doc_lens))[0].detach().to(torch.bfloat16)
     recorded = _record_attention(monkeypatch)
 
@@ -748,7 +747,7 @@ def test_absent_slots_are_marked_negative_rather_than_pointed_at_a_pad_row(doc_l
     this asserts the contract directly.
     """
     module = v4flash_attention(V4FLASH_CSA_LAYER, dtype=torch.bfloat16)
-    packed = _packed_context(doc_lens, torch.bfloat16, _v4flash_config())
+    packed = _packed_context(doc_lens, torch.bfloat16, V4FLASH_CONFIG)
     hidden_states = _v4flash_hidden_states(sum(doc_lens))[0].detach().to(torch.bfloat16)
     recorded = _record_attention(monkeypatch)
 
@@ -843,8 +842,8 @@ def test_sparse_attention_kernel_matches_eager(doc_lens, monkeypatch):
 
     monkeypatch.setattr(dsv4_attention, "dsv4_sparse_attn", counting_kernel)
 
-    kernel_output, _ = kernel_module(kernel_input, packed=_packed_context(doc_lens, torch.bfloat16, _v4flash_config()))
-    eager_output, _ = eager_module(eager_input, packed=_packed_context(doc_lens, torch.float32, _v4flash_config()))
+    kernel_output, _ = kernel_module(kernel_input, packed=_packed_context(doc_lens, torch.bfloat16, V4FLASH_CONFIG))
+    eager_output, _ = eager_module(eager_input, packed=_packed_context(doc_lens, torch.float32, V4FLASH_CONFIG))
     assert calls == [seq_len], f"the forward never reached the kernel, calls={calls}"
     _assert_relative(kernel_output, eager_output, EAGER_KERNEL_RTOL, "attention output")
 
@@ -879,7 +878,7 @@ def test_sparse_attention_kernel_packed_matches_unpacked(monkeypatch):
     a fallback would leave this test asserting a property of the gather reference instead.
     """
     module = v4flash_attention(V4FLASH_CSA_LAYER, dtype=torch.bfloat16)
-    packed = _packed_context(KERNEL_DOC_LENS, torch.bfloat16, _v4flash_config())
+    packed = _packed_context(KERNEL_DOC_LENS, torch.bfloat16, V4FLASH_CONFIG)
     with torch.device("cuda"):
         hidden = torch.randn(1, sum(KERNEL_DOC_LENS), V4FLASH_MODEL["hidden_size"], dtype=torch.bfloat16)
     packed_input, alone_input = hidden.clone().requires_grad_(True), hidden.clone().requires_grad_(True)
@@ -903,7 +902,7 @@ def test_sparse_attention_kernel_packed_matches_unpacked(monkeypatch):
     for index, length in enumerate(KERNEL_DOC_LENS):
         span = _doc_slice(KERNEL_DOC_LENS, index)
         alone_output, _ = module(
-            alone_input[:, span], packed=_packed_context((length,), torch.bfloat16, _v4flash_config())
+            alone_input[:, span], packed=_packed_context((length,), torch.bfloat16, V4FLASH_CONFIG)
         )
         _assert_relative(packed_output[:, span], alone_output, KERNEL_RTOL, f"document {index}")
         (alone_output * weight[:, span]).sum().backward()
@@ -928,7 +927,7 @@ def test_sparse_attention_kernel_trains_every_parameter(monkeypatch):
     asserting a property of the gather reference.
     """
     module = v4flash_attention(V4FLASH_CSA_LAYER, dtype=torch.bfloat16)
-    packed = _packed_context(KERNEL_DOC_LENS, torch.bfloat16, _v4flash_config())
+    packed = _packed_context(KERNEL_DOC_LENS, torch.bfloat16, V4FLASH_CONFIG)
     with torch.device("cuda"):
         hidden_states = torch.randn(1, sum(KERNEL_DOC_LENS), V4FLASH_MODEL["hidden_size"], dtype=torch.bfloat16)
     hidden_states.requires_grad_(True)
@@ -994,7 +993,7 @@ def test_v4flash_hca_attention_packed_matches_unpacked():
     )
     seq_len = sum(V4FLASH_HCA_DOCS)
     packed_input, alone_input = _v4flash_hidden_states(seq_len)
-    packed = _packed_context(V4FLASH_HCA_DOCS, torch.float32, _v4flash_config())
+    packed = _packed_context(V4FLASH_HCA_DOCS, torch.float32, V4FLASH_CONFIG)
 
     q_residual = module.q_a_norm(module.q_a_proj(packed_input.detach()))
     _, picks = module.compressor(packed_input.detach(), q_residual, packed)
@@ -1011,9 +1010,7 @@ def test_v4flash_hca_attention_packed_matches_unpacked():
 
     for index, length in enumerate(V4FLASH_HCA_DOCS):
         span = _doc_slice(V4FLASH_HCA_DOCS, index)
-        alone_output, _ = module(
-            alone_input[:, span], packed=_packed_context((length,), torch.float32, _v4flash_config())
-        )
+        alone_output, _ = module(alone_input[:, span], packed=_packed_context((length,), torch.float32, V4FLASH_CONFIG))
         _assert_relative(packed_output[:, span], alone_output, PACKED_RTOL, f"document {index}")
         (alone_output * weight[:, span]).sum().backward()
 
@@ -1106,7 +1103,7 @@ def test_kernel_and_eager_consumers_agree_on_shared_weights(layer_idx, doc_lens)
         ("eager_fp32", eager_fp32, torch.float32),
     ):
         hidden_states = hidden.to(dtype).clone().requires_grad_(True)
-        packed = _packed_context(doc_lens, dtype, _v4flash_config())
+        packed = _packed_context(doc_lens, dtype, V4FLASH_CONFIG)
         with _SparseAttnCallCounter() as counter:
             output, _ = layer(hidden_states, packed=packed)
         assert counter.count == (1 if name == "kernel" else 0), f"{name} made {counter.count} kernel calls"

--- a/tests/unit/train/models/test_deepseek_v4_kernels.py
+++ b/tests/unit/train/models/test_deepseek_v4_kernels.py
@@ -123,21 +123,9 @@ def _compare_accumulated_grads(
         _assert_relative(param.grad, expected[name], rtol, name)
 
 
-def _set_attn_impl(module: nn.Module, impl: str) -> None:
-    """Pin the CSA attention implementation on every attention layer `module` owns.
-
-    `modules()` yields `module` itself, so this covers a lone attention layer as well as a model
-    holding several of them.
-    """
-    for submodule in module.modules():
-        if isinstance(submodule, DeepseekV4Attention):
-            submodule.attn_impl = impl
-
-
 # The real DeepSeek V4-Flash attention shapes, written out as a literal so nothing here depends on a local HF
-# cache. This file runs these shapes and no others: the kernel does not tile smaller ones, and the
-# sparse path it serves only exists at this size. The MoE fields are shrunk to nothing, since
-# `DeepseekV4Attention` reads none of them.
+# cache. This file runs these shapes and no others: the sparse path the kernel serves only exists at
+# this size. The MoE fields are shrunk to nothing, since `DeepseekV4Attention` reads none of them.
 V4FLASH_MODEL = dict(
     vocab_size=64,
     hidden_size=4096,
@@ -523,15 +511,17 @@ V4FLASH_DOC_LENS = [(517, 1019), (3,), (300,), (3, 129, 1021), (2600,)]
 V4FLASH_DOC_IDS = ["two-docs", "no-entries", "one-short-doc", "three-docs", "saturated-topk"]
 
 
-def _v4flash_config(attn_impl: str = "kernel") -> DeepseekV4Config:
-    return DeepseekV4Config(**V4FLASH_MODEL, _attn_impl=attn_impl)
+def _v4flash_config() -> DeepseekV4Config:
+    return DeepseekV4Config(**V4FLASH_MODEL)
 
 
-def v4flash_attention(layer_idx: int, dtype: torch.dtype = torch.float32, attn_impl: str = "kernel") -> nn.Module:
+def v4flash_attention(layer_idx: int, dtype: torch.dtype = torch.float32, eager: bool = False) -> nn.Module:
     """One attention layer at the real DeepSeek V4 Flash shapes, 126M parameters of it."""
     with torch.device("cuda"), default_dtype(dtype):
-        module = DeepseekV4Attention(_v4flash_config(attn_impl), layer_idx=layer_idx)
+        module = DeepseekV4Attention(_v4flash_config(), layer_idx=layer_idx)
     _randomize(module)
+    if eager:
+        eager_reference.use_eager_attention(module)
     return module
 
 
@@ -547,26 +537,19 @@ def _v4flash_hidden_states(seq_len: int) -> tuple[torch.Tensor, torch.Tensor]:
 
 
 def _record_attention(monkeypatch) -> dict[str, torch.Tensor]:
-    """Capture what each attention path is handed and what it returns, from real forwards.
+    """Capture what the kernel is handed and what it returns, from real forwards.
 
-    Both implementations are module-level functions the layer looks up by name, so patching them
+    `dsv4_sparse_attn` is a module-level function the layer looks up by name, so patching it
     records the call the layer actually made rather than a reconstruction of it.
     """
     recorded: dict[str, torch.Tensor] = {}
-    real_eager = dsv4_attention.eager_attention_with_sinks
     real_kernel = dsv4_attention.dsv4_sparse_attn
-
-    def eager(query, key, value, sinks, attention_mask, **kwargs):
-        recorded["mask"] = attention_mask
-        recorded["eager"] = real_eager(query, key, value, sinks, attention_mask, **kwargs)
-        return recorded["eager"]
 
     def kernel(q, kv_buf, indices, sinks, scale):
         recorded["kv_buf"], recorded["indices"] = kv_buf, indices
         recorded["kernel"] = real_kernel(q, kv_buf, indices, sinks, scale)
         return recorded["kernel"]
 
-    monkeypatch.setattr(dsv4_attention, "eager_attention_with_sinks", eager)
     monkeypatch.setattr(dsv4_attention, "dsv4_sparse_attn", kernel)
     return recorded
 
@@ -633,6 +616,14 @@ def _selected_positions(indices: torch.Tensor, n_positions: int) -> torch.Tensor
     safe = torch.where(slots >= 0, slots, n_positions)
     selected = torch.zeros((indices.shape[1], n_positions + 1), dtype=torch.bool, device=indices.device)
     return selected.scatter_(1, safe, True)[:, :n_positions]
+
+
+@requires_sparse_attn_kernel
+def test_deepseek_v4_refuses_a_shape_the_kernel_cannot_tile():
+    """The constructor refuses a head count the kernels cannot tile, rather than the first forward."""
+    config = DeepseekV4Config(**{**V4FLASH_MODEL, "num_attention_heads": 16})
+    with pytest.raises(ValueError, match="cannot run the fused sparse-attention kernel"):
+        DeepseekV4Attention(config, layer_idx=V4FLASH_CSA_LAYER)
 
 
 @requires_sparse_attn_kernel
@@ -836,7 +827,7 @@ def test_sparse_attention_kernel_matches_eager(doc_lens, monkeypatch):
     seq_len = sum(doc_lens)
     kernel_module = v4flash_attention(V4FLASH_CSA_LAYER, dtype=torch.bfloat16)
     eager_module = copy.deepcopy(kernel_module).float()
-    _set_attn_impl(eager_module, "eager")
+    eager_reference.use_eager_attention(eager_module)
 
     with torch.device("cuda"):
         base = torch.randn(1, seq_len, V4FLASH_MODEL["hidden_size"], dtype=torch.bfloat16)
@@ -928,8 +919,8 @@ def test_sparse_attention_kernel_trains_every_parameter(monkeypatch):
     """Every parameter of a CSA layer that can train does, with the kernel in the path.
 
     `test_deepseek_v4_backward` makes this assertion through the assembled model, but only on the
-    gather path: the kernel does not tile the toy shapes that file runs. This is the same assertion
-    at module level and at the real Flash shapes, and it is not implied by its neighbour above, which
+    dense reference, which is what that whole file binds. This is the same assertion at module
+    level and at the real Flash shapes, and it is not implied by its neighbour above, which
     compares two runs of the same path and would pass unchanged if both left a parameter at zero.
 
     The call count is load-bearing rather than decoration: `dsv4_sparse_attn` raises today
@@ -983,6 +974,7 @@ def test_sparse_attention_kernel_trains_every_parameter(monkeypatch):
 V4FLASH_HCA_DOCS = (256, 512)
 
 
+@requires_sparse_attn_kernel
 def test_v4flash_hca_attention_packed_matches_unpacked():
     """An HCA layer at production shapes must answer each document as if it stood alone.
 
@@ -996,7 +988,7 @@ def test_v4flash_hca_attention_packed_matches_unpacked():
     `test_attention_packed_matches_unpacked[hca]` asserts the same invariant at toy shapes and
     rate 8.
     """
-    module = v4flash_attention(V4FLASH_HCA_LAYER, dtype=torch.float32, attn_impl="eager")
+    module = v4flash_attention(V4FLASH_HCA_LAYER, dtype=torch.float32, eager=True)
     assert module.layer_type == "heavily_compressed_attention", (
         f"expected the Flash config's HCA layer, got {module.layer_type}"
     )
@@ -1084,8 +1076,8 @@ def test_kernel_and_eager_consumers_agree_on_shared_weights(layer_idx, doc_lens)
     """The two consumers of one `SparseAttnInputs` must compute the same attention, and its gradient.
 
     They are handed the identical index tensor, so this is not about which keys a query reads,
-    which its neighbours settle on integers. What is at stake is the attention core the layer picks
-    between: the sink term in the softmax denominator, the scale, the value weighting and the
+    which its neighbours settle on integers. What is at stake is the attention core itself: the
+    sink term in the softmax denominator, the scale, the value weighting and the
     backward's scatter. A kernel that dropped the sink, weighted a head with another head's
     probabilities or lost a term in `dQ` would still hand back finite numbers of the right shape,
     and every packing test in this file would still pass, because both halves of those comparisons
@@ -1098,9 +1090,9 @@ def test_kernel_and_eager_consumers_agree_on_shared_weights(layer_idx, doc_lens)
     """
     module = v4flash_attention(layer_idx, dtype=torch.bfloat16)
     weights = module.state_dict()
-    eager_bf16 = v4flash_attention(layer_idx, dtype=torch.bfloat16, attn_impl="eager")
+    eager_bf16 = v4flash_attention(layer_idx, dtype=torch.bfloat16, eager=True)
     eager_bf16.load_state_dict(weights)
-    eager_fp32 = v4flash_attention(layer_idx, dtype=torch.float32, attn_impl="eager")
+    eager_fp32 = v4flash_attention(layer_idx, dtype=torch.float32, eager=True)
     eager_fp32.load_state_dict({name: tensor.float() for name, tensor in weights.items()})
 
     with torch.device("cuda"):


### PR DESCRIPTION
Moves the eager-model helpers off the production path and into the eager impl file for cleaner prod code. Also fixes a previous CI breakage where we asserted on batch size == 1 which broke packing equivalence tests, and performs other minor cleanup. 