### PR TITLE
fix(qwen3.5): address follow-up review cleanup

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -235,7 +235,8 @@ def apply_force_balanced_routing(model: nn.Module) -> None:
 
 
 def is_tt_moe_model(model: nn.Module) -> bool:
-    return hasattr(model.config, "num_experts") or hasattr(model.config, "n_routed_experts")
+    config = getattr(model.config, "text_config", model.config)
+    return hasattr(config, "num_experts") or hasattr(config, "n_routed_experts")
 
 
 def get_load_balance_stats(

--- a/src/prime_rl/trainer/models/base.py
+++ b/src/prime_rl/trainer/models/base.py
@@ -46,7 +46,6 @@ class PreTrainedModelPrimeRL(PreTrainedModel):
     @classmethod
     def from_config(cls, config, trust_remote_code: bool = False, **kwargs):
         """Public from_config that mirrors the Auto class API."""
-        del trust_remote_code
         return cls._from_config(config, **kwargs)
 
     @classmethod

--- a/src/prime_rl/trainer/models/qwen3_5/gated_delta_net.py
+++ b/src/prime_rl/trainer/models/qwen3_5/gated_delta_net.py
@@ -8,7 +8,8 @@ from torch import nn
 
 from prime_rl.trainer.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
 
-# FLA's CP convolution uses an all-gather layout that Dynamo cannot trace.
+# Dynamo's all-gather rewrite cannot handle FLA's stacked output buffer.
+# https://github.com/pytorch/pytorch/issues/155632
 causal_conv1d_with_context_parallelism = torch.compiler.disable(causal_conv1d)
 
 

--- a/src/prime_rl/trainer/models/qwen3_5/gated_delta_net.py
+++ b/src/prime_rl/trainer/models/qwen3_5/gated_delta_net.py
@@ -8,7 +8,8 @@ from torch import nn
 
 from prime_rl.trainer.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
 
-# Dynamo's all-gather rewrite cannot handle FLA's stacked output buffer.
+# Dynamo lowers all-gather to concatenation, then fails to copy the result into
+# FLA's stacked output buffer. Keep CP convolution eager until this is fixed:
 # https://github.com/pytorch/pytorch/issues/155632
 causal_conv1d_with_context_parallelism = torch.compiler.disable(causal_conv1d)
 

--- a/src/prime_rl/trainer/models/qwen3_5/rotary_embedding.py
+++ b/src/prime_rl/trainer/models/qwen3_5/rotary_embedding.py
@@ -48,7 +48,6 @@ class Qwen3_5RotaryEmbedding(nn.Module):
         device: torch.device | None = None,
         seq_len: int | None = None,
     ) -> tuple[torch.Tensor, float]:
-        del seq_len
         rope_parameters = config.rope_parameters
         rotary_dim = int(config.head_dim * rope_parameters.get("partial_rotary_factor", 1.0))
         positions = torch.arange(0, rotary_dim, 2, dtype=torch.int64, device=device).float()

--- a/tests/unit/train/models/qwen3_5/test_model.py
+++ b/tests/unit/train/models/qwen3_5/test_model.py
@@ -1,9 +1,7 @@
-import os
 from unittest.mock import MagicMock
 
 import pytest
 import torch
-import torch.distributed as dist
 
 from prime_rl.configs.trainer import ModelConfig
 from prime_rl.trainer.model import resolve_auto_attn
@@ -19,8 +17,6 @@ from prime_rl.trainer.models.qwen3_5 import (
     Qwen3_5VisionConfig,
 )
 from prime_rl.trainer.models.qwen3_5.attention import Qwen3_5Attention
-from prime_rl.trainer.models.qwen3_5.gated_delta_net import Qwen3_5GatedDeltaNet
-from prime_rl.trainer.models.qwen3_5.norm import Qwen3_5RMSNorm
 from prime_rl.utils.cp import setup_model_cp
 
 
@@ -88,15 +84,6 @@ def get_model(config, device="cuda"):
 
 
 @pytest.mark.gpu
