### PR TITLE
Add Total Router Recall for MoE training

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 
 
@@ -9,6 +11,10 @@ def apply_shared_vllm_patches():
     load failures (``load_plugins_by_group`` logs and continues), so a broken
     entry-point target silently skips ALL of these patches.
     """
+    if os.environ.get("PRIME_TOTAL_ROUTER_RECALL") == "1":
+        from prime_rl.inference.total_router_recall import enable_total_router_capture
+
+        enable_total_router_capture()
     _patch_lora_key_prefix()
     _patch_qwen35_moe_lora_format()
     monkey_patch_nano_v3_reasoning_parser()

--- a/src/prime_rl/inference/total_router_recall.py
+++ b/src/prime_rl/inference/total_router_recall.py
@@ -33,8 +33,8 @@ def enable_total_router_capture():
     original_manager_init = RoutedExpertsManager.__init__
 
     def check_config(config):
-        if config.model_config.hf_text_config.model_type not in ("qwen3_moe", "glm4_moe"):
-            raise ValueError("Experimental TRR supports Qwen3 MoE and GLM4 MoE only")
+        if config.model_config.hf_text_config.model_type != "qwen3_moe":
+            raise ValueError("Experimental TRR currently supports Qwen3 MoE only")
         if config.parallel_config.tensor_parallel_size != 1 or config.parallel_config.enable_expert_parallel:
             raise ValueError("Experimental TRR requires TP1 and EP1")
         if not config.model_config.enforce_eager:

--- a/src/prime_rl/inference/total_router_recall.py
+++ b/src/prime_rl/inference/total_router_recall.py
@@ -33,8 +33,9 @@ def enable_total_router_capture():
     original_manager_init = RoutedExpertsManager.__init__
 
     def check_config(config):
-        if config.model_config.hf_text_config.model_type != "qwen3_moe":
-            raise ValueError("Experimental TRR currently supports Qwen3 MoE only")
+        model_type = config.model_config.hf_text_config.model_type
+        if model_type not in {"glm4_moe", "qwen3_moe"}:
+            raise ValueError(f"Experimental TRR does not support {model_type}")
         if config.parallel_config.tensor_parallel_size != 1 or config.parallel_config.enable_expert_parallel:
             raise ValueError("Experimental TRR requires TP1 and EP1")
         if not config.model_config.enforce_eager:

--- a/src/prime_rl/inference/total_router_recall.py
+++ b/src/prime_rl/inference/total_router_recall.py
@@ -1,0 +1,68 @@
+"""Experimental vLLM 0.28 TRR capture over the existing routed-experts transport.
+
+The int32 payload has shape [tokens, layers, 2 * top_k]: logical expert IDs
+followed by the bit patterns of the FP32 combine weights. Both halves therefore
+undergo exactly the same request slicing, truncation, and trainer packing.
+"""
+
+import logging
+
+import numpy as np
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def pack_routing(ids: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
+    if weights.dtype != torch.float32 or weights.shape != ids.shape:
+        raise ValueError("TRR requires FP32 weights with the same shape as expert IDs")
+    return torch.cat((ids.to(torch.int32), weights.contiguous().view(torch.int32)), dim=-1)
+
+
+def enable_total_router_capture():
+    from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
+        RoutedExpertsCapturer,
+        RoutedExpertsManager,
+    )
+    from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
+
+    if getattr(BaseRouter, "_prime_trr", False):
+        return
+
+    original_capture_init = RoutedExpertsCapturer.__init__
+    original_manager_init = RoutedExpertsManager.__init__
+
+    def check_config(config):
+        if config.model_config.hf_text_config.model_type not in ("qwen3_moe", "glm4_moe"):
+            raise ValueError("Experimental TRR supports Qwen3 MoE and GLM4 MoE only")
+        if config.parallel_config.tensor_parallel_size != 1 or config.parallel_config.enable_expert_parallel:
+            raise ValueError("Experimental TRR requires TP1 and EP1")
+        if not config.model_config.enforce_eager:
+            raise ValueError("Experimental TRR requires eager inference")
+
+    def capture_init(self, max_num_batched_tokens, vllm_config, kv_cache_config):
+        check_config(vllm_config)
+        original_capture_init(self, max_num_batched_tokens, vllm_config, kv_cache_config)
+        shape = (*self.device_buffer.shape[:-1], self.device_buffer.shape[-1] * 2)
+        self.device_buffer = torch.zeros(shape, dtype=torch.int32, device=self.device_buffer.device)
+        logger.info("TRR capture enabled: %s int32 IDs + FP32 weight bits", shape)
+
+    def manager_init(self, vllm_config, kv_cache_config):
+        check_config(vllm_config)
+        original_manager_init(self, vllm_config, kv_cache_config)
+        shape = (*self.routed_experts_by_slot.shape[:-1], self.routed_experts_by_slot.shape[-1] * 2)
+        self.routed_experts_by_slot = np.zeros(shape, dtype=np.int32)
+        logger.info("TRR scheduler storage: %.3f GB, shape %s", self.routed_experts_by_slot.nbytes / 1e9, shape)
+
+    def select_experts(self, hidden_states, router_logits, topk_indices_dtype=None, *, input_ids=None):
+        self._validate_eplb_state()
+        weights, ids = self._compute_routing(hidden_states, router_logits, topk_indices_dtype, input_ids=input_ids)
+        if self.capture_fn is not None:
+            self.capture_fn(pack_routing(ids, weights))
+        ids = self._apply_eplb_mapping(ids)
+        return weights, self._convert_indices_dtype(ids, topk_indices_dtype)
+
+    RoutedExpertsCapturer.__init__ = capture_init
+    RoutedExpertsManager.__init__ = manager_init
+    BaseRouter._select_experts = select_experts
+    BaseRouter._prime_trr = True

--- a/src/prime_rl/inference/vllm/routed_experts.py
+++ b/src/prime_rl/inference/vllm/routed_experts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -15,8 +16,12 @@ def serialize_routed_experts(routed_experts: Any, start: int = 0) -> dict[str, A
     array = np.asarray(routed_experts)
     assert array.ndim == 3
     assert np.issubdtype(array.dtype, np.integer)
-    dtype = np.uint8
-    if array.size:
+    total_recall = os.environ.get("PRIME_TOTAL_ROUTER_RECALL") == "1"
+    dtype = np.int32 if total_recall else np.uint8
+    if total_recall:
+        if array.dtype != np.int32 or array.shape[-1] % 2:
+            raise ValueError("TRR export requires int32 IDs and FP32 weight bits")
+    elif array.size:
         assert array.min() >= 0
         if array.max() > np.iinfo(np.uint8).max:
             # Models with >256 experts (e.g. NemotronH Super/Ultra: 512) need wider

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-
+import os
 from dataclasses import dataclass
 from typing import Literal
 
@@ -247,6 +247,13 @@ class TokenChoiceTopKRouter(nn.Module):
                 - routing_confidence_sum (torch.Tensor):
                     Sum over tokens of the selected-expert probability mass before route normalization/scaling.
         """
