### PR TITLE
Reclaim consumed CPU gradient pages during full offload

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -66,6 +66,15 @@ class OptimizerInBackwardOffloadConfig(BaseConfig):
     numa_bind: bool = True
     """Pin each rank's CPUs to its GPU's NUMA node. Disable when the launcher already manages CPU affinity or GPU sysfs topology is unavailable."""
 
+    release_gradient_pages: bool = False
+    """Release consumed FP32 CPU gradient pages after each native optimizer chunk. Requires Linux anonymous mmap; reduces resident memory when optimizer steps overlap backward."""
+
+    @model_validator(mode="after")
+    def gradient_page_release_requires_native(self):
+        if self.release_gradient_pages and self.cpu_optimizer_backend != "native":
+            raise ValueError("release_gradient_pages requires cpu_optimizer_backend='native'")
+        return self
+
 
 def _normalize_optimizer_in_backward_offload(value: Any) -> Any:
     if value is True:

--- a/src/prime_rl/trainer/optim/gradient_slab.py
+++ b/src/prime_rl/trainer/optim/gradient_slab.py
@@ -1,0 +1,23 @@
+"""Page-aligned FP32 gradient storage whose consumed pages can be reclaimed."""
+
+import mmap
+
+import torch
+
+
+class ReclaimableGradientSlab:
+    alignment = mmap.PAGESIZE // torch.float32.itemsize
+
+    def __init__(self, numel: int):
+        if numel <= 0 or numel % self.alignment:
+            raise ValueError("Gradient slab size must be a positive whole number of pages")
+        self.mapping = mmap.mmap(-1, numel * torch.float32.itemsize, flags=mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS)
+        self.tensor = torch.frombuffer(self.mapping, dtype=torch.float32, count=numel)
+
+    def release(self, offset: int, numel: int) -> None:
+        if offset < 0 or numel < 0 or offset + numel > self.tensor.numel():
+            raise ValueError("Gradient page range is outside its slab")
+        if offset % self.alignment or numel % self.alignment:
+            raise ValueError("Gradient release range must contain whole pages")
+        if numel:
+            self.mapping.madvise(mmap.MADV_DONTNEED, offset * torch.float32.itemsize, numel * torch.float32.itemsize)

--- a/src/prime_rl/trainer/optim/offload.py
+++ b/src/prime_rl/trainer/optim/offload.py
@@ -21,6 +21,7 @@ from prime_rl.trainer.optim.cpu_adam import add_bfloat16_ as native_add_bfloat16
 from prime_rl.trainer.optim.cpu_adam import copy_or_add_bfloat16_multi_ as native_copy_or_add_bfloat16_multi_
 from prime_rl.trainer.optim.cpu_adam import load_cpu_adamw_kernel
 from prime_rl.trainer.optim.cpu_adam import sign_sgd_step as native_cpu_sign_sgd_step
+from prime_rl.trainer.optim.gradient_slab import ReclaimableGradientSlab
 from prime_rl.trainer.sign_sgd import SignSGD
 from prime_rl.utils.logger import get_logger
 
@@ -485,6 +486,7 @@ class BoundedGradientOffloadManager(GradientOffloadManager):
         chunk_ready_callback: Callable[[int], None],
         gradient_dtypes: dict[int, torch.dtype],
         compute_dtypes: dict[int, torch.dtype],
+        release_gradient_pages: bool = False,
     ):
         self._chunks = chunks
         self._dp_replicate = dp_replicate
@@ -514,7 +516,7 @@ class BoundedGradientOffloadManager(GradientOffloadManager):
         if len(dtensor_params) != len(params):
             raise TypeError("Bounded gradient offload requires FSDP2 DTensor parameters")
 
-        alignment = 256 // torch.empty((), dtype=torch.float32).element_size()
+        alignment = ReclaimableGradientSlab.alignment if release_gradient_pages else 64
         offsets: dict[int, int] = {}
         slab_numel = 0
         max_param_numel: dict[torch.dtype, int] = defaultdict(int)
@@ -524,7 +526,16 @@ class BoundedGradientOffloadManager(GradientOffloadManager):
             slab_numel += (local.numel() + alignment - 1) // alignment * alignment
             gradient_dtype = gradient_dtypes[id(param)]
             max_param_numel[gradient_dtype] = max(max_param_numel[gradient_dtype], local.numel())
