### PR TITLE
feat(algo): add optional SWE-2 length-weighted group baseline

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -143,7 +143,7 @@ At runtime, each env's resolved config builds two objects: a `GenerationSource` 
 
 | `algo.type` | Class | hook(s) — stage |
 |---|---|---|
-| `grpo` | `GRPOAlgorithm` | `score_group`: group-norm credit (optional length penalty) |
+| `grpo` | `GRPOAlgorithm` | `score_group`: group-norm credit (optional length penalty and length-weighted baseline) |
 | `echo` | `EchoAlgorithm` | `score_episode`: weighted ce on observation tokens; `score_group`: group-norm credit (inherited) |
 | `max_rl` | `MaxRLAlgorithm` | `score_group`: mean-normalized group credit |
 | `rae` | `RAEAlgorithm` | `score_group`: per-agent EMA-baseline credit |
@@ -275,7 +275,7 @@ The per-token training signal is set by `algo.type` and the [algorithm](#the-alg
 
 | Type | Component | Effect |
 |---|---|---|
-| `grpo` | `rl` | Group-norm: reward minus per-group baseline, optional length penalty. |
+| `grpo` | `rl` | Group-norm: reward minus per-group baseline, optional length penalty and length-weighted baseline. |
 | `max_rl` | `rl` | Mean-normalized group credit (maximum-likelihood RL). |
 | `rae` | `rl` | Reward minus a per-agent EMA baseline (SPIRAL's role-conditioned advantage estimation) — for multi-agent self-play envs. |
 | `hierarchical_grpo` | `rl` | GRPO for proposer-solver envs: solvers are compared within one proposed problem, while proposers are compared across proposals. |
@@ -298,6 +298,14 @@ type = "grpo"
 
 [orchestrator.algo.length_penalty]
 type = "linear"
+```
+
+A **length-weighted baseline** (`length_weighted_baseline = true` on the `grpo`-family algorithms, off by default) replaces the group-mean baseline $\bar{s}$ with the length-weighted group baseline $b = \frac{\sum_i s_i L_i}{\sum_i L_i}$, where $L_i$ is rollout $i$'s trainable-token count — SWE-2's baseline ([cognition.com/blog/swe-2](https://cognition.com/blog/swe-2)). The variance-optimal REINFORCE baseline weights each rollout by its score-gradient norm, and that norm is empirically correlated with rollout length, so weighting by trainable tokens approximates it at no extra cost; SWE-2's ablations credit it with more stable training and lower inference–training KL. Like the group mean, it is estimated from the sampled group, so its bias decays as $1/\text{group\_size}$. Its advantages no longer sum to zero over the group's rollouts — instead the trainable-token-weighted sum is zero, so longer rollouts carry proportionally smaller credit. It applies to the rewards after the optional length penalty, so both can be combined.
+
+```toml
+[orchestrator.algo]
+type = "grpo"
+length_weighted_baseline = true
 ```
 
 ### Hierarchical GRPO

--- a/packages/prime-rl-configs/src/prime_rl/configs/algorithm.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/algorithm.py
@@ -200,13 +200,18 @@ class BaseAlgoConfig(BaseConfig):
 
 class GRPOAlgoConfig(BaseAlgoConfig):
     type: Literal["grpo"] = "grpo"
-    """GRPO: scalar advantage = reward minus the per-group mean baseline,
-    consumed by the ``rl`` loss component on the rollout's action tokens."""
+    """GRPO: scalar advantage = reward minus the per-group baseline — the group
+    mean, or the trainable-token-weighted mean when ``length_weighted_baseline``
+    is set — consumed by the ``rl`` loss component on the rollout's action
+    tokens."""
 
     action_loss_type: ClassVar[ActionLossType] = "rl"
 
     length_penalty: LengthPenaltyConfig | None = None
     """Linear length penalty subtracted from each reward before the GRPO baseline (see ``LinearLengthPenaltyConfig``): a ``pass_rate``-scaled sum of output-token, input-token, and turns terms, each normalized by the group's own max for that quantity. None disables it."""
+
+    length_weighted_baseline: bool = False
+    """Weight the group baseline by rollout length (SWE-2's length-weighted group baseline, https://cognition.com/blog/swe-2): instead of the plain group mean, the baseline becomes ``sum(reward_i * trainable_tokens_i) / sum(trainable_tokens_i)``. A cheap proxy for the optimal REINFORCE baseline, which weights each rollout by its score-gradient norm — empirically correlated with its trainable-token count — reducing gradient variance at no extra cost. Applied to the rewards left after the optional ``length_penalty`` shaping. False keeps the plain group mean."""
 
 
 class EchoAlgoConfig(GRPOAlgoConfig):

--- a/src/prime_rl/orchestrator/algo/grpo.py
+++ b/src/prime_rl/orchestrator/algo/grpo.py
@@ -13,33 +13,48 @@ if TYPE_CHECKING:
     from prime_rl.orchestrator.clients import InferenceClient
 
 
+def num_trainable_tokens(trace: vf.Trace) -> int:
+    """Trainable (mask-True) tokens across the trace's trainable branches."""
+    trainable_nodes = {id(node) for branch in trace.branches if branch.trainable for node in branch.nodes}
+    return sum(sum(node.mask) for node in trace.nodes if id(node) in trainable_nodes)
+
+
 class GRPOAlgorithm(Algorithm):
     """Group Relative Policy Optimization: sample a group of rollouts from the
-    policy per example; credit = reward minus the group mean (optionally
-    length-shaped); action tokens feed the ``rl`` loss."""
+    policy per example; credit = reward minus the group baseline — the group
+    mean, or the trainable-token-weighted mean (SWE-2) — optionally length-
+    shaped first; action tokens feed the ``rl`` loss."""
 
     def __init__(self, config: GRPOAlgoConfig, clients: InferenceClient):
         super().__init__(config, clients)
         self.length_penalty = config.length_penalty
+        self.length_weighted_baseline = config.length_weighted_baseline
 
     async def score_group(self, episodes: list[vf.Episode]) -> None:
         traces = [trace for _, trace in iter_trainable_traces(episodes)]
         rewards = torch.tensor([trace.reward for trace in traces], dtype=torch.float32)
-        length_penalty = self.length_penalty
-        if length_penalty is None:
-            advantages = rewards - rewards.mean()
-        else:
-            output = torch.tensor([trace.num_output_tokens for trace in traces], dtype=rewards.dtype)
-            total = torch.tensor([trace.num_total_tokens for trace in traces], dtype=rewards.dtype)
-            turns = torch.tensor([trace.num_turns for trace in traces], dtype=rewards.dtype)
-            input = total - output
-            penalty_frac = (
-                length_penalty.num_output_tokens_weight * (output / output.max().clamp(min=1))
-                + length_penalty.num_input_tokens_weight * (input / input.max().clamp(min=1))
-                + length_penalty.num_turns_weight * (turns / turns.max().clamp(min=1))
-            )
-            penalty = rewards.mean() * penalty_frac
-            shaped_rewards = rewards - penalty
-            advantages = shaped_rewards - shaped_rewards.mean()
+        shaped_rewards = self._apply_length_penalty(rewards, traces)
+        advantages = shaped_rewards - self._baseline(shaped_rewards, traces)
         for trace, advantage in zip(traces, advantages.tolist(), strict=True):
             assign_advantages(trace, advantage)
+
+    def _apply_length_penalty(self, rewards: torch.Tensor, traces: list[vf.Trace]) -> torch.Tensor:
+        length_penalty = self.length_penalty
+        if length_penalty is None:
+            return rewards
+        output = torch.tensor([trace.num_output_tokens for trace in traces], dtype=rewards.dtype)
+        total = torch.tensor([trace.num_total_tokens for trace in traces], dtype=rewards.dtype)
+        turns = torch.tensor([trace.num_turns for trace in traces], dtype=rewards.dtype)
+        input = total - output
+        penalty_frac = (
+            length_penalty.num_output_tokens_weight * (output / output.max().clamp(min=1))
+            + length_penalty.num_input_tokens_weight * (input / input.max().clamp(min=1))
+            + length_penalty.num_turns_weight * (turns / turns.max().clamp(min=1))
+        )
+        return rewards - rewards.mean() * penalty_frac
+
+    def _baseline(self, rewards: torch.Tensor, traces: list[vf.Trace]) -> torch.Tensor:
+        if not self.length_weighted_baseline:
+            return rewards.mean()
+        lengths = torch.tensor([num_trainable_tokens(trace) for trace in traces], dtype=rewards.dtype)
+        return (rewards * lengths).sum() / lengths.sum()

--- a/tests/unit/orchestrator/test_advantage.py
+++ b/tests/unit/orchestrator/test_advantage.py
@@ -151,9 +151,12 @@ def _scalar(episode: vf.Episode) -> float:
     raise AssertionError("episode has no trainable token")
 
 
-def _grpo(group: list[vf.Episode], length_penalty=None) -> list[float]:
+def _grpo(group: list[vf.Episode], length_penalty=None, length_weighted_baseline=False) -> list[float]:
     """Drive ``GRPOAlgorithm.score_group`` and read back each per-rollout scalar."""
-    algo = GRPOAlgorithm(GRPOAlgoConfig(length_penalty=length_penalty), clients=None)
+    algo = GRPOAlgorithm(
+        GRPOAlgoConfig(length_penalty=length_penalty, length_weighted_baseline=length_weighted_baseline),
+        clients=None,
+    )
     asyncio.run(algo.score_group(group))
     return [_scalar(episode) for episode in group]
 
@@ -188,6 +191,41 @@ def test_max_rl_mean_normalized():
     assert _max_rl(_make_group(rewards=[0.0, 0.0])) == pytest.approx([0.0, 0.0])
     # ... and all-success groups center to zero like GRPO
     assert _max_rl(_make_group(rewards=[1.0, 1.0])) == pytest.approx([0.0, 0.0])
+
+
+# --------------------------------------------------------------------------
+# GRPO length-weighted baseline (SWE-2): trainable-token-weighted group mean.
+# --------------------------------------------------------------------------
+
+
+def test_length_weighted_baseline_weights_by_trainable_tokens():
+    """b = sum(R*L)/sum(L): rewards [1, 0] with trainable lengths [1, 3] give
+    b = 0.25, so the long rollout's credit is damped and the trainable-token-
+    weighted advantage sum is zero (not the plain sum)."""
+    advs = _grpo(
+        _make_group(rewards=[1.0, 0.0], completion_lengths=[1, 3]),
+        length_weighted_baseline=True,
+    )
+    assert advs == pytest.approx([0.75, -0.25], abs=1e-6)
+    assert sum(a * l for a, l in zip(advs, [1, 3])) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_length_weighted_baseline_equal_lengths_reduce_to_plain_grpo():
+    """Equal trainable lengths → the weighted baseline equals the plain group mean."""
+    plain = _grpo(_make_group(rewards=[1.0, 0.5, 0.8], completion_lengths=[10, 10, 10]))
+    weighted = _grpo(
+        _make_group(rewards=[1.0, 0.5, 0.8], completion_lengths=[10, 10, 10]),
+        length_weighted_baseline=True,
+    )
+    assert weighted == pytest.approx(plain, abs=1e-6)
+
+
+def test_length_weighted_baseline_off_by_default():
+    """The default config keeps the plain group-mean baseline (SWE-2 baseline is opt-in)."""
+    rewards, lengths = [1.0, 0.0, 0.0], [1, 4, 4]
+    advs = _grpo(_make_group(rewards=rewards, completion_lengths=lengths))
+    baseline = sum(rewards) / len(rewards)
+    assert advs == pytest.approx([reward - baseline for reward in rewards], abs=1e-6)
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds SWE-2's length-weighted group baseline ([cognition.com/blog/swe-2](https://cognition.com/blog/swe-2)) as an optional GRPO knob, off by default.

- New `orchestrator.algo.length_weighted_baseline` (default `false`) on the `grpo`-family algorithms (`grpo` and `echo`).
- When enabled, the per-group baseline becomes `b = Σᵢ Rᵢ·Lᵢ / Σᵢ Lᵢ` instead of the plain group mean, where `Lᵢ` is rollout `i`'s trainable-token count. This is a cheap proxy for the variance-optimal REINFORCE baseline (which weights each rollout by its score-gradient norm, empirically correlated with rollout length) — reduced gradient variance at no extra cost.
- Advantages still sum to zero when token-weighted (`Σᵢ Lᵢ·(Rᵢ − b) = 0`), so longer rollouts carry proportionally smaller credit.
- Composes with the existing `length_penalty`: the baseline weights the shaped rewards, so both can be enabled together.
- `hierarchical_grpo` keeps its own per-problem baseline logic and is unchanged.

Enable it with:

```toml
[orchestrator.algo]
type = "grpo"
length_weighted_baseline = true
```

## Verification

- `uv run pytest tests/unit/orchestrator/test_advantage.py` — 13 passed (3 new tests: baseline weights by trainable tokens, equal lengths reduce to plain GRPO, off by default).
- `uv run ruff check` / `ruff format --check` clean.
- The two pre-existing failures in `tests/unit/orchestrator/test_prefill_logprobs.py` and `test_qwen3_vl_e2e.py` also fail on `main` and are unrelated.