+        if os.environ.get("PRIME_TOTAL_ROUTER_RECALL") == "1":
+            from prime_rl.trainer.rl.total_router_recall import replay_router
+
+            return replay_router(self, x, routed_experts, TokenChoiceTopKRouter.live_forward)
+        return self.live_forward(x, routed_experts)
+
+    def live_forward(self, x, routed_experts=None):
         # scores shape (bs*slen, num_experts)
         assert routed_experts is None or routed_experts.shape[-1] == self.top_k, (
             f"routed_experts shape: {routed_experts.shape}, top_k: {self.top_k}"

--- a/src/prime_rl/trainer/rl/total_router_recall.py
+++ b/src/prime_rl/trainer/rl/total_router_recall.py
@@ -1,0 +1,98 @@
+"""Paired live-router / ID replay / total recall experiment on identical rollouts."""
+
+import json
+import os
+from contextlib import contextmanager
+from pathlib import Path
+
+import torch
+
+from prime_rl.trainer.rl.mismatch import mismatch_diagnostics
+
+REPLAY_MODE = "weights"
+
+
+def unpack_routing(payload, top_k):
+    if payload.dtype != torch.int32 or payload.shape[-1] != 2 * top_k:
+        raise ValueError("TRR requires int32 [expert IDs, FP32 weight bits] for every token/layer")
+    ids = payload[:, :top_k].to(torch.int64)
+    weights = payload[:, top_k:].contiguous().view(torch.float32)
+    return ids, weights
+
+
+@contextmanager
+def replay_mode(mode):
+    global REPLAY_MODE
+    previous = REPLAY_MODE
+    REPLAY_MODE = mode
+    try:
+        yield
+    finally:
+        REPLAY_MODE = previous
+
+
+def replay_router(router, x, payload, live_forward):
+    if payload is None:
+        raise ValueError("TRR enabled but routing payload is missing")
+    ids, weights = unpack_routing(payload, router.top_k)
+    if REPLAY_MODE == "live":
+        return live_forward(router, x, None)
+    if REPLAY_MODE == "ids":
+        return live_forward(router, x, ids)
+    if REPLAY_MODE != "weights":
+        raise ValueError(f"Unknown TRR mode {REPLAY_MODE}")
+    counts = torch.bincount(ids.flatten(), minlength=router.num_experts)
+    return weights, ids, counts, weights.sum()
+
+
+@torch.no_grad()
+def shadow_forwards(forward, model, input_ids, position_ids, **kwargs):
+    outputs = {}
+    for mode in ("live", "ids"):
+        with replay_mode(mode):
+            out = forward(model, input_ids, position_ids, **kwargs)
+        if out.get("logprobs") is None:
+            raise ValueError("TRR comparison requires a head returning selected logprobs")
+        outputs[mode] = out["logprobs"].detach().cpu()
+    return outputs
+
+
+@torch.no_grad()
+def record_comparison(output_dir, step, micro_step, shadows, trr, inference, mask, micro_batch):
+    # Trainer head scores the next token; rollout logprobs are aligned to the token itself.
+    mask = mask.cpu()
+    inference = inference.cpu()[mask]
+    values = {mode: torch.roll(logprobs, 1, dims=1)[mask] for mode, logprobs in shadows.items()}
+    values["weights"] = trr.detach().cpu()[mask]
+    payload = micro_batch["routed_experts"]
+    real = torch.tensor([bool(name) for name in micro_batch["env_names"]])
+    layers, width = payload.shape[-2:]
+    ids, weights = unpack_routing(payload.reshape(-1, width), width // 2)
+    weights = weights.reshape(1, -1, layers, width // 2)[:, real]
+    ids = ids.reshape(1, -1, layers, width // 2)[:, real]
+    if not torch.isfinite(weights).all() or not (weights >= 0).all():
+        raise ValueError("Nonfinite or negative routing weights after rollout transport")
+    if not ((weights.sum(-1) - 1).abs() < 2e-6).all():
+        raise ValueError("Missing or non-normalized routing payload for a real token/layer")
+    if not ((ids >= 0) & (ids < 128)).all():
+        raise ValueError("Invalid Qwen3-30B expert ID after transport")
+    record = {
+        "routing_rows": int(real.sum()) * layers,
+        "routing_payload_bytes": payload.numel() * payload.element_size(),
+        "step": step,
+        "micro_step": micro_step,
+        "tokens": int(mask.sum()),
+        "trace_ids": micro_batch["trace_ids"],
+        "modes": {},
+    }
+    for mode, logprobs in values.items():
+        metrics = mismatch_diagnostics(logprobs, inference)
+        record["modes"][mode] = {
+            name: {"sum": float(v.double().sum()), "max": float(v.max()) if v.numel() else 0.0}
+            for name, v in metrics.items()
+        }
+    path = Path(output_dir) / "trr-paired"
+    path.mkdir(exist_ok=True, parents=True)
+    rank = int(os.environ["RANK"])
+    with (path / f"rank_{rank}.jsonl").open("a") as handle:
+        handle.write(json.dumps(record) + "\n")

--- a/src/prime_rl/trainer/rl/total_router_recall.py
+++ b/src/prime_rl/trainer/rl/total_router_recall.py
@@ -20,6 +20,16 @@ def unpack_routing(payload, top_k):
     return ids, weights
 
 
+def routing_geometry(config):
+    if config.model_type not in {"glm4_moe", "qwen3_moe"}:
+        raise ValueError(f"Experimental TRR does not support {config.model_type}")
+    num_experts = getattr(config, "num_experts", None) or getattr(config, "n_routed_experts", None)
+    if num_experts is None:
+        raise ValueError("TRR model config is missing its routed expert count")
+    first_moe_layer = getattr(config, "first_k_dense_replace", 0)
+    return config.num_hidden_layers, first_moe_layer, num_experts
+
+
 @contextmanager
 def replay_mode(mode):
     global REPLAY_MODE
@@ -58,7 +68,7 @@ def shadow_forwards(forward, model, input_ids, position_ids, **kwargs):
 
 
 @torch.no_grad()
-def record_comparison(output_dir, step, micro_step, shadows, trr, inference, mask, micro_batch):
+def record_comparison(output_dir, step, micro_step, shadows, trr, inference, mask, micro_batch, model_config):
     # Trainer head scores the next token; rollout logprobs are aligned to the token itself.
     mask = mask.cpu()
     inference = inference.cpu()[mask]
@@ -67,17 +77,26 @@ def record_comparison(output_dir, step, micro_step, shadows, trr, inference, mas
     payload = micro_batch["routed_experts"]
     real = torch.tensor([bool(name) for name in micro_batch["env_names"]])
     layers, width = payload.shape[-2:]
+    expected_layers, first_moe_layer, num_experts = routing_geometry(model_config)
+    if layers != expected_layers:
+        raise ValueError(f"TRR payload has {layers} layers; model config requires {expected_layers}")
     ids, weights = unpack_routing(payload.reshape(-1, width), width // 2)
     weights = weights.reshape(1, -1, layers, width // 2)[:, real]
     ids = ids.reshape(1, -1, layers, width // 2)[:, real]
+    if first_moe_layer:
+        if payload.reshape(1, -1, layers, width)[:, real, :first_moe_layer].count_nonzero():
+            raise ValueError("Dense model layers unexpectedly contain routing payload")
+        weights = weights[:, :, first_moe_layer:]
+        ids = ids[:, :, first_moe_layer:]
     if not torch.isfinite(weights).all() or not (weights >= 0).all():
         raise ValueError("Nonfinite or negative routing weights after rollout transport")
-    if not ((weights.sum(-1) - 1).abs() < 2e-6).all():
+    route_scale = getattr(model_config, "routed_scaling_factor", 1.0)
+    if not ((weights.sum(-1) - route_scale).abs() < 2e-6).all():
         raise ValueError("Missing or non-normalized routing payload for a real token/layer")
-    if not ((ids >= 0) & (ids < 128)).all():
-        raise ValueError("Invalid Qwen3-30B expert ID after transport")
+    if not ((ids >= 0) & (ids < num_experts)).all():
+        raise ValueError("Invalid expert ID after routing transport")
     record = {
-        "routing_rows": int(real.sum()) * layers,
+        "routing_rows": int(real.sum()) * (layers - first_moe_layer),
         "routing_payload_bytes": payload.numel() * payload.element_size(),
         "step": step,
         "micro_step": micro_step,

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -543,6 +543,7 @@ def train(config: TrainerConfig):
                     inference_logprobs,
                     loss_mask,
                     micro_batch,
+                    model.config,
                 )
 
             # Compute loss

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -1,3 +1,5 @@
+import os
+
 import prime_rl._compat  # noqa: F401 — patch ring_flash_attn compat before import
 
 from contextlib import nullcontext
@@ -466,6 +468,27 @@ def train(config: TrainerConfig):
                     f"labels shape {tuple(labels.shape)}"
                 )
 
+            trr_shadows = None
+            if os.environ.get("PRIME_TRR_COMPARE") == "1":
+                from prime_rl.trainer.rl.total_router_recall import shadow_forwards
+
+                if cp_enabled:
+                    raise ValueError("Paired TRR experiment requires CP1")
+                trr_shadows = shadow_forwards(
+                    forward,
+                    model,
+                    input_ids,
+                    position_ids,
+                    labels=labels,
+                    temperature=temperatures,
+                    mm_kwargs=mm_kwargs,
+                    mm_token_type_ids=mm_token_type_ids,
+                    seq_lens=seq_lens,
+                    seq_lens_are_pre_shard=seq_lens_are_pre_shard,
+                    routed_experts=routed_experts,
+                    sampling_mask=sampling_mask,
+                )
+
             # Forward pass with per-token temperatures
             with maybe_record_function("forward"), maybe_activation_offloading(config.model.ac_offloading):
                 out = forward(
@@ -507,6 +530,20 @@ def train(config: TrainerConfig):
             out["entropy"] = shift_tensor_right(
                 out["entropy"], pad_value=torch.log(torch.tensor(float(vocab_size))).item()
             )
+
+            if trr_shadows is not None:
+                from prime_rl.trainer.rl.total_router_recall import record_comparison
+
+                record_comparison(
+                    config.output_dir,
+                    progress.step,
+                    micro_step,
+                    trr_shadows,
+                    out["logprobs"],
+                    inference_logprobs,
+                    loss_mask,
+                    micro_batch,
+                )
 
             # Compute loss
             sequence_lengths = micro_batch["sequence_lengths"]


### PR DESCRIPTION
Total Router Recall makes the sampler’s MoE routing decision part of the rollout contract. vLLM records each selected expert ID and its normalized FP32 combine weight; the trainer uses both values directly when scoring the same tokens. This removes routing selection and routing-weight recomputation from the train/inference comparison.

This is a draft stacked on #3520 so the diff contains only the Total Router Recall implementation.

## What this adds

- Capture logical expert IDs and normalized FP32 combine weights from vLLM’s router before EPLB remapping.
- Pack the weights losslessly into the existing token-aligned routed-experts payload, so request slicing, truncation, batching, and padding apply to IDs and weights together.
- Replay the captured weights and IDs directly in the trainer while freezing router parameters.
- Optionally score an identical rollout with the live trainer router, ID-only replay, and Total Router Recall for paired K3 measurements.
- Support the Qwen3 MoE and GLM-4.5-Air routing layouts. GLM’s dense prefix layer is excluded from routing validation.

The packed payload is `int32 [expert IDs, FP32 weight bits]` with width `2 * top_k`. Its raw size is 8 bytes per selected expert per MoE layer per token: 3,072 bytes/token for Qwen3-30B-A3B and 2,880 bytes/token for GLM-4.5-Air.

The current implementation requires eager vLLM with TP1/EP1. Replaying sampler weights removes the normal router gradient, so router parameters are frozen. Paired diagnostics add two shadow forwards and are intended for measurement.

## Results

Sampled-token-weighted mean stable K3 on Qwen3-30B-A3B:

| Workload | Steps | Tokens | Live router | ID replay | Total recall |
| --- | ---: | ---: | ---: | ---: | ---: |
| Reverse text | 20 | 40,070 | 0.03765341 | 0.00294146 | 0.00197086 |
| Single-turn GSM8K | 8 | 49,715 | 0.00230447 | 0.000300226 | 0.000260851 |
| Frozen reverse text | 3 | 3,902 | 0.02975694 | 0.00232855 | 0.00155784 |

Every measured batch favored total recall over ID-only replay. The GSM8K result is near the `3e-4` K3 reported for Total Router Recall in the mismatch article. Total recall does not make these ordinary trainer/vLLM forward paths bitwise identical; remaining dense arithmetic differences still contribute mismatch.

The GLM GPU run is queued behind the current priority allocation. Its 46-layer payload geometry, including the dense layer-0 exclusion and 45 MoE layers, has been validated on CPU.

## Validation

- `ruff check` passes for all six changed source files.
- `pytest -q tests/unit/train/rl/test_mismatch.py`: 3 passed.
- Qwen runs validated finite normalized weights, valid expert IDs, policy-version agreement, direct replay, and paired metric agreement.
- Synthetic Qwen and GLM payload checks validated FP32 packing and model-derived layer/expert geometry.