### PR TITLE
feat(algo): add debug advantage algorithm

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/algorithm.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/algorithm.py
@@ -1,7 +1,8 @@
 """Algorithm abstraction: sampling and the per-token training signal.
 
 An algorithm is a named, self-contained config — a discriminated union keyed
-on ``type`` (``grpo``, ``max_rl``, ``opd``, ``opsd``, ``sft``, ``echo``).
+on ``type`` (``grpo``, ``max_rl``, ``rae``, ``hierarchical_grpo``, ``opd``,
+``opsd``, ``sft``, ``echo``, ``debug``).
 The bundle *is* the algorithm: each variant carries
 its sampling component and its credit-assignment / loss-routing parameters,
 and its class defaults are the vetted setting — ``type = "opd"`` with a
@@ -364,6 +365,32 @@ class SFTAlgoConfig(BaseAlgoConfig):
         return self
 
 
+class DebugAlgoConfig(BaseAlgoConfig):
+    type: Literal["debug"] = "debug"
+    """Debugging algorithm for infra work: every sampled token of every clean
+    trainable trace gets the same constant ``advantage`` (default 1.0),
+    ignoring rewards entirely. Every admitted rollout is trainable and every
+    action token carries gradient signal, so the full RL path (advantage
+    transport, importance ratios, trust region, optimizer, weight update)
+    can be exercised regardless of the reward function. Not a real training
+    signal — a policy pushed by it drifts monotonically."""
+
+    action_loss_type: ClassVar[ActionLossType] = "rl"
+
+    advantage: float = Field(1.0, allow_inf_nan=False)
+    """The constant per-token advantage. Must be nonzero: a zero advantage
+    makes nothing trainable, the exact failure this debug tool exists to
+    rule out."""
+
+    @model_validator(mode="after")
+    def require_nonzero_advantage(self):
+        if self.advantage == 0.0:
+            raise ValueError(
+                "the 'debug' algorithm needs a nonzero advantage — a zero advantage leaves nothing trainable."
+            )
+        return self
+
+
 AlgoConfig: TypeAlias = Annotated[
     GRPOAlgoConfig
     | EchoAlgoConfig
@@ -372,7 +399,8 @@ AlgoConfig: TypeAlias = Annotated[
     | HierarchicalGRPOAlgoConfig
     | OPDAlgoConfig
     | OPSDAlgoConfig
-    | SFTAlgoConfig,
+    | SFTAlgoConfig
+    | DebugAlgoConfig,
     Field(discriminator="type"),
 ]
 """The training algorithm: sampling plus the per-token training signal (credit
@@ -387,6 +415,8 @@ its class defaults are the vetted setting.
 - ``opsd`` — SDFT: policy samples, demo-conditioned reverse KL against the live policy (the teacher is the policy itself).
 - ``sft`` — a frozen model samples, the policy trains with CE on its tokens. Needs a frozen ``sampling.source``.
 - ``echo`` — GRPO on action tokens + weighted CE on tool-response observation tokens.
+- ``debug`` — the same constant advantage on every sampled token, ignoring
+  rewards. Debugging only: for infra work that needs every token trainable.
 
 A new credit-assignment scheme is a new named algorithm in code (subclass
 ``Algorithm``, register it), not a config that points at an import path.

--- a/src/prime_rl/orchestrator/algo/__init__.py
+++ b/src/prime_rl/orchestrator/algo/__init__.py
@@ -6,8 +6,8 @@ turns the signal half into runtime objects (the sampling half is the env's
 :class:`~prime_rl.orchestrator.generation_source.GenerationSource`):
 
 - one module per algorithm (``grpo``, ``echo``, ``max_rl``, ``rae``,
-  ``hierarchical_grpo``, ``opd``, ``opsd``, ``sft``) — each named class owns
-  its scoring hooks
+  ``hierarchical_grpo``, ``opd``, ``opsd``, ``sft``, ``debug``) — each named
+  class owns its scoring hooks
   (``score_episode`` / ``score_group``) and declares what it needs (loss
   component, a "teacher", ...). One instance per env, built by
   :func:`build_algorithm`. A new credit-assignment scheme is a new named class:
@@ -23,6 +23,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from prime_rl.orchestrator.algo.base import Algorithm, connect_frozen_client
+from prime_rl.orchestrator.algo.debug import DebugAlgorithm
 from prime_rl.orchestrator.algo.echo import EchoAlgorithm
 from prime_rl.orchestrator.algo.grpo import GRPOAlgorithm
 from prime_rl.orchestrator.algo.hierarchical_grpo import HierarchicalGRPOAlgorithm
@@ -48,6 +49,7 @@ ALGORITHM_CLASSES: dict[str, type[Algorithm]] = {
     "opd": OPDAlgorithm,
     "opsd": OPSDAlgorithm,
     "sft": SFTDistillAlgorithm,
+    "debug": DebugAlgorithm,
 }
 
 
@@ -64,6 +66,7 @@ def build_algorithm(config: AlgoConfig, clients: InferenceClient) -> Algorithm:
 
 __all__ = [
     "Algorithm",
+    "DebugAlgorithm",
     "EchoAlgorithm",
     "GRPOAlgorithm",
     "HierarchicalGRPOAlgorithm",

--- a/src/prime_rl/orchestrator/algo/debug.py
+++ b/src/prime_rl/orchestrator/algo/debug.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import verifiers.v1 as vf
+
+from prime_rl.configs.algorithm import DebugAlgoConfig
+from prime_rl.orchestrator.algo.base import Algorithm, iter_trainable_traces
+from prime_rl.orchestrator.algo.routing import assign_advantages
+
+if TYPE_CHECKING:
+    from prime_rl.orchestrator.clients import InferenceClient
+
+
+class DebugAlgorithm(Algorithm):
+    """Debugging credit assignment: the same constant advantage (default 1.0)
+    on every sampled token of every clean trainable trace, ignoring rewards
+    entirely. For infra work — every rollout is trainable and every action
+    token carries gradient signal, so the full RL path (advantage transport,
+    importance ratios, trust region, optimizer, weight update) can be exercised
+    regardless of the reward function. Not a real training signal: a policy
+    pushed by it drifts monotonically."""
+
+    def __init__(self, config: DebugAlgoConfig, clients: InferenceClient):
+        super().__init__(config, clients)
+        self.advantage = config.advantage
+
+    async def score_episode(self, episode: vf.Episode) -> None:
+        for _, trace in iter_trainable_traces([episode]):
+            assign_advantages(trace, self.advantage)


### PR DESCRIPTION
## What

Adds a `debug` algorithm (`[orchestrator.algo] type = "debug"`) that assigns the same constant advantage (default `advantage = 1.0`) to every sampled token of every clean trainable trace, ignoring rewards entirely.

## Why

Purely a debugging feature for infra work: with constant advantages every admitted rollout is trainable and every action token carries gradient signal, so the full RL path — advantage transport, importance ratios, trust region, trainer loss, optimizer, weight update — can be exercised regardless of the reward function (e.g. to rule out "all-zero advantages / nothing trainable" when smoke-testing a pipeline). The config validator rejects `advantage = 0`, the exact failure this tool exists to rule out.

## How

Follows the existing "a new credit-assignment scheme is a new named class" pattern:

- `DebugAlgoConfig` in `prime_rl.configs.algorithm` (discriminated-union member, `action_loss_type = "rl"`, nonzero-advantage validator)
- `DebugAlgorithm` (`score_episode` — the signal is rollout-local, no group-relative work needed) registered in `ALGORITHM_CLASSES`

Intentionally not documented in `docs/` or the skills — it is a debug tool, and the code docstrings are the reference.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in debug algorithm only; no changes to existing algo behavior or production defaults.
> 
> **Overview**
> Adds a **`debug`** training algorithm for pipeline smoke tests: set `[orchestrator.algo] type = "debug"` to assign the same constant per-token advantage (default **1.0**) on every clean trainable trace, **ignoring rewards**, so admitted rollouts always produce RL gradient through the full stack (advantage transport, ratios, trust region, trainer, optimizer).
> 
> **Config:** `DebugAlgoConfig` joins the `AlgoConfig` discriminated union with `action_loss_type = "rl"` and a validator that rejects `advantage = 0` (the “nothing trainable” case this mode is meant to rule out). **Runtime:** `DebugAlgorithm` implements `score_episode` via `iter_trainable_traces` + `assign_advantages`, registered in `ALGORITHM_CLASSES` like other algorithms. Docstrings mark it as infra-only—not a real training signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce6ca60585b3f259780492b892157b356b0569cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->