### PR TITLE
feat(trainer): support Dynamo VLM training

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -453,6 +453,14 @@ class RLConfig(BaseConfig):
         validate_shared_seq_len(self.trainer, self.orchestrator)
         validate_shared_ckpt_config(self.trainer, self.orchestrator)
         validate_shared_wandb_config(self.trainer, self.orchestrator)
+        trainer_vlm = self.trainer.model.vlm
+        orchestrator_vlm = self.orchestrator.model.vlm
+        if (
+            trainer_vlm is not None
+            and not trainer_vlm.pack_samples
+            and (orchestrator_vlm is None or orchestrator_vlm.pack_samples)
+        ):
+            raise ValueError("model.vlm.pack_samples=false must be shared by the trainer and orchestrator")
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -542,6 +542,8 @@ class SFTConfig(BaseConfig):
     def validate_vlm_constraints(self):
         if self.model.vlm is None:
             return self
+        if self.model.impl != "custom":
+            raise ValueError("VLM SFT requires model.impl='custom'.")
         if self.model.optimization_dtype != "bfloat16" or self.model.reduce_dtype != "bfloat16":
             raise ValueError(
                 "VLM models must use optimization_dtype='bfloat16' and reduce_dtype='bfloat16' to match vLLM inference."

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -151,7 +151,7 @@ class VLMConfig(BaseConfig):
     """Freeze the vision encoder parameters during training."""
 
     pack_samples: bool = True
-    """Pack multiple multimodal samples into one sequence. Disable for generic Hugging Face VLMs that do not accept Prime's packed-document boundaries."""
+    """Pack multiple samples into one sequence. Disable all cross-sample packing for generic Hugging Face VLMs."""
 
 
 class BaseModelConfig(BaseConfig):

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -150,6 +150,9 @@ class VLMConfig(BaseConfig):
     freeze_vision_encoder: bool = True
     """Freeze the vision encoder parameters during training."""
 
+    pack_samples: bool = True
+    """Pack multiple multimodal samples into one sequence. Disable for generic Hugging Face VLMs that do not accept Prime's packed-document boundaries."""
+
 
 class BaseModelConfig(BaseConfig):
     name: str = "Qwen/Qwen3-0.6B"

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -353,12 +353,6 @@ class ModelConfig(BaseModelConfig):
         return self
 
     @model_validator(mode="after")
-    def vlm_only_with_custom_impl(self):
-        if self.vlm is not None and self.impl != "custom":
-            raise ValueError("VLM training requires model.impl='custom'")
-        return self
-
-    @model_validator(mode="after")
     def vlm_cp_requires_ulysses(self):
         if self.vlm is not None and self.cp > 1 and self.cp_style != "ulysses":
             raise ValueError("VLM models require cp_style='ulysses' for context parallelism")

--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -76,6 +76,14 @@ def propagate_shared_fields(data: Any) -> Any:
         "trainer.model.vlm",
         "orchestrator.model.vlm",
     )
+    trainer_vlm = get("trainer.model.vlm")
+    orchestrator_vlm = get("orchestrator.model.vlm")
+    if trainer_vlm is not None and orchestrator_vlm is not None and trainer_vlm != orchestrator_vlm:
+        conflicts.append(("trainer.model.vlm", "orchestrator.model.vlm"))
+    elif trainer_vlm is not None:
+        fill("orchestrator.model.vlm", trainer_vlm)
+    elif orchestrator_vlm is not None:
+        fill("trainer.model.vlm", orchestrator_vlm)
 
     # [log]
     propagate("log.level", "trainer.log.level", "orchestrator.log.level", "inference.log.level")

--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -76,14 +76,6 @@ def propagate_shared_fields(data: Any) -> Any:
         "trainer.model.vlm",
         "orchestrator.model.vlm",
     )
-    trainer_vlm = get("trainer.model.vlm")
-    orchestrator_vlm = get("orchestrator.model.vlm")
-    if trainer_vlm is not None and orchestrator_vlm is not None and trainer_vlm != orchestrator_vlm:
-        conflicts.append(("trainer.model.vlm", "orchestrator.model.vlm"))
-    elif trainer_vlm is not None:
-        fill("orchestrator.model.vlm", trainer_vlm)
-    elif orchestrator_vlm is not None:
-        fill("trainer.model.vlm", orchestrator_vlm)
 
     # [log]
     propagate("log.level", "trainer.log.level", "orchestrator.log.level", "inference.log.level")

