### PR TITLE
feat(trainer): select MoE compute by layer

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -68,6 +68,20 @@ type = "torch"
 transport = "mxfp8"
 ```
 
+All MoE compute backends accept `apply_to`, a list of routed-expert module paths. The default `["*"]` selects every expert group; `[]` selects none. Shell-style patterns match full names, and `re:` prefixes a regular expression matched from the start of the name. Unmatched groups use BF16 compute and BF16 token transport while retaining the configured dispatch backend and expert parallelism. Dense linear quantization is configured separately.
+
+For example, this selects routed experts in Qwen3's first four model layers:
+
+```toml
+[trainer.model.moe.compute]
+type = "mxfp8"
+apply_to = ["model.layers.[0-3].mlp.experts"]
+```
+
+Patterns refer to the trainer's module names, including the `.experts` suffix. Layer numbers are model block indices, including non-MoE blocks in hybrid models. A match selects the whole routed-expert group, including all its projections. Backend shape checks and token alignment apply only to the selected compute path.
+
+In RL runs, configure the same precision selection for rollouts. Inference module names can differ from the trainer's names, and inference precision is configured explicitly, not inferred from `apply_to`. Check the selected modules on both sides before comparing trainer and rollout logprobs.
+
 GLM-5.2 adds IndexShare: the DSA sparse-attention indexer runs only on a subset of layers and the remaining layers reuse the cached top-k indices. The trainer reads this schedule from the model's `indexer_types` config field and enables the index cache automatically, so no extra config is needed. To override the schedule manually, set `[trainer.model.index_cache]` (`topk_freq` or `topk_pattern`).
 
 ### Expert Parallelism Backends

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -68,17 +68,23 @@ type = "torch"
 transport = "mxfp8"
 ```
 
-All MoE compute backends accept `apply_to`, a list of routed-expert module paths. The default `["*"]` selects every expert group; `[]` selects none. Shell-style patterns match full names, and `re:` prefixes a regular expression matched from the start of the name. Unmatched groups use BF16 compute and BF16 token transport while retaining the configured dispatch backend and expert parallelism. Dense linear quantization is configured separately.
+All MoE compute backends accept `apply_to`:
+
+- `"all"` (default) applies the backend to all expert groups.
+- `"85%"` applies it to the first 85% of model layers, rounded down. For a 48-layer model, this selects layers 0–39.
+- `[0, 1, 2, 3]` selects explicit zero-based model layer indices; `[]` selects none.
+
+Percentages must be between 0% and 100%; explicit indices must be within the model's layer count. Non-MoE blocks in hybrid models count toward layer indices and percentages. Each selected layer uses the backend for all its routed experts. Other expert groups use BF16 compute and BF16 token transport while retaining the configured dispatch backend and expert parallelism. Dense linear quantization is configured separately.
 
 For example, this selects routed experts in Qwen3's first four model layers:
 
 ```toml
 [trainer.model.moe.compute]
 type = "mxfp8"
-apply_to = ["model.layers.[0-3].mlp.experts"]
+apply_to = [0, 1, 2, 3]
 ```
 
-Patterns refer to the trainer's module names, including the `.experts` suffix. Layer numbers are model block indices, including non-MoE blocks in hybrid models. A match selects the whole routed-expert group, including all its projections. Backend shape checks and token alignment apply only to the selected compute path.
+Backend shape checks and token alignment apply only to the selected compute path.
 
 In RL runs, configure the same precision selection for rollouts. Inference module names can differ from the trainer's names, and inference precision is configured explicitly, not inferred from `apply_to`. Check the selected modules on both sides before comparing trainer and rollout logprobs.
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -1,6 +1,5 @@
 import re
 import warnings
-from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
 