-        accumulator_slab = torch.empty(slab_numel, dtype=torch.float32, device="cpu")
+        self._reclaimable_slab = ReclaimableGradientSlab(slab_numel) if release_gradient_pages else None
+        accumulator_slab = (
+            self._reclaimable_slab.tensor
+            if self._reclaimable_slab is not None
+            else torch.empty(slab_numel, dtype=torch.float32, device="cpu")
+        )
+        self._gradient_page_ranges = {
+            id(param): (offsets[id(param)], (param.to_local().numel() + alignment - 1) // alignment * alignment)
+            for param in dtensor_params
+        }
         self._buffers: dict[int, _CPUGradientBuffer] = {}
         self._ready_events: dict[int, list[torch.cuda.Event]] = {}
         for param in dtensor_params:
@@ -642,6 +653,13 @@ class BoundedGradientOffloadManager(GradientOffloadManager):
         for slot in slots:
             free_slots["normal" if slot.tensor.numel() == normal_numel else "oversized"].put(slot)
         return slots, free_slots
+
+    def release_chunk(self, chunk_idx: int, target_params: list[nn.Parameter] | None = None) -> None:
+        super().release_chunk(chunk_idx, target_params)
+        if self._reclaimable_slab is not None:
+            for param in self._chunks[chunk_idx]:
+                self._reclaimable_slab.release(*self._gradient_page_ranges[id(param)])
+                self._buffers[id(param)].initialized = False
 
     @staticmethod
     def _free_slot_count(slots: dict[str, queue.Queue[_PinnedTransferSlot]]) -> int:
@@ -1118,6 +1136,7 @@ class FullCPUOffloadOptimizer(OffloadOptimizer):
                 chunk_ready_callback=self._step_cpu_chunk,
                 gradient_dtypes=gradient_dtypes,
                 compute_dtypes=compute_dtypes,
+                release_gradient_pages=offload_config.release_gradient_pages,
             )
         else:
             self._gradient_manager = GradientOffloadManager(

--- a/tests/unit/train/test_cpu_adam.py
+++ b/tests/unit/train/test_cpu_adam.py
@@ -1,3 +1,6 @@
+import sys
+
+import pytest
 import torch
 
 from prime_rl.trainer.optim.cpu_adam import (
@@ -7,8 +10,29 @@ from prime_rl.trainer.optim.cpu_adam import (
     copy_or_add_bfloat16_multi_,
     sign_sgd_step,
 )
+from prime_rl.trainer.optim.gradient_slab import ReclaimableGradientSlab
 from prime_rl.trainer.optim.offload import _cast_full_offload_compute_parameters
 from prime_rl.trainer.sign_sgd import SignSGD
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Anonymous gradient page reclamation requires Linux")
+def test_reclaimed_gradient_pages_preserve_other_regions_and_allow_reuse():
+    page = ReclaimableGradientSlab.alignment
+    slab = ReclaimableGradientSlab(3 * page)
+    before, consumed, after = slab.tensor.chunk(3)
+    before.fill_(1.25)
+    consumed.fill_(2.5)
+    after.fill_(-3.75)
+    slab.release(page, page)
+    torch.testing.assert_close(before, torch.full_like(before, 1.25), rtol=0, atol=0)
+    torch.testing.assert_close(after, torch.full_like(after, -3.75), rtol=0, atol=0)
+    assert consumed.count_nonzero() == 0
+    consumed.add_(4.5)
+    torch.testing.assert_close(consumed, torch.full_like(consumed, 4.5), rtol=0, atol=0)
+    with pytest.raises(ValueError, match="whole pages"):
+        slab.release(1, page)
+    with pytest.raises(ValueError, match="outside"):
+        slab.release(3 * page, page)
 
 
 def test_full_offload_preserves_per_parameter_compute_dtypes():


### PR DESCRIPTION
Native full CPU offload keeps its FP32 gradient accumulator resident even after the optimizer has consumed each chunk. For large models, those dead gradient pages can push host memory over the limit while parameters and optimizer state already occupy most of RAM.

This adds **opt-in reclamation of consumed gradient pages**. The virtual slab stays allocated; completed chunks return their physical pages to the OS and can reuse the storage on the next step.

## What changes

- Add `trainer.model.full_offload.release_gradient_pages`, defaulting to `false`. The option requires the native CPU optimizer backend.
- Back the FP32 accumulator with a page-aligned anonymous mmap when enabled.
- After an optimizer chunk is consumed, release its pages with Linux `MADV_DONTNEED` and reset the gradient-buffer initialization state.
- Add a targeted test for untouched neighboring regions, zeroed/reusable released pages, alignment, and bounds checks.

This changes gradient storage lifetime, not optimizer arithmetic. The existing `optimization_dtype` and `reduce_dtype` settings are unchanged.

Reclamation happens only after a chunk is consumed. It therefore does **not** eliminate the memory needed for unfinished gradient accumulation; workloads with multiple accumulated microbatches must still budget for that peak.

## Validation

- **2 targeted CPU tests passed** on this independent branch: gradient-page reclamation/reuse and preservation of per-parameter compute dtypes (`-k 'reclaimed_gradient_pages or full_offload_preserves'`; 2 other tests deselected).
- Earlier integration validation compared three real native CPU-offloaded Adam steps with two microbatches each. Reclamation enabled versus disabled produced bitwise-identical FP32 master parameters and Adam moments, with actual parameter updates.
- The same implementation was used successfully in the completed GLM-4.5-Air reverse-text, GSM8K, and frozen long-input runs.
- Ruff lint/format and diff whitespace checks passed.

This is a four-file runtime/test change, based directly on `main`. It has no dependency on the numerical-alignment implementation in [#3520](https://github.com/PrimeIntellect-ai/prime-rl/pull/3520), and introduces no experiment configs, evidence files, or development tools.