--- a/src/prime_rl/orchestrator/packing.py
+++ b/src/prime_rl/orchestrator/packing.py
@@ -13,6 +13,7 @@ class BatchPacker:
         self.seq_len = config.seq_len
         self.num_train_workers = config.num_train_workers
         self.pad_to_multiple_of = config.pad_to_multiple_of
+        self.pack_samples = config.model.vlm is None or config.model.vlm.pack_samples
         try:
             model_config = AutoConfig.from_pretrained(
                 config.model.name, trust_remote_code=config.tokenizer.trust_remote_code
@@ -32,4 +33,5 @@ class BatchPacker:
             num_train_workers=self.num_train_workers,
             bin_cost=self.bin_cost,
             pad_to_multiple_of=self.pad_to_multiple_of,
+            pack_samples=self.pack_samples,
         )

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -523,7 +523,7 @@ class _MicroBatchBin:
                 return sample
         return None
 
-    def can_add(self, sample: MicroBatch, max_seq_len: int) -> bool:
+    def can_add(self, sample: MicroBatch, max_seq_len: int, pack_samples: bool) -> bool:
         # Loss routing is per token (component weight streams), so samples of
         # different loss types pack together freely. Multimodal packing is still
         # constrained by modality sidecars, length, and routed experts.
@@ -533,6 +533,8 @@ class _MicroBatchBin:
         if (first_sample.routed_experts is None) != (sample.routed_experts is None):
             return False
 
+        if not pack_samples:
+            return False
         sample_is_mm = _is_multimodal_sample(sample)
         existing_mm_sample = self.first_multimodal_sample
         if existing_mm_sample is not None and sample_is_mm:
@@ -694,6 +696,7 @@ def packed_samples_into_micro_bs(
     max_seq_len: int,
     num_train_workers: int,
     bin_cost: Callable[[Sequence[int]], int],
+    pack_samples: bool = True,
 ) -> list[MicroBatch]:
     """
     Pack samples into micro_batch efficiently.
@@ -713,7 +716,7 @@ def packed_samples_into_micro_bs(
         # Try to find a bin that can fit this sequence. Multimodal samples only
         # pack when their sidecar tensors are compatible.
         for bin_content in bins:
-            if bin_content.can_add(sample, max_seq_len):
+            if bin_content.can_add(sample, max_seq_len, pack_samples):
                 bin_content.add(sample)
                 break
         else:
@@ -877,6 +880,7 @@ def prepare_batch(
     num_train_workers: int,
     bin_cost: Callable[[Sequence[int]], int],
     pad_to_multiple_of: int = 1,
+    pack_samples: bool = True,
 ) -> list[list[MicroBatch]]:
     """
     Prepare a batch of problems for each GPU. Each batch is a list of micro batches.