@@ -183,30 +182,30 @@ QuantizationConfig: TypeAlias = Annotated[FP8Config | MXFP8Config, Field(discrim
 
 
 class MoEComputeConfigBase(BaseConfig):
-    apply_to: list[str] = ["*"]
-    """Routed-expert module paths to use this backend for, e.g. ``model.layers.[0-3].mlp.experts``.
-    Patterns match full names using shell-style wildcards, or ``re:``-prefixed regular expressions.
-    Unmatched expert groups use BF16 compute and transport. ``["*"]`` selects all; ``[]`` selects none.
+    apply_to: str | list[Annotated[int, Field(ge=0, strict=True)]] = "all"
+    """Model layers to use this backend for: ``"all"``, a percentage such as ``"85%"``,
+    or zero-based layer indices such as ``[0, 1, 2]``. Percentages select the first fraction
+    of model layers, rounded down. Other expert groups use BF16 compute and transport.
     """
 
     @field_validator("apply_to")
     @classmethod
-    def validate_apply_to(cls, patterns: list[str]) -> list[str]:
-        for pattern in patterns:
-            if not pattern or pattern == "re:":
-                raise ValueError("apply_to patterns must not be empty")
-            if pattern.startswith("re:"):
-                try:
-                    re.compile(pattern[3:])
-                except re.error as exc:
-                    raise ValueError(f"Invalid apply_to regex {pattern!r}: {exc}") from exc
-        return patterns
+    def validate_apply_to(cls, value: str | list[int]) -> str | list[int]:
+        if isinstance(value, str) and value != "all":
+            if re.fullmatch(r"\d+(?:\.\d+)?%", value) is None or float(value[:-1]) > 100:
+                raise ValueError('apply_to must be "all", a percentage from "0%" to "100%", or a list of layer indices')
+        return value
 
-    def matches_module(self, name: str) -> bool:
-        return any(
-            re.match(pattern[3:], name) is not None if pattern.startswith("re:") else fnmatchcase(name, pattern)
-            for pattern in self.apply_to
-        )
+    def resolve_layers(self, num_layers: int) -> set[int]:
+        if isinstance(self.apply_to, list):
+            invalid = [index for index in self.apply_to if index >= num_layers]
+            if invalid:
+                raise ValueError(
+                    f"apply_to layer indices {invalid} are out of range for a model with {num_layers} layers"
+                )
+            return set(self.apply_to)
+        count = num_layers if self.apply_to == "all" else int(num_layers * float(self.apply_to[:-1]) / 100)
+        return set(range(count))
 
 
 class BF16MoEComputeConfig(MoEComputeConfigBase):

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -1,8 +1,10 @@
+import re
 import warnings
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
 
-from pydantic import BeforeValidator, Field, model_validator
+from pydantic import BeforeValidator, Field, field_validator, model_validator
 
 from prime_rl.configs.monitors import MonitorsConfig
 from prime_rl.configs.shared import (
@@ -180,19 +182,46 @@ class MXFP8Config(BaseConfig):
 QuantizationConfig: TypeAlias = Annotated[FP8Config | MXFP8Config, Field(discriminator="type")]
 
 
-class BF16MoEComputeConfig(BaseConfig):
+class MoEComputeConfigBase(BaseConfig):
+    apply_to: list[str] = ["*"]
+    """Routed-expert module paths to use this backend for, e.g. ``model.layers.[0-3].mlp.experts``.
+    Patterns match full names using shell-style wildcards, or ``re:``-prefixed regular expressions.
+    Unmatched expert groups use BF16 compute and transport. ``["*"]`` selects all; ``[]`` selects none.
+    """
+
+    @field_validator("apply_to")
+    @classmethod
+    def validate_apply_to(cls, patterns: list[str]) -> list[str]:
+        for pattern in patterns:
+            if not pattern or pattern == "re:":
+                raise ValueError("apply_to patterns must not be empty")
+            if pattern.startswith("re:"):
+                try:
+                    re.compile(pattern[3:])
+                except re.error as exc:
+                    raise ValueError(f"Invalid apply_to regex {pattern!r}: {exc}") from exc
+        return patterns
+
+    def matches_module(self, name: str) -> bool:
+        return any(
+            re.match(pattern[3:], name) is not None if pattern.startswith("re:") else fnmatchcase(name, pattern)
+            for pattern in self.apply_to
+        )
+
+
+class BF16MoEComputeConfig(MoEComputeConfigBase):
     """Run routed-expert grouped GEMMs in bfloat16."""
 
     type: Literal["bf16"] = "bf16"
 
 
-class DeepGemmFP8MoEComputeConfig(BaseConfig):
+class DeepGemmFP8MoEComputeConfig(MoEComputeConfigBase):
     """Run routed-expert grouped GEMMs with DeepGEMM FP8 kernels."""
 
     type: Literal["deepgemm_fp8"] = "deepgemm_fp8"
 
 
-class MXFP8MoEComputeConfig(BaseConfig):
+class MXFP8MoEComputeConfig(MoEComputeConfigBase):
     """Run routed-expert grouped GEMMs with Prime's vendored MXFP8 implementation."""
 
     type: Literal["mxfp8"] = "mxfp8"

--- a/src/prime_rl/trainer/moe_runtime.py
+++ b/src/prime_rl/trainer/moe_runtime.py
@@ -56,17 +56,24 @@ def _resolve_grouped_gemm(config: ModelConfig) -> GroupedGemm:
 
 
 def configure_moe_runtime(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims) -> None:
-    moe_layers = [module for module in model.modules() if isinstance(module, MoE)]
+    moe_layers = {
+        f"{name}.experts" if name else "experts": module
+        for name, module in model.named_modules()
+        if isinstance(module, MoE)
+    }
     if not moe_layers:
         if config.moe != MoERuntimeConfig():
             raise ValueError("A non-default model.moe runtime was configured, but the model has no custom MoE layers.")
         return
 
-    grouped_gemm = _resolve_grouped_gemm(config)
+    selected_layers = {name for name in moe_layers if config.moe.compute.matches_module(name)}
+    bf16_grouped_gemm = BF16GroupedGemm()
+    selected_grouped_gemm = _resolve_grouped_gemm(config) if selected_layers else bf16_grouped_gemm
     ep_mesh = parallel_dims.get_mesh("ep") if parallel_dims.ep_enabled else None
     dispatch = config.moe.dispatch
 
-    for moe in moe_layers:
+    for name, moe in moe_layers.items():
+        grouped_gemm = selected_grouped_gemm if name in selected_layers else bf16_grouped_gemm
         if ep_mesh is not None and moe.experts.num_experts % parallel_dims.ep:
             raise ValueError(
                 f"MoE expert count {moe.experts.num_experts} must be divisible by model.ep={parallel_dims.ep}."
@@ -79,7 +86,7 @@ def configure_moe_runtime(model: nn.Module, config: ModelConfig, parallel_dims: 
                 token_group_alignment=grouped_gemm.token_group_alignment,
             )
         elif isinstance(dispatch, TorchMoEDispatchConfig):
-            if dispatch.transport == "mxfp8":
+            if dispatch.transport == "mxfp8" and isinstance(grouped_gemm, MXFP8GroupedGemm):
                 token_dispatcher = MXFP8TorchTokenDispatcher(
                     num_experts=moe.experts.num_experts,
                     top_k=moe.router.top_k,
@@ -111,6 +118,7 @@ def configure_moe_runtime(model: nn.Module, config: ModelConfig, parallel_dims: 
             parallelize_module(moe.experts, device_mesh=ep_mesh, parallelize_plan=ExpertWeightParallel())
 
     get_logger().info(
-        f"Configured {len(moe_layers)} MoE layers with compute={config.moe.compute.type}, "
-        f"dispatch={config.moe.dispatch.type}, ep={parallel_dims.ep}"
+        f"Configured {len(selected_layers)}/{len(moe_layers)} MoE layers with compute={config.moe.compute.type}, "
+        f"apply_to={config.moe.compute.apply_to}, fallback=bf16, dispatch={config.moe.dispatch.type}, ep={parallel_dims.ep}"
     )
+    get_logger().debug(f"Selected routed-expert modules: {sorted(selected_layers)}")

--- a/src/prime_rl/trainer/moe_runtime.py
+++ b/src/prime_rl/trainer/moe_runtime.py
@@ -28,6 +28,7 @@ from prime_rl.trainer.models.layers.grouped_gemm import (
 from prime_rl.trainer.models.layers.moe import MoE
 from prime_rl.trainer.parallel_dims import ParallelDims
 from prime_rl.utils.logger import get_logger
+from prime_rl.utils.vlm import get_language_model
 
 
 def _resolve_grouped_gemm(config: ModelConfig) -> GroupedGemm:
@@ -56,24 +57,33 @@ def _resolve_grouped_gemm(config: ModelConfig) -> GroupedGemm:
 
 
 def configure_moe_runtime(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims) -> None:
-    moe_layers = {
-        f"{name}.experts" if name else "experts": module
-        for name, module in model.named_modules()
-        if isinstance(module, MoE)
-    }
+    moe_layers = [module for module in model.modules() if isinstance(module, MoE)]
     if not moe_layers:
         if config.moe != MoERuntimeConfig():
             raise ValueError("A non-default model.moe runtime was configured, but the model has no custom MoE layers.")
         return
 
-    selected_layers = {name for name in moe_layers if config.moe.compute.matches_module(name)}
+    selected_moes = set(moe_layers)
+    if config.moe.compute.apply_to != "all":
+        language_model = get_language_model(
+            model, override=config.vlm.language_model_attr if config.vlm is not None else None
+        )
+        selected_layers = config.moe.compute.resolve_layers(len(language_model.layers))
+        selected_moes = {
+            module
+            for index, layer in enumerate(language_model.layers.children())
+            if index in selected_layers
+            for module in layer.modules()
+            if isinstance(module, MoE)
+        }
+        get_logger().debug(f"Selected model layers for MoE compute: {sorted(selected_layers)}")
     bf16_grouped_gemm = BF16GroupedGemm()
-    selected_grouped_gemm = _resolve_grouped_gemm(config) if selected_layers else bf16_grouped_gemm
+    selected_grouped_gemm = _resolve_grouped_gemm(config) if selected_moes else bf16_grouped_gemm
     ep_mesh = parallel_dims.get_mesh("ep") if parallel_dims.ep_enabled else None
     dispatch = config.moe.dispatch
 
-    for name, moe in moe_layers.items():
-        grouped_gemm = selected_grouped_gemm if name in selected_layers else bf16_grouped_gemm
+    for moe in moe_layers:
+        grouped_gemm = selected_grouped_gemm if moe in selected_moes else bf16_grouped_gemm
         if ep_mesh is not None and moe.experts.num_experts % parallel_dims.ep:
             raise ValueError(
                 f"MoE expert count {moe.experts.num_experts} must be divisible by model.ep={parallel_dims.ep}."
@@ -118,7 +128,6 @@ def configure_moe_runtime(model: nn.Module, config: ModelConfig, parallel_dims: 
             parallelize_module(moe.experts, device_mesh=ep_mesh, parallelize_plan=ExpertWeightParallel())
 
     get_logger().info(
-        f"Configured {len(selected_layers)}/{len(moe_layers)} MoE layers with compute={config.moe.compute.type}, "
+        f"Configured {len(selected_moes)}/{len(moe_layers)} MoE layers with compute={config.moe.compute.type}, "
         f"apply_to={config.moe.compute.apply_to}, fallback=bf16, dispatch={config.moe.dispatch.type}, ep={parallel_dims.ep}"
     )
-    get_logger().debug(f"Selected routed-expert modules: {sorted(selected_layers)}")

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -189,7 +189,35 @@ def test_moe_runtime_defaults_are_independent_from_dense_quantization():
     ],
 )
 def test_supported_moe_runtime_configs(model):
-    TrainerModelConfig.model_validate(model)
+    config = TrainerModelConfig.model_validate(model)
+    assert config.moe.compute.matches_module("model.layers.42.mlp.experts")
+
+
+@pytest.mark.parametrize("backend", ["bf16", "deepgemm_fp8", "mxfp8"])
+@pytest.mark.parametrize(
+    ("patterns", "selected"),
+    [
+        (["*"], [0, 1, 2, 10]),
+        ([], []),
+        (["model.layers.[0-2].mlp.experts"], [0, 1, 2]),
+        (["model.layers.0.mlp.experts", "model.layers.10.mlp.experts"], [0, 10]),
+        ([r"re:model\.layers\.(0|2)\.mlp\.experts$"], [0, 2]),
+        (["model.layers.0.mlp.router"], []),
+    ],
+)
+def test_moe_compute_apply_to(backend, patterns, selected):
+    config = TrainerModelConfig.model_validate({"moe": {"compute": {"type": backend, "apply_to": patterns}}})
+    config = TrainerModelConfig.model_validate_json(config.model_dump_json())
+    actual = [
+        index for index in (0, 1, 2, 10) if config.moe.compute.matches_module(f"model.layers.{index}.mlp.experts")
+    ]
+    assert actual == selected
+
+
+@pytest.mark.parametrize("pattern", ["", "re:", "re:["])
+def test_moe_compute_rejects_invalid_apply_to(pattern):
+    with pytest.raises(ValidationError, match="apply_to"):
+        TrainerModelConfig.model_validate({"moe": {"compute": {"type": "mxfp8", "apply_to": [pattern]}}})
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -190,34 +190,45 @@ def test_moe_runtime_defaults_are_independent_from_dense_quantization():
 )
 def test_supported_moe_runtime_configs(model):
     config = TrainerModelConfig.model_validate(model)
-    assert config.moe.compute.matches_module("model.layers.42.mlp.experts")
+    assert config.moe.compute.resolve_layers(43) == set(range(43))
 
 
 @pytest.mark.parametrize("backend", ["bf16", "deepgemm_fp8", "mxfp8"])
 @pytest.mark.parametrize(
-    ("patterns", "selected"),
+    ("selection", "num_layers", "selected"),
     [
-        (["*"], [0, 1, 2, 10]),
-        ([], []),
-        (["model.layers.[0-2].mlp.experts"], [0, 1, 2]),
-        (["model.layers.0.mlp.experts", "model.layers.10.mlp.experts"], [0, 10]),
-        ([r"re:model\.layers\.(0|2)\.mlp\.experts$"], [0, 2]),
-        (["model.layers.0.mlp.router"], []),
+        ("all", 10, set(range(10))),
+        ("85%", 48, set(range(40))),
+        ("100%", 3, {0, 1, 2}),
+        ("0%", 3, set()),
+        ("33.3%", 10, {0, 1, 2}),
+        ([], 10, set()),
+        ([2, 0], 10, {0, 2}),
+        ([0, 2, 2], 3, {0, 2}),
     ],
 )
-def test_moe_compute_apply_to(backend, patterns, selected):
-    config = TrainerModelConfig.model_validate({"moe": {"compute": {"type": backend, "apply_to": patterns}}})
+def test_moe_compute_apply_to(backend, selection, num_layers, selected):
+    config = TrainerModelConfig.model_validate({"moe": {"compute": {"type": backend, "apply_to": selection}}})
     config = TrainerModelConfig.model_validate_json(config.model_dump_json())
-    actual = [
-        index for index in (0, 1, 2, 10) if config.moe.compute.matches_module(f"model.layers.{index}.mlp.experts")
-    ]
-    assert actual == selected
+    assert config.moe.compute.resolve_layers(num_layers) == selected
 
 
-@pytest.mark.parametrize("pattern", ["", "re:", "re:["])
-def test_moe_compute_rejects_invalid_apply_to(pattern):
+@pytest.mark.parametrize("selection", ["*", "model.layers.*", "", "101%", "-1%", "nan%", [-1], [1.5], [True]])
+def test_moe_compute_rejects_invalid_apply_to(selection):
     with pytest.raises(ValidationError, match="apply_to"):
-        TrainerModelConfig.model_validate({"moe": {"compute": {"type": "mxfp8", "apply_to": [pattern]}}})
+        TrainerModelConfig.model_validate({"moe": {"compute": {"type": "mxfp8", "apply_to": selection}}})
+
+
+def test_moe_compute_rejects_out_of_range_layer():
+    config = TrainerModelConfig.model_validate({"moe": {"compute": {"type": "mxfp8", "apply_to": [3]}}})
+    with pytest.raises(ValueError, match="out of range"):
+        config.moe.compute.resolve_layers(3)
+
+
+@pytest.mark.parametrize(("selection", "selected"), [("all", {0, 1, 2}), ("50%", {0}), ("[0, 2]", {0, 2})])
+def test_moe_compute_apply_to_cli(selection, selected):
+    config = cli(TrainerModelConfig, args=["--moe.compute.type", "mxfp8", "--moe.compute.apply-to", selection])
+    assert config.moe.compute.resolve_layers(3) == selected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/train/models/test_moe.py
+++ b/tests/unit/train/models/test_moe.py
@@ -2,14 +2,33 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from prime_rl.configs.trainer import ModelConfig
 from prime_rl.trainer.distributed.token_dispatcher import LocalTokenDispatcher
 from prime_rl.trainer.models.layers.activations import ActivationDispatch
+from prime_rl.trainer.models.layers.grouped_gemm import BF16GroupedGemm
 from prime_rl.trainer.models.layers.mlp import FeedForward
 from prime_rl.trainer.models.layers.moe import (
     GroupedExperts,
     MoE,
     MoEArgs,
 )
+from prime_rl.trainer.moe_runtime import configure_moe_runtime
+from prime_rl.trainer.parallel_dims import ParallelDims
+
+
+@pytest.mark.parametrize("patterns", [[], ["other.experts"]])
+def test_unselected_moe_uses_bf16_without_loading_quantization_backend(patterns):
+    moe = MoE.from_args(MoEArgs(num_experts=2), dim=4, hidden_dim=8, shared_expert=None)
+    parameters = dict(moe.named_parameters())
+    config = ModelConfig.model_validate({"moe": {"compute": {"type": "mxfp8", "apply_to": patterns}}})
+    dims = ParallelDims(dp_replicate=1, dp_shard=1, cp=1, pp=1, ep=1, world_size=1)
+
+    configure_moe_runtime(moe, config, dims)
+
+    assert isinstance(moe.experts.grouped_gemm, BF16GroupedGemm)
+    assert isinstance(moe.token_dispatcher, LocalTokenDispatcher)
+    assert moe.token_dispatcher.token_group_alignment == moe.experts.grouped_gemm.token_group_alignment
+    assert all(moe.get_parameter(name) is parameter for name, parameter in parameters.items())
 
 
 def _grouped_mm_reference(x: torch.Tensor, weights: torch.Tensor, *, offs: torch.Tensor) -> torch.Tensor:

--- a/tests/unit/train/models/test_moe.py
+++ b/tests/unit/train/models/test_moe.py
@@ -16,14 +16,17 @@ from prime_rl.trainer.moe_runtime import configure_moe_runtime
 from prime_rl.trainer.parallel_dims import ParallelDims
 
 
-@pytest.mark.parametrize("patterns", [[], ["other.experts"]])
-def test_unselected_moe_uses_bf16_without_loading_quantization_backend(patterns):
+@pytest.mark.parametrize("selection", [[], [0], "0%", "50%"])
+def test_unselected_moe_uses_bf16_without_loading_quantization_backend(selection):
     moe = MoE.from_args(MoEArgs(num_experts=2), dim=4, hidden_dim=8, shared_expert=None)
     parameters = dict(moe.named_parameters())
-    config = ModelConfig.model_validate({"moe": {"compute": {"type": "mxfp8", "apply_to": patterns}}})
+    model = torch.nn.Module()
+    model.model = torch.nn.Module()
+    model.model.layers = torch.nn.ModuleList([torch.nn.Identity(), moe])
+    config = ModelConfig.model_validate({"moe": {"compute": {"type": "mxfp8", "apply_to": selection}}})
     dims = ParallelDims(dp_replicate=1, dp_shard=1, cp=1, pp=1, ep=1, world_size=1)
 
-    configure_moe_runtime(moe, config, dims)
+    configure_moe_runtime(model, config, dims)
 
     assert isinstance(moe.experts.grouped_gemm, BF16GroupedGemm)
     assert isinstance(moe.token_dispatcher, LocalTokenDispatcher)


### PR DESCRIPTION
Select the model layers that use the configured MoE compute backend with `model.moe.compute.apply_to`:

- `"all"` (default): all routed-expert groups.
- `"85%"`: the first 85% of model layers, rounded down; 48 layers selects indices 0–39.
- `[0, 1, 2, 3]`: explicit zero-based model layer indices. `[]` selects none.

Non-MoE blocks in hybrid models count toward indices and percentages. Other expert groups use BF16 compute and transport while retaining the configured dispatch backend and expert parallelism. Out-of-range indices and invalid percentages fail early. Dense linear quantization is unchanged.

```toml
[trainer.model.moe.compute]
type = "mxfp8"
apply_to = "85%"
```

BF16, DeepGEMM FP8 and MXFP8 configs inherit the common selector. NVFP4 inherits it in #3511. Inference precision remains configured separately.

First PR in the stack: main → #3518 → #3515 (filter flag) → #3513 (vLLM upgrade) → #3511 (NVFP4).

Validation: 62 focused MoE/config tests passed on this main-based branch, including all three forms through CLI/config round trips, percentage rounding, hybrid-layer indexing, and invalid indices. Ruff lint/format and whitespace checks passed. GB200 mixed DeepGEMM-FP8/BF16 forward/backward passed with an exact BF16 fallback output and unchanged parameters/checkpoint keys. EP2 with layer-index selection verified MXFP8 transport for the selected group, BF16 transport for the excluded group, both forwards, and BF16 fallback backward. MXFP8 backward has a separately reproduced CuTe TMA-alignment compiler failure in the existing kernel; that kernel is unchanged here.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Per-layer MoE precision and transport wiring affects forward/backward numerics and expert-parallel paths; misaligned trainer vs inference precision could skew RL logprobs if rollout config is not matched manually.
> 
> **Overview**
> Adds **`model.moe.compute.apply_to`** so BF16, DeepGEMM FP8, and MXFP8 routed-expert backends can target **all layers**, a **leading percentage** (e.g. `"85%"`, rounded down), or **explicit zero-based layer indices** (including `[]` for none). Shared **`MoEComputeConfigBase`** validates inputs and **`resolve_layers`** maps selections to layer sets; out-of-range indices fail at resolve time.
> 
> **`configure_moe_runtime`** maps selection onto language-model **`layers`** (including VLM via **`get_language_model`**): selected MoE modules get the configured grouped GEMM; others **fall back to BF16** compute and matching token dispatch alignment. **MXFP8 torch transport** is used only when that layer’s grouped GEMM is actually **`MXFP8GroupedGemm`**, so excluded layers no longer take MXFP8 all-to-all when compute is partial. Startup logging reports selected vs total MoE layers.
> 
> Docs describe hybrid-layer counting, dense-quant independence, and RL rollout/inference precision alignment. Unit tests cover config/CLI round-trips and BF16 fallback without loading MXFP8 backends when nothing is selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f367d4866ddcc0debd53faebe8944f096eb3ba44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->