-def test_norms_remain_zero_centered_after_model_init(text_config):
-    model = get_model(text_config)
-
-    norms = [module for module in model.modules() if isinstance(module, Qwen3_5RMSNorm)]
-    assert norms
-    assert all(torch.count_nonzero(norm.weight) == 0 for norm in norms)
-
-
-@pytest.mark.gpu
 def test_context_parallel_setup_chain_text_and_vlm(text_config):
     cp_group = MagicMock()
 
@@ -114,62 +101,6 @@ def test_context_parallel_setup_chain_text_and_vlm(text_config):
     setup_model_cp(vlm_model, cp_group, cp_rank=0, cp_world_size=2)
     assert vlm_model.model.language_model.context_parallel_group is cp_group
     assert vlm_model.model.language_model.layers[0].linear_attn.context_parallel_world_size == 2
-
-
-@pytest.mark.gpu
-def test_qwen3_5_gated_delta_net_context_parallel():
-    if int(os.environ.get("WORLD_SIZE", 1)) != 2:
-        pytest.skip("run with torchrun --nproc-per-node=2")
-
-    dist.init_process_group("nccl")
-    local_rank = int(os.environ["LOCAL_RANK"])
-    torch.cuda.set_device(local_rank)
-
-    try:
-        torch.manual_seed(0)
-        config = get_text_config()
-        config.hidden_size = 64
-        config.linear_key_head_dim = 128
-        config.linear_value_head_dim = 128
-        config.linear_num_key_heads = 16
-        config.linear_num_value_heads = 32
-        reference = Qwen3_5GatedDeltaNet(config).cuda().to(torch.bfloat16)
-        context_parallel = Qwen3_5GatedDeltaNet(config).cuda().to(torch.bfloat16)
-        context_parallel.load_state_dict(reference.state_dict())
-        context_parallel.set_context_parallel_attributes(dist.group.WORLD, world_size=2)
-
-        hidden_states = torch.randn(1, 16, config.hidden_size, device="cuda", dtype=torch.bfloat16)
-        dist.broadcast(hidden_states, src=0)
-        cu_seqlens = torch.tensor([0, 5, 11, 16], device="cuda", dtype=torch.int32)
-
-        reference_input = hidden_states.detach().clone().requires_grad_()
-        expected = reference(
-            reference_input,
-            cu_seqlens,
-        )
-        output_gradient = torch.randn_like(expected)
-        dist.broadcast(output_gradient, src=0)
-        expected.backward(output_gradient)
-
-        local_slice = slice(local_rank * 8, (local_rank + 1) * 8)
-        local_input = hidden_states[:, local_slice].detach().clone().requires_grad_()
-        actual = context_parallel(
-            local_input,
-            cu_seqlens,
-        )
-        actual.backward(output_gradient[:, local_slice])
-
-        gathered = [torch.empty_like(actual) for _ in range(2)]
-        dist.all_gather(gathered, actual)
-        torch.testing.assert_close(torch.cat(gathered, dim=1), expected, rtol=3e-2, atol=3e-2)
-        torch.testing.assert_close(
-            local_input.grad,
-            reference_input.grad[:, local_slice],
-            rtol=5e-2,
-            atol=5e-2,
-        )
-    finally:
-        dist.destroy_process_group()
 
 
 def test_setup_model_cp_requires_hook_only_for_hybrid_models():

--- a/tests/unit/train/models/test_moe.py
+++ b/tests/unit/train/models/test_moe.py
@@ -4,6 +4,7 @@ import torch.nn.functional as F
 
 from prime_rl.configs.trainer import ModelConfig
 from prime_rl.trainer.distributed.token_dispatcher import LocalTokenDispatcher
+from prime_rl.trainer.model import is_tt_moe_model
 from prime_rl.trainer.models.layers.activations import ActivationDispatch
 from prime_rl.trainer.models.layers.grouped_gemm import BF16GroupedGemm
 from prime_rl.trainer.models.layers.mlp import FeedForward
@@ -12,8 +13,30 @@ from prime_rl.trainer.models.layers.moe import (
     MoE,
     MoEArgs,
 )
+from prime_rl.trainer.models.qwen3_5 import (
+    Qwen3_5Config,
+    Qwen3_5MoeConfig,
+    Qwen3_5MoeTextConfig,
+    Qwen3_5TextConfig,
+)
 from prime_rl.trainer.moe_runtime import configure_moe_runtime
 from prime_rl.trainer.parallel_dims import ParallelDims