@@ -889,7 +893,13 @@ def prepare_batch(
     """
     all_samples = [prepare_sample(rollout, seq_len) for rollout in rollouts]
 
-    micro_batches = packed_samples_into_micro_bs(all_samples, seq_len, num_train_workers, bin_cost)
+    micro_batches = packed_samples_into_micro_bs(
+        all_samples,
+        seq_len,
+        num_train_workers,
+        bin_cost,
+        pack_samples=pack_samples,
+    )
     micro_batches = [pad_micro_batch(micro_batch, pad_to_multiple_of) for micro_batch in micro_batches]
 
     # Separate by modality so each step index has uniform modality across all ranks

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -550,15 +550,14 @@ def _validate_vlm_implementation(
     is_vlm_arch: bool,
     custom_vlm_available: bool,
     impl_to_use: str,
-    world_size: int,
 ) -> None:
     if config.vlm is None:
         return
     if impl_to_use == "hf":
-        if not is_vlm_arch or config.vlm.pack_samples or world_size != 1:
+        if not is_vlm_arch or config.vlm.pack_samples:
             raise ValueError(
                 f"Generic Hugging Face VLM training is not supported for {model_type!r} with this configuration; "
-                "it requires model.impl='hf', model.vlm.pack_samples=false, and one trainer process."
+                "the implementation must resolve to Hugging Face and model.vlm.pack_samples must be false."
             )
         return
     if not (is_vlm_arch and custom_vlm_available):
@@ -571,8 +570,6 @@ def get_model(
     config: ModelConfig,
     device: torch.device = torch.device("cpu"),
     dtype: torch.dtype = torch.bfloat16,
-    *,
-    world_size: int = 1,
 ) -> nn.Module:
     logger = get_logger()
     logger.debug(
@@ -711,7 +708,6 @@ def get_model(
         is_vlm_arch=is_vlm_arch,
         custom_vlm_available=custom_vlm_cls is not None,
         impl_to_use=impl_to_use,
-        world_size=world_size,
     )
 
     with device:
@@ -1264,12 +1260,7 @@ def setup_model(
     logger = get_logger()
 
     # 1. We load to meta device by default
-    model = get_model(
-        config,
-        device=torch.device("meta"),
-        dtype=DTYPE_MAP[config.optimization_dtype],
-        world_size=parallel_dims.world_size,
-    )
+    model = get_model(config, device=torch.device("meta"), dtype=DTYPE_MAP[config.optimization_dtype])
 
     possible_to_load_to_meta = can_reinit_empty_buffers(model)
 
@@ -1281,12 +1272,7 @@ def setup_model(
     # 1a. We load to CPU if we cannot reinit empty buffers
     if not possible_to_load_to_meta:
         logger.warning("Cannot load model to meta device only, loading to CPU instead.")
-        model = get_model(
-            config,
-            device=torch.device("cpu"),
-            dtype=DTYPE_MAP[config.optimization_dtype],
-            world_size=parallel_dims.world_size,
-        )
+        model = get_model(config, device=torch.device("cpu"), dtype=DTYPE_MAP[config.optimization_dtype])
 
     if config.fusions.enabled and config.lora is not None:
         logger.warning("Skipping runtime model fusions because LoRA targets the unfused projections")

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -543,8 +543,36 @@ def get_load_balance_stats(
     }
 
 
+def _validate_vlm_implementation(
+    config: ModelConfig,
+    *,
+    model_type: str,
+    is_vlm_arch: bool,
+    custom_vlm_available: bool,
+    impl_to_use: str,
+    world_size: int,
+) -> None:
+    if config.vlm is None:
+        return
+    if impl_to_use == "hf":
+        if not is_vlm_arch or config.vlm.pack_samples or world_size != 1:
+            raise ValueError(
+                f"Generic Hugging Face VLM training is not supported for {model_type!r} with this configuration; "
+                "it requires model.impl='hf', model.vlm.pack_samples=false, and one trainer process."
+            )
+        return
+    if not (is_vlm_arch and custom_vlm_available):
+        raise ValueError(
+            f"VLM training requires a registered custom PrimeRL VLM implementation; {model_type!r} has none."
+        )
+
+
 def get_model(
-    config: ModelConfig, device: torch.device = torch.device("cpu"), dtype: torch.dtype = torch.bfloat16
+    config: ModelConfig,
+    device: torch.device = torch.device("cpu"),
+    dtype: torch.dtype = torch.bfloat16,
+    *,
+    world_size: int = 1,
 ) -> nn.Module:
     logger = get_logger()
     logger.debug(
@@ -677,11 +705,14 @@ def get_model(
                 f"({support.reason}); {supported}."
             )
 
-    if config.vlm is not None and not (is_vlm_arch and custom_vlm_cls):
-        raise ValueError(
-            "VLM training requires a registered custom PrimeRL VLM implementation; "
-            f"{getattr(model_config, 'model_type', config.name)!r} has none."
-        )
+    _validate_vlm_implementation(
+        config,
+        model_type=getattr(model_config, "model_type", config.name),
+        is_vlm_arch=is_vlm_arch,
+        custom_vlm_available=custom_vlm_cls is not None,
+        impl_to_use=impl_to_use,
+        world_size=world_size,
+    )
 
     with device:
         if impl_to_use == "custom" and custom_vlm_cls is not None:
@@ -1233,7 +1264,12 @@ def setup_model(
     logger = get_logger()
 
     # 1. We load to meta device by default
-    model = get_model(config, device=torch.device("meta"), dtype=DTYPE_MAP[config.optimization_dtype])
+    model = get_model(
+        config,
+        device=torch.device("meta"),
+        dtype=DTYPE_MAP[config.optimization_dtype],
+        world_size=parallel_dims.world_size,
+    )
 
     possible_to_load_to_meta = can_reinit_empty_buffers(model)
 
@@ -1245,7 +1281,12 @@ def setup_model(
     # 1a. We load to CPU if we cannot reinit empty buffers
     if not possible_to_load_to_meta:
         logger.warning("Cannot load model to meta device only, loading to CPU instead.")
-        model = get_model(config, device=torch.device("cpu"), dtype=DTYPE_MAP[config.optimization_dtype])
+        model = get_model(
+            config,
+            device=torch.device("cpu"),
+            dtype=DTYPE_MAP[config.optimization_dtype],
+            world_size=parallel_dims.world_size,
+        )
 
     if config.fusions.enabled and config.lora is not None:
         logger.warning("Skipping runtime model fusions because LoRA targets the unfused projections")

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -150,7 +150,11 @@ def train(config: TrainerConfig):
     model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
     logger.debug(f"Initialized model in {format_time(time.perf_counter() - t0)}")
 
-    if config.model.vlm is not None and not getattr(model, "supports_packed_multimodal_training", False):
+    if (
+        config.model.vlm is not None
+        and config.model.vlm.pack_samples
+        and not getattr(model, "supports_packed_multimodal_training", False)
+    ):
         raise ValueError("Packed multimodal training requires model support")
 
     # Set up the loss function for the RL loss type (ce / ref_kl are fixed)

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -513,6 +513,51 @@ def test_prepare_batch_packs_multimodal_with_text():
     assert batch.env_names == ["mm-env"] * 3 + ["text-env"] * 2
 
 
+def test_prepare_batch_keeps_multimodal_samples_separate_when_packing_disabled():
+    samples = [
+        TrainingSample(
+            token_ids=[10 + offset, 11 + offset, 12 + offset],
+            mask=[False, True, True],
+            logprobs=[0.0, -0.1, -0.2],
+            temperatures=[1.0, 1.0, 1.0],
+            advantages=[0.0, 1.0, 1.0],
+            env_name=f"mm-env-{offset}",
+            mm_token_type_ids=[0, 1, 0],
+            mm_kwargs={
+                "pixel_values": _encoded(np.array([[1.0 + offset, 2.0 + offset]], dtype=np.float32)),
+                "image_grid_thw": _encoded(np.array([[1, 2, 2]], dtype=np.int64)),
+            },
+        )
+        for offset in range(2)
+    ]
+
+    batches_per_gpu = prepare_batch(
+        rollouts=samples,
+        seq_len=8,
+        num_train_workers=1,
+        bin_cost=build_bin_cost(None),
+        pack_samples=False,
+    )
+
+    real_batches = [batch for batch in _flatten_batches(batches_per_gpu) if _has_loss_tokens(batch)]
+    assert len(real_batches) == 2
+    assert [batch.seq_lens for batch in real_batches] == [[3], [3]]
+
+
+def test_prepare_batch_keeps_text_samples_separate_when_packing_disabled(make_training_example):
+    batches_per_gpu = prepare_batch(
+        rollouts=[make_training_example(), make_training_example()],
+        seq_len=8,
+        num_train_workers=1,
+        bin_cost=build_bin_cost(None),
+        pack_samples=False,
+    )
+
+    real_batches = [batch for batch in _flatten_batches(batches_per_gpu) if _has_loss_tokens(batch)]
+    assert len(real_batches) == 2
+    assert [batch.seq_lens for batch in real_batches] == [[4], [4]]
+
+
 def test_prepare_sample_none_routed_experts():
     """When routed_experts is None, micro_batch.routed_experts is None."""
     sample = TrainingSample(

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -843,6 +843,26 @@ def test_sft_allows_unused_default_renderer_for_fake_data():
     assert config.renderer.name == "default"
 
 
+def test_sft_rejects_generic_hf_vlm():
+    with pytest.raises(ValidationError, match="VLM SFT requires model.impl='custom'"):
+        SFTConfig.model_validate(
+            {
+                "data": {"type": "fake"},
+                "renderer": {"name": "default"},
+                "model": {
+                    "impl": "hf",
+                    "attn": "flash_attention_2",
+                    "optimization_dtype": "bfloat16",
+                    "reduce_dtype": "bfloat16",
+                    "vlm": {
+                        "vision_encoder_attr": "model.visual",
+                        "language_model_attr": "model.language_model",
+                    },
+                },
+            }
+        )
+
+
 def test_orchestrator_explicit_renderer_skips_unmapped_check():
     """Explicit renderer.name bypasses the auto-resolution check — user opted in."""
     config = OrchestratorConfig.model_validate(
@@ -926,3 +946,28 @@ def test_combined_replay_uses_v2_runner(monkeypatch):
     assert config.enable_return_sampling_mask is True
     assert config.vllm.enable_return_routed_experts is True
     assert os.environ["VLLM_USE_V2_MODEL_RUNNER"] == "1"
+
+
+def test_rl_propagates_trainer_vlm_to_orchestrator():
+    config = RLConfig.model_validate(
+        {
+            "trainer": {
+                "model": {
+                    "impl": "hf",
+                    "attn": "flash_attention_2",
+                    "optimization_dtype": "bfloat16",
+                    "reduce_dtype": "bfloat16",
+                    "vlm": {
+                        "vision_encoder_attr": "model.visual",
+                        "language_model_attr": "model.language_model",
+                        "pack_samples": False,
+                    },
+                }
+            },
+            "orchestrator": {},
+            "inference": {},
+        }
+    )
+
+    assert config.orchestrator.model.vlm is not None
+    assert config.orchestrator.model.vlm.pack_samples is False

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -946,28 +946,3 @@ def test_combined_replay_uses_v2_runner(monkeypatch):
     assert config.enable_return_sampling_mask is True
     assert config.vllm.enable_return_routed_experts is True
     assert os.environ["VLLM_USE_V2_MODEL_RUNNER"] == "1"
-
-
-def test_rl_propagates_trainer_vlm_to_orchestrator():
-    config = RLConfig.model_validate(
-        {
-            "trainer": {
-                "model": {
-                    "impl": "hf",
-                    "attn": "flash_attention_2",
-                    "optimization_dtype": "bfloat16",
-                    "reduce_dtype": "bfloat16",
-                    "vlm": {
-                        "vision_encoder_attr": "model.visual",
-                        "language_model_attr": "model.language_model",
-                        "pack_samples": False,
-                    },
-                }
-            },
-            "orchestrator": {},
-            "inference": {},
-        }
-    )
-
-    assert config.orchestrator.model.vlm is not None
-    assert config.orchestrator.model.vlm.pack_samples is False

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -863,6 +863,32 @@ def test_sft_rejects_generic_hf_vlm():
         )
 
 
+def test_rl_requires_unpacked_vlm_setting_to_be_shared():
+    with pytest.raises(
+        ValidationError,
+        match="model.vlm.pack_samples=false must be shared by the trainer and orchestrator",
+    ):
+        RLConfig.model_validate(
+            {
+                "trainer": {
+                    "model": {
+                        "impl": "hf",
+                        "attn": "flash_attention_2",
+                        "optimization_dtype": "bfloat16",
+                        "reduce_dtype": "bfloat16",
+                        "vlm": {
+                            "vision_encoder_attr": "model.visual",
+                            "language_model_attr": "model.language_model",
+                            "pack_samples": False,
+                        },
+                    }
+                },
+                "orchestrator": {},
+                "inference": {},
+            }
+        )
+
+
 def test_orchestrator_explicit_renderer_skips_unmapped_check():
     """Explicit renderer.name bypasses the auto-resolution check — user opted in."""
     config = OrchestratorConfig.model_validate(

--- a/tests/unit/train/test_model_forward.py
+++ b/tests/unit/train/test_model_forward.py
@@ -1,9 +1,11 @@
 from types import SimpleNamespace
 
+import pytest
 import torch
 import torch.nn as nn
 
-from prime_rl.trainer.model import forward
+from prime_rl.configs.trainer import ModelConfig
+from prime_rl.trainer.model import _validate_vlm_implementation, forward
 
 
 class _CaptureModel(nn.Module):
@@ -16,6 +18,28 @@ class _CaptureModel(nn.Module):
         self.kwargs = kwargs
         input_ids = kwargs["input_ids"]
         return {"logits": torch.zeros(*input_ids.shape, 4)}
+
+
+def test_generic_hf_vlm_rejects_multiple_trainers_when_custom_impl_exists():
+    config = ModelConfig(
+        impl="hf",
+        attn="flash_attention_2",
+        vlm={
+            "vision_encoder_attr": "model.visual",
+            "language_model_attr": "model.language_model",
+            "pack_samples": False,
+        },
+    )
+
+    with pytest.raises(ValueError, match="one trainer process"):
+        _validate_vlm_implementation(
+            config,
+            model_type="qwen3_5",
+            is_vlm_arch=True,
+            custom_vlm_available=True,
+            impl_to_use="hf",
+            world_size=2,
+        )
 
 
 def test_forward_passes_renderer_mm_token_type_ids_through():

--- a/tests/unit/train/test_model_forward.py
+++ b/tests/unit/train/test_model_forward.py
@@ -20,7 +20,7 @@ class _CaptureModel(nn.Module):
         return {"logits": torch.zeros(*input_ids.shape, 4)}
 
 
-def test_generic_hf_vlm_rejects_multiple_trainers_when_custom_impl_exists():
+def test_generic_hf_vlm_allows_unpacked_samples():
     config = ModelConfig(
         impl="hf",
         attn="flash_attention_2",
@@ -31,14 +31,32 @@ def test_generic_hf_vlm_rejects_multiple_trainers_when_custom_impl_exists():
         },
     )
 
-    with pytest.raises(ValueError, match="one trainer process"):
+    _validate_vlm_implementation(
+        config,
+        model_type="qwen3_5",
+        is_vlm_arch=True,
+        custom_vlm_available=True,
+        impl_to_use="hf",
+    )
+
+
+def test_generic_hf_vlm_rejects_packed_samples():
+    config = ModelConfig(
+        impl="hf",
+        attn="flash_attention_2",
+        vlm={
+            "vision_encoder_attr": "model.visual",
+            "language_model_attr": "model.language_model",
+        },
+    )
+
+    with pytest.raises(ValueError, match="pack_samples must be false"):
         _validate_vlm_implementation(
             config,
             model_type="qwen3_5",
             is_vlm_arch=True,
             custom_vlm_available=True,
             impl_to_use="hf",
-            world_size=2,
         )
 
 


### PR DESCRIPTION
## Summary

- Allow recognized Hugging Face VLMs in the RL trainer while preserving the custom-only SFT path.
- Add an explicit no-cross-sample packing mode required by the Dynamo Qwen3-VL flow.
- Require trainer and orchestrator to share the no-packing decision.
- Keep existing packed custom-VLM behavior unchanged.

## Why

Dynamo supplies multimodal rollouts with preprocessed image features. Generic Hugging Face VLMs cannot consume Prime-RL's packed-document boundaries, so these rollouts must remain isolated through batch preparation and model selection.

## Scope

This replaces #3483 with only the Prime-RL changes required by the Dynamo VLM training stack. It intentionally excludes managed Dynamo launcher/admin changes, weight-transfer changes, examples, dependency updates, `pyproject.toml`, and `uv.lock`.

The trainer-side model and batching mechanics remain backend-neutral because trainer workers do not receive inference-backend identity. No non-Dynamo inference or admin path is changed.

## Paired PRs

- Dynamo: ai-dynamo/dynamo#14244
- vLLM Rust frontend: vllm-project/vllm#55047

## Diff

- 11 files
- 200 additions, 17 deletions
- 66 production additions; remaining lines are focused regression tests

## Validation

Completed on the `bis-rl-3` dev GPU pod over SSH:

- Ruff format: clean
- Ruff check: passed
- Seven focused VLM configuration, packing, model-selection, and forward-path tests: passed

Exact-head cross-repository end-to-end validation is not yet complete. The latest refreshed Qwen3-VL-4B math attempt reached the Dynamo/vLLM request boundary but stopped before training step 1 because the Dynamo sidecar rejected unsupported `dynamo_mm_routing_hashes` metadata. A prior predecessor stack completed five image-bearing training steps, but that result does not validate the current three PR heads.
