### PR TITLE
Preserve FP32 MoE routers during weight transfer

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -437,6 +437,10 @@ def apply_fp32_moe_router(model: nn.Module) -> None:
     # No-op for non-MoE and HF-impl models: moe_router_dtype='float32' is the default,
     # so absence of custom-impl MoE routers is the common case, not an error.
     if num_routers > 0:
+        original_keep_fp32 = model.keep_in_fp32_for_weight_transfer
+        model.keep_in_fp32_for_weight_transfer = lambda name: (
+            name.endswith(("mlp.router.gate.weight", "mlp.router.gate.bias")) or original_keep_fp32(name)
+        )
         logger.info(f"Running {num_routers} MoE router gates in fp32")
 
 

--- a/tests/unit/train/models/test_moe.py
+++ b/tests/unit/train/models/test_moe.py
@@ -4,6 +4,7 @@ import torch.nn.functional as F
 
 from prime_rl.configs.trainer import ModelConfig
 from prime_rl.trainer.distributed.token_dispatcher import LocalTokenDispatcher
+from prime_rl.trainer.model import apply_fp32_moe_router
 from prime_rl.trainer.models.layers.activations import ActivationDispatch
 from prime_rl.trainer.models.layers.grouped_gemm import BF16GroupedGemm
 from prime_rl.trainer.models.layers.mlp import FeedForward
@@ -14,6 +15,23 @@ from prime_rl.trainer.models.layers.moe import (
 )
 from prime_rl.trainer.moe_runtime import configure_moe_runtime
 from prime_rl.trainer.parallel_dims import ParallelDims
+
+
+def test_fp32_router_parameters_keep_their_wire_dtype():
+    moe = MoE.from_args(MoEArgs(num_experts=2), dim=4, hidden_dim=8, shared_expert=None).to(torch.bfloat16)
+    layer = torch.nn.Module()
+    layer.mlp = moe
+    model = torch.nn.Module()
+    model.model = torch.nn.Module()
+    model.model.layers = torch.nn.ModuleList([layer])
+    model.keep_in_fp32_for_weight_transfer = lambda name: name.endswith("selection_bias")
+
+    apply_fp32_moe_router(model)
+
+    assert moe.router.gate.weight.dtype is torch.float32
+    assert model.keep_in_fp32_for_weight_transfer("model.layers.0.mlp.router.gate.weight")
+    assert model.keep_in_fp32_for_weight_transfer("model.layers.0.mlp.router.selection_bias")
+    assert not model.keep_in_fp32_for_weight_transfer("model.layers.0.mlp.experts.gate_proj")
 
 
 @pytest.mark.parametrize("selection", [[], [0], "0%", "50%"])


### PR DESCRIPTION
MoE routers configured with `moe_router_dtype = "float32"` run and update in FP32, but ordinary weight transfer downcasts them to BF16 unless the model includes them in `keep_in_fp32_for_weight_transfer`. The initial checkpoint is unaffected because its router values originate in BF16. After an optimizer update, the downcast discards learned FP32 mantissa bits and inference receives different router weights.

This change extends the model's existing transfer allowlist when `apply_fp32_moe_router()` finds a custom MoE router. Router gate weights and biases stay FP32 through NCCL, filesystem, and NIXL transfers, while other parameters retain the configured wire dtype. Existing model-specific FP32 declarations remain composed.

For Qwen3-30B-A3B, this adds about 25.2 MB per weight sync: 12.58M router parameters are sent as FP32 instead of BF16. It does not change optimization or reduction dtypes.

### Qwen3-30B-A3B ablation

The control and treatment used identical resolved trainer and orchestrator settings apart from output paths and run names.

| Router transfer | Step 1 K3 | Step 2 K3 | Step 3 K3 | Token bit mismatches |
| --- | ---: | ---: | ---: | ---: |
| BF16 | 0 | 0.0230061 | 0.0550924 | 3,866 / 6,396 |
| FP32 | 0 | 0 | 0 | 0 / 26,833 across 20 steps |

Step 1 measures the initial checkpoint. The BF16 control diverged after the first optimizer update. The FP32 treatment retained exact K3 and bitwise agreement for all 20 steps, with matched policy versions and nonzero gradients throughout.

This ablation used the aligned training/inference stack. The change removes the router wire-downcast regression; unrelated forward-kernel differences can still cause mismatch outside that stack.

### Validation

- `uv run --no-sync ruff check src/prime_rl/trainer/model.py tests/unit/train/models/test_moe.py`
- `uv run --no-sync pytest -q tests/unit/train/models/test_moe.py -k fp32_router_parameters_keep_their_wire_dtype` — 1 passed, 11 deselected