+
+
+@pytest.mark.parametrize(
+    ("config_cls", "expected"),
+    [
+        (Qwen3_5TextConfig, False),
+        (Qwen3_5MoeTextConfig, True),
+        (Qwen3_5Config, False),
+        (Qwen3_5MoeConfig, True),
+    ],
+    ids=["dense-text", "moe-text", "dense-vlm", "moe-vlm"],
+)
+def test_moe_detection_for_text_and_vlm(config_cls, expected):
+    model = torch.nn.Module()
+    model.config = config_cls()
+    assert is_tt_moe_model(model) is expected
 
 
 @pytest.mark.parametrize("selection", [[], [0], "0%", "50%"])


### PR DESCRIPTION
Follow up on Garrett's review of #3429. Composite MoE models store expert counts in `text_config`, so `is_tt_moe_model` missed them and the trainers skipped their load-balancing statistics. Resolve the text config before checking expert counts, with a CPU check covering dense/MoE text and VLM configs.

Remove the unused-argument `del` statements while preserving the public signatures. Drop the zero-initialization assertion and the two-rank GDN test that ordinary CI always skipped, as requested in review. Keep the native forward/backward, packing, vision, MRoPE, and router replay coverage.

Retain the existing compiler disable for CP convolution and link its exact upstream bug. Two-rank H200 testing on PyTorch 2.13.0+cu130 / FLA a954753 reproduces a Dynamo `copy_` shape error without the disable: the functional collective returns `[6, 8192]`, while FLA supplies a stacked `[2, 3, 8192]` output buffer. The same operation works eagerly; an isolated compiled collective using a concatenated buffer followed by reshape also passes.

Upstream status checked September 12: FLA main (`516143e`) still has the identical communication helper. PyTorch issues [#138795](https://github.com/pytorch/pytorch/issues/138795) and [#155632](https://github.com/pytorch/pytorch/issues/155632) remain open. The matching [fix #177205](https://github.com/pytorch/pytorch/pull/177205) closed without merging, and current PyTorch main still lacks the reshape. FLA's [graph-capture RFC #1155](https://github.com/fla-org/flash-linear-attention/issues/1155#issuecomment-5354945885) defers CP; no exact FLA fix was found.

Validation:

- H200 Slurm 486: Qwen3.5 and shared MoE suite, **33 passed**. CPU MoE suite: **15 passed**. Ruff check/format and whitespace checks pass.
- Standalone GDN probes use two H200 ranks and `torch.compile` with default settings (graph breaks allowed), two packed layouts, native unsharded output/input-gradient comparisons, and finite parameter gradients. These isolate the convolution boundary; they do not establish full trainer or image+CP compilation support.

| CP convolution disable | Selective AC | Result | Slurm job |
|---|---|---|---|
| Present | Off | Both layouts pass on both ranks | 484 |
| Removed in probe | Off | Dynamo collective shape error | 485 |
| Present | On | Both layouts pass on both ranks | 487 |
| Removed in probe | On | Both layouts pass on both ranks | 488 |

The checkpointed probe passing does not make removal safe: the supported non-checkpointed configuration still fails. The isolated stacked/concatenated collective comparison passed its expected failure and parity checks (Slurm 489). Probe scripts and logs are retained outside the repository under `/home/matej/prime-rl-verify/qwen35-review-20260912/`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted config lookup and test/doc cleanup; MoE detection fix reduces risk of missing load-balance metrics on composite MoE models.
> 
> **Overview**
> **MoE detection** now reads expert counts from `text_config` when present, so Qwen3.5 MoE VLMs are recognized and trainers collect load-balancing stats instead of treating them as dense models. A CPU parametrized test covers dense/MoE text and VLM config classes.
> 
> Review cleanup removes unused `del` stubs on public APIs (`from_config`, RoPE helpers), drops CI-skipped Qwen3.5 tests (zero-init norm assertion and two-rank gated-delta-net CP parity), and tightens the comment on why context-parallel `causal_conv1d` stays outside `torch.compile` (Dynamo all-gather vs FLA buffer layout, [pytorch#155632](https://github.com/pytorch/pytorch/issues/155632)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0520d09809547dfb8e982f2590702eee079c7e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->