### PR TITLE
chore(examples): drop empty [monitors.prime] sections

### DIFF
--- a/examples/advanced/glm-4.5-air/search.toml
+++ b/examples/advanced/glm-4.5-air/search.toml
@@ -25,8 +25,6 @@ num_infer_replicas = 4
 project = "search-ablations"
 name = "glm45air-search"
 
-[monitors.prime]
-
 [weight_broadcast]
 type = "nccl"
 timeout = 3600

--- a/examples/advanced/glm-4.5-air/swe.toml
+++ b/examples/advanced/glm-4.5-air/swe.toml
@@ -39,8 +39,6 @@ num_infer_replicas = 3
 project = "swe-ablations"
 name = "glm45air-scaleswe"
 
-[monitors.prime]
-
 [weight_broadcast]
 type = "nccl"
 timeout = 3600

--- a/examples/advanced/glm-4.5-air/terminal.toml
+++ b/examples/advanced/glm-4.5-air/terminal.toml
@@ -26,8 +26,6 @@ num_infer_replicas = 4
 project = "terminal-ablations"
 name = "glm45air-terminal"
 
-[monitors.prime]
-
 [weight_broadcast]
 type = "nccl"
 timeout = 3600

--- a/examples/advanced/nemotron-3-super/swe.toml
+++ b/examples/advanced/nemotron-3-super/swe.toml
@@ -22,8 +22,6 @@ num_infer_replicas = 4
 project = "nemotron-3-super"
 name = "nemotron-3-super-swe"
 
-[monitors.prime]
-
 [weight_broadcast]
 type = "nccl"
 timeout = 3600


### PR DESCRIPTION
## What

Removes the bare `[monitors.prime]` sections (empty tables, no keys) from the example configs:

- `examples/advanced/glm-4.5-air/search.toml`
- `examples/advanced/glm-4.5-air/swe.toml`
- `examples/advanced/glm-4.5-air/terminal.toml`
- `examples/advanced/nemotron-3-super/swe.toml`

## Why

An empty `[monitors.prime]` table silently enables Prime Lab platform monitoring (streaming metrics/episodes to the platform) for anyone who starts a run from these examples. Dropping the section keeps the examples monitoring-free apart from W&B, matching the other examples (`glm-5.2`, `intellect-3.1`, `minimax-m2.5`, `qwen3-30b-a3b`, and all `basic` examples), which never declare it.

Users who want platform monitoring can re-enable it with `--monitors.prime` or the section itself (see `docs/training.md` -> Platform monitoring).

## Notes

- Pure deletion of 8 lines across 4 files; all files still parse as valid TOML.
- `configs/debug/concurrency.toml` also declares `[monitors.prime]`; left untouched since this PR is scoped to examples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only TOML deletions; default monitoring behavior for runs started from these four configs changes from implicit Prime Lab on to off, with no runtime or training logic changes.
> 
> **Overview**
> Removes bare **`[monitors.prime]`** blocks (empty tables with no keys) from four advanced example training configs: GLM-4.5-Air **search**, **swe**, and **terminal**, plus **nemotron-3-super** SWE.
> 
> Those sections were enough to turn on **Prime Lab platform monitoring** (metrics/episodes streaming) for anyone launching from the examples, even though only **`[monitors.wandb]`** was intentionally configured. After this change, the examples match the rest of the tree (W&B only unless users opt in via **`--monitors.prime`** or a populated **`[monitors.prime]`** section).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb5bd42edfef2ea4ed67951352a0519a9964e57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->